### PR TITLE
feat(cost-optimization-report): add openshift cost optimization report

### DIFF
--- a/reconcile/gql_definitions/cost_report/cost_namespaces.gql
+++ b/reconcile/gql_definitions/cost_report/cost_namespaces.gql
@@ -3,6 +3,7 @@
 query CostNamespaces($filter: JSON) {
   namespaces: namespaces_v1(filter: $filter) {
     name
+    labels
     app {
       name
     }

--- a/reconcile/gql_definitions/cost_report/cost_namespaces.py
+++ b/reconcile/gql_definitions/cost_report/cost_namespaces.py
@@ -22,6 +22,7 @@ DEFINITION = """
 query CostNamespaces($filter: JSON) {
   namespaces: namespaces_v1(filter: $filter) {
     name
+    labels
     app {
       name
     }
@@ -57,6 +58,7 @@ class ClusterV1(ConfiguredBaseModel):
 
 class NamespaceV1(ConfiguredBaseModel):
     name: str = Field(..., alias="name")
+    labels: Optional[Json] = Field(..., alias="labels")
     app: AppV1 = Field(..., alias="app")
     cluster: ClusterV1 = Field(..., alias="cluster")
 

--- a/reconcile/typed_queries/cost_report/cost_namespaces.py
+++ b/reconcile/typed_queries/cost_report/cost_namespaces.py
@@ -4,14 +4,16 @@ from reconcile.gql_definitions.cost_report.cost_namespaces import query
 from reconcile.utils.gql import GqlApi
 
 
-class CostNamespace(BaseModel):
+class CostNamespaceLabels(BaseModel, frozen=True):
+    insights_cost_management_optimizations: str | None = None
+
+
+class CostNamespace(BaseModel, frozen=True):
     name: str
+    labels: CostNamespaceLabels
     app_name: str
     cluster_name: str
     cluster_external_id: str | None
-
-    class Config:
-        frozen = True
 
 
 def get_cost_namespaces(
@@ -30,6 +32,7 @@ def get_cost_namespaces(
     return [
         CostNamespace(
             name=namespace.name,
+            labels=CostNamespaceLabels.parse_obj(namespace.labels or {}),
             app_name=namespace.app.name,
             cluster_name=namespace.cluster.name,
             cluster_external_id=namespace.cluster.spec.external_id

--- a/tools/cli_commands/cost_report/aws.py
+++ b/tools/cli_commands/cost_report/aws.py
@@ -4,17 +4,15 @@ from typing import Self
 
 from sretoolbox.utils import threaded
 
-from reconcile.typed_queries.app_interface_vault_settings import (
-    get_app_interface_vault_settings,
-)
 from reconcile.typed_queries.cost_report.app_names import App, get_app_names
-from reconcile.typed_queries.cost_report.settings import get_cost_report_settings
 from reconcile.utils import gql
-from reconcile.utils.secret_reader import create_secret_reader
 from tools.cli_commands.cost_report.cost_management_api import CostManagementApi
 from tools.cli_commands.cost_report.model import ChildAppReport, Report, ReportItem
 from tools.cli_commands.cost_report.response import ReportCostResponse
-from tools.cli_commands.cost_report.util import process_reports
+from tools.cli_commands.cost_report.util import (
+    fetch_cost_report_secret,
+    process_reports,
+)
 from tools.cli_commands.cost_report.view import render_aws_cost_report
 
 THREAD_POOL_SIZE = 10
@@ -127,21 +125,10 @@ class AwsCostReportCommand:
         )
 
     @classmethod
-    def create(
-        cls,
-    ) -> Self:
+    def create(cls) -> Self:
         gql_api = gql.get_api()
-        vault_settings = get_app_interface_vault_settings(gql_api.query)
-        secret_reader = create_secret_reader(use_vault=vault_settings.vault)
-        cost_report_settings = get_cost_report_settings(gql_api)
-        secret = secret_reader.read_all_secret(cost_report_settings.credentials)
-        cost_management_api = CostManagementApi(
-            base_url=secret["api_base_url"],
-            token_url=secret["token_url"],
-            client_id=secret["client_id"],
-            client_secret=secret["client_secret"],
-            scope=secret["scope"].split(" "),
-        )
+        secret = fetch_cost_report_secret(gql_api)
+        cost_management_api = CostManagementApi.create_from_secret(secret)
         return cls(
             gql_api=gql_api,
             cost_management_api=cost_management_api,

--- a/tools/cli_commands/cost_report/aws.py
+++ b/tools/cli_commands/cost_report/aws.py
@@ -8,7 +8,7 @@ from reconcile.typed_queries.cost_report.app_names import App, get_app_names
 from reconcile.utils import gql
 from tools.cli_commands.cost_report.cost_management_api import CostManagementApi
 from tools.cli_commands.cost_report.model import ChildAppReport, Report, ReportItem
-from tools.cli_commands.cost_report.response import ReportCostResponse
+from tools.cli_commands.cost_report.response import AwsReportCostResponse
 from tools.cli_commands.cost_report.util import (
     fetch_cost_report_secret,
     process_reports,
@@ -43,13 +43,13 @@ class AwsCostReportCommand:
         """
         return get_app_names(self.gql_api)
 
-    def _get_report(self, app: App) -> tuple[str, ReportCostResponse]:
+    def _get_report(self, app: App) -> tuple[str, AwsReportCostResponse]:
         return app.name, self.cost_management_api.get_aws_costs_report(app.name)
 
     def get_reports(
         self,
         apps: Iterable[App],
-    ) -> Mapping[str, ReportCostResponse]:
+    ) -> Mapping[str, AwsReportCostResponse]:
         """
         Fetch reports from cost management API
         """
@@ -59,7 +59,7 @@ class AwsCostReportCommand:
     def process_reports(
         self,
         apps: Iterable[App],
-        responses: Mapping[str, ReportCostResponse],
+        responses: Mapping[str, AwsReportCostResponse],
     ) -> dict[str, Report]:
         """
         Build reports with parent-child app tree.
@@ -82,7 +82,7 @@ class AwsCostReportCommand:
         parent_app_name: str | None,
         child_apps: list[str],
         reports: Mapping[str, Report],
-        response: ReportCostResponse,
+        response: AwsReportCostResponse,
     ) -> Report:
         child_app_reports = [
             ChildAppReport(

--- a/tools/cli_commands/cost_report/cost_management_api.py
+++ b/tools/cli_commands/cost_report/cost_management_api.py
@@ -107,7 +107,7 @@ class CostManagementApi(ApiBase):
         params = {
             "cluster": cluster,
             "project": project,
-            "limit": PAGE_LIMIT,
+            "limit": str(PAGE_LIMIT),
             "memory-unit": MEMORY_UNIT,
             "cpu-unit": CPU_UNIT,
         }

--- a/tools/cli_commands/cost_report/cost_management_api.py
+++ b/tools/cli_commands/cost_report/cost_management_api.py
@@ -17,6 +17,8 @@ from tools.cli_commands.cost_report.response import (
 
 REQUEST_TIMEOUT = 60
 PAGE_LIMIT = 100
+MEMORY_UNIT = "MiB"
+CPU_UNIT = "millicores"
 
 
 class CostManagementApi(ApiBase):
@@ -106,6 +108,8 @@ class CostManagementApi(ApiBase):
             "cluster": cluster,
             "project": project,
             "limit": PAGE_LIMIT,
+            "memory-unit": MEMORY_UNIT,
+            "cpu-unit": CPU_UNIT,
         }
         response = self.session.request(
             method="GET",

--- a/tools/cli_commands/cost_report/cost_management_api.py
+++ b/tools/cli_commands/cost_report/cost_management_api.py
@@ -1,3 +1,6 @@
+from collections.abc import Mapping
+from typing import Self
+
 from urllib3.util import Retry
 
 from reconcile.utils.oauth2_backend_application_session import (
@@ -13,6 +16,12 @@ REQUEST_TIMEOUT = 60
 
 
 class CostManagementApi(ApiBase):
+    """
+    Cost Management API client.
+
+    Doc at https://console.redhat.com/docs/api/cost-management
+    """
+
     def __init__(
         self,
         base_url: str,
@@ -80,3 +89,16 @@ class CostManagementApi(ApiBase):
         )
         response.raise_for_status()
         return OpenShiftReportCostResponse.parse_obj(response.json())
+
+    @classmethod
+    def create_from_secret(
+        cls,
+        secret: Mapping[str, str],
+    ) -> Self:
+        return cls(
+            base_url=secret["api_base_url"],
+            token_url=secret["token_url"],
+            client_id=secret["client_id"],
+            client_secret=secret["client_secret"],
+            scope=secret["scope"].split(" "),
+        )

--- a/tools/cli_commands/cost_report/cost_management_api.py
+++ b/tools/cli_commands/cost_report/cost_management_api.py
@@ -8,8 +8,9 @@ from reconcile.utils.oauth2_backend_application_session import (
 )
 from reconcile.utils.rest_api_base import ApiBase
 from tools.cli_commands.cost_report.response import (
+    AwsReportCostResponse,
+    OpenShiftCostOptimizationReportResponse,
     OpenShiftReportCostResponse,
-    ReportCostResponse,
 )
 
 REQUEST_TIMEOUT = 60
@@ -48,7 +49,7 @@ class CostManagementApi(ApiBase):
             max_retries=max_retries,
         )
 
-    def get_aws_costs_report(self, app: str) -> ReportCostResponse:
+    def get_aws_costs_report(self, app: str) -> AwsReportCostResponse:
         params = {
             "cost_type": "calculated_amortized_cost",
             "delta": "cost",
@@ -65,7 +66,7 @@ class CostManagementApi(ApiBase):
             timeout=self.read_timeout,
         )
         response.raise_for_status()
-        return ReportCostResponse.parse_obj(response.json())
+        return AwsReportCostResponse.parse_obj(response.json())
 
     def get_openshift_costs_report(
         self,
@@ -89,6 +90,24 @@ class CostManagementApi(ApiBase):
         )
         response.raise_for_status()
         return OpenShiftReportCostResponse.parse_obj(response.json())
+
+    def get_openshift_cost_optimization_report(
+        self,
+        cluster: str,
+        project: str,
+    ) -> OpenShiftCostOptimizationReportResponse:
+        params = {
+            "cluster": cluster,
+            "project": project,
+        }
+        response = self.session.request(
+            method="GET",
+            url=f"{self.host}/recommendations/openshift",
+            params=params,
+            timeout=self.read_timeout,
+        )
+        response.raise_for_status()
+        return OpenShiftCostOptimizationReportResponse.parse_obj(response.json())
 
     @classmethod
     def create_from_secret(

--- a/tools/cli_commands/cost_report/model.py
+++ b/tools/cli_commands/cost_report/model.py
@@ -26,3 +26,24 @@ class Report(BaseModel):
     items_delta_value: Decimal
     items_total: Decimal
     total: Decimal
+
+
+class OptimizationReportItem(BaseModel):
+    cluster: str
+    project: str
+    workload: str
+    workload_type: str
+    container: str
+    current_cpu_limit: str | None
+    current_cpu_request: str | None
+    current_memory_limit: str | None
+    current_memory_request: str | None
+    recommend_cpu_limit: str | None
+    recommend_cpu_request: str | None
+    recommend_memory_limit: str | None
+    recommend_memory_request: str | None
+
+
+class OptimizationReport(BaseModel):
+    app_name: str
+    items: list[OptimizationReportItem]

--- a/tools/cli_commands/cost_report/openshift.py
+++ b/tools/cli_commands/cost_report/openshift.py
@@ -5,21 +5,19 @@ from typing import Self
 
 from sretoolbox.utils import threaded
 
-from reconcile.typed_queries.app_interface_vault_settings import (
-    get_app_interface_vault_settings,
-)
 from reconcile.typed_queries.cost_report.app_names import App, get_app_names
 from reconcile.typed_queries.cost_report.cost_namespaces import (
     CostNamespace,
     get_cost_namespaces,
 )
-from reconcile.typed_queries.cost_report.settings import get_cost_report_settings
 from reconcile.utils import gql
-from reconcile.utils.secret_reader import create_secret_reader
 from tools.cli_commands.cost_report.cost_management_api import CostManagementApi
 from tools.cli_commands.cost_report.model import ChildAppReport, Report, ReportItem
 from tools.cli_commands.cost_report.response import OpenShiftReportCostResponse
-from tools.cli_commands.cost_report.util import process_reports
+from tools.cli_commands.cost_report.util import (
+    fetch_cost_report_secret,
+    process_reports,
+)
 from tools.cli_commands.cost_report.view import render_openshift_cost_report
 
 THREAD_POOL_SIZE = 10
@@ -157,21 +155,10 @@ class OpenShiftCostReportCommand:
         )
 
     @classmethod
-    def create(
-        cls,
-    ) -> Self:
+    def create(cls) -> Self:
         gql_api = gql.get_api()
-        vault_settings = get_app_interface_vault_settings(gql_api.query)
-        secret_reader = create_secret_reader(use_vault=vault_settings.vault)
-        cost_report_settings = get_cost_report_settings(gql_api)
-        secret = secret_reader.read_all_secret(cost_report_settings.credentials)
-        cost_management_api = CostManagementApi(
-            base_url=secret["api_base_url"],
-            token_url=secret["token_url"],
-            client_id=secret["client_id"],
-            client_secret=secret["client_secret"],
-            scope=secret["scope"].split(" "),
-        )
+        secret = fetch_cost_report_secret(gql_api)
+        cost_management_api = CostManagementApi.create_from_secret(secret)
         return cls(
             gql_api=gql_api,
             cost_management_api=cost_management_api,

--- a/tools/cli_commands/cost_report/openshift_cost_optimization.py
+++ b/tools/cli_commands/cost_report/openshift_cost_optimization.py
@@ -11,12 +11,19 @@ from reconcile.typed_queries.cost_report.cost_namespaces import (
 )
 from reconcile.utils import gql
 from tools.cli_commands.cost_report.cost_management_api import CostManagementApi
-from tools.cli_commands.cost_report.model import OptimizationReport, OptimizationReportItem
+from tools.cli_commands.cost_report.model import (
+    OptimizationReport,
+    OptimizationReportItem,
+)
 from tools.cli_commands.cost_report.response import (
-    OpenShiftCostOptimizationReportResponse, OpenShiftCostOptimizationResponse, ResourceConfigResponse,
+    OpenShiftCostOptimizationReportResponse,
+    OpenShiftCostOptimizationResponse,
+    ResourceConfigResponse,
 )
 from tools.cli_commands.cost_report.util import fetch_cost_report_secret
-from tools.cli_commands.cost_report.view import render_openshift_cost_optimization_report
+from tools.cli_commands.cost_report.view import (
+    render_openshift_cost_optimization_report,
+)
 
 THREAD_POOL_SIZE = 10
 
@@ -124,7 +131,9 @@ class OpenShiftCostOptimizationReportCommand:
             recommend_cpu_limit=self._build_resource_config(recommend.limits.cpu),
             recommend_cpu_request=self._build_resource_config(recommend.requests.cpu),
             recommend_memory_limit=self._build_resource_config(recommend.limits.memory),
-            recommend_memory_request=self._build_resource_config(recommend.requests.memory),
+            recommend_memory_request=self._build_resource_config(
+                recommend.requests.memory
+            ),
         )
 
     @staticmethod

--- a/tools/cli_commands/cost_report/openshift_cost_optimization.py
+++ b/tools/cli_commands/cost_report/openshift_cost_optimization.py
@@ -1,0 +1,10 @@
+from typing import Self
+
+
+class OpenShiftCostOptimizationReportCommand:
+    def execute(self) -> str:
+        return ""
+
+    @classmethod
+    def create(cls) -> Self:
+        return OpenShiftCostOptimizationReportCommand()

--- a/tools/cli_commands/cost_report/openshift_cost_optimization.py
+++ b/tools/cli_commands/cost_report/openshift_cost_optimization.py
@@ -1,5 +1,10 @@
 from typing import Self
 
+from reconcile.typed_queries.cost_report.app_names import App, get_app_names
+from reconcile.typed_queries.cost_report.cost_namespaces import (
+    CostNamespace,
+    get_cost_namespaces,
+)
 from reconcile.utils import gql
 from tools.cli_commands.cost_report.cost_management_api import CostManagementApi
 from tools.cli_commands.cost_report.util import fetch_cost_report_secret
@@ -19,7 +24,15 @@ class OpenShiftCostOptimizationReportCommand:
         self.thread_pool_size = thread_pool_size
 
     def execute(self) -> str:
+        apps = self.get_apps()
+        cost_namespaces = self.get_cost_namespaces()
         return ""
+
+    def get_apps(self) -> list[App]:
+        return get_app_names(self.gql_api)
+
+    def get_cost_namespaces(self) -> list[CostNamespace]:
+        return get_cost_namespaces(self.gql_api)
 
     @classmethod
     def create(cls) -> Self:

--- a/tools/cli_commands/cost_report/openshift_cost_optimization.py
+++ b/tools/cli_commands/cost_report/openshift_cost_optimization.py
@@ -1,10 +1,33 @@
 from typing import Self
 
+from reconcile.utils import gql
+from tools.cli_commands.cost_report.cost_management_api import CostManagementApi
+from tools.cli_commands.cost_report.util import fetch_cost_report_secret
+
+THREAD_POOL_SIZE = 10
+
 
 class OpenShiftCostOptimizationReportCommand:
+    def __init__(
+        self,
+        gql_api: gql.GqlApi,
+        cost_management_api: CostManagementApi,
+        thread_pool_size: int = THREAD_POOL_SIZE,
+    ) -> None:
+        self.gql_api = gql_api
+        self.cost_management_api = cost_management_api
+        self.thread_pool_size = thread_pool_size
+
     def execute(self) -> str:
         return ""
 
     @classmethod
     def create(cls) -> Self:
-        return OpenShiftCostOptimizationReportCommand()
+        gql_api = gql.get_api()
+        secret = fetch_cost_report_secret(gql_api)
+        cost_management_api = CostManagementApi.create_from_secret(secret)
+        return cls(
+            gql_api=gql_api,
+            cost_management_api=cost_management_api,
+            thread_pool_size=THREAD_POOL_SIZE,
+        )

--- a/tools/cli_commands/cost_report/openshift_cost_optimization.py
+++ b/tools/cli_commands/cost_report/openshift_cost_optimization.py
@@ -50,7 +50,12 @@ class OpenShiftCostOptimizationReportCommand:
         return get_app_names(self.gql_api)
 
     def get_cost_namespaces(self) -> list[CostNamespace]:
-        return get_cost_namespaces(self.gql_api)
+        cost_namespaces = get_cost_namespaces(self.gql_api)
+        return [
+            n
+            for n in cost_namespaces
+            if n.labels.insights_cost_management_optimizations == "true"
+        ]
 
     def get_reports(
         self,

--- a/tools/cli_commands/cost_report/openshift_cost_optimization.py
+++ b/tools/cli_commands/cost_report/openshift_cost_optimization.py
@@ -163,7 +163,9 @@ class OpenShiftCostOptimizationReportCommand:
         )
 
     @staticmethod
-    def _build_resource_config(response: ResourceConfigResponse) -> str:
+    def _build_resource_config(response: ResourceConfigResponse) -> str | None:
+        if response.amount is None:
+            return None
         if response.format is None:
             return str(round(response.amount))
         return f"{round(response.amount)}{response.format}"

--- a/tools/cli_commands/cost_report/response.py
+++ b/tools/cli_commands/cost_report/response.py
@@ -70,7 +70,7 @@ class OpenShiftReportCostResponse(BaseModel):
 
 
 class ResourceConfigResponse(BaseModel):
-    amount: float
+    amount: float | None = None
     format: str | None = None
 
 

--- a/tools/cli_commands/cost_report/response.py
+++ b/tools/cli_commands/cost_report/response.py
@@ -42,7 +42,7 @@ class CostResponse(BaseModel):
     services: list[ServiceCostResponse]
 
 
-class ReportCostResponse(BaseModel):
+class AwsReportCostResponse(BaseModel):
     meta: ReportMetaResponse
     data: list[CostResponse]
 
@@ -67,3 +67,58 @@ class OpenShiftCostResponse(BaseModel):
 class OpenShiftReportCostResponse(BaseModel):
     meta: ReportMetaResponse
     data: list[OpenShiftCostResponse]
+
+
+class ResourceConfigResponse(BaseModel):
+    amount: float
+    format: str | None = None
+
+
+class ResourceResponse(BaseModel):
+    cpu: ResourceConfigResponse
+    memory: ResourceConfigResponse
+
+
+class RecommendationResourcesResponse(BaseModel):
+    limits: ResourceResponse
+    requests: ResourceResponse
+
+
+class RecommendationEngineResponse(BaseModel):
+    config: RecommendationResourcesResponse
+    variation: RecommendationResourcesResponse
+
+
+class RecommendationEnginesResponse(BaseModel):
+    cost: RecommendationEngineResponse
+    performance: RecommendationEngineResponse
+
+
+class RecommendationTermResponse(BaseModel):
+    recommendation_engines: RecommendationEnginesResponse | None = None
+
+
+class RecommendationTermsResponse(BaseModel):
+    long_term: RecommendationTermResponse
+    medium_term: RecommendationTermResponse
+    short_term: RecommendationTermResponse
+
+
+class RecommendationsResponse(BaseModel):
+    current: RecommendationResourcesResponse
+    recommendation_terms: RecommendationTermsResponse
+
+
+class OpenShiftCostOptimizationResponse(BaseModel):
+    cluster_alias: str
+    cluster_uuid: str
+    container: str
+    id: str
+    project: str
+    recommendations: RecommendationsResponse
+    workload: str
+    workload_type: str
+
+
+class OpenShiftCostOptimizationReportResponse(BaseModel):
+    data: list[OpenShiftCostOptimizationResponse]

--- a/tools/cli_commands/cost_report/util.py
+++ b/tools/cli_commands/cost_report/util.py
@@ -2,7 +2,13 @@ from collections import defaultdict
 from collections.abc import Callable, Iterable, Mapping, MutableMapping
 from typing import Any
 
+from reconcile.typed_queries.app_interface_vault_settings import (
+    get_app_interface_vault_settings,
+)
 from reconcile.typed_queries.cost_report.app_names import App
+from reconcile.typed_queries.cost_report.settings import get_cost_report_settings
+from reconcile.utils.gql import GqlApi
+from reconcile.utils.secret_reader import create_secret_reader
 from tools.cli_commands.cost_report.model import Report
 
 
@@ -57,3 +63,10 @@ def process_reports(
             report_builder=report_builder,
         )
     return reports
+
+
+def fetch_cost_report_secret(gql_api: GqlApi) -> dict[str, str]:
+    vault_settings = get_app_interface_vault_settings(gql_api.query)
+    secret_reader = create_secret_reader(use_vault=vault_settings.vault)
+    cost_report_settings = get_cost_report_settings(gql_api)
+    return secret_reader.read_all_secret(cost_report_settings.credentials)

--- a/tools/cli_commands/cost_report/view.py
+++ b/tools/cli_commands/cost_report/view.py
@@ -1,10 +1,10 @@
-from collections.abc import Callable, Mapping, Iterable
+from collections.abc import Callable, Iterable, Mapping
 from decimal import Decimal
 from typing import Any
 
 from pydantic import BaseModel
 
-from tools.cli_commands.cost_report.model import Report, OptimizationReport
+from tools.cli_commands.cost_report.model import OptimizationReport, Report
 
 LAYOUT = """\
 [TOC]
@@ -454,14 +454,38 @@ def render_optimization(
         fields=[
             TableField(key="namespace", label="Namespace", sortable=True),
             TableField(key="workload", label="Workload", sortable=True),
-            TableField(key="current_cpu_request", label="Current CPU Request", sortable=True),
-            TableField(key="recommend_cpu_request", label="Recommend CPU Request", sortable=True),
-            TableField(key="current_cpu_limit", label="Current CPU Limit", sortable=True),
-            TableField(key="recommend_cpu_limit", label="Recommend CPU Limit", sortable=True),
-            TableField(key="current_memory_request", label="Current Memory Request", sortable=True),
-            TableField(key="recommend_memory_request", label="Recommend Memory Request", sortable=True),
-            TableField(key="current_memory_limit", label="Current Memory Limit", sortable=True),
-            TableField(key="recommend_memory_limit", label="Recommend Memory Limit", sortable=True),
+            TableField(
+                key="current_cpu_request", label="Current CPU Request", sortable=True
+            ),
+            TableField(
+                key="recommend_cpu_request",
+                label="Recommend CPU Request",
+                sortable=True,
+            ),
+            TableField(
+                key="current_cpu_limit", label="Current CPU Limit", sortable=True
+            ),
+            TableField(
+                key="recommend_cpu_limit", label="Recommend CPU Limit", sortable=True
+            ),
+            TableField(
+                key="current_memory_request",
+                label="Current Memory Request",
+                sortable=True,
+            ),
+            TableField(
+                key="recommend_memory_request",
+                label="Recommend Memory Request",
+                sortable=True,
+            ),
+            TableField(
+                key="current_memory_limit", label="Current Memory Limit", sortable=True
+            ),
+            TableField(
+                key="recommend_memory_limit",
+                label="Recommend Memory Limit",
+                sortable=True,
+            ),
         ],
     )
     return OPTIMIZATION.format(

--- a/tools/cli_commands/cost_report/view.py
+++ b/tools/cli_commands/cost_report/view.py
@@ -32,6 +32,15 @@ OPENSHIFT_HEADER = """\
 
 OPTIMIZATION_HEADER = """\
 # OpenShift Cost Optimization Report
+
+Report is generated for optimization enabled namespaces
+(`insights_cost_management_optimizations='true'` in namespace `labels`).
+
+In Cost optimizations, recommendations get generated when
+CPU usage is at or above the 60th percentile and
+memory usage is at the 100th percentile.
+
+View details in [Cost Management Optimizations](https://console.redhat.com/openshift/cost-management/optimizations).
 """
 
 AWS_SUMMARY = """\

--- a/tools/cli_commands/cost_report/view.py
+++ b/tools/cli_commands/cost_report/view.py
@@ -168,14 +168,14 @@ class ViewChildAppReport(BaseModel):
 class ViewOptimizationReportItem(BaseModel):
     namespace: str
     workload: str
-    current_cpu_limit: str
-    current_cpu_request: str
-    current_memory_limit: str
-    current_memory_request: str
-    recommend_cpu_limit: str
-    recommend_cpu_request: str
-    recommend_memory_limit: str
-    recommend_memory_request: str
+    current_cpu_limit: str | None
+    current_cpu_request: str | None
+    current_memory_limit: str | None
+    current_memory_request: str | None
+    recommend_cpu_limit: str | None
+    recommend_cpu_request: str | None
+    recommend_memory_limit: str | None
+    recommend_memory_request: str | None
 
 
 def format_cost_value(value: Decimal) -> str:

--- a/tools/cli_commands/test/conftest.py
+++ b/tools/cli_commands/test/conftest.py
@@ -135,3 +135,196 @@ OPENSHIFT_COST_OPTIMIZATION_RESPONSE = OpenShiftCostOptimizationReportResponse(
         )
     ]
 )
+
+OPENSHIFT_COST_OPTIMIZATION_WITH_FUZZY_MATCH_RESPONSE = (
+    OpenShiftCostOptimizationReportResponse(
+        data=[
+            OpenShiftCostOptimizationResponse(
+                cluster_alias="some-cluster",
+                cluster_uuid="some-cluster-uuid",
+                container="test",
+                id="id-uuid",
+                project="some-project",
+                workload="test-deployment",
+                workload_type="deployment",
+                recommendations=RecommendationsResponse(
+                    current=RecommendationResourcesResponse(
+                        limits=ResourceResponse(
+                            cpu=ResourceConfigResponse(amount=4),
+                            memory=ResourceConfigResponse(amount=5, format="Gi"),
+                        ),
+                        requests=ResourceResponse(
+                            cpu=ResourceConfigResponse(amount=1),
+                            memory=ResourceConfigResponse(amount=400, format="Mi"),
+                        ),
+                    ),
+                    recommendation_terms=RecommendationTermsResponse(
+                        long_term=RecommendationTermResponse(),
+                        medium_term=RecommendationTermResponse(),
+                        short_term=RecommendationTermResponse(
+                            recommendation_engines=RecommendationEnginesResponse(
+                                cost=RecommendationEngineResponse(
+                                    config=RecommendationResourcesResponse(
+                                        limits=ResourceResponse(
+                                            cpu=ResourceConfigResponse(amount=5),
+                                            memory=ResourceConfigResponse(
+                                                amount=6, format="Gi"
+                                            ),
+                                        ),
+                                        requests=ResourceResponse(
+                                            cpu=ResourceConfigResponse(amount=3),
+                                            memory=ResourceConfigResponse(
+                                                amount=700, format="Mi"
+                                            ),
+                                        ),
+                                    ),
+                                    variation=RecommendationResourcesResponse(
+                                        limits=ResourceResponse(
+                                            cpu=ResourceConfigResponse(amount=1),
+                                            memory=ResourceConfigResponse(
+                                                amount=1, format="Gi"
+                                            ),
+                                        ),
+                                        requests=ResourceResponse(
+                                            cpu=ResourceConfigResponse(amount=2),
+                                            memory=ResourceConfigResponse(
+                                                amount=300, format="Mi"
+                                            ),
+                                        ),
+                                    ),
+                                ),
+                                performance=RecommendationEngineResponse(
+                                    config=RecommendationResourcesResponse(
+                                        limits=ResourceResponse(
+                                            cpu=ResourceConfigResponse(amount=3),
+                                            memory=ResourceConfigResponse(
+                                                amount=6, format="Gi"
+                                            ),
+                                        ),
+                                        requests=ResourceResponse(
+                                            cpu=ResourceConfigResponse(
+                                                amount=600, format="millicores"
+                                            ),
+                                            memory=ResourceConfigResponse(
+                                                amount=700, format="Mi"
+                                            ),
+                                        ),
+                                    ),
+                                    variation=RecommendationResourcesResponse(
+                                        limits=ResourceResponse(
+                                            cpu=ResourceConfigResponse(amount=-1),
+                                            memory=ResourceConfigResponse(
+                                                amount=1, format="Gi"
+                                            ),
+                                        ),
+                                        requests=ResourceResponse(
+                                            cpu=ResourceConfigResponse(
+                                                amount=-400, format="millicores"
+                                            ),
+                                            memory=ResourceConfigResponse(
+                                                amount=300, format="Mi"
+                                            ),
+                                        ),
+                                    ),
+                                ),
+                            )
+                        ),
+                    ),
+                ),
+            ),
+            OpenShiftCostOptimizationResponse(
+                cluster_alias="some-cluster2",
+                cluster_uuid="some-cluster-uuid2",
+                container="test",
+                id="id-uuid",
+                project="some-project2",
+                workload="test-deployment",
+                workload_type="deployment",
+                recommendations=RecommendationsResponse(
+                    current=RecommendationResourcesResponse(
+                        limits=ResourceResponse(
+                            cpu=ResourceConfigResponse(amount=4),
+                            memory=ResourceConfigResponse(amount=5, format="Gi"),
+                        ),
+                        requests=ResourceResponse(
+                            cpu=ResourceConfigResponse(amount=1),
+                            memory=ResourceConfigResponse(amount=400, format="Mi"),
+                        ),
+                    ),
+                    recommendation_terms=RecommendationTermsResponse(
+                        long_term=RecommendationTermResponse(),
+                        medium_term=RecommendationTermResponse(),
+                        short_term=RecommendationTermResponse(
+                            recommendation_engines=RecommendationEnginesResponse(
+                                cost=RecommendationEngineResponse(
+                                    config=RecommendationResourcesResponse(
+                                        limits=ResourceResponse(
+                                            cpu=ResourceConfigResponse(amount=5),
+                                            memory=ResourceConfigResponse(
+                                                amount=6, format="Gi"
+                                            ),
+                                        ),
+                                        requests=ResourceResponse(
+                                            cpu=ResourceConfigResponse(amount=3),
+                                            memory=ResourceConfigResponse(
+                                                amount=700, format="Mi"
+                                            ),
+                                        ),
+                                    ),
+                                    variation=RecommendationResourcesResponse(
+                                        limits=ResourceResponse(
+                                            cpu=ResourceConfigResponse(amount=1),
+                                            memory=ResourceConfigResponse(
+                                                amount=1, format="Gi"
+                                            ),
+                                        ),
+                                        requests=ResourceResponse(
+                                            cpu=ResourceConfigResponse(amount=2),
+                                            memory=ResourceConfigResponse(
+                                                amount=300, format="Mi"
+                                            ),
+                                        ),
+                                    ),
+                                ),
+                                performance=RecommendationEngineResponse(
+                                    config=RecommendationResourcesResponse(
+                                        limits=ResourceResponse(
+                                            cpu=ResourceConfigResponse(amount=3),
+                                            memory=ResourceConfigResponse(
+                                                amount=6, format="Gi"
+                                            ),
+                                        ),
+                                        requests=ResourceResponse(
+                                            cpu=ResourceConfigResponse(
+                                                amount=600, format="millicores"
+                                            ),
+                                            memory=ResourceConfigResponse(
+                                                amount=700, format="Mi"
+                                            ),
+                                        ),
+                                    ),
+                                    variation=RecommendationResourcesResponse(
+                                        limits=ResourceResponse(
+                                            cpu=ResourceConfigResponse(amount=-1),
+                                            memory=ResourceConfigResponse(
+                                                amount=1, format="Gi"
+                                            ),
+                                        ),
+                                        requests=ResourceResponse(
+                                            cpu=ResourceConfigResponse(
+                                                amount=-400, format="millicores"
+                                            ),
+                                            memory=ResourceConfigResponse(
+                                                amount=300, format="Mi"
+                                            ),
+                                        ),
+                                    ),
+                                ),
+                            )
+                        ),
+                    ),
+                ),
+            ),
+        ]
+    )
+)

--- a/tools/cli_commands/test/conftest.py
+++ b/tools/cli_commands/test/conftest.py
@@ -29,8 +29,10 @@ COST_MANAGEMENT_CONSOLE_BASE_URL = (
     "https://console.redhat.com/openshift/cost-management"
 )
 
+COST_MANAGEMENT_API_HOST = "https://host/"
+
 COST_REPORT_SECRET = {
-    "api_base_url": "base_url",
+    "api_base_url": f"{COST_MANAGEMENT_API_HOST}/v1",
     "token_url": "token_url",
     "client_id": "client_id",
     "client_secret": "client_secret",

--- a/tools/cli_commands/test/conftest.py
+++ b/tools/cli_commands/test/conftest.py
@@ -10,3 +10,17 @@ def fx() -> Callable:
         return (Path(__file__).parent / "fixtures" / name).read_text()
 
     return _fx
+
+
+COST_MANAGEMENT_CONSOLE_BASE_URL = (
+    "https://console.redhat.com/openshift/cost-management"
+)
+
+COST_REPORT_SECRET = {
+    "api_base_url": "base_url",
+    "token_url": "token_url",
+    "client_id": "client_id",
+    "client_secret": "client_secret",
+    "scope": "scope",
+    "console_base_url": COST_MANAGEMENT_CONSOLE_BASE_URL,
+}

--- a/tools/cli_commands/test/conftest.py
+++ b/tools/cli_commands/test/conftest.py
@@ -3,6 +3,19 @@ from pathlib import Path
 
 import pytest
 
+from tools.cli_commands.cost_report.response import (
+    OpenShiftCostOptimizationReportResponse,
+    OpenShiftCostOptimizationResponse,
+    RecommendationEngineResponse,
+    RecommendationEnginesResponse,
+    RecommendationResourcesResponse,
+    RecommendationsResponse,
+    RecommendationTermResponse,
+    RecommendationTermsResponse,
+    ResourceConfigResponse,
+    ResourceResponse,
+)
+
 
 @pytest.fixture
 def fx() -> Callable:
@@ -24,3 +37,101 @@ COST_REPORT_SECRET = {
     "scope": "scope",
     "console_base_url": COST_MANAGEMENT_CONSOLE_BASE_URL,
 }
+
+OPENSHIFT_COST_OPTIMIZATION_RESPONSE = OpenShiftCostOptimizationReportResponse(
+    data=[
+        OpenShiftCostOptimizationResponse(
+            cluster_alias="some-cluster",
+            cluster_uuid="some-cluster-uuid",
+            container="test",
+            id="id-uuid",
+            project="some-project",
+            workload="test-deployment",
+            workload_type="deployment",
+            recommendations=RecommendationsResponse(
+                current=RecommendationResourcesResponse(
+                    limits=ResourceResponse(
+                        cpu=ResourceConfigResponse(amount=4),
+                        memory=ResourceConfigResponse(amount=5, format="Gi"),
+                    ),
+                    requests=ResourceResponse(
+                        cpu=ResourceConfigResponse(amount=1),
+                        memory=ResourceConfigResponse(amount=400, format="Mi"),
+                    ),
+                ),
+                recommendation_terms=RecommendationTermsResponse(
+                    long_term=RecommendationTermResponse(),
+                    medium_term=RecommendationTermResponse(),
+                    short_term=RecommendationTermResponse(
+                        recommendation_engines=RecommendationEnginesResponse(
+                            cost=RecommendationEngineResponse(
+                                config=RecommendationResourcesResponse(
+                                    limits=ResourceResponse(
+                                        cpu=ResourceConfigResponse(amount=5),
+                                        memory=ResourceConfigResponse(
+                                            amount=6, format="Gi"
+                                        ),
+                                    ),
+                                    requests=ResourceResponse(
+                                        cpu=ResourceConfigResponse(amount=3),
+                                        memory=ResourceConfigResponse(
+                                            amount=700, format="Mi"
+                                        ),
+                                    ),
+                                ),
+                                variation=RecommendationResourcesResponse(
+                                    limits=ResourceResponse(
+                                        cpu=ResourceConfigResponse(amount=1),
+                                        memory=ResourceConfigResponse(
+                                            amount=1, format="Gi"
+                                        ),
+                                    ),
+                                    requests=ResourceResponse(
+                                        cpu=ResourceConfigResponse(amount=2),
+                                        memory=ResourceConfigResponse(
+                                            amount=300, format="Mi"
+                                        ),
+                                    ),
+                                ),
+                            ),
+                            performance=RecommendationEngineResponse(
+                                config=RecommendationResourcesResponse(
+                                    limits=ResourceResponse(
+                                        cpu=ResourceConfigResponse(amount=3),
+                                        memory=ResourceConfigResponse(
+                                            amount=6, format="Gi"
+                                        ),
+                                    ),
+                                    requests=ResourceResponse(
+                                        cpu=ResourceConfigResponse(
+                                            amount=600, format="millicores"
+                                        ),
+                                        memory=ResourceConfigResponse(
+                                            amount=700, format="Mi"
+                                        ),
+                                    ),
+                                ),
+                                variation=RecommendationResourcesResponse(
+                                    limits=ResourceResponse(
+                                        cpu=ResourceConfigResponse(amount=-1),
+                                        memory=ResourceConfigResponse(
+                                            amount=1, format="Gi"
+                                        ),
+                                    ),
+                                    requests=ResourceResponse(
+                                        cpu=ResourceConfigResponse(
+                                            amount=-400, format="millicores"
+                                        ),
+                                        memory=ResourceConfigResponse(
+                                            amount=300, format="Mi"
+                                        ),
+                                    ),
+                                ),
+                            ),
+                        )
+                    ),
+                ),
+            ),
+        )
+    ]
+)

--- a/tools/cli_commands/test/fixtures/empty_openshift_cost_optimization_report.md
+++ b/tools/cli_commands/test/fixtures/empty_openshift_cost_optimization_report.md
@@ -1,0 +1,3 @@
+[TOC]
+
+# OpenShift Cost Optimization Report

--- a/tools/cli_commands/test/fixtures/empty_openshift_cost_optimization_report.md
+++ b/tools/cli_commands/test/fixtures/empty_openshift_cost_optimization_report.md
@@ -1,3 +1,12 @@
 [TOC]
 
 # OpenShift Cost Optimization Report
+
+Report is generated for optimization enabled namespaces
+(`insights_cost_management_optimizations='true'` in namespace `labels`).
+
+In Cost optimizations, recommendations get generated when
+CPU usage is at or above the 60th percentile and
+memory usage is at the 100th percentile.
+
+View details in [Cost Management Optimizations](https://console.redhat.com/openshift/cost-management/optimizations).

--- a/tools/cli_commands/test/fixtures/openshift_cost_optimization_report.json
+++ b/tools/cli_commands/test/fixtures/openshift_cost_optimization_report.json
@@ -1,0 +1,192 @@
+{
+  "data": [
+    {
+      "cluster_alias": "some-cluster",
+      "cluster_uuid": "some-cluster-uuid",
+      "container": "test",
+      "id": "id-uuid",
+      "last_reported": "2023-04-18T15:48:54.000Z",
+      "project": "some-project",
+      "recommendations": {
+        "current": {
+          "limits": {
+            "cpu": {
+              "amount": 4,
+              "format": null
+            },
+            "memory": {
+              "amount": 5,
+              "format": "Gi"
+            }
+          },
+          "requests": {
+            "cpu": {
+              "amount": 1,
+              "format": null
+            },
+            "memory": {
+              "amount": 400,
+              "format": "Mi"
+            }
+          }
+        },
+        "monitoring_end_time": "2024-05-13T05:56:06.466Z",
+        "notifications": {
+          "type": "info",
+          "code": "112101",
+          "message": "Short Term Recommendations Available"
+        },
+        "recommendation_terms": {
+          "long_term": {
+            "duration_in_hours": 24.7,
+            "monitoring_start_time": "0001-01-01T00:00:00Z",
+            "notifications": {
+              "120001": {
+                "code": 120001,
+                "message": "There is not enough data available to generate a recommendation.",
+                "type": "info"
+              }
+            }
+          },
+          "medium_term": {
+            "duration_in_hours": 24.7,
+            "monitoring_start_time": "0001-01-01T00:00:00Z",
+            "notifications": {
+              "120001": {
+                "code": 120001,
+                "message": "There is not enough data available to generate a recommendation.",
+                "type": "info"
+              }
+            }
+          },
+          "short_term": {
+            "duration_in_hours": 24.7,
+            "monitoring_start_time": "0001-01-01T00:00:00Z",
+            "notifications": {
+              "112101": {
+                "code": 112101,
+                "message": "Cost Recommendations Available",
+                "type": "info"
+              },
+              "112102": {
+                "code": 112102,
+                "message": "Performance Recommendations Available",
+                "type": "info"
+              }
+            },
+            "recommendation_engines": {
+              "cost": {
+                "config": {
+                  "limits": {
+                    "cpu": {
+                      "amount": 5,
+                      "format": null
+                    },
+                    "memory": {
+                      "amount": 6,
+                      "format": "Gi"
+                    }
+                  },
+                  "requests": {
+                    "cpu": {
+                      "amount": 3,
+                      "format": null
+                    },
+                    "memory": {
+                      "amount": 700,
+                      "format": "Mi"
+                    }
+                  }
+                },
+                "pods_count": 1,
+                "variation": {
+                  "limits": {
+                    "cpu": {
+                      "amount": 1,
+                      "format": null
+                    },
+                    "memory": {
+                      "amount": 1,
+                      "format": "Gi"
+                    }
+                  },
+                  "requests": {
+                    "cpu": {
+                      "amount": 2,
+                      "format": null
+                    },
+                    "memory": {
+                      "amount": 300,
+                      "format": "Mi"
+                    }
+                  }
+                }
+              },
+              "performance": {
+                "config": {
+                  "limits": {
+                    "cpu": {
+                      "amount": 3,
+                      "format": null
+                    },
+                    "memory": {
+                      "amount": 6,
+                      "format": "Gi"
+                    }
+                  },
+                  "requests": {
+                    "cpu": {
+                      "amount": 600,
+                      "format": "millicores"
+                    },
+                    "memory": {
+                      "amount": 700,
+                      "format": "Mi"
+                    }
+                  }
+                },
+                "pods_count": 1,
+                "variation": {
+                  "limits": {
+                    "cpu": {
+                      "amount": -1,
+                      "format": null
+                    },
+                    "memory": {
+                      "amount": 1,
+                      "format": "Gi"
+                    }
+                  },
+                  "requests": {
+                    "cpu": {
+                      "amount": -400,
+                      "format": "millicores"
+                    },
+                    "memory": {
+                      "amount": 300,
+                      "format": "Mi"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "source_id": "some-source-id",
+      "workload": "test-deployment",
+      "workload_type": "deployment"
+    }
+  ],
+  "meta": {
+    "count": 1,
+    "limit": 10,
+    "offset": 0
+  },
+  "links": {
+    "first": "string",
+    "previous": "string",
+    "next": "string",
+    "last": "string"
+  }
+}

--- a/tools/cli_commands/test/fixtures/openshift_cost_optimization_report.json
+++ b/tools/cli_commands/test/fixtures/openshift_cost_optimization_report.json
@@ -184,9 +184,8 @@
     "offset": 0
   },
   "links": {
-    "first": "string",
-    "previous": "string",
-    "next": "string",
-    "last": "string"
+    "first": "",
+    "previous": "",
+    "last": ""
   }
 }

--- a/tools/cli_commands/test/fixtures/openshift_cost_optimization_report.md
+++ b/tools/cli_commands/test/fixtures/openshift_cost_optimization_report.md
@@ -2,6 +2,15 @@
 
 # OpenShift Cost Optimization Report
 
+Report is generated for optimization enabled namespaces
+(`insights_cost_management_optimizations='true'` in namespace `labels`).
+
+In Cost optimizations, recommendations get generated when
+CPU usage is at or above the 60th percentile and
+memory usage is at the 100th percentile.
+
+View details in [Cost Management Optimizations](https://console.redhat.com/openshift/cost-management/optimizations).
+
 ## app
 
 ```json:table

--- a/tools/cli_commands/test/fixtures/openshift_cost_optimization_report.md
+++ b/tools/cli_commands/test/fixtures/openshift_cost_optimization_report.md
@@ -1,0 +1,33 @@
+[TOC]
+
+# OpenShift Cost Optimization Report
+## app
+
+```json:table
+{
+  "filter": true,
+  "items": [],
+  "fields": [
+    {
+      "key": "namespace",
+      "label": "Namespace",
+      "sortable": true
+    },
+    {
+      "key": "workload",
+      "label": "Workload",
+      "sortable": true
+    },
+    {
+      "key": "child_apps_total",
+      "label": "Child Apps ($)",
+      "sortable": true
+    },
+    {
+      "key": "total",
+      "label": "Total ($)",
+      "sortable": true
+    }
+  ]
+}
+```

--- a/tools/cli_commands/test/fixtures/openshift_cost_optimization_report.md
+++ b/tools/cli_commands/test/fixtures/openshift_cost_optimization_report.md
@@ -1,12 +1,26 @@
 [TOC]
 
 # OpenShift Cost Optimization Report
+
 ## app
 
 ```json:table
 {
   "filter": true,
-  "items": [],
+  "items": [
+    {
+      "namespace": "some-cluster/some-project",
+      "workload": "deployment/test-deployment/test",
+      "current_cpu_limit": "4",
+      "current_cpu_request": "1",
+      "current_memory_limit": "5Gi",
+      "current_memory_request": "400Mi",
+      "recommend_cpu_limit": "5",
+      "recommend_cpu_request": "3",
+      "recommend_memory_limit": "6Gi",
+      "recommend_memory_request": "700Mi"
+    }
+  ],
   "fields": [
     {
       "key": "namespace",
@@ -19,13 +33,43 @@
       "sortable": true
     },
     {
-      "key": "child_apps_total",
-      "label": "Child Apps ($)",
+      "key": "current_cpu_request",
+      "label": "Current CPU Request",
       "sortable": true
     },
     {
-      "key": "total",
-      "label": "Total ($)",
+      "key": "recommend_cpu_request",
+      "label": "Recommend CPU Request",
+      "sortable": true
+    },
+    {
+      "key": "current_cpu_limit",
+      "label": "Current CPU Limit",
+      "sortable": true
+    },
+    {
+      "key": "recommend_cpu_limit",
+      "label": "Recommend CPU Limit",
+      "sortable": true
+    },
+    {
+      "key": "current_memory_request",
+      "label": "Current Memory Request",
+      "sortable": true
+    },
+    {
+      "key": "recommend_memory_request",
+      "label": "Recommend Memory Request",
+      "sortable": true
+    },
+    {
+      "key": "current_memory_limit",
+      "label": "Current Memory Limit",
+      "sortable": true
+    },
+    {
+      "key": "recommend_memory_limit",
+      "label": "Recommend Memory Limit",
       "sortable": true
     }
   ]

--- a/tools/cli_commands/test/test_aws_cost_report.py
+++ b/tools/cli_commands/test/test_aws_cost_report.py
@@ -8,7 +8,7 @@ from pytest_mock import MockerFixture
 from reconcile.typed_queries.cost_report.app_names import App
 from tools.cli_commands.cost_report.aws import AwsCostReportCommand
 from tools.cli_commands.cost_report.model import ChildAppReport, Report, ReportItem
-from tools.cli_commands.cost_report.response import ReportCostResponse
+from tools.cli_commands.cost_report.response import AwsReportCostResponse
 from tools.cli_commands.test.conftest import (
     COST_REPORT_SECRET,
 )
@@ -111,8 +111,8 @@ def aws_report_cost_response_builder(
     delta_percent: int,
     total: int,
     service: str,
-) -> ReportCostResponse:
-    return ReportCostResponse.parse_obj({
+) -> AwsReportCostResponse:
+    return AwsReportCostResponse.parse_obj({
         "meta": {
             "delta": {
                 "value": delta_value,

--- a/tools/cli_commands/test/test_cost_management_api.py
+++ b/tools/cli_commands/test/test_cost_management_api.py
@@ -24,6 +24,7 @@ from tools.cli_commands.cost_report.response import (
     ServiceCostValueResponse,
     TotalMetaResponse,
 )
+from tools.cli_commands.test.conftest import COST_REPORT_SECRET
 
 
 @pytest.fixture
@@ -40,9 +41,24 @@ def base_url(httpserver: HTTPServer) -> str:
 
 
 TOKEN_URL = "token_url"
-CLIENT_ID = "client_id"
-CLIENT_SECRET = "client_secret"
-SCOPE = ["some-scope"]
+CLIENT_ID = COST_REPORT_SECRET["client_id"]
+CLIENT_SECRET = COST_REPORT_SECRET["client_secret"]
+SCOPE = ["scope"]
+
+
+def test_cost_management_api_create_from_secret(
+    mock_session: Any,
+) -> None:
+    api = CostManagementApi.create_from_secret(COST_REPORT_SECRET)
+
+    assert api.host == COST_REPORT_SECRET["api_base_url"]
+    assert api.session == mock_session.return_value
+    mock_session.assert_called_once_with(
+        client_id=CLIENT_ID,
+        client_secret=CLIENT_SECRET,
+        token_url=TOKEN_URL,
+        scope=SCOPE,
+    )
 
 
 def test_cost_management_api_init(mock_session: Any, base_url: str) -> None:

--- a/tools/cli_commands/test/test_cost_management_api.py
+++ b/tools/cli_commands/test/test_cost_management_api.py
@@ -295,6 +295,8 @@ def test_get_openshift_cost_optimization_report(
             "cluster": cluster,
             "project": project,
             "limit": "100",
+            "memory-unit": "MiB",
+            "cpu-unit": "millicores",
         },
     ).respond_with_data(response_body)
 

--- a/tools/cli_commands/test/test_cost_management_api.py
+++ b/tools/cli_commands/test/test_cost_management_api.py
@@ -15,26 +15,19 @@ from tools.cli_commands.cost_report.response import (
     CostTotalResponse,
     DeltaResponse,
     MoneyResponse,
-    OpenShiftCostOptimizationReportResponse,
-    OpenShiftCostOptimizationResponse,
     OpenShiftCostResponse,
     OpenShiftReportCostResponse,
     ProjectCostResponse,
     ProjectCostValueResponse,
-    RecommendationEngineResponse,
-    RecommendationEnginesResponse,
-    RecommendationResourcesResponse,
-    RecommendationsResponse,
-    RecommendationTermResponse,
-    RecommendationTermsResponse,
     ReportMetaResponse,
-    ResourceConfigResponse,
-    ResourceResponse,
     ServiceCostResponse,
     ServiceCostValueResponse,
     TotalMetaResponse,
 )
-from tools.cli_commands.test.conftest import COST_REPORT_SECRET
+from tools.cli_commands.test.conftest import (
+    COST_REPORT_SECRET,
+    OPENSHIFT_COST_OPTIMIZATION_RESPONSE,
+)
 
 
 @pytest.fixture
@@ -283,105 +276,6 @@ def test_get_openshift_costs_report_error(
     assert error.value.response.status_code == 500
 
 
-EXPECTED_OPENSHIFT_COST_OPTIMIZATION_RESPONSE = OpenShiftCostOptimizationReportResponse(
-    data=[
-        OpenShiftCostOptimizationResponse(
-            cluster_alias="some-cluster",
-            cluster_uuid="some-cluster-uuid",
-            container="test",
-            id="id-uuid",
-            project="some-project",
-            workload="test-deployment",
-            workload_type="deployment",
-            recommendations=RecommendationsResponse(
-                current=RecommendationResourcesResponse(
-                    limits=ResourceResponse(
-                        cpu=ResourceConfigResponse(amount=4),
-                        memory=ResourceConfigResponse(amount=5, format="Gi"),
-                    ),
-                    requests=ResourceResponse(
-                        cpu=ResourceConfigResponse(amount=1),
-                        memory=ResourceConfigResponse(amount=400, format="Mi"),
-                    ),
-                ),
-                recommendation_terms=RecommendationTermsResponse(
-                    long_term=RecommendationTermResponse(),
-                    medium_term=RecommendationTermResponse(),
-                    short_term=RecommendationTermResponse(
-                        recommendation_engines=RecommendationEnginesResponse(
-                            cost=RecommendationEngineResponse(
-                                config=RecommendationResourcesResponse(
-                                    limits=ResourceResponse(
-                                        cpu=ResourceConfigResponse(amount=5),
-                                        memory=ResourceConfigResponse(
-                                            amount=6, format="Gi"
-                                        ),
-                                    ),
-                                    requests=ResourceResponse(
-                                        cpu=ResourceConfigResponse(amount=3),
-                                        memory=ResourceConfigResponse(
-                                            amount=700, format="Mi"
-                                        ),
-                                    ),
-                                ),
-                                variation=RecommendationResourcesResponse(
-                                    limits=ResourceResponse(
-                                        cpu=ResourceConfigResponse(amount=1),
-                                        memory=ResourceConfigResponse(
-                                            amount=1, format="Gi"
-                                        ),
-                                    ),
-                                    requests=ResourceResponse(
-                                        cpu=ResourceConfigResponse(amount=2),
-                                        memory=ResourceConfigResponse(
-                                            amount=300, format="Mi"
-                                        ),
-                                    ),
-                                ),
-                            ),
-                            performance=RecommendationEngineResponse(
-                                config=RecommendationResourcesResponse(
-                                    limits=ResourceResponse(
-                                        cpu=ResourceConfigResponse(amount=3),
-                                        memory=ResourceConfigResponse(
-                                            amount=6, format="Gi"
-                                        ),
-                                    ),
-                                    requests=ResourceResponse(
-                                        cpu=ResourceConfigResponse(
-                                            amount=600, format="millicores"
-                                        ),
-                                        memory=ResourceConfigResponse(
-                                            amount=700, format="Mi"
-                                        ),
-                                    ),
-                                ),
-                                variation=RecommendationResourcesResponse(
-                                    limits=ResourceResponse(
-                                        cpu=ResourceConfigResponse(amount=-1),
-                                        memory=ResourceConfigResponse(
-                                            amount=1, format="Gi"
-                                        ),
-                                    ),
-                                    requests=ResourceResponse(
-                                        cpu=ResourceConfigResponse(
-                                            amount=-400, format="millicores"
-                                        ),
-                                        memory=ResourceConfigResponse(
-                                            amount=300, format="Mi"
-                                        ),
-                                    ),
-                                ),
-                            ),
-                        )
-                    ),
-                ),
-            ),
-        )
-    ]
-)
-
-
 def test_get_openshift_cost_optimization_report(
     cost_management_api: CostManagementApi,
     fx: Callable,
@@ -403,7 +297,7 @@ def test_get_openshift_cost_optimization_report(
         project=project,
     )
 
-    assert report_cost_response == EXPECTED_OPENSHIFT_COST_OPTIMIZATION_RESPONSE
+    assert report_cost_response == OPENSHIFT_COST_OPTIMIZATION_RESPONSE
 
 
 def test_get_openshift_cost_optimization_report_error(

--- a/tools/cli_commands/test/test_openshift_cost_optimization_report.py
+++ b/tools/cli_commands/test/test_openshift_cost_optimization_report.py
@@ -1,0 +1,62 @@
+from typing import Any
+
+import pytest
+from pytest_mock import MockerFixture
+
+from tools.cli_commands.cost_report.openshift_cost_optimization import (
+    OpenShiftCostOptimizationReportCommand,
+)
+from tools.cli_commands.test.conftest import (
+    COST_REPORT_SECRET,
+)
+
+
+@pytest.fixture
+def mock_gql(mocker: MockerFixture) -> Any:
+    return mocker.patch(
+        "tools.cli_commands.cost_report.openshift_cost_optimization.gql"
+    )
+
+
+@pytest.fixture
+def mock_cost_management_api(mocker: MockerFixture) -> Any:
+    return mocker.patch(
+        "tools.cli_commands.cost_report.openshift_cost_optimization.CostManagementApi",
+        autospec=True,
+    )
+
+
+@pytest.fixture
+def mock_fetch_cost_report_secret(mocker: MockerFixture) -> Any:
+    return mocker.patch(
+        "tools.cli_commands.cost_report.openshift_cost_optimization.fetch_cost_report_secret",
+        return_value=COST_REPORT_SECRET,
+    )
+
+
+def test_openshift_cost_optimization_report_create(
+    mock_gql: Any,
+    mock_cost_management_api: Any,
+    mock_fetch_cost_report_secret: Any,
+) -> None:
+    openshift_cost_optimization_report_command = (
+        OpenShiftCostOptimizationReportCommand.create()
+    )
+
+    assert isinstance(
+        openshift_cost_optimization_report_command,
+        OpenShiftCostOptimizationReportCommand,
+    )
+    assert (
+        openshift_cost_optimization_report_command.gql_api
+        == mock_gql.get_api.return_value
+    )
+    assert (
+        openshift_cost_optimization_report_command.cost_management_api
+        == mock_cost_management_api.create_from_secret.return_value
+    )
+    assert openshift_cost_optimization_report_command.thread_pool_size == 10
+    mock_cost_management_api.create_from_secret.assert_called_once_with(
+        COST_REPORT_SECRET
+    )
+    mock_fetch_cost_report_secret.assert_called_once_with(mock_gql.get_api.return_value)

--- a/tools/cli_commands/test/test_openshift_cost_optimization_report.py
+++ b/tools/cli_commands/test/test_openshift_cost_optimization_report.py
@@ -10,6 +10,7 @@ from tools.cli_commands.cost_report.openshift_cost_optimization import (
 )
 from tools.cli_commands.test.conftest import (
     COST_REPORT_SECRET,
+    OPENSHIFT_COST_OPTIMIZATION_RESPONSE,
 )
 
 
@@ -97,7 +98,7 @@ APP_NAMESPACE = CostNamespace(
 )
 
 
-def test_openshift_cost_report_execute(
+def test_openshift_cost_optimization_report_execute(
     openshift_cost_optimization_report_command: OpenShiftCostOptimizationReportCommand,
     mock_get_app_names: Any,
     mock_get_cost_namespaces: Any,
@@ -110,7 +111,7 @@ def test_openshift_cost_report_execute(
     assert output == ""
 
 
-def test_openshift_cost_report_get_apps(
+def test_openshift_cost_optimization_report_get_apps(
     openshift_cost_optimization_report_command: OpenShiftCostOptimizationReportCommand,
     mock_get_app_names: Any,
 ) -> None:
@@ -122,7 +123,7 @@ def test_openshift_cost_report_get_apps(
     assert apps == expected_apps
 
 
-def test_openshift_cost_report_get_cost_namespaces(
+def test_openshift_cost_optimization_report_get_cost_namespaces(
     openshift_cost_optimization_report_command: OpenShiftCostOptimizationReportCommand,
     mock_get_cost_namespaces: Any,
 ) -> None:
@@ -132,3 +133,21 @@ def test_openshift_cost_report_get_cost_namespaces(
     apps = openshift_cost_optimization_report_command.get_cost_namespaces()
 
     assert apps == expected_namespaces
+
+
+def test_openshift_cost_optimization_report_get_reports(
+    openshift_cost_optimization_report_command: OpenShiftCostOptimizationReportCommand,
+    mock_cost_management_api: Any,
+) -> None:
+    mocked_api = mock_cost_management_api.create_from_secret.return_value
+    mocked_api.get_openshift_cost_optimization_report.return_value = (
+        OPENSHIFT_COST_OPTIMIZATION_RESPONSE
+    )
+
+    reports = openshift_cost_optimization_report_command.get_reports([APP_NAMESPACE])
+
+    assert reports == {APP_NAMESPACE: OPENSHIFT_COST_OPTIMIZATION_RESPONSE}
+    mocked_api.get_openshift_cost_optimization_report.assert_called_once_with(
+        project=APP_NAMESPACE.name,
+        cluster=APP_NAMESPACE.cluster_external_id,
+    )

--- a/tools/cli_commands/test/test_openshift_cost_optimization_report.py
+++ b/tools/cli_commands/test/test_openshift_cost_optimization_report.py
@@ -1,3 +1,4 @@
+from collections.abc import Callable
 from typing import Any
 
 import pytest
@@ -103,13 +104,15 @@ def test_openshift_cost_optimization_report_execute(
     openshift_cost_optimization_report_command: OpenShiftCostOptimizationReportCommand,
     mock_get_app_names: Any,
     mock_get_cost_namespaces: Any,
+    fx: Callable,
 ) -> None:
     mock_get_app_names.return_value = []
     mock_get_cost_namespaces.return_value = []
+    expected_output = fx("empty_openshift_cost_optimization_report.md")
 
     output = openshift_cost_optimization_report_command.execute()
 
-    assert output == ""
+    assert output.rstrip() == expected_output.rstrip()
 
 
 def test_openshift_cost_optimization_report_get_apps(
@@ -154,7 +157,7 @@ def test_openshift_cost_optimization_report_get_reports(
     )
 
 
-EXPECTED_REPORT = OptimizationReport(
+APP_REPORT = OptimizationReport(
     app_name=APP.name,
     items=[OptimizationReportItem(
         cluster=APP_NAMESPACE.cluster_name,
@@ -177,9 +180,7 @@ EXPECTED_REPORT = OptimizationReport(
 def test_openshift_cost_report_process_reports(
     openshift_cost_optimization_report_command: OpenShiftCostOptimizationReportCommand,
 ) -> None:
-    expected_reports = {
-        "app": EXPECTED_REPORT,
-    }
+    expected_reports = [APP_REPORT]
 
     reports = openshift_cost_optimization_report_command.process_reports(
         apps=[APP],
@@ -189,3 +190,15 @@ def test_openshift_cost_report_process_reports(
     )
 
     assert reports == expected_reports
+
+
+def test_openshift_cost_report_render(
+    openshift_cost_optimization_report_command: OpenShiftCostOptimizationReportCommand,
+    fx: Callable,
+) -> None:
+    expected_output = fx("openshift_cost_optimization_report.md")
+    reports = [APP_REPORT]
+
+    output = openshift_cost_optimization_report_command.render(reports)
+
+    assert output == expected_output

--- a/tools/cli_commands/test/test_openshift_cost_optimization_report.py
+++ b/tools/cli_commands/test/test_openshift_cost_optimization_report.py
@@ -3,6 +3,8 @@ from typing import Any
 import pytest
 from pytest_mock import MockerFixture
 
+from reconcile.typed_queries.cost_report.app_names import App
+from reconcile.typed_queries.cost_report.cost_namespaces import CostNamespace
 from tools.cli_commands.cost_report.openshift_cost_optimization import (
     OpenShiftCostOptimizationReportCommand,
 )
@@ -60,3 +62,73 @@ def test_openshift_cost_optimization_report_create(
         COST_REPORT_SECRET
     )
     mock_fetch_cost_report_secret.assert_called_once_with(mock_gql.get_api.return_value)
+
+
+@pytest.fixture
+def openshift_cost_optimization_report_command(
+    mock_gql: Any,
+    mock_cost_management_api: Any,
+    mock_fetch_cost_report_secret: Any,
+) -> OpenShiftCostOptimizationReportCommand:
+    return OpenShiftCostOptimizationReportCommand.create()
+
+
+@pytest.fixture
+def mock_get_app_names(mocker: MockerFixture) -> Any:
+    return mocker.patch(
+        "tools.cli_commands.cost_report.openshift_cost_optimization.get_app_names"
+    )
+
+
+@pytest.fixture
+def mock_get_cost_namespaces(mocker: MockerFixture) -> Any:
+    return mocker.patch(
+        "tools.cli_commands.cost_report.openshift_cost_optimization.get_cost_namespaces"
+    )
+
+
+APP = App(name="app", parent_app_name=None)
+
+APP_NAMESPACE = CostNamespace(
+    name="app_namespace",
+    app_name=APP.name,
+    cluster_name="cluster",
+    cluster_external_id="cluster_external_id",
+)
+
+
+def test_openshift_cost_report_execute(
+    openshift_cost_optimization_report_command: OpenShiftCostOptimizationReportCommand,
+    mock_get_app_names: Any,
+    mock_get_cost_namespaces: Any,
+) -> None:
+    mock_get_app_names.return_value = []
+    mock_get_cost_namespaces.return_value = []
+
+    output = openshift_cost_optimization_report_command.execute()
+
+    assert output == ""
+
+
+def test_openshift_cost_report_get_apps(
+    openshift_cost_optimization_report_command: OpenShiftCostOptimizationReportCommand,
+    mock_get_app_names: Any,
+) -> None:
+    expected_apps = [APP]
+    mock_get_app_names.return_value = expected_apps
+
+    apps = openshift_cost_optimization_report_command.get_apps()
+
+    assert apps == expected_apps
+
+
+def test_openshift_cost_report_get_cost_namespaces(
+    openshift_cost_optimization_report_command: OpenShiftCostOptimizationReportCommand,
+    mock_get_cost_namespaces: Any,
+) -> None:
+    expected_namespaces = [APP_NAMESPACE]
+    mock_get_cost_namespaces.return_value = expected_namespaces
+
+    apps = openshift_cost_optimization_report_command.get_cost_namespaces()
+
+    assert apps == expected_namespaces

--- a/tools/cli_commands/test/test_openshift_cost_optimization_report.py
+++ b/tools/cli_commands/test/test_openshift_cost_optimization_report.py
@@ -6,7 +6,10 @@ from pytest_mock import MockerFixture
 
 from reconcile.typed_queries.cost_report.app_names import App
 from reconcile.typed_queries.cost_report.cost_namespaces import CostNamespace
-from tools.cli_commands.cost_report.model import OptimizationReportItem, OptimizationReport
+from tools.cli_commands.cost_report.model import (
+    OptimizationReport,
+    OptimizationReportItem,
+)
 from tools.cli_commands.cost_report.openshift_cost_optimization import (
     OpenShiftCostOptimizationReportCommand,
 )
@@ -159,21 +162,23 @@ def test_openshift_cost_optimization_report_get_reports(
 
 APP_REPORT = OptimizationReport(
     app_name=APP.name,
-    items=[OptimizationReportItem(
-        cluster=APP_NAMESPACE.cluster_name,
-        project=APP_NAMESPACE.name,
-        workload="test-deployment",
-        workload_type="deployment",
-        container="test",
-        current_cpu_limit="4",
-        current_cpu_request="1",
-        current_memory_limit="5Gi",
-        current_memory_request="400Mi",
-        recommend_cpu_request="3",
-        recommend_cpu_limit="5",
-        recommend_memory_request="700Mi",
-        recommend_memory_limit="6Gi",
-    )]
+    items=[
+        OptimizationReportItem(
+            cluster=APP_NAMESPACE.cluster_name,
+            project=APP_NAMESPACE.name,
+            workload="test-deployment",
+            workload_type="deployment",
+            container="test",
+            current_cpu_limit="4",
+            current_cpu_request="1",
+            current_memory_limit="5Gi",
+            current_memory_request="400Mi",
+            recommend_cpu_request="3",
+            recommend_cpu_limit="5",
+            recommend_memory_request="700Mi",
+            recommend_memory_limit="6Gi",
+        )
+    ],
 )
 
 

--- a/tools/cli_commands/test/test_openshift_cost_optimization_report.py
+++ b/tools/cli_commands/test/test_openshift_cost_optimization_report.py
@@ -16,6 +16,7 @@ from tools.cli_commands.cost_report.openshift_cost_optimization import (
 from tools.cli_commands.test.conftest import (
     COST_REPORT_SECRET,
     OPENSHIFT_COST_OPTIMIZATION_RESPONSE,
+    OPENSHIFT_COST_OPTIMIZATION_WITH_FUZZY_MATCH_RESPONSE,
 )
 
 
@@ -99,7 +100,7 @@ APP_NAMESPACE = CostNamespace(
     name="some-project",
     app_name=APP.name,
     cluster_name="some-cluster",
-    cluster_external_id="cluster_external_id",
+    cluster_external_id="some-cluster-uuid",
 )
 
 
@@ -149,6 +150,24 @@ def test_openshift_cost_optimization_report_get_reports(
     mocked_api = mock_cost_management_api.create_from_secret.return_value
     mocked_api.get_openshift_cost_optimization_report.return_value = (
         OPENSHIFT_COST_OPTIMIZATION_RESPONSE
+    )
+
+    reports = openshift_cost_optimization_report_command.get_reports([APP_NAMESPACE])
+
+    assert reports == {APP_NAMESPACE: OPENSHIFT_COST_OPTIMIZATION_RESPONSE}
+    mocked_api.get_openshift_cost_optimization_report.assert_called_once_with(
+        project=APP_NAMESPACE.name,
+        cluster=APP_NAMESPACE.cluster_external_id,
+    )
+
+
+def test_openshift_cost_optimization_report_get_reports_with_fuzzy_results(
+    openshift_cost_optimization_report_command: OpenShiftCostOptimizationReportCommand,
+    mock_cost_management_api: Any,
+) -> None:
+    mocked_api = mock_cost_management_api.create_from_secret.return_value
+    mocked_api.get_openshift_cost_optimization_report.return_value = (
+        OPENSHIFT_COST_OPTIMIZATION_WITH_FUZZY_MATCH_RESPONSE
     )
 
     reports = openshift_cost_optimization_report_command.get_reports([APP_NAMESPACE])

--- a/tools/cli_commands/test/test_openshift_cost_optimization_report.py
+++ b/tools/cli_commands/test/test_openshift_cost_optimization_report.py
@@ -5,7 +5,10 @@ import pytest
 from pytest_mock import MockerFixture
 
 from reconcile.typed_queries.cost_report.app_names import App
-from reconcile.typed_queries.cost_report.cost_namespaces import CostNamespace
+from reconcile.typed_queries.cost_report.cost_namespaces import (
+    CostNamespace,
+    CostNamespaceLabels,
+)
 from tools.cli_commands.cost_report.model import (
     OptimizationReport,
     OptimizationReportItem,
@@ -98,6 +101,15 @@ APP = App(name="app", parent_app_name=None)
 
 APP_NAMESPACE = CostNamespace(
     name="some-project",
+    labels=CostNamespaceLabels(insights_cost_management_optimizations="true"),
+    app_name=APP.name,
+    cluster_name="some-cluster",
+    cluster_external_id="some-cluster-uuid",
+)
+
+APP_NAMESPACE_OPTIMIZATION_DISABLED = CostNamespace(
+    name="some-project-disabled",
+    labels=CostNamespaceLabels(),
     app_name=APP.name,
     cluster_name="some-cluster",
     cluster_external_id="some-cluster-uuid",
@@ -132,6 +144,21 @@ def test_openshift_cost_optimization_report_get_apps(
 
 
 def test_openshift_cost_optimization_report_get_cost_namespaces(
+    openshift_cost_optimization_report_command: OpenShiftCostOptimizationReportCommand,
+    mock_get_cost_namespaces: Any,
+) -> None:
+    expected_namespaces = [APP_NAMESPACE]
+    mock_get_cost_namespaces.return_value = [
+        APP_NAMESPACE,
+        APP_NAMESPACE_OPTIMIZATION_DISABLED,
+    ]
+
+    apps = openshift_cost_optimization_report_command.get_cost_namespaces()
+
+    assert apps == expected_namespaces
+
+
+def test_openshift_cost_optimization_report_get_cost_namespaces_filter(
     openshift_cost_optimization_report_command: OpenShiftCostOptimizationReportCommand,
     mock_get_cost_namespaces: Any,
 ) -> None:

--- a/tools/cli_commands/test/test_openshift_cost_report.py
+++ b/tools/cli_commands/test/test_openshift_cost_report.py
@@ -6,7 +6,10 @@ import pytest
 from pytest_mock import MockerFixture
 
 from reconcile.typed_queries.cost_report.app_names import App
-from reconcile.typed_queries.cost_report.cost_namespaces import CostNamespace
+from reconcile.typed_queries.cost_report.cost_namespaces import (
+    CostNamespace,
+    CostNamespaceLabels,
+)
 from tools.cli_commands.cost_report.model import ChildAppReport, Report, ReportItem
 from tools.cli_commands.cost_report.openshift import OpenShiftCostReportCommand
 from tools.cli_commands.cost_report.response import OpenShiftReportCostResponse
@@ -80,12 +83,14 @@ CHILD_APP = App(name="child", parent_app_name="parent")
 
 PARENT_APP_NAMESPACE = CostNamespace(
     name="parent_namespace",
+    labels=CostNamespaceLabels(),
     app_name=PARENT_APP.name,
     cluster_name="parent_cluster",
     cluster_external_id="parent_cluster_external_id",
 )
 CHILD_APP_NAMESPACE = CostNamespace(
     name="child_namespace",
+    labels=CostNamespaceLabels(),
     app_name=CHILD_APP.name,
     cluster_name="child_cluster",
     cluster_external_id="child_cluster_external_id",

--- a/tools/cli_commands/test/test_openshift_cost_report.py
+++ b/tools/cli_commands/test/test_openshift_cost_report.py
@@ -5,16 +5,14 @@ from typing import Any
 import pytest
 from pytest_mock import MockerFixture
 
-from reconcile.gql_definitions.common.app_interface_vault_settings import (
-    AppInterfaceSettingsV1,
-)
-from reconcile.gql_definitions.cost_report.settings import CostReportSettingsV1
-from reconcile.gql_definitions.fragments.vault_secret import VaultSecret
 from reconcile.typed_queries.cost_report.app_names import App
 from reconcile.typed_queries.cost_report.cost_namespaces import CostNamespace
 from tools.cli_commands.cost_report.model import ChildAppReport, Report, ReportItem
 from tools.cli_commands.cost_report.openshift import OpenShiftCostReportCommand
 from tools.cli_commands.cost_report.response import OpenShiftReportCostResponse
+from tools.cli_commands.test.conftest import (
+    COST_REPORT_SECRET,
+)
 
 
 @pytest.fixture
@@ -30,55 +28,18 @@ def mock_cost_management_api(mocker: MockerFixture) -> Any:
     )
 
 
-VAULT_SETTINGS = AppInterfaceSettingsV1(vault=True)
-COST_REPORT_SETTINGS = CostReportSettingsV1(
-    credentials=VaultSecret(
-        path="some-path",
-        field="all",
-        version=None,
-        format=None,
-    )
-)
-
-
 @pytest.fixture
-def mock_get_app_interface_vault_settings(mocker: MockerFixture) -> Any:
+def mock_fetch_cost_report_secret(mocker: MockerFixture) -> Any:
     return mocker.patch(
-        "tools.cli_commands.cost_report.openshift.get_app_interface_vault_settings",
-        return_value=VAULT_SETTINGS,
-    )
-
-
-@pytest.fixture
-def mock_create_secret_reader(mocker: MockerFixture) -> Any:
-    mock = mocker.patch(
-        "tools.cli_commands.cost_report.openshift.create_secret_reader",
-        autospec=True,
-    )
-    mock.return_value.read_all_secret.return_value = {
-        "api_base_url": "base_url",
-        "token_url": "token_url",
-        "client_id": "client_id",
-        "client_secret": "client_secret",
-        "scope": "scope",
-    }
-    return mock
-
-
-@pytest.fixture
-def mock_get_cost_report_settings(mocker: MockerFixture) -> Any:
-    return mocker.patch(
-        "tools.cli_commands.cost_report.openshift.get_cost_report_settings",
-        return_value=COST_REPORT_SETTINGS,
+        "tools.cli_commands.cost_report.openshift.fetch_cost_report_secret",
+        return_value=COST_REPORT_SECRET,
     )
 
 
 def test_openshift_cost_report_create(
     mock_gql: Any,
     mock_cost_management_api: Any,
-    mock_get_app_interface_vault_settings: Any,
-    mock_create_secret_reader: Any,
-    mock_get_cost_report_settings: Any,
+    mock_fetch_cost_report_secret: Any,
 ) -> None:
     openshift_cost_report_command = OpenShiftCostReportCommand.create()
 
@@ -86,33 +47,20 @@ def test_openshift_cost_report_create(
     assert openshift_cost_report_command.gql_api == mock_gql.get_api.return_value
     assert (
         openshift_cost_report_command.cost_management_api
-        == mock_cost_management_api.return_value
+        == mock_cost_management_api.create_from_secret.return_value
     )
     assert openshift_cost_report_command.thread_pool_size == 10
-    mock_cost_management_api.assert_called_once_with(
-        base_url="base_url",
-        token_url="token_url",
-        client_id="client_id",
-        client_secret="client_secret",
-        scope=["scope"],
+    mock_cost_management_api.create_from_secret.assert_called_once_with(
+        COST_REPORT_SECRET
     )
-    mock_get_app_interface_vault_settings.assert_called_once_with(
-        mock_gql.get_api.return_value.query
-    )
-    mock_get_cost_report_settings.assert_called_once_with(mock_gql.get_api.return_value)
-    mock_create_secret_reader.assert_called_once_with(use_vault=True)
-    mock_create_secret_reader.return_value.read_all_secret.assert_called_once_with(
-        COST_REPORT_SETTINGS.credentials
-    )
+    mock_fetch_cost_report_secret.assert_called_once_with(mock_gql.get_api.return_value)
 
 
 @pytest.fixture
 def openshift_cost_report_command(
     mock_gql: Any,
     mock_cost_management_api: Any,
-    mock_get_app_interface_vault_settings: Any,
-    mock_create_secret_reader: Any,
-    mock_get_cost_report_settings: Any,
+    mock_fetch_cost_report_secret: Any,
 ) -> OpenShiftCostReportCommand:
     return OpenShiftCostReportCommand.create()
 
@@ -253,14 +201,13 @@ def test_openshift_cost_report_get_reports(
     openshift_cost_report_command: OpenShiftCostReportCommand,
     mock_cost_management_api: Any,
 ) -> None:
-    mock_cost_management_api.return_value.get_openshift_costs_report.return_value = (
-        PARENT_APP_COST_RESPONSE
-    )
+    mocked_api = mock_cost_management_api.create_from_secret.return_value
+    mocked_api.get_openshift_costs_report.return_value = PARENT_APP_COST_RESPONSE
 
     reports = openshift_cost_report_command.get_reports([PARENT_APP_NAMESPACE])
 
     assert reports == {PARENT_APP_NAMESPACE: PARENT_APP_COST_RESPONSE}
-    mock_cost_management_api.return_value.get_openshift_costs_report.assert_called_once_with(
+    mocked_api.get_openshift_costs_report.assert_called_once_with(
         project=PARENT_APP_NAMESPACE.name,
         cluster=PARENT_APP_NAMESPACE.cluster_external_id,
     )

--- a/tools/cli_commands/test/test_util.py
+++ b/tools/cli_commands/test/test_util.py
@@ -1,0 +1,70 @@
+from typing import Any
+from unittest.mock import create_autospec
+
+import pytest
+from pytest_mock import MockerFixture
+
+from reconcile.gql_definitions.common.app_interface_vault_settings import (
+    AppInterfaceSettingsV1,
+)
+from reconcile.gql_definitions.cost_report.settings import CostReportSettingsV1
+from reconcile.gql_definitions.fragments.vault_secret import VaultSecret
+from reconcile.utils.gql import GqlApi
+from tools.cli_commands.cost_report.util import fetch_cost_report_secret
+from tools.cli_commands.test.conftest import (
+    COST_REPORT_SECRET,
+)
+
+VAULT_SETTINGS = AppInterfaceSettingsV1(vault=True)
+COST_REPORT_SETTINGS = CostReportSettingsV1(
+    credentials=VaultSecret(
+        path="some-path",
+        field="all",
+        version=None,
+        format=None,
+    )
+)
+
+
+@pytest.fixture
+def mock_get_app_interface_vault_settings(mocker: MockerFixture) -> Any:
+    return mocker.patch(
+        "tools.cli_commands.cost_report.util.get_app_interface_vault_settings",
+        return_value=VAULT_SETTINGS,
+    )
+
+
+@pytest.fixture
+def mock_create_secret_reader(mocker: MockerFixture) -> Any:
+    mock = mocker.patch(
+        "tools.cli_commands.cost_report.util.create_secret_reader",
+        autospec=True,
+    )
+    mock.return_value.read_all_secret.return_value = COST_REPORT_SECRET
+    return mock
+
+
+@pytest.fixture
+def mock_get_cost_report_settings(mocker: MockerFixture) -> Any:
+    return mocker.patch(
+        "tools.cli_commands.cost_report.util.get_cost_report_settings",
+        return_value=COST_REPORT_SETTINGS,
+    )
+
+
+def test_fetch_cost_report_secret(
+    mock_get_app_interface_vault_settings: Any,
+    mock_create_secret_reader: Any,
+    mock_get_cost_report_settings: Any,
+) -> None:
+    mock_gql_api = create_autospec(GqlApi)
+
+    secret = fetch_cost_report_secret(mock_gql_api)
+
+    assert secret == COST_REPORT_SECRET
+    mock_get_app_interface_vault_settings.assert_called_once_with(mock_gql_api.query)
+    mock_get_cost_report_settings.assert_called_once_with(mock_gql_api)
+    mock_create_secret_reader.assert_called_once_with(use_vault=True)
+    mock_create_secret_reader.return_value.read_all_secret.assert_called_once_with(
+        COST_REPORT_SETTINGS.credentials
+    )

--- a/tools/qontract_cli.py
+++ b/tools/qontract_cli.py
@@ -151,14 +151,14 @@ from reconcile.utils.state import init_state
 from reconcile.utils.terraform_client import TerraformClient as Terraform
 from tools.cli_commands.cost_report.aws import AwsCostReportCommand
 from tools.cli_commands.cost_report.openshift import OpenShiftCostReportCommand
+from tools.cli_commands.cost_report.openshift_cost_optimization import (
+    OpenShiftCostOptimizationReportCommand,
+)
 from tools.cli_commands.erv2 import (
     Erv2Cli,
     TerraformCli,
     progress_spinner,
     task,
-)
-from tools.cli_commands.cost_report.openshift_cost_optimization import (
-    OpenShiftCostOptimizationReportCommand,
 )
 from tools.cli_commands.gpg_encrypt import (
     GPGEncryptCommand,

--- a/tools/qontract_cli.py
+++ b/tools/qontract_cli.py
@@ -157,7 +157,9 @@ from tools.cli_commands.erv2 import (
     progress_spinner,
     task,
 )
-from tools.cli_commands.cost_report.openshift_cost_optimization import OpenShiftCostOptimizationReportCommand
+from tools.cli_commands.cost_report.openshift_cost_optimization import (
+    OpenShiftCostOptimizationReportCommand,
+)
 from tools.cli_commands.gpg_encrypt import (
     GPGEncryptCommand,
     GPGEncryptCommandData,

--- a/tools/qontract_cli.py
+++ b/tools/qontract_cli.py
@@ -157,6 +157,7 @@ from tools.cli_commands.erv2 import (
     progress_spinner,
     task,
 )
+from tools.cli_commands.cost_report.openshift_cost_optimization import OpenShiftCostOptimizationReportCommand
 from tools.cli_commands.gpg_encrypt import (
     GPGEncryptCommand,
     GPGEncryptCommandData,
@@ -2769,6 +2770,13 @@ def aws_cost_report(ctx):
 @click.pass_context
 def openshift_cost_report(ctx):
     command = OpenShiftCostReportCommand.create()
+    print(command.execute())
+
+
+@get.command()
+@click.pass_context
+def openshift_cost_optimization_report(ctx):
+    command = OpenShiftCostOptimizationReportCommand.create()
     print(command.execute())
 
 

--- a/tools/test/test_qontract_cli.py
+++ b/tools/test/test_qontract_cli.py
@@ -171,3 +171,25 @@ def test_get_openshift_cost_report(
     assert result.output == "some report\n"
     mock_openshift_cost_report_command.create.assert_called_once_with()
     mock_openshift_cost_report_command.create.return_value.execute.assert_called_once_with()
+
+@pytest.fixture
+def mock_openshift_cost_optimization_report_command(mocker):
+    return mocker.patch("tools.qontract_cli.OpenShiftCostOptimizationReportCommand", autospec=True)
+
+def test_get_openshift_cost_optimization_report(
+    env_vars, mock_queries, mock_openshift_cost_optimization_report_command
+):
+    mock_openshift_cost_optimization_report_command.create.return_value.execute.return_value = (
+        "some report"
+    )
+    runner = CliRunner()
+    result = runner.invoke(
+        qontract_cli.get,
+        "openshift-cost-optimization-report",
+        obj={},
+    )
+
+    assert result.exit_code == 0
+    assert result.output == "some report\n"
+    mock_openshift_cost_optimization_report_command.create.assert_called_once_with()
+    mock_openshift_cost_optimization_report_command.create.return_value.execute.assert_called_once_with()

--- a/tools/test/test_qontract_cli.py
+++ b/tools/test/test_qontract_cli.py
@@ -172,16 +172,18 @@ def test_get_openshift_cost_report(
     mock_openshift_cost_report_command.create.assert_called_once_with()
     mock_openshift_cost_report_command.create.return_value.execute.assert_called_once_with()
 
+
 @pytest.fixture
 def mock_openshift_cost_optimization_report_command(mocker):
-    return mocker.patch("tools.qontract_cli.OpenShiftCostOptimizationReportCommand", autospec=True)
+    return mocker.patch(
+        "tools.qontract_cli.OpenShiftCostOptimizationReportCommand", autospec=True
+    )
+
 
 def test_get_openshift_cost_optimization_report(
     env_vars, mock_queries, mock_openshift_cost_optimization_report_command
 ):
-    mock_openshift_cost_optimization_report_command.create.return_value.execute.return_value = (
-        "some report"
-    )
+    mock_openshift_cost_optimization_report_command.create.return_value.execute.return_value = "some report"
     runner = CliRunner()
     result = runner.invoke(
         qontract_cli.get,


### PR DESCRIPTION
Export openshift cost optimization report from [Cost Management Optimizations](https://console.redhat.com/openshift/cost-management/optimizations).

Preview a sample report at [test cost optimization report](https://gitlab.cee.redhat.com/-/snippets/8885).

Local verification:

```shell
qontract-cli --config config.toml get openshift-cost-optimization-report > openshift-cost-optimization-report.md
```

[design doc](https://gitlab.cee.redhat.com/service/app-interface/-/blob/master/docs/app-sre/design-docs/openshift-cost-report.md#for-cost-optimization)

[APPSRE-10233](https://issues.redhat.com/browse/APPSRE-10233)