### PR TITLE
Container Images used report

### DIFF
--- a/reconcile/test/fixtures/container_images_report/app-sre-observability-stage-pods.yaml
+++ b/reconcile/test/fixtures/container_images_report/app-sre-observability-stage-pods.yaml
@@ -1,0 +1,23 @@
+- apiVersion: v1
+  kind: Pod
+  metadata:
+    name: blackbox-exporter-b8b5658c4-25xmr
+    namespace: app-sre-observability-stage
+  spec:
+    containers:
+    - image: quay.io/prometheus/blackbox-exporter:v0.25.0
+      name: blackbox-exporter
+- apiVersion: v1
+  kind: Pod
+  metadata:
+    name: gitlab-project-exporter-f64f9c9f8-225x4
+    namespace: app-sre-observability-stage
+  spec:
+    containers:
+    - image: quay.io/redhat-services-prod/app-sre-tenant/gitlab-project-exporter-main/gitlab-project-exporter-main:4175d51
+      name: gitlab-project-exporter
+    - image: quay.io/app-sre/internal-redhat-ca:0.2.0
+      name: certificates
+    initContainers:
+    - image: quay.io/app-sre/internal-redhat-ca:0.2.0
+      name: certificates

--- a/reconcile/test/fixtures/container_images_report/app-sre-pipelines-pods.yaml
+++ b/reconcile/test/fixtures/container_images_report/app-sre-pipelines-pods.yaml
@@ -1,0 +1,30 @@
+- apiVersion: v1
+  kind: Pod
+  metadata:
+    name: saas-aws-resource-exporter-app-sre-stage-b8rm7-clamav-scan-pod
+    namespace: app-sre-pipelines
+  spec:
+    containers:
+    - image: quay.io/app-sre/clamav@sha256:70b78ac82860ef7d50e4558cea655a671499d5dfe0dee8ca6607d88046db390a
+      name: step-clamav-scan
+    - image: quay.io/redhat-appstudio/clamav-db:v1
+      name: sidecar-database
+    - image: registry.redhat.io/openshift-pipelines/pipelines-entrypoint-rhel8@sha256:a8b0fc4ca05fb7b2d22cf0f62fc85986c231fa6604c62f487560400dc0d32a1f
+      name: prepare
+    initContainers:
+    - image: registry.redhat.io/openshift-pipelines/pipelines-entrypoint-rhel8@sha256:a8b0fc4ca05fb7b2d22cf0f62fc85986c231fa6604c62f487560400dc0d32a1f
+      name: prepare
+- apiVersion: v1
+  kind: Pod
+  metadata:
+    name: saas-aws-resource-exporter-app-sre-stage-b8rm7-dast-scan-pod
+    namespace: app-sre-pipelines
+  spec:
+    containers:
+    - image: quay.io/app-sre/internal-redhat-ca:0.3.0
+      name: step-init-dast-config
+    - image: quay.io/redhatproductsecurity/rapidast:latest
+      name: step-dast-scan
+    initContainers:
+    - image: registry.redhat.io/openshift-pipelines/pipelines-entrypoint-rhel8@sha256:a8b0fc4ca05fb7b2d22cf0f62fc85986c231fa6604c62f487560400dc0d32a1f
+      name: prepare

