### PR TITLE
Erv2: Implement resource reconciliation dependencies

### DIFF
--- a/grafana-dashboards/grafana-dashboard-external-resource-log.configmap.yaml
+++ b/grafana-dashboards/grafana-dashboard-external-resource-log.configmap.yaml
@@ -218,6 +218,33 @@ data:
             }
           ],
           "title": "Reconcile Time (seconds)",
+          "transformations": [
+            {
+              "id": "renameByRegex",
+              "options": {
+                "regex": "sum.*",
+                "renamePattern": "time"
+              }
+            },
+            {
+              "id": "filterByValue",
+              "options": {
+                "filters": [
+                  {
+                    "config": {
+                      "id": "equal",
+                      "options": {
+                        "value": ""
+                      }
+                    },
+                    "fieldName": "time"
+                  }
+                ],
+                "match": "all",
+                "type": "exclude"
+              }
+            }
+          ],
           "type": "stat"
         },
         {
@@ -431,7 +458,7 @@ data:
         "list": [
           {
             "current": {
-              "selected": true,
+              "selected": false,
               "text": "aws",
               "value": "aws"
             },
@@ -458,9 +485,9 @@ data:
           },
           {
             "current": {
-              "selected": false,
-              "text": "insights-perf",
-              "value": "insights-perf"
+              "selected": true,
+              "text": "app-sre-stage",
+              "value": "app-sre-stage"
             },
             "datasource": {
               "type": "prometheus",
@@ -485,9 +512,9 @@ data:
           },
           {
             "current": {
-              "selected": false,
-              "text": "msk",
-              "value": "msk"
+              "selected": true,
+              "text": "rds",
+              "value": "rds"
             },
             "datasource": {
               "type": "prometheus",
@@ -512,9 +539,9 @@ data:
           },
           {
             "current": {
-              "selected": false,
-              "text": "consoledot-perf",
-              "value": "consoledot-perf"
+              "selected": true,
+              "text": "grafana-dev",
+              "value": "grafana-dev"
             },
             "datasource": {
               "type": "prometheus",
@@ -540,8 +567,8 @@ data:
           {
             "current": {
               "selected": false,
-              "text": "er-16c68767e2",
-              "value": "er-16c68767e2"
+              "text": "er-916ace39e5",
+              "value": "er-916ace39e5"
             },
             "datasource": {
               "type": "prometheus",

--- a/reconcile/external_resources/factories.py
+++ b/reconcile/external_resources/factories.py
@@ -60,6 +60,13 @@ class ExternalResourceFactory(ABC):
     def validate_external_resource(self, resource: ExternalResource) -> None:
         pass
 
+    def find_linked_resources(
+        self, spec: ExternalResourceSpec
+    ) -> set[ExternalResourceKey]:
+        """Method to find dependant resources. Resources in this list
+        will be reconciled every time the parent resource finishes its reconciliation."""
+        return set()
+
 
 class ModuleProvisionDataFactory(ABC):
     @abstractmethod
@@ -148,3 +155,9 @@ class AWSExternalResourceFactory(ExternalResourceFactory):
     def validate_external_resource(self, resource: ExternalResource) -> None:
         f = self.resource_factories.get_factory(resource.provision.provider)
         f.validate(resource)
+
+    def find_linked_resources(
+        self, spec: ExternalResourceSpec
+    ) -> set[ExternalResourceKey]:
+        f = self.resource_factories.get_factory(spec.provider)
+        return f.find_linked_resources(spec)

--- a/reconcile/external_resources/secrets_sync.py
+++ b/reconcile/external_resources/secrets_sync.py
@@ -20,7 +20,9 @@ from reconcile.external_resources.meta import (
     SECRET_UPDATED_AT,
     SECRET_UPDATED_AT_TIMEFORMAT,
 )
-from reconcile.external_resources.model import ExternalResourceKey
+from reconcile.external_resources.model import (
+    ExternalResourceKey,
+)
 from reconcile.openshift_base import ApplyOptions, apply_action
 from reconcile.typed_queries.clusters_minimal import get_clusters_minimal
 from reconcile.utils.differ import diff_mappings
@@ -207,7 +209,7 @@ class SecretsReconciler:
             If current is newer; don't apply.
             If other changes; apply and Recycle Pods
             Desired can not be newer than current.
-        External reosurce to Cluster (last reconciliation):
+        External resource to Cluster (last reconciliation):
             If updated_at annotation is the only change; Don't update
             If other changes; Update Secret and Recycle Pods
             Current can not be newer then Desired
@@ -233,7 +235,7 @@ class SecretsReconciler:
 
         if self.ri.has_error_registered():
             # Return all specs as error if there are errors.
-            # There is no a clear way to kwno which specs failed.
+            # There is not a clear way to know which specs have failed.
             return list(specs)
         else:
             return []


### PR DESCRIPTION
This PR implements resource reconciliation dependencies. 

The main use case for now is RDS read replicas. Every time a Primary is reconciled, it will trigger a reconciliation for its read replicas. This is needed to sync the credentials output secrets in case a password reset is requested.  