### PR TITLE
feat(aus): allow cluster upgrade to a version without version gates

### DIFF
--- a/reconcile/aus/base.py
+++ b/reconcile/aus/base.py
@@ -1115,18 +1115,6 @@ def calculate_diff(
                     gates=gates,
                     target_version_prefix=target_version_prefix,
                 )
-                # skipping upgrades when there are no version gates is a safety
-                # precaution to prevent cluster upgrades being scheduled.
-                # missing version gates are an indicator that the version has not yet gone
-                # through SREP gap analysis and is not yet ready for upgrades.
-                #
-                # this might change in the future - revisite for 4.16
-                if not minor_version_gates:
-                    logging.info(
-                        f"[{spec.org.org_id}/{spec.org.name}/{spec.cluster.name}] no gates found for {target_version_prefix}. "
-                        "Skip creation of an upgrade policy."
-                    )
-                    continue
                 gates_with_missing_agreements = gates_to_agree(
                     gates=minor_version_gates,
                     cluster=spec.cluster,

--- a/reconcile/test/ocm/aus/test_calculate_diff.py
+++ b/reconcile/test/ocm/aus/test_calculate_diff.py
@@ -118,7 +118,12 @@ def test_calculate_diff_create_cluster_upgrade_no_gates(
     ocm_api: OCMBaseClient,
     cluster: OCMCluster,
     now: datetime,
+    mocker: MockerFixture,
 ) -> None:
+    get_version_agreement_mock = mocker.patch(
+        "reconcile.aus.base.get_version_agreement"
+    )
+    get_version_agreement_mock.return_value = []
     workload = "wl"
     org_upgrade_spec = build_organization_upgrade_spec(
         specs=[
@@ -141,7 +146,17 @@ def test_calculate_diff_create_cluster_upgrade_no_gates(
             soak_days=11,
         ),
     )
-    assert diffs == []
+    assert diffs == [
+        UpgradePolicyHandler(
+            action="create",
+            policy=ClusterUpgradePolicy(
+                cluster=cluster,
+                version="4.12.19",
+                schedule_type="manual",
+                next_run="2021-08-30T18:07:00Z",
+            ),
+        )
+    ]
 
 
 def test_calculate_diff_create_cluster_upgrade_all_gates_agreed(
@@ -260,6 +275,10 @@ def test_calculate_diff_create_control_plane_upgrade_all_gates_agreed(
 def test_calculate_diff_create_control_plane_upgrade_no_gates(
     ocm_api: OCMBaseClient, cluster: OCMCluster, now: datetime, mocker: MockerFixture
 ) -> None:
+    get_version_agreement_mock = mocker.patch(
+        "reconcile.aus.base.get_version_agreement"
+    )
+    get_version_agreement_mock.return_value = []
     cnpd = mocker.patch("reconcile.aus.base._calculate_node_pool_diffs")
     cnpd.return_value = None
     workload = "wl"
@@ -285,7 +304,17 @@ def test_calculate_diff_create_control_plane_upgrade_no_gates(
             soak_days=11,
         ),
     )
-    assert diffs == []
+    assert diffs == [
+        UpgradePolicyHandler(
+            action="create",
+            policy=ControlPlaneUpgradePolicy(
+                cluster=cluster,
+                version="4.12.19",
+                schedule_type="manual",
+                next_run="2021-08-30T18:07:00Z",
+            ),
+        )
+    ]
 
 
 def test_calculate_diff_create_control_plane_node_pool_only(


### PR DESCRIPTION
not all gap analysis will create version gate, no gate for 4.17, removing this check to allow cluster version upgrade. 