--- a/tools/cli_commands/container_images_report.py
+++ b/tools/cli_commands/container_images_report.py
@@ -1,0 +1,129 @@
+import re
+from collections import defaultdict
+from collections.abc import Sequence
+from typing import Any
+
+from pydantic import BaseModel
+from sretoolbox.utils import threaded
+
+from reconcile.gql_definitions.common.namespaces_minimal import NamespaceV1
+from reconcile.typed_queries.app_interface_vault_settings import (
+    get_app_interface_vault_settings,
+)
+from reconcile.typed_queries.namespaces_minimal import get_namespaces_minimal
+from reconcile.utils.oc_filters import filter_namespaces_by_cluster_and_namespace
+from reconcile.utils.oc_map import OCMap, init_oc_map_from_namespaces
+from reconcile.utils.secret_reader import create_secret_reader
+
+IMAGE_NAME_REGEX = re.compile(r"^(?P<name>[a-zA-Z0-9][a-zA-Z0-9/_.-]+)(?:@sha256)?:.+$")
+
+
+class NamespaceImages(BaseModel):
+    namespace_name: str
+    image_names: list[str]
+
+
+def get_all_pods_images(
+    cluster_name: Sequence[str] | None = None,
+    namespace_name: Sequence[str] | None = None,
+    thread_pool_size: int = 10,
+    use_jump_host: bool = True,
+    include_pattern: str | None = None,
+    exclude_pattern: str | None = None,
+) -> list[dict[str, Any]]:
+    """Gets all the images in the clusters/namespaces given. Returns a list of dicts
+    with the following keys:
+      * name: image name
+      * namespaces:  a comma separated list of namespaces where the instance is used
+      * count: number of uses of the image
+    """
+    all_namespaces = get_namespaces_minimal()
+    namespaces = filter_namespaces_by_cluster_and_namespace(
+        namespaces=all_namespaces,
+        cluster_names=cluster_name,
+        namespace_names=namespace_name,
+    )
+    vault_settings = get_app_interface_vault_settings()
+    secret_reader = create_secret_reader(use_vault=vault_settings.vault)
+    oc_map = init_oc_map_from_namespaces(
+        namespaces=namespaces,
+        integration="qontract-cli-get-namespace_images",
+        secret_reader=secret_reader,
+        use_jump_host=use_jump_host,
+        thread_pool_size=thread_pool_size,
+        init_projects=True,
+    )
+
+    return fetch_pods_images_from_namespaces(
+        namespaces=namespaces,
+        oc_map=oc_map,
+        exclude_pattern=exclude_pattern,
+        include_pattern=include_pattern,
+        thread_pool_size=thread_pool_size,
+    )
+
+
+def fetch_pods_images_from_namespaces(
+    namespaces: list[NamespaceV1],
+    oc_map: OCMap,
+    include_pattern: str | None = None,
+    exclude_pattern: str | None = None,
+    thread_pool_size: int = 10,
+) -> list[dict[str, Any]]:
+    all_namespace_images = threaded.run(
+        func=_get_namespace_images,
+        iterable=namespaces,
+        thread_pool_size=thread_pool_size,
+        oc_map=oc_map,
+    )
+
+    result: defaultdict = defaultdict(_get_all_images_default)
+    for ni in all_namespace_images:
+        for name in ni.image_names:
+            result[name]["namespaces"].add(ni.namespace_name)
+            result[name]["count"] += 1
+
+    exclude_pattern_compiled: re.Pattern | None = None
+    if exclude_pattern:
+        exclude_pattern_compiled = re.compile(exclude_pattern)
+
+    include_pattern_compiled: re.Pattern | None = None
+    if include_pattern:
+        include_pattern_compiled = re.compile(include_pattern)
+
+    result_filtered_flattened: list[dict[str, Any]] = []
+    for name, value in result.items():
+        if include_pattern_compiled and not include_pattern_compiled.match(name):
+            continue
+        if exclude_pattern_compiled and exclude_pattern_compiled.match(name):
+            continue
+
+        result_filtered_flattened.append({
+            "name": name,
+            "namespaces": ",".join(sorted(value["namespaces"])),
+            "count": value["count"],
+        })
+
+    return result_filtered_flattened
+
+
+def _get_all_images_default() -> dict[str, Any]:
+    return {"namespaces": set(), "count": 0}
+
+
+def _get_namespace_images(ns: NamespaceV1, oc_map: OCMap) -> NamespaceImages:
+    image_names = []
+    oc = oc_map.get_cluster(ns.cluster.name)
+    pod_items = oc.get_items("Pod", namespace=ns.name)
+    for pod in pod_items:
+        containers = pod.get("spec", {}).get("containers", [])
+        containers.extend(pod.get("spec", {}).get("initContainers", []))
+
+        for c in containers:
+            if m := IMAGE_NAME_REGEX.match(c["image"]):
+                image_names.append(m.group("name"))
+
+    return NamespaceImages(
+        namespace_name=ns.name,
+        image_names=image_names,
+    )

