### PR TITLE
Improve error message for ocm machine pools validation

### DIFF
--- a/reconcile/ocm_machine_pools.py
+++ b/reconcile/ocm_machine_pools.py
@@ -465,7 +465,7 @@ def calculate_diff(
         if invalid_diff:
             errors.append(
                 InvalidUpdateError(
-                    f"can not update {invalid_diff} for existing machine pool on cluster {cluster_name}"
+                    f"can not update {invalid_diff} for existing machine pool on cluster {cluster_name}, CURRENT: {diff_pair.current.json()}, DESIRED: {diff_pair.desired.json()}"
                 )
             )
         else:


### PR DESCRIPTION
Related to: [APPSRE-10481](https://issues.redhat.com/browse/APPSRE-10481)

This validates that if the user wants to create machine pools that uses the ROSA HCP default machine pools ids (workers-0, workers-1 and workers-2) and the subnet ids attached to them is not in the correct alphabetical order the `ocm-machine-pools` integrations fails.

This is due to a limitation on the cluster creation side that is well documented on the ticket.

To test this you can use the template from this [MR](https://gitlab.cee.redhat.com/service/app-interface/-/merge_requests/114908#969c6a8503d37323d7484aa18c2bfeac0f348c2f).

The templating side was already fixed this is a safe measure for if someone tries to create cluster by using only the cluster schema.

EDIT: 

After much debate and analysis I think It's bet to let things be as they are right now and just improve the error message.