### PR TITLE
Handle errors in container-images report

### DIFF
--- a/tools/test/test_get_container_images.py
+++ b/tools/test/test_get_container_images.py
@@ -99,27 +99,17 @@ def oc_map(mocker: MockerFixture, oc: OCNative) -> OCMap:
     return oc_map
 
 
-# convert a list of dicts into a set of tuples to use it in assertions
-def _to_set(list_of_dicts: list[dict]) -> set[tuple]:
-    return {tuple(d.items()) for d in list_of_dicts}
-
-
-def testfetch_no_filter(namespaces: list[NamespaceV1], oc_map: OCMap) -> None:
+def test_fetch_no_filter(namespaces: list[NamespaceV1], oc_map: OCMap) -> None:
     images = fetch_pods_images_from_namespaces(
         namespaces=namespaces,
         oc_map=oc_map,
         thread_pool_size=2,
     )
 
-    assert _to_set(images) == _to_set([
+    assert images == [
         {
-            "name": "quay.io/prometheus/blackbox-exporter",
-            "namespaces": "app-sre-observability-stage",
-            "count": 1,
-        },
-        {
-            "name": "quay.io/redhat-services-prod/app-sre-tenant/gitlab-project-exporter-main/gitlab-project-exporter-main",
-            "namespaces": "app-sre-observability-stage",
+            "name": "quay.io/app-sre/clamav",
+            "namespaces": "app-sre-pipelines",
             "count": 1,
         },
         {
@@ -128,8 +118,8 @@ def testfetch_no_filter(namespaces: list[NamespaceV1], oc_map: OCMap) -> None:
             "count": 3,
         },
         {
-            "name": "quay.io/app-sre/clamav",
-            "namespaces": "app-sre-pipelines",
+            "name": "quay.io/prometheus/blackbox-exporter",
+            "namespaces": "app-sre-observability-stage",
             "count": 1,
         },
         {
@@ -138,26 +128,31 @@ def testfetch_no_filter(namespaces: list[NamespaceV1], oc_map: OCMap) -> None:
             "count": 1,
         },
         {
-            "name": "registry.redhat.io/openshift-pipelines/pipelines-entrypoint-rhel8",
-            "namespaces": "app-sre-pipelines",
-            "count": 3,
+            "name": "quay.io/redhat-services-prod/app-sre-tenant/gitlab-project-exporter-main/gitlab-project-exporter-main",
+            "namespaces": "app-sre-observability-stage",
+            "count": 1,
         },
         {
             "name": "quay.io/redhatproductsecurity/rapidast",
             "namespaces": "app-sre-pipelines",
             "count": 1,
         },
-    ])
+        {
+            "name": "registry.redhat.io/openshift-pipelines/pipelines-entrypoint-rhel8",
+            "namespaces": "app-sre-pipelines",
+            "count": 3,
+        },
+    ]
 
 
-def testfetch_exclude_pattern(namespaces: list[NamespaceV1], oc_map: OCMap) -> None:
+def test_fetch_exclude_pattern(namespaces: list[NamespaceV1], oc_map: OCMap) -> None:
     images = fetch_pods_images_from_namespaces(
         namespaces=namespaces,
         oc_map=oc_map,
         thread_pool_size=2,
         exclude_pattern="quay.io/redhat|quay.io/app-sre",
     )
-    assert _to_set(images) == _to_set([
+    assert images == [
         {
             "name": "quay.io/prometheus/blackbox-exporter",
             "namespaces": "app-sre-observability-stage",
@@ -168,10 +163,10 @@ def testfetch_exclude_pattern(namespaces: list[NamespaceV1], oc_map: OCMap) -> N
             "namespaces": "app-sre-pipelines",
             "count": 3,
         },
-    ])
+    ]
 
 
-def testfetch_include_pattern(namespaces: list[NamespaceV1], oc_map: OCMap) -> None:
+def test_fetch_include_pattern(namespaces: list[NamespaceV1], oc_map: OCMap) -> None:
     images = fetch_pods_images_from_namespaces(
         namespaces=namespaces,
         oc_map=oc_map,
@@ -183,5 +178,43 @@ def testfetch_include_pattern(namespaces: list[NamespaceV1], oc_map: OCMap) -> N
             "name": "registry.redhat.io/openshift-pipelines/pipelines-entrypoint-rhel8",
             "namespaces": "app-sre-pipelines",
             "count": 3,
+        },
+    ]
+
+
+def test_fetch_exception(
+    namespaces: list[NamespaceV1], mocker: MockerFixture, observability_pods: list[dict]
+) -> None:
+    oc = mocker.patch("reconcile.utils.oc.OCNative", autospec=True)
+    oc.get_items.side_effect = [observability_pods, Exception("generic error")]
+    oc_map = mocker.patch("reconcile.utils.oc_map.OCMap", autospec=True)
+    oc_map.get_cluster.return_value = oc
+
+    images = fetch_pods_images_from_namespaces(
+        namespaces=namespaces,
+        oc_map=oc_map,
+        thread_pool_size=2,
+    )
+
+    assert images == [
+        {
+            "name": "quay.io/app-sre/internal-redhat-ca",
+            "namespaces": "app-sre-observability-stage",
+            "count": 2,
+        },
+        {
+            "name": "quay.io/prometheus/blackbox-exporter",
+            "namespaces": "app-sre-observability-stage",
+            "count": 1,
+        },
+        {
+            "name": "quay.io/redhat-services-prod/app-sre-tenant/gitlab-project-exporter-main/gitlab-project-exporter-main",
+            "namespaces": "app-sre-observability-stage",
+            "count": 1,
+        },
+        {
+            "name": "error",
+            "namespaces": "app-sre-pipelines/generic error",
+            "count": 1,
         },
     ]


### PR DESCRIPTION
The code from #4769 did not handle errors properly. Errors have been added in a sort of hackish way (at the end of the image list), but it is better to show them somewhere than hiding them.

Output is now sorted by default for clarity.

APPSRE-11229