### PR TITLE
fix(vpc-peering): match new security group name for HCP cluster

### DIFF
--- a/reconcile/test/utils/test_aws_api.py
+++ b/reconcile/test/utils/test_aws_api.py
@@ -415,3 +415,60 @@ def test_get_cluster_vpc_details_no_endpoints(
     assert route_table_ids is None
     assert subnets_id_az is None
     assert api_security_group_id is None
+
+
+@pytest.mark.parametrize(
+    "group_name",
+    [
+        "abc-default-sg",
+        "abc-vpce-private-router",
+    ],
+)
+def test_get_cluster_vpc_details_with_hcp_security_group(
+    mocker: MockerFixture,
+    aws_api: AWSApi,
+    group_name: str,
+) -> None:
+    expected_vpc_id = "id"
+    expected_sg_id = "sg-id"
+    mocker.patch.object(
+        aws_api,
+        "get_account_vpcs",
+        return_value=[
+            {
+                "CidrBlock": "cidr",
+                "VpcId": expected_vpc_id,
+            }
+        ],
+    )
+    mocker.patch.object(
+        AWSApi,
+        "_get_vpc_endpoints",
+        return_value=[
+            {
+                "VpcEndpointId": "vpce-id",
+                "Groups": [
+                    {
+                        "GroupName": group_name,
+                        "GroupId": expected_sg_id,
+                    }
+                ],
+            }
+        ],
+    )
+
+    vpc_id, route_table_ids, subnets_id_az, api_security_group_id = (
+        aws_api.get_cluster_vpc_details(
+            {
+                "name": "some-account",
+                "assume_region": "us-east-1",
+                "assume_cidr": "cidr",
+            },
+            hcp_vpc_endpoint_sg=True,
+        )
+    )
+
+    assert vpc_id == expected_vpc_id
+    assert route_table_ids is None
+    assert subnets_id_az is None
+    assert api_security_group_id == expected_sg_id

--- a/reconcile/utils/aws_api.py
+++ b/reconcile/utils/aws_api.py
@@ -979,12 +979,15 @@ class AWSApi:  # pylint: disable=too-many-public-methods
             raise ValueError(
                 f"exactly one VPC endpoint for private API router in VPC {vpc_id} expected but {len(endpoints)} found"
             )
-        vpc_endpoint_id = endpoints[0]["VpcEndpointId"]
+        endpoint = endpoints[0]
+        vpc_endpoint_id = endpoint["VpcEndpointId"]
         # https://github.com/openshift/hypershift/blob/c855f68e84e78924ccc9c2132b75dc7e30c4e1d8/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go#L4243
+        # https://github.com/openshift/hypershift/blob/2569f3353ef5ac0858eace9ee77310c3cc38b8e0/control-plane-operator/controllers/awsprivatelink/awsprivatelink_controller.go#L787
         security_groups = [
             sg
-            for sg in endpoints[0]["Groups"]
+            for sg in endpoint["Groups"]
             if sg["GroupName"].endswith("-default-sg")
+            or sg["GroupName"].endswith("-vpce-private-router")
         ]
         if len(security_groups) != 1:
             raise ValueError(


### PR DESCRIPTION
Update security group name match to include `-vpce-private-router` ones as the logic changed in HCP, new clusters will have the new security group name.


[APPSRE-11280](https://issues.redhat.com/browse/APPSRE-11280)