### PR TITLE
fix(vpc-peering): skip security group for HCP if no endpoints

### DIFF
--- a/reconcile/test/utils/test_aws_api.py
+++ b/reconcile/test/utils/test_aws_api.py
@@ -378,3 +378,40 @@ def test_get_cluster_vpc_details_aws_error(
             "name": "some-account",
             "assume_region": "us-east-1",
         })
+
+
+def test_get_cluster_vpc_details_no_endpoints(
+    mocker: MockerFixture, aws_api: AWSApi
+) -> None:
+    expected_vpc_id = "id"
+    mocker.patch.object(
+        aws_api,
+        "get_account_vpcs",
+        return_value=[
+            {
+                "CidrBlock": "cidr",
+                "VpcId": expected_vpc_id,
+            }
+        ],
+    )
+    mocker.patch.object(
+        AWSApi,
+        "_get_vpc_endpoints",
+        return_value=[],
+    )
+
+    vpc_id, route_table_ids, subnets_id_az, api_security_group_id = (
+        aws_api.get_cluster_vpc_details(
+            {
+                "name": "some-account",
+                "assume_region": "us-east-1",
+                "assume_cidr": "cidr",
+            },
+            hcp_vpc_endpoint_sg=True,
+        )
+    )
+
+    assert vpc_id == expected_vpc_id
+    assert route_table_ids is None
+    assert subnets_id_az is None
+    assert api_security_group_id is None


### PR DESCRIPTION
When no endpoints found before HCP cluster creation but peering config in `cluster.yml` file exist, integration `terraform-vpc-peerings` will fail with error

```
Traceback (most recent call last):
  File "/usr/local/lib/python3.11/site-packages/reconcile/cli.py", line 609, in run_class_integration
    run_integration_cfg(
  File "/usr/local/lib/python3.11/site-packages/reconcile/utils/runtime/runner.py", line 155, in run_integration_cfg
    _integration_dry_run(run_cfg.integration, desired_state_diff)
  File "/usr/local/lib/python3.11/site-packages/reconcile/utils/runtime/runner.py", line 226, in _integration_dry_run
    integration.run(True)
  File "/usr/local/lib/python3.11/site-packages/reconcile/utils/runtime/integration.py", line 315, in run
    self.params.module.run(dry_run, *self.params.args, **self.params.kwargs)
  File "/usr/local/lib/python3.11/site-packages/reconcile/utils/defer.py", line 13, in func_wrapper
    return func(*args, defer=stack.callback, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/reconcile/terraform_vpc_peerings.py", line 595, in run
    desired_state_vpc, err = build_desired_state_vpc(
                             ^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/reconcile/terraform_vpc_peerings.py", line 553, in build_desired_state_vpc
    items = build_desired_state_vpc_single_cluster(
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/reconcile/terraform_vpc_peerings.py", line 500, in build_desired_state_vpc_single_cluster
    awsapi.get_cluster_vpc_details(
  File "/usr/local/lib/python3.11/site-packages/reconcile/utils/aws_api.py", line 973, in get_cluster_vpc_details
    vpc_endpoint_id = endpoints[0]["VpcEndpointId"]
                      ~~~~~~~~~^^^
IndexError: list index out of range
```

Expect to skip security group when no endpoints.

This pull request introduces a new test case and refactors the `get_cluster_vpc_details` function to handle scenarios where there are no VPC endpoints. The changes include adding a new helper method and modifying the return logic.

### New Test Case:
* Added `test_get_cluster_vpc_details_no_endpoints` to handle cases with no VPC endpoints in `reconcile/test/utils/test_aws_api.py`.

### Function Refactoring:
* Refactored `get_cluster_vpc_details` in `reconcile/utils/aws_api.py` to include a call to a new helper method `_get_api_security_group_id`.
* Added a new helper method `_get_api_security_group_id` to retrieve the API security group ID, returning `None` if no endpoints are found. [[1]](diffhunk://#diff-fa53225044580356ab5fbddd2d4f182e37bfeef41768289fa3f6e185e5f87302R976-R977) [[2]](diffhunk://#diff-fa53225044580356ab5fbddd2d4f182e37bfeef41768289fa3f6e185e5f87302L985-R994)