### PR TITLE
[change-log] enhance item with commit description

### DIFF
--- a/reconcile/change_owners/change_log_tracking.py
+++ b/reconcile/change_owners/change_log_tracking.py
@@ -40,6 +40,7 @@ class ChangeLogItem:
     change_types: list[str] = field(default_factory=list)
     error: bool = False
     apps: list[str] = field(default_factory=list)
+    description: str = ""
 
 
 @dataclass
@@ -136,6 +137,7 @@ class ChangeLogIntegration(QontractReconcileIntegration[ChangeLogIntegrationPara
             change_log_item = ChangeLogItem(
                 commit=commit,
                 merged_at=merged_at,
+                description=gl_commit.message.split("\n")[2],
             )
             change_log.items.append(change_log_item)
             obj = diff_state.get(key, None)


### PR DESCRIPTION
part of https://issues.redhat.com/browse/APPSRE-11125

this PR adds an optional description to a change log item, and initiates it from from the commit message.

a commit message has the following structure: `<commit title>\n\n<merge request title>\n<merge request refernce>`
for example:
```
"Merge branch 'create_clusters_updates_mr-e71167' into 'master'\n\n[create_clusters_updates_mr] clusters updates\n\nSee merge request service/app-interface!123657"
```

we want a one line description that is as human friendly as possible, which is why we use the original merge request title.