### PR TITLE
[tf-repo] remove restriction on number of repos that can be updated in one MR

### DIFF
--- a/reconcile/test/test_terraform_repo.py
+++ b/reconcile/test/test_terraform_repo.py
@@ -193,7 +193,6 @@ def test_addition_to_existing_repo(existing_repo, new_repo, int_params, state_mo
         desired_state=desired,
         dry_run=False,
         state=state_mock,
-        recreate_state=False,
     )
 
     assert diff == [new_repo]
@@ -215,7 +214,6 @@ def test_updating_repo_ref(existing_repo, int_params, state_mock):
         desired_state=[updated_repo],
         dry_run=False,
         state=state_mock,
-        recreate_state=False,
     )
 
     assert diff == [updated_repo]
@@ -236,7 +234,6 @@ def test_force_rerun(existing_repo, int_params, state_mock):
         desired_state=[updated_repo],
         dry_run=False,
         state=state_mock,
-        recreate_state=False,
     )
 
     assert diff == [updated_repo]
@@ -263,7 +260,6 @@ def test_fail_on_update_invalid_repo_params(existing_repo, int_params):
             desired_state=[updated_repo],
             dry_run=True,
             state=None,
-            recreate_state=False,
         )
 
 
@@ -279,7 +275,6 @@ def test_delete_repo(existing_repo, int_params, state_mock):
         desired_state=[updated_repo],
         dry_run=False,
         state=state_mock,
-        recreate_state=False,
     )
 
     assert diff == [updated_repo]
@@ -298,7 +293,6 @@ def test_delete_repo_without_flag(existing_repo, int_params):
             desired_state=[],
             dry_run=True,
             state=None,
-            recreate_state=False,
         )
 
 
@@ -361,7 +355,6 @@ def test_update_repo_state(int_params, existing_repo, state_mock):
         desired_state=desired_state,
         dry_run=False,
         state=state_mock,
-        recreate_state=False,
     )
 
     state_mock.add.assert_called_once_with(
@@ -384,7 +377,6 @@ def test_output_correct_statefile(
         desired_state=desired_state,
         dry_run=True,
         state=state_mock,
-        recreate_state=False,
     )
 
     assert diff
@@ -406,28 +398,12 @@ def test_output_correct_no_statefile(
         desired_state=desired_state,
         dry_run=True,
         state=state_mock,
-        recreate_state=False,
     )
 
     assert diff
     current_output = integration.print_output(diff, True)
 
     assert new_repo_output == current_output
-
-
-def test_fail_on_multiple_repos_dry_run(int_params, existing_repo, new_repo):
-    integration = TerraformRepoIntegration(params=int_params)
-
-    desired_state = [existing_repo, new_repo]
-
-    with pytest.raises(Exception):
-        integration.calculate_diff(
-            existing_state=[],
-            desired_state=desired_state,
-            dry_run=True,
-            state=None,
-            recreate_state=False,
-        )
 
 
 def test_succeed_on_multiple_repos_non_dry_run(int_params, existing_repo, new_repo):
@@ -440,7 +416,6 @@ def test_succeed_on_multiple_repos_non_dry_run(int_params, existing_repo, new_re
         desired_state=desired_state,
         dry_run=False,
         state=None,
-        recreate_state=False,
     )
 
     assert diff
@@ -460,7 +435,6 @@ def test_no_op_succeeds(int_params, existing_repo):
         desired_state=state,
         dry_run=True,
         state=None,
-        recreate_state=False,
     )
 
     assert diff is None


### PR DESCRIPTION
Terraform Repo was created initially with a limit at the PR check level: only one repo can be modified in one PR

While this made sense when the project was initially created, it limits AppSRE whenever we need to make an update to [the schema](https://github.com/app-sre/qontract-schemas/blob/main/schemas/aws/terraform-repo-1.yml). If we add a new required property that requires mass-updating each reference to that schema, AppSRE would have to submit a separate MR for each repo file. This removes that limitation allowing for mass updates like other integrations.

The concern around tenants updating multiple repos at once is addressed through change-types within App-Interface limiting the amount of repos a tenant can self-service.

This will enable faster updates of tf-repo going forward.

Related to [APPSRE-11139](https://issues.redhat.com/browse/APPSRE-11139)