### PR TITLE
Add settings to exclude providers from provisioners in terraform_resources

### DIFF
--- a/reconcile/queries.py
+++ b/reconcile/queries.py
@@ -102,6 +102,12 @@ APP_INTERFACE_SETTINGS_QUERY = """
       readTimeout
       connectTimeout
     }
+    terraformResourcesProviderExclusionsByProvisioner {
+      provisioner {
+          name
+      }
+      excludedProviders
+    }
   }
 }
 """
@@ -2754,3 +2760,24 @@ JENKINS_CONFIGS = """
 def get_jenkins_configs():
     gqlapi = gql.get_api()
     return gqlapi.query(JENKINS_CONFIGS)["jenkins_configs"]
+
+
+TF_RESOURCES_PROVIDER_EXCLUSIONS_BY_PROVISIONER = """
+{
+  tf_provider_exclusions_by_provisioner: app_interface_settings_v1 {
+    terraformResourcesProviderExclusionsByProvisioner {
+      provisioner {
+          name
+      }
+      excludedProviders
+    }
+  }
+}
+"""
+
+
+def get_tf_resources_provider_exclusions_by_provisioner():
+    gqlapi = gql.get_api()
+    return gqlapi.query(TF_RESOURCES_PROVIDER_EXCLUSIONS_BY_PROVISIONER)[
+        "tf_provider_exclusions_by_provisioner"
+    ]

--- a/reconcile/terraform_resources.py
+++ b/reconcile/terraform_resources.py
@@ -241,7 +241,7 @@ def setup(
     vault_settings = get_app_interface_vault_settings()
     secret_reader = create_secret_reader(use_vault=vault_settings.vault)
 
-    settings = queries.get_app_interface_settings()
+    settings = queries.get_app_interface_settings() or {}
     # initialize terrascript (scripting engine to generate terraform manifests)
     ts, working_dirs = init_working_dirs(accounts, thread_pool_size, settings=settings)
 
@@ -265,7 +265,15 @@ def setup(
     else:
         ocm_map = None
     tf_namespaces_dicts = [ns.dict(by_alias=True) for ns in tf_namespaces]
-    ts.init_populate_specs(tf_namespaces_dicts, account_names)
+
+    provider_exclusions_by_provisioner = (
+        settings.get("terraformResourcesProviderExclusionsByProvisioner") or []
+    )
+    ts.init_populate_specs(
+        tf_namespaces_dicts,
+        account_names,
+        provider_exclusions_by_provisioner=provider_exclusions_by_provisioner,
+    )
     tf.populate_terraform_output_secrets(
         resource_specs=ts.resource_spec_inventory, init_rds_replica_source=True
     )

--- a/reconcile/utils/external_resources.py
+++ b/reconcile/utils/external_resources.py
@@ -1,9 +1,6 @@
 import json
 from collections import Counter
-from collections.abc import (
-    Mapping,
-    MutableMapping,
-)
+from collections.abc import Mapping, MutableMapping
 from typing import Any
 
 import anymarkup
@@ -25,7 +22,8 @@ PROVIDER_CLOUDFLARE = "cloudflare"
 
 
 def get_external_resource_specs(
-    namespace_info: Mapping[str, Any], provision_provider: str | None = None
+    namespace_info: Mapping[str, Any],
+    provision_provider: str | None = None,
 ) -> list[ExternalResourceSpec]:
     specs: list[ExternalResourceSpec] = []
     if not managed_external_resources(namespace_info):
@@ -34,8 +32,6 @@ def get_external_resource_specs(
     external_resources = namespace_info.get("externalResources") or []
     for e in external_resources:
         for r in e.get("resources", []):
-            if r.get("managed_by_erv2"):
-                continue
             spec = ExternalResourceSpec(
                 provision_provider=e["provider"],
                 provisioner=e["provisioner"],


### PR DESCRIPTION
This allows external resource providers to be excluded from specific provisioners (accounts) for terraform_resources. For example, once all RDS instances have been migrated to V2, we don't want new RDS resources to use terraform_resources. 

schemas: app-sre/qontract-schemas#725