--- a/tools/test/test_get_container_images.py
+++ b/tools/test/test_get_container_images.py
@@ -1,0 +1,187 @@
+import pytest
+from pytest_mock import MockerFixture
+
+from reconcile.gql_definitions.common.namespaces_minimal import ClusterV1, NamespaceV1
+from reconcile.gql_definitions.fragments.vault_secret import VaultSecret
+from reconcile.test.fixtures import Fixtures
+from reconcile.utils.oc import OCNative
+from reconcile.utils.oc_map import OCMap
+from tools.cli_commands.container_images_report import (
+    fetch_pods_images_from_namespaces,
+)
+
+fxt = Fixtures("container_images_report")
+
+
+@pytest.fixture
+def observability_pods() -> list[dict]:
+    return fxt.get_anymarkup("app-sre-observability-stage-pods.yaml")
+
+
+@pytest.fixture
+def pipeline_pods() -> list[dict]:
+    return fxt.get_anymarkup("app-sre-pipelines-pods.yaml")
+
+
+@pytest.fixture
+def namespaces() -> list[NamespaceV1]:
+    return [
+        NamespaceV1(
+            name="app-sre-observability-stage",
+            delete=None,
+            labels="{}",
+            clusterAdmin=None,
+            cluster=ClusterV1(
+                name="appsres09ue1",
+                serverUrl="https://api.appsres09ue1.24ep.p3.openshiftapps.com:443",
+                insecureSkipTLSVerify=None,
+                jumpHost=None,
+                automationToken=VaultSecret(
+                    path="app-sre/integrations-output/openshift-cluster-bots/appsres09ue1",
+                    field="token",
+                    version=None,
+                    format=None,
+                ),
+                clusterAdminAutomationToken=VaultSecret(
+                    path="app-sre/integrations-output/openshift-cluster-bots/appsres09ue1-cluster-admin",
+                    field="token",
+                    version=None,
+                    format=None,
+                ),
+                internal=True,
+                disable=None,
+            ),
+        ),
+        NamespaceV1(
+            name="app-sre-pipelines",
+            delete=None,
+            labels='{"provider": "tekton"}',
+            clusterAdmin=None,
+            cluster=ClusterV1(
+                name="appsres09ue1",
+                serverUrl="https://api.appsres09ue1.24ep.p3.openshiftapps.com:443",
+                insecureSkipTLSVerify=None,
+                jumpHost=None,
+                automationToken=VaultSecret(
+                    path="app-sre/integrations-output/openshift-cluster-bots/appsres09ue1",
+                    field="token",
+                    version=None,
+                    format=None,
+                ),
+                clusterAdminAutomationToken=VaultSecret(
+                    path="app-sre/integrations-output/openshift-cluster-bots/appsres09ue1-cluster-admin",
+                    field="token",
+                    version=None,
+                    format=None,
+                ),
+                internal=True,
+                disable=None,
+            ),
+        ),
+    ]
+
+
+@pytest.fixture
+def oc(
+    mocker: MockerFixture,
+    observability_pods: list[dict],
+    pipeline_pods: list[dict],
+) -> OCNative:
+    oc = mocker.patch("reconcile.utils.oc.OCNative", autospec=True)
+    oc.get_items.side_effect = [observability_pods, pipeline_pods]
+    return oc
+
+
+@pytest.fixture
+def oc_map(mocker: MockerFixture, oc: OCNative) -> OCMap:
+    oc_map = mocker.patch("reconcile.utils.oc_map.OCMap", autospec=True)
+    oc_map.get_cluster.return_value = oc
+    return oc_map
+
+
+# convert a list of dicts into a set of tuples to use it in assertions
+def _to_set(list_of_dicts: list[dict]) -> set[tuple]:
+    return {tuple(d.items()) for d in list_of_dicts}
+
+
+def testfetch_no_filter(namespaces: list[NamespaceV1], oc_map: OCMap) -> None:
+    images = fetch_pods_images_from_namespaces(
+        namespaces=namespaces,
+        oc_map=oc_map,
+        thread_pool_size=2,
+    )
+
+    assert _to_set(images) == _to_set([
+        {
+            "name": "quay.io/prometheus/blackbox-exporter",
+            "namespaces": "app-sre-observability-stage",
+            "count": 1,
+        },
+        {
+            "name": "quay.io/redhat-services-prod/app-sre-tenant/gitlab-project-exporter-main/gitlab-project-exporter-main",
+            "namespaces": "app-sre-observability-stage",
+            "count": 1,
+        },
+        {
+            "name": "quay.io/app-sre/internal-redhat-ca",
+            "namespaces": "app-sre-observability-stage,app-sre-pipelines",
+            "count": 3,
+        },
+        {
+            "name": "quay.io/app-sre/clamav",
+            "namespaces": "app-sre-pipelines",
+            "count": 1,
+        },
+        {
+            "name": "quay.io/redhat-appstudio/clamav-db",
+            "namespaces": "app-sre-pipelines",
+            "count": 1,
+        },
+        {
+            "name": "registry.redhat.io/openshift-pipelines/pipelines-entrypoint-rhel8",
+            "namespaces": "app-sre-pipelines",
+            "count": 3,
+        },
+        {
+            "name": "quay.io/redhatproductsecurity/rapidast",
+            "namespaces": "app-sre-pipelines",
+            "count": 1,
+        },
+    ])
+
+
+def testfetch_exclude_pattern(namespaces: list[NamespaceV1], oc_map: OCMap) -> None:
+    images = fetch_pods_images_from_namespaces(
+        namespaces=namespaces,
+        oc_map=oc_map,
+        thread_pool_size=2,
+        exclude_pattern="quay.io/redhat|quay.io/app-sre",
+    )
+    assert _to_set(images) == _to_set([
+        {
+            "name": "quay.io/prometheus/blackbox-exporter",
+            "namespaces": "app-sre-observability-stage",
+            "count": 1,
+        },
+        {
+            "name": "registry.redhat.io/openshift-pipelines/pipelines-entrypoint-rhel8",
+            "namespaces": "app-sre-pipelines",
+            "count": 3,
+        },
+    ])
+
+
+def testfetch_include_pattern(namespaces: list[NamespaceV1], oc_map: OCMap) -> None:
+    images = fetch_pods_images_from_namespaces(
+        namespaces=namespaces,
+        oc_map=oc_map,
+        thread_pool_size=2,
+        include_pattern="^registry.redhat.io",
+    )
+    assert images == [
+        {
+            "name": "registry.redhat.io/openshift-pipelines/pipelines-entrypoint-rhel8",
+            "namespaces": "app-sre-pipelines",
+            "count": 3,
+        },
+    ]


### PR DESCRIPTION
```
$ qontract-cli --config config.development.toml get  container-images --help
Usage: qontract-cli get container-images [OPTIONS]

  Get all container images in app-interface defined namespaces

Options:
  --cluster-name TEXT             openshift cluster names to act on i.e.:
                                  --cluster-name cluster-1 --cluster-name
                                  cluster-2
  --namespace-name TEXT           namespace name to act on.
  --thread-pool-size INTEGER      number of threads to run in parallel.
  --use-jump-host / --no-use-jump-host
                                  use jump host if defined.
  --exclude-pattern TEXT          Exclude images that match this pattern
  --include-pattern TEXT          Only include images that match this pattern
  --help                          Show this message and exit.
```

APPSRE-11229