### PR TITLE
Allow "2nd friday of each month" type of schedule in AUS and saas-deploy

### DIFF
--- a/reconcile/aus/base.py
+++ b/reconcile/aus/base.py
@@ -941,7 +941,7 @@ def verify_schedule_should_skip(
     addon_id: str = "",
 ) -> str | None:
     schedule = desired.upgrade_policy.schedule
-    iter = croniter(schedule)
+    iter = croniter(schedule, day_or=False)
     # ClusterService refuses scheduling upgrades less than 5m in advance
     # Let's find the next schedule that is at least 5m ahead.
     # We do not need that much delay for addon upgrades since they run

--- a/reconcile/saas_auto_promotions_manager/subscriber.py
+++ b/reconcile/saas_auto_promotions_manager/subscriber.py
@@ -131,7 +131,7 @@ class Subscriber:
                 self.schedule,
             )
             return False
-        return croniter.match(self.schedule, datetime.now(UTC))
+        return croniter.match(self.schedule, datetime.now(UTC), day_or=False)
 
     def _compute_desired_ref(self) -> None:
         """


### PR DESCRIPTION
https://issues.redhat.com/browse/APPSRE-11287

The `croniter` `day_or` parameter allows to AND the 2 `day` of a cron expression instead of the default OR.

For example, by default `0 13 1-7 * 2` matches all first 7 days of each months AND all tuesdays of each month. This is because the `day-of-month` and `day-of-week` fields are ORed by default.

With `day_or=False`, the `day-of-month` and `day-of-week` fields are ANDed, which allows to get "the first tuesday of each month"