### PR TITLE
APPSRE-11133: fix desired state in case of inactive/blocked user

### DIFF
--- a/reconcile/gitlab_members.py
+++ b/reconcile/gitlab_members.py
@@ -224,7 +224,6 @@ def reconcile_gitlab_members(
                 key,
                 "remove_user_from_group",
                 group.name,
-                gl.get_access_level_string(group_member.access_level),
             ])
             if not dry_run:
                 gl.remove_group_member(group, group_member.id)

--- a/reconcile/gitlab_members.py
+++ b/reconcile/gitlab_members.py
@@ -38,6 +38,7 @@ QONTRACT_INTEGRATION = "gitlab-members"
 class GitlabUser(BaseModel):
     user: str
     access_level: str
+    state: str | None
 
 
 State = dict[str, list[GitlabUser]]
@@ -60,7 +61,7 @@ def get_current_state(instance: GitlabInstanceV1, gl: GitLabApi) -> State:
     """Get current gitlab group members for all managed groups."""
     return {
         g: [
-            GitlabUser(user=u["user"], access_level=u["access_level"])
+            GitlabUser(user=u["user"], access_level=u["access_level"],state=u["state"])
             for u in gl.get_group_members(g)
         ]
         for g in instance.managed_groups
@@ -136,7 +137,7 @@ def subtract_states(
                     continue
                 found = True
                 break
-            if not found:
+            if not found and f_user.state=="active":
                 result.append(
                     Diff(
                         action=action,

--- a/reconcile/gitlab_members.py
+++ b/reconcile/gitlab_members.py
@@ -79,9 +79,6 @@ def get_current_state(
 def add_or_update_user(
     group_members: Desired_State, group_name: str, gitlab_user: GitlabUser
 ) -> None:
-    # existing_users = [
-    #     gu for gu in group_members[group_name].members if gu.user == gitlab_user.user
-    # ]
     existing_user = group_members[group_name].members.get(gitlab_user.user)
     if not existing_user:
         group_members[group_name].members[gitlab_user.user] = gitlab_user

--- a/reconcile/gitlab_members.py
+++ b/reconcile/gitlab_members.py
@@ -86,7 +86,7 @@ def get_current_state(
                     state=u["state"],
                     id=u["id"],
                 )
-                for u in gl.get_group_members(g)
+                for u in gl.get_group_members(gitlab_groups_map.get(g))
             ],
         )
         for g in instance.managed_groups
@@ -228,11 +228,7 @@ def get_gitlab_instance(query_func: Callable) -> GitlabInstanceV1:
 
 
 def get_all_groups_map(group_names: list[str], gl: GitLabApi) -> dict[str, Group]:
-    gitlab_groups = {
-        group_name: gitlab_group
-        for group_name in group_names
-        if (gitlab_group := gl.get_group(group_name))
-    }
+    gitlab_groups = {group_name: gl.get_group(group_name) for group_name in group_names}
     return gitlab_groups
 
 
@@ -273,9 +269,8 @@ def run(
         instance, pagerduty_map, permissions, all_gitlab_groups_map, all_users
     )
     diffs = calculate_diff(current_state, desired_state)
-
     for diff in diffs:
-        logging.info(diff)
+        logging.info([diff.user.user, diff.action, diff.group.name])
 
         if not dry_run:
             act(diff, gl)

--- a/reconcile/gitlab_members.py
+++ b/reconcile/gitlab_members.py
@@ -3,6 +3,9 @@ import logging
 from collections.abc import Callable
 from typing import Any
 
+from gitlab.v4.objects import (
+    Group,
+)
 from pydantic import BaseModel
 
 from reconcile import queries
@@ -36,12 +39,21 @@ QONTRACT_INTEGRATION = "gitlab-members"
 
 
 class GitlabUser(BaseModel):
+    id: str | None
     user: str
     access_level: str
     state: str | None
 
 
-State = dict[str, list[GitlabUser]]
+class GitLabGroup(BaseModel):
+    group: Group
+    members: list[GitlabUser]
+
+    class Config:
+        arbitrary_types_allowed = True
+
+
+State = dict[str, GitLabGroup]
 
 
 class Action(enum.Enum):
@@ -52,18 +64,31 @@ class Action(enum.Enum):
 
 class Diff(BaseModel):
     action: Action
-    group: str
-    user: str
+    group: Group
+    user: GitlabUser
     access_level: str
 
+    class Config:
+        arbitrary_types_allowed = True
 
-def get_current_state(instance: GitlabInstanceV1, gl: GitLabApi) -> State:
+
+def get_current_state(
+    instance: GitlabInstanceV1, gl: GitLabApi, gitlab_groups_map: dict[str, Group]
+) -> State:
     """Get current gitlab group members for all managed groups."""
     return {
-        g: [
-            GitlabUser(user=u["user"], access_level=u["access_level"],state=u["state"])
-            for u in gl.get_group_members(g)
-        ]
+        g: GitLabGroup(
+            group=gitlab_groups_map.get(g),
+            members=[
+                GitlabUser(
+                    user=u["user"],
+                    access_level=u["access_level"],
+                    state=u["state"],
+                    id=u["id"],
+                )
+                for u in gl.get_group_members(g)
+            ],
+        )
         for g in instance.managed_groups
     }
 
@@ -72,10 +97,10 @@ def add_or_update_user(
     group_members: State, group_name: str, gitlab_user: GitlabUser
 ) -> None:
     existing_users = [
-        gu for gu in group_members[group_name] if gu.user == gitlab_user.user
+        gu for gu in group_members[group_name].members if gu.user == gitlab_user.user
     ]
     if not existing_users:
-        group_members[group_name].append(gitlab_user)
+        group_members[group_name].members.append(gitlab_user)
     else:
         existing_user = existing_users[0]
         if GitLabApi.get_access_level(
@@ -88,10 +113,14 @@ def get_desired_state(
     instance: GitlabInstanceV1,
     pagerduty_map: PagerDutyMap,
     permissions: list[PermissionGitlabGroupMembershipV1],
+    gitlab_group_map: dict[str, Group],
     all_users: list[User],
 ) -> State:
     """Fetch all desired gitlab users from app-interface."""
-    desired_group_members: State = {g: [] for g in instance.managed_groups}
+    desired_group_members: State = {
+        g: GitLabGroup(group=gitlab_group_map.get(g), members=[])
+        for g in instance.managed_groups
+    }
     for g in desired_group_members:
         for p in permissions:
             if p.group == g:
@@ -128,21 +157,21 @@ def subtract_states(
 ) -> list[Diff]:
     """Return diff objects for items in from_state but not in subtract_state."""
     result = []
-    for f_group, f_users in from_state.items():
-        s_group = subtract_state[f_group]
-        for f_user in f_users:
+    for f_group_name, f_gitlab_group in from_state.items():
+        s_group = subtract_state[f_group_name]
+        for f_user in f_gitlab_group.members:
             found = False
-            for s_user in s_group:
+            for s_user in s_group.members:
                 if f_user.user != s_user.user:
                     continue
                 found = True
                 break
-            if not found and f_user.state=="active":
+            if not found:
                 result.append(
                     Diff(
                         action=action,
-                        group=f_group,
-                        user=f_user.user,
+                        group=f_gitlab_group.group,
+                        user=f_user,
                         access_level=f_user.access_level,
                     )
                 )
@@ -152,17 +181,17 @@ def subtract_states(
 def check_access(current_state: State, desired_state: State) -> list[Diff]:
     """Return diff objects for item where access level is different."""
     result = []
-    for d_group, d_users in desired_state.items():
-        c_group = current_state[d_group]
-        for d_user in d_users:
-            for c_user in c_group:
+    for d_group_name, d_gitlab_group in desired_state.items():
+        c_group = current_state[d_group_name]
+        for d_user in d_gitlab_group.members:
+            for c_user in c_group.members:
                 if d_user.user == c_user.user:
                     if d_user.access_level != c_user.access_level:
                         result.append(
                             Diff(
                                 action=Action.change_access,
-                                group=d_group,
-                                user=c_user.user,
+                                group=d_gitlab_group.group,
+                                user=c_user,
                                 access_level=d_user.access_level,
                             )
                         )
@@ -198,6 +227,15 @@ def get_gitlab_instance(query_func: Callable) -> GitlabInstanceV1:
     raise AppInterfaceSettingsError("No gitlab instance found!")
 
 
+def get_all_groups_map(group_names: list[str], gl: GitLabApi) -> dict[str, Group]:
+    gitlab_groups = {
+        group_name: gitlab_group
+        for group_name in group_names
+        if (gitlab_group := gl.get_group(group_name))
+    }
+    return gitlab_groups
+
+
 @defer
 def run(
     dry_run: bool,
@@ -229,10 +267,11 @@ def run(
     pagerduty_map = get_pagerduty_map(
         secret_reader, pagerduty_instances=pagerduty_instances
     )
-
-    # act
-    current_state = get_current_state(instance, gl)
-    desired_state = get_desired_state(instance, pagerduty_map, permissions, all_users)
+    all_gitlab_groups_map = get_all_groups_map(instance.managed_groups, gl)
+    current_state = get_current_state(instance, gl, all_gitlab_groups_map)
+    desired_state = get_desired_state(
+        instance, pagerduty_map, permissions, all_gitlab_groups_map, all_users
+    )
     diffs = calculate_diff(current_state, desired_state)
 
     for diff in diffs:

--- a/reconcile/gitlab_members.py
+++ b/reconcile/gitlab_members.py
@@ -42,7 +42,6 @@ class GitlabUser(BaseModel):
     id: str | None
     user: str
     access_level: str
-    state: str | None
 
 
 class GitLabGroup(BaseModel):
@@ -82,7 +81,6 @@ def get_current_state(
                 GitlabUser(
                     user=u["user"],
                     access_level=u["access_level"],
-                    state=u["state"],
                     id=u["id"],
                 )
                 for u in gl.get_group_members(gitlab_groups_map.get(g))

--- a/reconcile/test/test_gitlab_members.py
+++ b/reconcile/test/test_gitlab_members.py
@@ -111,13 +111,11 @@ def test_gitlab_members_get_current_state(
                 "user": "user1",
                 "access_level": "developer",
                 "id": "123",
-                "state": "active",
             },
             {
                 "user": "user2",
                 "access_level": "maintainer",
                 "id": "124",
-                "state": "active",
             },
         ],
         [
@@ -125,13 +123,11 @@ def test_gitlab_members_get_current_state(
                 "user": "user3",
                 "access_level": "developer",
                 "id": "125",
-                "state": "active",
             },
             {
                 "user": "user4",
                 "access_level": "maintainer",
                 "id": "126",
-                "state": "active",
             },
         ],
     ]
@@ -198,7 +194,7 @@ def test_gitlab_members_subtract_states_add(
     current_state = copy.deepcopy(state)
     # enforce add users to groups
     current_state["group2"].members = [
-        GitlabUser(access_level="maintainer", user="otherone", state="active", id="121")
+        GitlabUser(access_level="maintainer", user="otherone", id="121")
     ]
     del current_state["group1"].members[1]
 
@@ -209,23 +205,17 @@ def test_gitlab_members_subtract_states_add(
         Diff(
             action=Action.add_user_to_group,
             group=gitlab_groups_map.get("group1"),
-            user=GitlabUser(
-                user="user2", access_level="maintainer", id="124", state="active"
-            ),
+            user=GitlabUser(user="user2", access_level="maintainer", id="124"),
         ),
         Diff(
             action=Action.add_user_to_group,
             group=gitlab_groups_map.get("group2"),
-            user=GitlabUser(
-                user="user3", access_level="developer", id="125", state="active"
-            ),
+            user=GitlabUser(user="user3", access_level="developer", id="125"),
         ),
         Diff(
             action=Action.add_user_to_group,
             group=gitlab_groups_map.get("group2"),
-            user=GitlabUser(
-                user="user4", access_level="maintainer", id="126", state="active"
-            ),
+            user=GitlabUser(user="user4", access_level="maintainer", id="126"),
         ),
     ]
 
@@ -236,7 +226,7 @@ def test_gitlab_members_subtract_states_remove(
     current_state = copy.deepcopy(state)
     # enforce remove user from group
     current_state["group2"].members = [
-        GitlabUser(access_level="maintainer", user="otherone", state="active", id="121")
+        GitlabUser(access_level="maintainer", user="otherone", id="121")
     ]
 
     desired_state = state
@@ -246,9 +236,7 @@ def test_gitlab_members_subtract_states_remove(
         Diff(
             action=Action.remove_user_from_group,
             group=gitlab_groups_map.get("group2"),
-            user=GitlabUser(
-                access_level="maintainer", user="otherone", state="active", id="121"
-            ),
+            user=GitlabUser(access_level="maintainer", user="otherone", id="121"),
         )
     ]
 
@@ -269,9 +257,7 @@ def test_gitlab_members_check_access(
         Diff(
             action=Action.change_access,
             group=gitlab_groups_map.get("group1"),
-            user=GitlabUser(
-                access_level="developer", user="user1", state="active", id="123"
-            ),
+            user=GitlabUser(access_level="developer", user="user1", id="123"),
         ),
     ]
 
@@ -282,7 +268,7 @@ def test_gitlab_members_calculate_diff_changes(
     current_state = copy.deepcopy(state)
     # enforce remove user from group
     current_state["group2"].members = [
-        GitlabUser(access_level="maintainer", user="otherone", id="121", state="active")
+        GitlabUser(access_level="maintainer", user="otherone", id="121")
     ]
     # enforce add user to group
     del current_state["group1"].members[1]
@@ -293,37 +279,31 @@ def test_gitlab_members_calculate_diff_changes(
         Diff(
             action=Action.add_user_to_group,
             group=gitlab_groups_map.get("group1"),
-            user=GitlabUser(
-                access_level="maintainer", user="user2", state="active", id="124"
-            ),
+            user=GitlabUser(access_level="maintainer", user="user2", id="124"),
         ),
         Diff(
             action=Action.add_user_to_group,
             group=gitlab_groups_map.get("group2"),
-            user=GitlabUser(
-                access_level="developer", user="user3", state="active", id="125"
-            ),
+            user=GitlabUser(access_level="developer", user="user3", id="125"),
         ),
         Diff(
             action=Action.add_user_to_group,
             group=gitlab_groups_map.get("group2"),
-            user=GitlabUser(
-                access_level="maintainer", user="user4", state="active", id="126"
-            ),
+            user=GitlabUser(access_level="maintainer", user="user4", id="126"),
         ),
         Diff(
             action=Action.remove_user_from_group,
             group=gitlab_groups_map.get("group2"),
             user=GitlabUser(
-                access_level="maintainer", user="otherone", id="121", state="active"
+                access_level="maintainer",
+                user="otherone",
+                id="121",
             ),
         ),
         Diff(
             action=Action.change_access,
             group=gitlab_groups_map.get("group1"),
-            user=GitlabUser(
-                access_level="developer", user="user1", state="active", id="123"
-            ),
+            user=GitlabUser(access_level="developer", user="user1", id="123"),
         ),
     ]
 
@@ -335,9 +315,7 @@ def test_gitlab_members_act_add(
     diff = Diff(
         action=Action.add_user_to_group,
         group=gitlab_groups_map.get("group2"),
-        user=GitlabUser(
-            access_level="maintainer", user="user4", state="active", id="126"
-        ),
+        user=GitlabUser(access_level="maintainer", user="user4", id="126"),
     )
     gitlab_members.act(diff, gl_mock)
     gl_mock.add_group_member.assert_called_once()
@@ -352,9 +330,7 @@ def test_gitlab_members_act_remove(
     diff = Diff(
         action=Action.remove_user_from_group,
         group=gitlab_groups_map.get("group2"),
-        user=GitlabUser(
-            access_level="maintainer", user="otherone", state="active", id="121"
-        ),
+        user=GitlabUser(access_level="maintainer", user="otherone", id="121"),
     )
     gitlab_members.act(diff, gl_mock)
     gl_mock.add_group_member.assert_not_called()
@@ -369,9 +345,7 @@ def test_gitlab_members_act_change(
     diff = Diff(
         action=Action.change_access,
         group=gitlab_groups_map.get("group1"),
-        user=GitlabUser(
-            access_level="developer", user="user1", state="active", id="121"
-        ),
+        user=GitlabUser(access_level="developer", user="user1", id="121"),
     )
     gitlab_members.act(diff, gl_mock)
     gl_mock.add_group_member.assert_not_called()
@@ -382,7 +356,7 @@ def test_gitlab_members_act_change(
 def test_add_or_update_user_add():
     grp = create_autospec(Group, name="t")
     group_members: State = {"t": GitLabGroup(members=[], group=grp)}
-    gu = GitlabUser(user="u", access_level="owner", id="1234", state="active")
+    gu = GitlabUser(user="u", access_level="owner", id="1234")
     add_or_update_user(group_members, "t", gu)
     assert group_members == {"t": GitLabGroup(members=[gu], group=grp)}
 

--- a/reconcile/test/test_gitlab_members.py
+++ b/reconcile/test/test_gitlab_members.py
@@ -10,9 +10,9 @@ from pytest_mock import MockerFixture
 
 from reconcile import gitlab_members
 from reconcile.gitlab_members import (
-    Current_State,
+    CurrentState,
     CurrentStateSpec,
-    Desired_State,
+    DesiredState,
     DesiredStateSpec,
     GitlabUser,
     add_or_update_user,
@@ -63,7 +63,7 @@ def all_users() -> list[GroupMember]:
 
 
 @pytest.fixture()
-def current_state(all_users: list[GroupMember]) -> Current_State:
+def current_state(all_users: list[GroupMember]) -> CurrentState:
     return {
         "group1": CurrentStateSpec(
             members={
@@ -104,7 +104,7 @@ def user() -> User:
 def test_gitlab_members_get_current_state(
     mocker: MockerFixture,
     instance: GitlabInstanceV1,
-    current_state: Current_State,
+    current_state: CurrentState,
     gitlab_groups_map: dict[str, Group],
     all_users: list[GroupMember],
 ) -> None:
@@ -162,7 +162,7 @@ def test_gitlab_members_reconcile_gitlab_members(
     all_users: list[GroupMember],
 ) -> None:
     gl_mock = mocker.create_autospec(GitLabApi)
-    current_state: Current_State = {
+    current_state: CurrentState = {
         "group1": CurrentStateSpec(
             members={
                 "user1": all_users[0],
@@ -172,7 +172,7 @@ def test_gitlab_members_reconcile_gitlab_members(
         )
     }
     new_user = GitlabUser(user="new_user", access_level=40)
-    desired_state: Desired_State = {
+    desired_state: DesiredState = {
         "group1": DesiredStateSpec(
             members={
                 "user1": GitlabUser(user="user1", access_level=30),
@@ -195,25 +195,25 @@ def test_gitlab_members_reconcile_gitlab_members(
 
 
 def test_add_or_update_user_add():
-    group_members: Desired_State = {"t": DesiredStateSpec(members={})}
+    desired_state_spec: DesiredStateSpec = DesiredStateSpec(members={})
     gu = GitlabUser(user="u", access_level=50, id="1234")
-    add_or_update_user(group_members, "t", gu)
-    assert group_members == {"t": DesiredStateSpec(members={"u": gu})}
+    add_or_update_user(desired_state_spec, gu)
+    assert desired_state_spec == DesiredStateSpec(members={"u": gu})
 
 
 def test_add_or_update_user_update_higher():
-    group_members: Desired_State = {"t": DesiredStateSpec(members={})}
+    desired_state_spec: DesiredStateSpec = DesiredStateSpec(members={})
     gu1 = GitlabUser(user="u", access_level=40)
     gu2 = GitlabUser(user="u", access_level=50)
-    add_or_update_user(group_members, "t", gu1)
-    add_or_update_user(group_members, "t", gu2)
-    assert group_members == {"t": DesiredStateSpec(members={"u": gu2})}
+    add_or_update_user(desired_state_spec, gu1)
+    add_or_update_user(desired_state_spec, gu2)
+    assert desired_state_spec == DesiredStateSpec(members={"u": gu2})
 
 
 def test_add_or_update_user_update_lower():
-    group_members: Desired_State = {"t": DesiredStateSpec(members={})}
+    desired_state_spec: DesiredStateSpec = DesiredStateSpec(members={})
     gu1 = GitlabUser(user="u", access_level=50)
     gu2 = GitlabUser(user="u", access_level=40)
-    add_or_update_user(group_members, "t", gu1)
-    add_or_update_user(group_members, "t", gu2)
-    assert group_members == {"t": DesiredStateSpec(members={"u": gu1})}
+    add_or_update_user(desired_state_spec, gu1)
+    add_or_update_user(desired_state_spec, gu2)
+    assert desired_state_spec == DesiredStateSpec(members={"u": gu1})

--- a/reconcile/test/utils/test_gitlab_api.py
+++ b/reconcile/test/utils/test_gitlab_api.py
@@ -453,10 +453,20 @@ def test_get_group_members(
     mocked_gl: Any,
     mocked_gitlab_api: GitLabApi,
 ):
-    user = create_autospec(GroupMember, username="small", access_level=50)
+    user = create_autospec(
+        GroupMember,
+        username="small",
+        access_level=50,
+        id="123",
+        state="active",
+    )
     # group bots should be ignored
     group_bot = create_autospec(
-        GroupMember, username="group_123_bot_deadbeef", access_level=50
+        GroupMember,
+        username="group_123_bot_deadbeef",
+        access_level=50,
+        id="121",
+        state="active",
     )
     group = create_autospec(Group)
     group.members = create_autospec(GroupMemberManager)
@@ -466,10 +476,8 @@ def test_get_group_members(
     groups.get.return_value = group
     mocked_gl.groups = groups
 
-    assert mocked_gitlab_api.get_group_if_exists("group") is group
-
-    assert mocked_gitlab_api.get_group_members("group") == [
-        {"user": "small", "access_level": "owner"}
+    assert mocked_gitlab_api.get_group_members(group) == [
+        {"user": "small", "access_level": "owner", "id": "123", "state": "active"}
     ]
 
 

--- a/reconcile/test/utils/test_gitlab_api.py
+++ b/reconcile/test/utils/test_gitlab_api.py
@@ -458,7 +458,6 @@ def test_get_group_members(
         username="small",
         access_level=50,
         id="123",
-        state="active",
     )
     # group bots should be ignored
     group_bot = create_autospec(
@@ -466,7 +465,6 @@ def test_get_group_members(
         username="group_123_bot_deadbeef",
         access_level=50,
         id="121",
-        state="active",
     )
     group = create_autospec(Group)
     group.members = create_autospec(GroupMemberManager)
@@ -477,7 +475,7 @@ def test_get_group_members(
     mocked_gl.groups = groups
 
     assert mocked_gitlab_api.get_group_members(group) == [
-        {"user": "small", "access_level": "owner", "id": "123", "state": "active"}
+        {"user": "small", "access_level": "owner", "id": "123"}
     ]
 
 

--- a/reconcile/test/utils/test_gitlab_api.py
+++ b/reconcile/test/utils/test_gitlab_api.py
@@ -474,9 +474,7 @@ def test_get_group_members(
     groups.get.return_value = group
     mocked_gl.groups = groups
 
-    assert mocked_gitlab_api.get_group_members(group) == [
-        {"user": "small", "access_level": "owner", "id": "123"}
-    ]
+    assert mocked_gitlab_api.get_group_members(group) == [user]
 
 
 def test_share_project_with_group_positive(

--- a/reconcile/utils/gitlab_api.py
+++ b/reconcile/utils/gitlab_api.py
@@ -314,17 +314,19 @@ class GitLabApi:  # pylint: disable=too-many-public-methods
             member.save()
 
     def add_group_member(self, group, user):
-        gitlab_request.labels(integration=INTEGRATION_NAME).inc()
-        try:
-            group.members.create({
-                "username": user.user,
-                "access_level": user.access_level,
-            })
-        except gitlab.exceptions.GitlabCreateError:
+        gitlab_user = self.get_user(user.user)
+        if gitlab_user is not None:
             gitlab_request.labels(integration=INTEGRATION_NAME).inc()
-            member = group.members.get(user.id)
-            member.access_level = user.access_level
-            member.save()
+            try:
+                group.members.create({
+                    "user_id": gitlab_user.id,
+                    "access_level": user.access_level,
+                })
+            except gitlab.exceptions.GitlabCreateError:
+                gitlab_request.labels(integration=INTEGRATION_NAME).inc()
+                member = group.members.get(user.user)
+                member.access_level = user.access_level
+                member.save()
 
     def remove_group_member(self, group, user_id):
         gitlab_request.labels(integration=INTEGRATION_NAME).inc()

--- a/reconcile/utils/gitlab_api.py
+++ b/reconcile/utils/gitlab_api.py
@@ -84,6 +84,8 @@ GROUP_BOT_NAME_REGEX = re.compile(r"group_.+_bot_.+")
 
 
 class GLGroupMember(TypedDict):
+    id: str
+    state: str
     user: str
     access_level: str
 
@@ -288,10 +290,9 @@ class GitLabApi:  # pylint: disable=too-many-public-methods
         """
         return GROUP_BOT_NAME_REGEX.match(username) is not None
 
-    def get_group_members(self, group_name: str) -> list[GLGroupMember]:
-        group = self.get_group_if_exists(group_name)
+    def get_group_members(self, group: Group | None) -> list[GLGroupMember]:
         if group is None:
-            logging.error(group_name + " group not found")
+            logging.error("no group provided")
             return []
         else:
             return [

--- a/reconcile/utils/gitlab_api.py
+++ b/reconcile/utils/gitlab_api.py
@@ -318,36 +318,28 @@ class GitLabApi:  # pylint: disable=too-many-public-methods
             member.access_level = access_level
             member.save()
 
-    def add_group_member(self, group_name, username, access):
-        group = self.get_group_if_exists(group_name)
-        if not group:
-            logging.error(group_name + " group not found")
-        else:
-            user = self.get_user(username)
-            access_level = self.get_access_level(access)
-            if user is not None:
-                gitlab_request.labels(integration=INTEGRATION_NAME).inc()
-                try:
-                    group.members.create({
-                        "user_id": user.id,
-                        "access_level": access_level,
-                    })
-                except gitlab.exceptions.GitlabCreateError:
-                    gitlab_request.labels(integration=INTEGRATION_NAME).inc()
-                    member = group.members.get(user.id)
-                    member.access_level = access_level
+    def add_group_member(self, group, user):
+        access_level = self.get_access_level(user.access_level)
+        gitlab_request.labels(integration=INTEGRATION_NAME).inc()
+        try:
+            group.members.create({
+                "user_id": user.id,
+                "access_level": access_level,
+            })
+        except gitlab.exceptions.GitlabCreateError:
+            gitlab_request.labels(integration=INTEGRATION_NAME).inc()
+            member = group.members.get(user.id)
+            member.access_level = access_level
+            member.save()
 
     def remove_group_member(self, group, user):
         gitlab_request.labels(integration=INTEGRATION_NAME).inc()
         group.members.delete(user.id)
 
-    def change_access(self, group, username, access):
-        gitlab_request.labels(integration=INTEGRATION_NAME).inc()
-        group = self.gl.groups.get(group)
-        user = self.get_user(username)
+    def change_access(self, group, user):
         gitlab_request.labels(integration=INTEGRATION_NAME).inc()
         member = group.members.get(user.id)
-        member.access_level = self.get_access_level(access)
+        member.access_level = self.get_access_level(user.access_level)
         gitlab_request.labels(integration=INTEGRATION_NAME).inc()
         member.save()
 

--- a/reconcile/utils/gitlab_api.py
+++ b/reconcile/utils/gitlab_api.py
@@ -298,6 +298,7 @@ class GitLabApi:  # pylint: disable=too-many-public-methods
                 {
                     "user": m.username,
                     "access_level": self.get_access_level_string(m.access_level),
+                    "state": m.state,
                 }
                 for m in self.get_items(group.members.list)
                 if not self._is_bot_username(m.username)

--- a/reconcile/utils/gitlab_api.py
+++ b/reconcile/utils/gitlab_api.py
@@ -296,6 +296,7 @@ class GitLabApi:  # pylint: disable=too-many-public-methods
         else:
             return [
                 {
+                    "id": m.id,
                     "user": m.username,
                     "access_level": self.get_access_level_string(m.access_level),
                     "state": m.state,
@@ -335,13 +336,9 @@ class GitLabApi:  # pylint: disable=too-many-public-methods
                     member = group.members.get(user.id)
                     member.access_level = access_level
 
-    def remove_group_member(self, group_name, username):
+    def remove_group_member(self, group, user):
         gitlab_request.labels(integration=INTEGRATION_NAME).inc()
-        group = self.gl.groups.get(group_name)
-        user = self.get_user(username)
-        if user is not None:
-            gitlab_request.labels(integration=INTEGRATION_NAME).inc()
-            group.members.delete(user.id)
+        group.members.delete(user.id)
 
     def change_access(self, group, username, access):
         gitlab_request.labels(integration=INTEGRATION_NAME).inc()

--- a/reconcile/utils/gitlab_api.py
+++ b/reconcile/utils/gitlab_api.py
@@ -85,7 +85,6 @@ GROUP_BOT_NAME_REGEX = re.compile(r"group_.+_bot_.+")
 
 class GLGroupMember(TypedDict):
     id: str
-    state: str
     user: str
     access_level: str
 
@@ -300,7 +299,6 @@ class GitLabApi:  # pylint: disable=too-many-public-methods
                     "id": m.id,
                     "user": m.username,
                     "access_level": self.get_access_level_string(m.access_level),
-                    "state": m.state,
                 }
                 for m in self.get_items(group.members.list)
                 if not self._is_bot_username(m.username)


### PR DESCRIPTION
issue - [APPSRE-11133](https://issues.redhat.com/browse/APPSRE-11133)
Changes - 
1. introduced `id` field to avoid user lookup while removing user.
2. modify code to use `username` while adding member to group to avoid additional lookup. 
3. changes to `state` object in `gitlab_members` to save group info to avoid additional lookup.
4. make use of `diff_mappings` to reconcile.
