### PR TITLE
Improve terraform-resources provider exclusions

### DIFF
--- a/reconcile/queries.py
+++ b/reconcile/queries.py
@@ -102,11 +102,12 @@ APP_INTERFACE_SETTINGS_QUERY = """
       readTimeout
       connectTimeout
     }
-    terraformResourcesProviderExclusionsByProvisioner {
-      provisioner {
-          name
+    terraformResourcesProviderExclusions {
+      provider
+      excludeProvisioners {
+        name
       }
-      excludedProviders
+      excludeAllProvisioners
     }
   }
 }
@@ -2764,12 +2765,13 @@ def get_jenkins_configs():
 
 TF_RESOURCES_PROVIDER_EXCLUSIONS_BY_PROVISIONER = """
 {
-  tf_provider_exclusions_by_provisioner: app_interface_settings_v1 {
-    terraformResourcesProviderExclusionsByProvisioner {
-      provisioner {
-          name
+  tf_provider_exclusions: app_interface_settings_v1 {
+    terraformResourcesProviderExclusions {
+      provider
+      excludeProvisioners {
+        name
       }
-      excludedProviders
+      excludeAllProvisioners
     }
   }
 }
@@ -2781,13 +2783,10 @@ def get_tf_resources_provider_exclusions_by_provisioner() -> (
 ):
     gqlapi = gql.get_api()
     settings = gqlapi.query(TF_RESOURCES_PROVIDER_EXCLUSIONS_BY_PROVISIONER)[
-        "tf_provider_exclusions_by_provisioner"
+        "tf_provider_exclusions"
     ]
-    if (
-        len(settings) == 1
-        and "terraformResourcesProviderExclusionsByProvisioner" in settings[0]
-    ):
-        return settings[0]["terraformResourcesProviderExclusionsByProvisioner"]
+    if len(settings) == 1 and "terraformResourcesProviderExclusions" in settings[0]:
+        return settings[0]["terraformResourcesProviderExclusions"]
     return None
 
 

--- a/reconcile/terraform_resources.py
+++ b/reconcile/terraform_resources.py
@@ -266,13 +266,11 @@ def setup(
         ocm_map = None
     tf_namespaces_dicts = [ns.dict(by_alias=True) for ns in tf_namespaces]
 
-    provider_exclusions_by_provisioner = (
-        settings.get("terraformResourcesProviderExclusionsByProvisioner") or []
-    )
+    provider_exclusions = settings.get("terraformResourcesProviderExclusions") or []
     ts.init_populate_specs(
         tf_namespaces_dicts,
         account_names,
-        provider_exclusions_by_provisioner=provider_exclusions_by_provisioner,
+        provider_exclusions,
     )
     tf.populate_terraform_output_secrets(
         resource_specs=ts.resource_spec_inventory, init_rds_replica_source=True

--- a/reconcile/test/utils/test_terrascript_aws_client.py
+++ b/reconcile/test/utils/test_terrascript_aws_client.py
@@ -881,7 +881,42 @@ def test_excluded_provider_throws_exception(mocker, ts):
         "reconcile.queries.get_tf_resources_provider_exclusions_by_provisioner",
         autospec=True,
     )
-    mock.return_value = [{"provisioner": {"name": "a"}, "excludedProviders": ["rds"]}]
+    mock.return_value = [{"provider": "rds", "excludeProvisioners": [{"name": "a"}]}]
+
+    with pytest.raises(ProviderExcludedError):
+        ts.init_populate_specs(namespaces, "account")
+
+
+def test_exclude_all_provisioners_throws_exception(mocker, ts):
+    external_resource_1 = {
+        "identifier": "a",
+        "provider": "rds",
+        "output_resource_name": "oa",
+    }
+    external_resource_2 = {
+        "identifier": "b",
+        "provider": "rds",
+        "output_resource_name": "ob",
+    }
+    namespace_1 = {
+        "name": "ns1",
+        "managedExternalResources": True,
+        "externalResources": [
+            {
+                "provider": "aws",
+                "provisioner": {"name": "a"},
+                "resources": [external_resource_1, external_resource_2],
+            }
+        ],
+        "cluster": {"name": "test"},
+    }
+    namespaces = [namespace_1]
+
+    mock = mocker.patch(
+        "reconcile.queries.get_tf_resources_provider_exclusions_by_provisioner",
+        autospec=True,
+    )
+    mock.return_value = [{"provider": "rds", "excludeAllProvisioners": True}]
 
     with pytest.raises(ProviderExcludedError):
         ts.init_populate_specs(namespaces, "account")


### PR DESCRIPTION
An improvement over how the provider exclusions are managed in AI settings. 
* Allows to exclude all provisioners for a provider: (useful for new modules and for new accounts when created) 
* Now the list is based on providers instead of provisioners. 

Requires: app-sre/qontract-schemas#727