### PR TITLE
:sparkles: ERv2: make outputs-secret image and version configurable

### DIFF
--- a/reconcile/external_resources/manager.py
+++ b/reconcile/external_resources/manager.py
@@ -247,7 +247,7 @@ class ExternalResourcesManager:
                 input=self._serialize_resource_input(resource),
                 action=Action.APPLY,
                 module_configuration=ExternalResourceModuleConfiguration.resolve_configuration(
-                    module, spec
+                    module, spec, self.settings
                 ),
             )
             r.add(reconciliation)

--- a/reconcile/external_resources/model.py
+++ b/reconcile/external_resources/model.py
@@ -198,12 +198,12 @@ def load_module_inventory(
 
 
 class ExternalResourceModuleConfiguration(BaseModel, frozen=True):
-    image: str
-    version: str
+    image: str = ""
+    version: str = ""
     reconcile_drift_interval_minutes: int = -1000
     reconcile_timeout_minutes: int = -1000
-    outputs_secret_image: str
-    outputs_secret_version: str
+    outputs_secret_image: str = ""
+    outputs_secret_version: str = ""
 
     @property
     def image_version(self) -> str:
@@ -251,9 +251,7 @@ class Reconciliation(BaseModel, frozen=True):
     input: str = ""
     action: Action = Action.APPLY
     module_configuration: ExternalResourceModuleConfiguration = (
-        ExternalResourceModuleConfiguration(
-            image="", version="", outputs_secret_image="", outputs_secret_version=""
-        )
+        ExternalResourceModuleConfiguration()
     )
 
 

--- a/reconcile/external_resources/reconciler.py
+++ b/reconcile/external_resources/reconciler.py
@@ -131,7 +131,6 @@ class ReconciliationK8sJob(K8sJob, BaseModel, frozen=True):
                         V1Container(
                             name="outputs",
                             image=self.reconciliation.module_configuration.outputs_secret_image_version,
-                            command=["/bin/bash", "/app/entrypoint.sh"],
                             image_pull_policy="Always",
                             env=[
                                 V1EnvVar(

--- a/reconcile/external_resources/reconciler.py
+++ b/reconcile/external_resources/reconciler.py
@@ -130,7 +130,7 @@ class ReconciliationK8sJob(K8sJob, BaseModel, frozen=True):
                     containers=[
                         V1Container(
                             name="outputs",
-                            image="quay.io/app-sre/er-outputs-secrets:0.0.1",
+                            image=self.reconciliation.module_configuration.outputs_secret_image_version,
                             command=["/bin/bash", "/app/entrypoint.sh"],
                             image_pull_policy="Always",
                             env=[

--- a/reconcile/external_resources/state.py
+++ b/reconcile/external_resources/state.py
@@ -112,8 +112,6 @@ class DynamoDBStateAdapter:
                     reconcile_timeout_minutes=self._get_value(
                         _modconf, self.MODCONF_TIMEOUT_MINS, _type="N"
                     ),
-                    outputs_secret_image="",
-                    outputs_secret_version="",
                 ),
             )
 

--- a/reconcile/external_resources/state.py
+++ b/reconcile/external_resources/state.py
@@ -112,6 +112,8 @@ class DynamoDBStateAdapter:
                     reconcile_timeout_minutes=self._get_value(
                         _modconf, self.MODCONF_TIMEOUT_MINS, _type="N"
                     ),
+                    outputs_secret_image="",
+                    outputs_secret_version="",
                 ),
             )
 

--- a/reconcile/gql_definitions/external_resources/external_resources_modules.gql
+++ b/reconcile/gql_definitions/external_resources/external_resources_modules.gql
@@ -10,5 +10,7 @@ query ExternalResourcesModules {
         reconcile_drift_interval_minutes
         reconcile_timeout_minutes
         outputs_secret_sync
+        outputs_secret_image
+        outputs_secret_version
     }
 }

--- a/reconcile/gql_definitions/external_resources/external_resources_modules.py
+++ b/reconcile/gql_definitions/external_resources/external_resources_modules.py
@@ -29,6 +29,8 @@ query ExternalResourcesModules {
         reconcile_drift_interval_minutes
         reconcile_timeout_minutes
         outputs_secret_sync
+        outputs_secret_image
+        outputs_secret_version
     }
 }
 """
@@ -49,6 +51,8 @@ class ExternalResourcesModuleV1(ConfiguredBaseModel):
     reconcile_drift_interval_minutes: int = Field(..., alias="reconcile_drift_interval_minutes")
     reconcile_timeout_minutes: int = Field(..., alias="reconcile_timeout_minutes")
     outputs_secret_sync: bool = Field(..., alias="outputs_secret_sync")
+    outputs_secret_image: Optional[str] = Field(..., alias="outputs_secret_image")
+    outputs_secret_version: Optional[str] = Field(..., alias="outputs_secret_version")
 
 
 class ExternalResourcesModulesQueryData(ConfiguredBaseModel):

--- a/reconcile/gql_definitions/external_resources/external_resources_namespaces.gql
+++ b/reconcile/gql_definitions/external_resources/external_resources_namespaces.gql
@@ -58,6 +58,8 @@ query ExternalResourcesNamespaces {
                     image
                     version
                     reconcile_timeout_minutes
+                    outputs_secret_image
+                    outputs_secret_version
                 }
             }
             ... on NamespaceTerraformResourceS3_v1 {
@@ -94,6 +96,8 @@ query ExternalResourcesNamespaces {
                   image
                   version
                   reconcile_timeout_minutes
+                  outputs_secret_image
+                  outputs_secret_version
                 }
             }
             ... on NamespaceTerraformResourceServiceAccount_v1 {
@@ -425,6 +429,8 @@ query ExternalResourcesNamespaces {
                   image
                   version
                   reconcile_timeout_minutes
+                  outputs_secret_image
+                  outputs_secret_version
                 }
             }
         }

--- a/reconcile/gql_definitions/external_resources/external_resources_namespaces.py
+++ b/reconcile/gql_definitions/external_resources/external_resources_namespaces.py
@@ -115,6 +115,8 @@ query ExternalResourcesNamespaces {
                     image
                     version
                     reconcile_timeout_minutes
+                    outputs_secret_image
+                    outputs_secret_version
                 }
             }
             ... on NamespaceTerraformResourceS3_v1 {
@@ -151,6 +153,8 @@ query ExternalResourcesNamespaces {
                   image
                   version
                   reconcile_timeout_minutes
+                  outputs_secret_image
+                  outputs_secret_version
                 }
             }
             ... on NamespaceTerraformResourceServiceAccount_v1 {
@@ -482,6 +486,8 @@ query ExternalResourcesNamespaces {
                   image
                   version
                   reconcile_timeout_minutes
+                  outputs_secret_image
+                  outputs_secret_version
                 }
             }
         }
@@ -564,6 +570,8 @@ class ExternalResourcesModuleOverridesV1(ConfiguredBaseModel):
     image: Optional[str] = Field(..., alias="image")
     version: Optional[str] = Field(..., alias="version")
     reconcile_timeout_minutes: Optional[int] = Field(..., alias="reconcile_timeout_minutes")
+    outputs_secret_image: Optional[str] = Field(..., alias="outputs_secret_image")
+    outputs_secret_version: Optional[str] = Field(..., alias="outputs_secret_version")
 
 
 class NamespaceTerraformResourceRDSV1(NamespaceTerraformResourceAWSV1):
@@ -615,6 +623,8 @@ class NamespaceTerraformResourceElastiCacheV1_ExternalResourcesModuleOverridesV1
     image: Optional[str] = Field(..., alias="image")
     version: Optional[str] = Field(..., alias="version")
     reconcile_timeout_minutes: Optional[int] = Field(..., alias="reconcile_timeout_minutes")
+    outputs_secret_image: Optional[str] = Field(..., alias="outputs_secret_image")
+    outputs_secret_version: Optional[str] = Field(..., alias="outputs_secret_version")
 
 
 class NamespaceTerraformResourceElastiCacheV1(NamespaceTerraformResourceAWSV1):
@@ -1016,6 +1026,8 @@ class NamespaceTerraformResourceMskV1_ExternalResourcesModuleOverridesV1(Configu
     image: Optional[str] = Field(..., alias="image")
     version: Optional[str] = Field(..., alias="version")
     reconcile_timeout_minutes: Optional[int] = Field(..., alias="reconcile_timeout_minutes")
+    outputs_secret_image: Optional[str] = Field(..., alias="outputs_secret_image")
+    outputs_secret_version: Optional[str] = Field(..., alias="outputs_secret_version")
 
 
 class NamespaceTerraformResourceMskV1(NamespaceTerraformResourceAWSV1):

--- a/reconcile/gql_definitions/external_resources/external_resources_settings.gql
+++ b/reconcile/gql_definitions/external_resources/external_resources_settings.gql
@@ -17,5 +17,7 @@ query ExternalResourcesSettings {
         tf_state_region
         tf_state_dynamodb_table
         vault_secrets_path
+        outputs_secret_image
+        outputs_secret_version
     }
 }

--- a/reconcile/gql_definitions/external_resources/external_resources_settings.py
+++ b/reconcile/gql_definitions/external_resources/external_resources_settings.py
@@ -36,6 +36,8 @@ query ExternalResourcesSettings {
         tf_state_region
         tf_state_dynamodb_table
         vault_secrets_path
+        outputs_secret_image
+        outputs_secret_version
     }
 }
 """
@@ -69,6 +71,8 @@ class ExternalResourcesSettingsV1(ConfiguredBaseModel):
     tf_state_region: Optional[str] = Field(..., alias="tf_state_region")
     tf_state_dynamodb_table: Optional[str] = Field(..., alias="tf_state_dynamodb_table")
     vault_secrets_path: str = Field(..., alias="vault_secrets_path")
+    outputs_secret_image: str = Field(..., alias="outputs_secret_image")
+    outputs_secret_version: str = Field(..., alias="outputs_secret_version")
 
 
 class ExternalResourcesSettingsQueryData(ConfiguredBaseModel):

--- a/reconcile/gql_definitions/introspection.json
+++ b/reconcile/gql_definitions/introspection.json
@@ -33573,6 +33573,38 @@
                             },
                             "isDeprecated": false,
                             "deprecationReason": null
