### PR TITLE
qontract-cli erv2 migration: fix warning and default upload answer

### DIFF
--- a/tools/cli_commands/erv2.py
+++ b/tools/cli_commands/erv2.py
@@ -470,7 +470,7 @@ class TerraformCli:
                 self.progress_spinner.stop()
             if not Confirm.ask(
                 "\nEverything ok? Would you like to upload the modified terraform states",
-                default=False,
+                default=True,
             ):
                 return
 

--- a/tools/qontract_cli.py
+++ b/tools/qontract_cli.py
@@ -4229,8 +4229,7 @@ def migrate(ctx, dry_run: bool, skip_build: bool) -> None:
 
     if not Confirm.ask(
         dedent("""
-            Please disable terraform-resources: [i blue]https://app-interface.unleash.devshift.net/projects/default/features/terraform-resources[/]
-            in Unleash before proceeding!
+            Please ensure [red]terraform-resources[/] is disabled before proceeding!
 
             Do you want to proceed?"""),
         default=True,


### PR DESCRIPTION
We disable `terraform-resources` via app-interface settings. Therefore, the Unleash note is misleading. Also, set the default answer to "yes" for "Would you like to upload the modified terraform states".