### PR TITLE
:bug: prod image: add missing helm charts

### DIFF
--- a/dockerfiles/Dockerfile
+++ b/dockerfiles/Dockerfile
@@ -62,6 +62,8 @@ RUN microdnf upgrade -y && microdnf clean all
 
 
 WORKDIR /work
+# the integration-manager needs the helm charts
+COPY helm helm
 COPY --from=build-image /work ./
 
 # Set the PATH to include the virtualenv
@@ -101,7 +103,6 @@ RUN uv sync --frozen --no-cache --group dev
 
 # Run tests
 COPY Makefile .
-COPY helm helm
 RUN make all-tests
 
 ###############################################################################


### PR DESCRIPTION
$TITLE


```
Traceback (most recent call last):
  File "/work/reconcile/cli.py", line 609, in run_class_integration
    run_integration_cfg(
  File "/work/reconcile/utils/runtime/runner.py", line 155, in run_integration_cfg
    _integration_dry_run(run_cfg.integration, desired_state_diff)
  File "/work/reconcile/utils/runtime/runner.py", line 226, in _integration_dry_run
    integration.run(True)
  File "/work/reconcile/utils/runtime/integration.py", line 315, in run
    self.params.module.run(dry_run, *self.params.args, **self.params.kwargs)
  File "/work/reconcile/utils/defer.py", line 13, in func_wrapper
    return func(*args, defer=stack.callback, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/work/reconcile/integrations_manager.py", line 299, in run
    fetch_desired_state(
  File "/work/reconcile/integrations_manager.py", line 216, in fetch_desired_state
    oc_resources = construct_oc_resources(ie, upstream, image, image_tag_from_ref)
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/work/reconcile/integrations_manager.py", line 185, in construct_oc_resources
    template = helm.template(values)
               ^^^^^^^^^^^^^^^^^^^^^
  File "/work/reconcile/utils/helm.py", line 105, in template
    return yaml.safe_load(do_template(values=values, path=path, namespace=namespace))
                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/work/reconcile/utils/helm.py", line 40, in do_template
    with open(
         ^^^^^
FileNotFoundError: [Errno 2] No such file or directory: './helm/qontract-reconcile/Chart.yaml'
```