+                        },
+                        {
+                            "name": "outputs_secret_image",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "NON_NULL",
+                                "name": null,
+                                "ofType": {
+                                    "kind": "SCALAR",
+                                    "name": "String",
+                                    "ofType": null
+                                }
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "outputs_secret_version",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "NON_NULL",
+                                "name": null,
+                                "ofType": {
+                                    "kind": "SCALAR",
+                                    "name": "String",
+                                    "ofType": null
+                                }
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
                         }
                     ],
                     "inputFields": null,
@@ -33747,6 +33779,30 @@
                                     "name": "Boolean",
                                     "ofType": null
                                 }
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "outputs_secret_image",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "SCALAR",
+                                "name": "String",
+                                "ofType": null
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "outputs_secret_version",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "SCALAR",
+                                "name": "String",
+                                "ofType": null
                             },
                             "isDeprecated": false,
                             "deprecationReason": null
@@ -42645,6 +42701,30 @@
                             "type": {
                                 "kind": "SCALAR",
                                 "name": "Int",
+                                "ofType": null
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "outputs_secret_image",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "SCALAR",
+                                "name": "String",
+                                "ofType": null
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "outputs_secret_version",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "SCALAR",
+                                "name": "String",
                                 "ofType": null
                             },
                             "isDeprecated": false,

