### PR TITLE
feat(quay-mirror): tags_exclude check take precedence than tags

### DIFF
--- a/reconcile/test/test_quay_mirror.py
+++ b/reconcile/test/test_quay_mirror.py
@@ -96,22 +96,15 @@ class TestIsCompareTags:
         (["^sha256-.+sig$", "^main-.+"], None, "main-755781cc", True),
         (["^sha256-.+sig$", "^main-.+"], None, "sha256-8b5.sig", True),
         (["^sha256-.+sig$", "^main-.+"], None, "1.2.3", False),
-        # Tags exclude tests.
+        # # Tags exclude tests.
         (None, ["^sha256-.+sig$", "^main-.+"], "main-755781cc", False),
         (None, ["^sha256-.+sig$", "^main-.+"], "sha256-8b5.sig", False),
-        # When both includes and excludes are explicitly given, includes take precedence.
-        (
-            ["^sha256-.+sig$", "^main-.+"],
-            ["^sha256-.+sig$", "^main-.+"],
-            "main-755781cc",
-            True,
-        ),
-        (
-            ["^sha256-.+sig$", "^main-.+"],
-            ["^sha256-.+sig$", "^main-.+"],
-            "sha256-8b5.sig",
-            True,
-        ),
+        (None, ["^sha256-.+sig$", "^main-.+"], "1.2.3", True),
+        # When both includes and excludes are explicitly given, exclude take precedence.
+        (["^sha256-.+sig$", "^main-.+"], ["main-755781cc"], "main-755781cc", False),
+        (["^sha256-.+sig$", "^main-.+"], ["main-755781cc"], "sha256-8b5.sig", True),
+        # both include and exclude are not set
+        (None, None, "main-755781cc", True),
     ],
 )
 def test_sync_tag(tags, tags_exclude, candidate, result):

--- a/reconcile/test/utils/test_helpers.py
+++ b/reconcile/test/utils/test_helpers.py
@@ -11,6 +11,7 @@ from reconcile.utils.helpers import (
     DEFAULT_TOGGLE_LEVEL,
     find_duplicates,
     flatten,
+    match_patterns,
     toggle_logger,
 )
 
@@ -98,3 +99,17 @@ def test_flatten(input_dict: dict, expected: dict, sep: str) -> None:
 )
 def test_find_duplicates(items: Iterable[Any], expected: Sequence[Any]) -> None:
     assert find_duplicates(items) == expected
+
+
+@pytest.mark.parametrize(
+    "patterns, string, expected",
+    [
+        [[], "abc", False],
+        [["abc"], "abc", True],
+        [[r"\w+"], "abc", True],
+        [[r"\d+"], "abc", False],
+        [[r"\d+", r"\w+"], "abc", True],
+    ],
+)
+def test_match_patterns(patterns: Iterable[str], string: str, expected: bool) -> None:
+    assert match_patterns(patterns, string) == expected

--- a/reconcile/utils/helpers.py
+++ b/reconcile/utils/helpers.py
@@ -1,5 +1,6 @@
 import logging
 import random
+import re
 import string
 from collections import Counter
 from collections.abc import (
@@ -52,3 +53,13 @@ def generate_random_password(string_length: int = 20) -> str:
     """Generate a random string of letters and digits"""
     letters_and_digits = string.ascii_letters + string.digits
     return "".join(random.choices(letters_and_digits, k=string_length))
+
+
+def match_patterns(patterns: Iterable[str], s: str) -> bool:
+    """
+    Check if any pattern matches the string.
+    :param patterns: patterns to match
+    :param s: string to check
+    :return: True if any pattern matches, False otherwise
+    """
+    return any(re.match(p, s) for p in patterns)


### PR DESCRIPTION
When both `tags` and `tags_exclude` are specified in mirror config, if the tag matches `tags`, `tags_exclude` will be ignored, this change bring exclude check take precedence than include check to allow matches in exclude list to be skipped for sync.

Example use case is to allow `\d+\.\d+\.\d+`, but to ignore `1.0.0`.

[APPSRE-11045](https://issues.redhat.com/browse/APPSRE-11045)