### PR TITLE
Count images w/out tag in container-images report

### DIFF
--- a/reconcile/test/fixtures/container_images_report/app-sre-observability-stage-pods.yaml
+++ b/reconcile/test/fixtures/container_images_report/app-sre-observability-stage-pods.yaml
@@ -10,6 +10,15 @@
 - apiVersion: v1
   kind: Pod
   metadata:
+    name: prom-cloudwatch-exporter-86dcf83a3-xdr63
+    namespace: app-sre-observability-stage
+  spec:
+    containers:
+    - image: quay.io/app-sre/prom-cloudwatch-exporter
+      name: prom-cloudwatch-exporter
+- apiVersion: v1
+  kind: Pod
+  metadata:
     name: gitlab-project-exporter-f64f9c9f8-225x4
     namespace: app-sre-observability-stage
   spec:

--- a/tools/cli_commands/container_images_report.py
+++ b/tools/cli_commands/container_images_report.py
@@ -15,7 +15,9 @@ from reconcile.utils.oc_filters import filter_namespaces_by_cluster_and_namespac
 from reconcile.utils.oc_map import OCMap, init_oc_map_from_namespaces
 from reconcile.utils.secret_reader import create_secret_reader
 
-IMAGE_NAME_REGEX = re.compile(r"^(?P<name>[a-zA-Z0-9][a-zA-Z0-9/_.-]+)(?:@sha256)?:.+$")
+IMAGE_NAME_REGEX = re.compile(
+    r"^(?P<name>[a-zA-Z0-9][a-zA-Z0-9/_.-]+)(?:$|(?:@sha256)?:.+.$)"
+)
 
 
 class NamespaceImages(BaseModel):

--- a/tools/test/test_get_container_images.py
+++ b/tools/test/test_get_container_images.py
@@ -118,6 +118,11 @@ def test_fetch_no_filter(namespaces: list[NamespaceV1], oc_map: OCMap) -> None:
             "count": 3,
         },
         {
+            "name": "quay.io/app-sre/prom-cloudwatch-exporter",
+            "namespaces": "app-sre-observability-stage",
+            "count": 1,
+        },
+        {
             "name": "quay.io/prometheus/blackbox-exporter",
             "namespaces": "app-sre-observability-stage",
             "count": 1,
@@ -201,6 +206,11 @@ def test_fetch_exception(
             "name": "quay.io/app-sre/internal-redhat-ca",
             "namespaces": "app-sre-observability-stage",
             "count": 2,
+        },
+        {
+            "name": "quay.io/app-sre/prom-cloudwatch-exporter",
+            "namespaces": "app-sre-observability-stage",
+            "count": 1,
         },
         {
             "name": "quay.io/prometheus/blackbox-exporter",


### PR DESCRIPTION
this is a valid image spec:

```
image: quay.io/app-sre/prom-cloudwatch-exporter
```

and the report is not taking it into account.