--- a/reconcile/test/external_resources/conftest.py
+++ b/reconcile/test/external_resources/conftest.py
@@ -38,6 +38,8 @@ def settings() -> ExternalResourcesSettingsV1:
         workers_cluster=ClusterV1(name="appint-ex-01"),
         workers_namespace=NamespaceV1(name="external-resources-poc"),
         vault_secrets_path="app-sre/integration-outputs/external-resources",
+        outputs_secret_image="path/to/er-output-secret-image",
+        outputs_secret_version="er-output-secret-version",
     )
 
 
@@ -63,6 +65,8 @@ def reconciliation(key: ExternalResourceKey) -> Reconciliation:
             version="0.0.1",
             reconcile_drift_interval_minutes=120,
             reconcile_timeout_minutes=30,
+            outputs_secret_image="path/to/er-output-secret-image",
+            outputs_secret_version="er-output-secret-version",
         ),
     )
 
@@ -91,6 +95,8 @@ def module() -> ExternalResourcesModuleV1:
         reconcile_drift_interval_minutes=60,
         reconcile_timeout_minutes=60,
         outputs_secret_sync=True,
+        outputs_secret_image=None,
+        outputs_secret_version=None,
     )
 
 

--- a/reconcile/test/external_resources/test_er_state.py
+++ b/reconcile/test/external_resources/test_er_state.py
@@ -57,6 +57,30 @@ def test_dynamodb_serialize(
 def test_dynamodb_deserialize(
     state: ExternalResourceState, dynamodb_serialized_values: Mapping
 ) -> None:
+    # the output_secret_image/version are not stored in the state
     adapter = DynamoDBStateAdapter()
     result = adapter.deserialize(dynamodb_serialized_values)
-    assert result == state
+    # not all fields are stored in the state, therefore we need to compare them separately
+    assert result.key == state.key
+    assert result.ts == state.ts
+    assert result.resource_status == state.resource_status
+    assert result.reconciliation.action == state.reconciliation.action
+    assert result.reconciliation.input == state.reconciliation.input
+    assert result.reconciliation.resource_hash == state.reconciliation.resource_hash
+    assert (
+        result.reconciliation.module_configuration.image
+        == state.reconciliation.module_configuration.image
+    )
+    assert (
+        result.reconciliation.module_configuration.version
+        == state.reconciliation.module_configuration.version
+    )
+    assert (
+        result.reconciliation.module_configuration.reconcile_drift_interval_minutes
+        == state.reconciliation.module_configuration.reconcile_drift_interval_minutes
+    )
+    assert (
+        result.reconciliation.module_configuration.reconcile_timeout_minutes
+        == state.reconciliation.module_configuration.reconcile_timeout_minutes
+    )
+    # the rest of the fields are not stored in the state

--- a/reconcile/test/external_resources/test_module_configuration.py
+++ b/reconcile/test/external_resources/test_module_configuration.py
@@ -2,16 +2,21 @@ from reconcile.external_resources.model import (
     ExternalResourceModuleConfiguration,
     ExternalResourcesModuleOverridesV1,
     ExternalResourcesModuleV1,
+    ExternalResourcesSettingsV1,
 )
 from reconcile.utils.external_resource_spec import ExternalResourceSpec
 
 
-def test_module_conf_overrides(module: ExternalResourcesModuleV1) -> None:
+def test_module_conf_overrides(
+    module: ExternalResourcesModuleV1, settings: ExternalResourcesSettingsV1
+) -> None:
     module_overrides = ExternalResourcesModuleOverridesV1(
         image="i_override",
         version="v_override",
         module_type=None,
         reconcile_timeout_minutes=None,
+        outputs_secret_image="whatever-image",
+        outputs_secret_version="whatever-version",
     )
     spec = ExternalResourceSpec(
         provision_provider="aws",
@@ -21,10 +26,12 @@ def test_module_conf_overrides(module: ExternalResourcesModuleV1) -> None:
     )
     spec.metadata = {"module_overrides": module_overrides}
     conf = ExternalResourceModuleConfiguration.resolve_configuration(
-        module=module, spec=spec
+        module=module, spec=spec, settings=settings
     )
     assert conf.image == module_overrides.image
     assert conf.version == module_overrides.version
     assert (
         conf.reconcile_drift_interval_minutes == module.reconcile_drift_interval_minutes
     )
+    assert conf.outputs_secret_image == module_overrides.outputs_secret_image
+    assert conf.outputs_secret_version == module_overrides.outputs_secret_version

--- a/tools/cli_commands/erv2.py
+++ b/tools/cli_commands/erv2.py
@@ -122,7 +122,7 @@ class Erv2Cli:
         f.validate_external_resource(self._resource)
         self._module_configuration = (
             ExternalResourceModuleConfiguration.resolve_configuration(
-                m_inventory.get_from_spec(spec), spec
+                m_inventory.get_from_spec(spec), spec, self._er_settings
             )
         )
 


### PR DESCRIPTION
Remove hardcoded `er-outputs-secrets` image and version.

The image and the version must be configured in `/external-resources/settings-1.yml` but can be overridden in `/external-resources/module-1.yml` and `/external-resources/module-overrides-1.yml`

Depends on: https://github.com/app-sre/qontract-schemas/pull/724
Ticket: [APPSRE-11049](https://issues.redhat.com/browse/APPSRE-11049)