### PR TITLE
[tf-repo secrets] allow tenants to use inputs OR outputs

### DIFF
--- a/reconcile/gql_definitions/introspection.json
+++ b/reconcile/gql_definitions/introspection.json
@@ -32452,13 +32452,9 @@
                             "description": null,
                             "args": [],
                             "type": {
-                                "kind": "NON_NULL",
-                                "name": null,
-                                "ofType": {
-                                    "kind": "OBJECT",
-                                    "name": "VaultSecret_v1",
-                                    "ofType": null
-                                }
+                                "kind": "OBJECT",
+                                "name": "VaultSecret_v1",
+                                "ofType": null
                             },
                             "isDeprecated": false,
                             "deprecationReason": null
@@ -32468,13 +32464,9 @@
                             "description": null,
                             "args": [],
                             "type": {
-                                "kind": "NON_NULL",
-                                "name": null,
-                                "ofType": {
-                                    "kind": "OBJECT",
-                                    "name": "VaultSecret_v1",
-                                    "ofType": null
-                                }
+                                "kind": "OBJECT",
+                                "name": "VaultSecret_v1",
+                                "ofType": null
                             },
                             "isDeprecated": false,
                             "deprecationReason": null

--- a/reconcile/gql_definitions/terraform_repo/terraform_repo.py
+++ b/reconcile/gql_definitions/terraform_repo/terraform_repo.py
@@ -100,8 +100,8 @@ class AppV1(ConfiguredBaseModel):
 
 
 class TerraformRepoVariablesV1(ConfiguredBaseModel):
-    inputs: VaultSecret = Field(..., alias="inputs")
-    outputs: VaultSecret = Field(..., alias="outputs")
+    inputs: Optional[VaultSecret] = Field(..., alias="inputs")
+    outputs: Optional[VaultSecret] = Field(..., alias="outputs")
 
 
 class TerraformRepoV1(ConfiguredBaseModel):


### PR DESCRIPTION
[APPSRE-11333](https://issues.redhat.com/browse/APPSRE-11333)

Allow our tenants using secrets for inputs/outputs to have the flexibility to specify one or the other, or both. Basically a [logical "disjunction"](https://en.wikipedia.org/wiki/Logical_disjunction)

Dependent MR:

- [Qontract Schemas](https://github.com/app-sre/qontract-schemas/pull/750)