### PR TITLE
:bug:  erv2: fix invalid outputs_secrets image

### DIFF
--- a/reconcile/test/external_resources/test_er_state.py
+++ b/reconcile/test/external_resources/test_er_state.py
@@ -34,6 +34,12 @@ def dynamodb_serialized_values() -> dict[str, Any]:
                         DynamoDBStateAdapter.MODCONF_VERSION: {"S": "0.0.1"},
                         DynamoDBStateAdapter.MODCONF_DRIFT_MINS: {"N": "120"},
                         DynamoDBStateAdapter.MODCONF_TIMEOUT_MINS: {"N": "30"},
+                        DynamoDBStateAdapter.MODCONF_OUTPUTS_SECRET_IMAGE: {
+                            "S": "path/to/er-output-secret-image"
+                        },
+                        DynamoDBStateAdapter.MODCONF_OUTPUTS_SECRET_VERSION: {
+                            "S": "er-output-secret-version"
+                        },
                     }
                 },
             }


### PR DESCRIPTION
Add missing global `outputs_secrets` related settings to the Dynamodb cache.