### PR TITLE
Fail ERv2 DRY-RUN mode when there are orphaned resources

### DIFF
--- a/reconcile/external_resources/manager.py
+++ b/reconcile/external_resources/manager.py
@@ -18,6 +18,7 @@ from reconcile.external_resources.model import (
     ExternalResource,
     ExternalResourceKey,
     ExternalResourceModuleConfiguration,
+    ExternalResourceOrphanedResourcesError,
     ExternalResourcesInventory,
     ExternalResourceValidationError,
     ModuleInventory,
@@ -198,6 +199,13 @@ class ExternalResourcesManager:
             to_reconcile.add(r)
         return to_reconcile
 
+    def _check_orphaned_objects(self) -> None:
+        state_keys = self.state_mgr.get_all_resource_keys()
+        inventory_keys = set(self.er_inventory.keys())
+        orphans = state_keys - inventory_keys
+        if len(orphans) > 0:
+            raise ExternalResourceOrphanedResourcesError(orphans)
+
     def _get_reconciliation_status(
         self,
         r: Reconciliation,
@@ -364,6 +372,7 @@ class ExternalResourcesManager:
             self._sync_secrets(to_sync_keys=to_sync_keys | pending_sync_keys)
 
     def handle_dry_run_resources(self) -> None:
+        self._check_orphaned_objects()
         desired_r = self._get_desired_objects_reconciliations()
         deleted_r = self._get_deleted_objects_reconciliations()
         reconciliations = desired_r.union(deleted_r)

--- a/reconcile/external_resources/model.py
+++ b/reconcile/external_resources/model.py
@@ -34,6 +34,17 @@ from reconcile.utils.external_resource_spec import (
 )
 
 
+class ExternalResourceOrphanedResourcesError(Exception):
+    def __init__(self, orphans: Iterable["ExternalResourceKey"]) -> None:
+        msg = [
+            "There are orphaned resources in the configuration. ",
+            "To delete ERv2 managed external resources, set the 'delete: true' attribute.\n",
+            "Orphans:\n",
+            "\n".join(map(str, orphans)),
+        ]
+        super().__init__("".join(msg))
+
+
 class ExternalResourceValidationError(Exception):
     errors: list[str] = []
 


### PR DESCRIPTION
Prevent Erv2 resources removal without setting the delete flag. 