### PR TITLE
Catch null project

### DIFF
--- a/reconcile/gitlab_permissions.py
+++ b/reconcile/gitlab_permissions.py
@@ -79,6 +79,8 @@ class GroupPermissionHandler:
 
     def can_share_project(self, project: Project) -> bool:
         # check if user have access greater or equal access to be shared with the group
+        if not project:
+            return False
         try:
             user = project.members_all.get(id=self.gl.user.id)
         except GitlabGetError:


### PR DESCRIPTION
We can create new repos via app-interface. Gitlab-permissions will fail though, if a repo doesn't exist yet. This leads to a chicken-egg problem.

We introduce a skip on non-existing app-interface managed projects, whenever a new addition is detected in the diff.

Tested locally with failing tenant MR.