### PR TITLE
:zap: slack-usergroups: performance fix

### DIFF
--- a/reconcile/slack_usergroups.py
+++ b/reconcile/slack_usergroups.py
@@ -314,7 +314,12 @@ def get_slack_usernames_from_owners(
             else:
                 raise TypeError(f"{type(repo_cli)} not supported")
 
-            repo_owners = repo_owner_class(git_cli=repo_cli, ref=ref)
+            repo_owners = repo_owner_class(
+                git_cli=repo_cli,
+                ref=ref,
+                # we just need the root level OWNERS file
+                recursive=False,
+            )
 
             try:
                 owners = repo_owners.get_root_owners()

--- a/reconcile/utils/github_api.py
+++ b/reconcile/utils/github_api.py
@@ -50,6 +50,9 @@ class GithubRepositoryApi:
     ) -> None:
         self.cleanup()
 
+    def __str__(self) -> str:
+        return self._repo.html_url
+
     def cleanup(self) -> None:
         """
         Align with GitLabApi

--- a/reconcile/utils/gitlab_api.py
+++ b/reconcile/utils/gitlab_api.py
@@ -146,6 +146,9 @@ class GitLabApi:  # pylint: disable=too-many-public-methods
     def __exit__(self, *exc):
         self.cleanup()
 
+    def __str__(self):
+        return self.project.web_url
+
     def cleanup(self):
         """
         Close gl session.

--- a/reconcile/utils/repo_owners.py
+++ b/reconcile/utils/repo_owners.py
@@ -133,14 +133,12 @@ class RepoOwners:
                 owners = None
             if owners is None:
                 _LOG.warning(
-                    "Non-parsable OWNERS file "
-                    f"{self._git_cli.project.web_url}:{owner_file.get('path')}"
+                    f"Non-parsable OWNERS file {self._git_cli!s}:{owner_file['path']}"
                 )
                 continue
             if not isinstance(owners, dict):
                 _LOG.warning(
-                    f"owner file {self._git_cli.project.web_url}:{owner_file.get('path')} "
-                    "content is not a dictionary"
+                    f"owner file {self._git_cli!s}:{owner_file['path']} content is not a dictionary"
                 )
                 continue
 

--- a/reconcile/utils/repo_owners.py
+++ b/reconcile/utils/repo_owners.py
@@ -127,6 +127,9 @@ class RepoOwners:
 
         for owner_file in owner_files:
             raw_owners = self._git_cli.get_file(path=owner_file["path"], ref=self._ref)
+            if not raw_owners:
+                _LOG.warning(f"{self._git_cli!s}:{owner_file['path']} not found")
+                continue
             try:
                 owners = yaml.safe_load(raw_owners.decode())
             except yaml.parser.ParserError:


### PR DESCRIPTION
Don't download the complete git repo file list.

`slack-usergroups` uses just the root level (`.`) `OWNERS` file but downloads a list of all files from the git repos. [clusterimagesets](https://gitlab.cee.redhat.com/service/clusterimagesets) has more than 31000 files, `get_repository_tree` receives the file catalog in 100 chunks. In total, ~310 HTTP requests, and each takes 1 second.


This fix reduces the runtime of a reconciliation loop by 6 minutes.