### PR TITLE
[terraform-repo] metrics

### DIFF
--- a/reconcile/typed_queries/app_interface_metrics_exporter/terraform_repo.py
+++ b/reconcile/typed_queries/app_interface_metrics_exporter/terraform_repo.py
@@ -1,0 +1,9 @@
+from collections import Counter
+
+from reconcile.gql_definitions.terraform_repo.terraform_repo import query
+from reconcile.utils.gql import GqlApi
+
+
+def get_tf_repo_inventory(gql: GqlApi) -> Counter:
+    repos = query(gql.query).repos or []
+    return Counter(r.account.name for r in repos)

--- a/tools/app_interface_metrics_exporter.py
+++ b/tools/app_interface_metrics_exporter.py
@@ -83,10 +83,10 @@ def main(
     log_level: str,
 ) -> None:
     init_env(log_level=log_level, config_file=configfile)
-    onboarding_status = get_onboarding_status(gql.get_api())
-    publish_onboarding_status_metrics(onboarding_status)
     repos = get_tf_repo_inventory(gql.get_api())
     publish_tf_repo_inventory(repos)
+    onboarding_status = get_onboarding_status(gql.get_api())
+    publish_onboarding_status_metrics(onboarding_status)
 
 
 if __name__ == "__main__":

--- a/tools/test/test_app_interface_metrics_exporter.py
+++ b/tools/test/test_app_interface_metrics_exporter.py
@@ -11,22 +11,35 @@ from tools.app_interface_metrics_exporter import (
 
 
 @pytest.fixture
-def onbaoarding_status() -> Counter:
+def onboarding_status() -> Counter:
     return Counter({
         "OnBoarded": 2,
     })
 
 
+@pytest.fixture
+def repo_inventory() -> Counter:
+    return Counter({
+        "app-sre",
+        5,
+    })
+
+
 def test_app_interface_metrics_exporter_main(
     mocker: MockerFixture,
-    onbaoarding_status: Counter,
+    onboarding_status: Counter,
+    repo_inventory: Counter,
 ) -> None:
     mocked_metrics = mocker.patch("tools.app_interface_metrics_exporter.metrics")
     mocked_init_env = mocker.patch("tools.app_interface_metrics_exporter.init_env")
     mocker.patch("tools.app_interface_metrics_exporter.gql")
     mocker.patch(
         "tools.app_interface_metrics_exporter.get_onboarding_status",
-        return_value=onbaoarding_status,
+        return_value=onboarding_status,
+    )
+    mocker.patch(
+        "tools.app_interface_metrics_exporter.get_tf_repo_inventory",
+        return_value=repo_inventory,
     )
 
     result = CliRunner().invoke(
@@ -35,14 +48,14 @@ def test_app_interface_metrics_exporter_main(
     )
 
     assert result.exit_code == 0
-    mocked_metrics.set_gauge.assert_called_once_with(
+    mocked_metrics.set_gauge.assert_called_with(
         OverviewOnboardingStatus(
             integration="app-interface-metrics-exporter",
             status="OnBoarded",
         ),
         2,
     )
-    mocked_init_env.assert_called_once_with(
+    mocked_init_env.assert_called_with(
         config_file="config.toml",
         log_level="DEBUG",
     )


### PR DESCRIPTION
[APPSRE-11304](https://issues.redhat.com/browse/APPSRE-11304)

Adds a new gauge to QR, `qontract_reconcile_terraform_repo_inventory` which tracks deployed Terraform Repositories via AWS account. The reason this is in the metrics exporter file rather than in [`reconcile/terraform_repo.py`](https://github.com/app-sre/qontract-reconcile/blob/master/reconcile/terraform_repo.py) has to do with the deployment architecture of Terraform Repo. 

The Terraform Repo integration is event-driven so trying to scrape metrics from it would probably involve a Prometheus gateway. Instead of that approach, I've just added it to this existing integration that is constantly reconciling and uses GQL information to create the gauge.