### PR TITLE
feat(cost-report): adjust thread pool size

### DIFF
--- a/tools/cli_commands/cost_report/aws.py
+++ b/tools/cli_commands/cost_report/aws.py
@@ -125,7 +125,7 @@ class AwsCostReportCommand:
         )
 
     @classmethod
-    def create(cls) -> Self:
+    def create(cls, thread_pool_size: int = THREAD_POOL_SIZE) -> Self:
         gql_api = gql.get_api()
         secret = fetch_cost_report_secret(gql_api)
         cost_management_api = CostManagementApi.create_from_secret(secret)
@@ -133,5 +133,5 @@ class AwsCostReportCommand:
             gql_api=gql_api,
             cost_management_api=cost_management_api,
             cost_management_console_base_url=secret["console_base_url"],
-            thread_pool_size=THREAD_POOL_SIZE,
+            thread_pool_size=thread_pool_size,
         )

--- a/tools/cli_commands/cost_report/openshift.py
+++ b/tools/cli_commands/cost_report/openshift.py
@@ -155,12 +155,12 @@ class OpenShiftCostReportCommand:
         )
 
     @classmethod
-    def create(cls) -> Self:
+    def create(cls, thread_pool_size: int = THREAD_POOL_SIZE) -> Self:
         gql_api = gql.get_api()
         secret = fetch_cost_report_secret(gql_api)
         cost_management_api = CostManagementApi.create_from_secret(secret)
         return cls(
             gql_api=gql_api,
             cost_management_api=cost_management_api,
-            thread_pool_size=THREAD_POOL_SIZE,
+            thread_pool_size=thread_pool_size,
         )

--- a/tools/cli_commands/cost_report/openshift_cost_optimization.py
+++ b/tools/cli_commands/cost_report/openshift_cost_optimization.py
@@ -176,12 +176,12 @@ class OpenShiftCostOptimizationReportCommand:
         return f"{round(response.amount)}{response.format}"
 
     @classmethod
-    def create(cls) -> Self:
+    def create(cls, thread_pool_size: int = THREAD_POOL_SIZE) -> Self:
         gql_api = gql.get_api()
         secret = fetch_cost_report_secret(gql_api)
         cost_management_api = CostManagementApi.create_from_secret(secret)
         return cls(
             gql_api=gql_api,
             cost_management_api=cost_management_api,
-            thread_pool_size=THREAD_POOL_SIZE,
+            thread_pool_size=thread_pool_size,
         )

--- a/tools/qontract_cli.py
+++ b/tools/qontract_cli.py
@@ -2771,22 +2771,27 @@ def alerts(ctx, file_path):
 
 @get.command()
 @click.pass_context
-def aws_cost_report(ctx):
-    command = AwsCostReportCommand.create()
+@thread_pool_size(default=5)
+def aws_cost_report(ctx, thread_pool_size):
+    command = AwsCostReportCommand.create(thread_pool_size=thread_pool_size)
     print(command.execute())
 
 
 @get.command()
 @click.pass_context
-def openshift_cost_report(ctx):
-    command = OpenShiftCostReportCommand.create()
+@thread_pool_size(default=5)
+def openshift_cost_report(ctx, thread_pool_size):
+    command = OpenShiftCostReportCommand.create(thread_pool_size=thread_pool_size)
     print(command.execute())
 
 
 @get.command()
 @click.pass_context
-def openshift_cost_optimization_report(ctx):
-    command = OpenShiftCostOptimizationReportCommand.create()
+@thread_pool_size(default=5)
+def openshift_cost_optimization_report(ctx, thread_pool_size):
+    command = OpenShiftCostOptimizationReportCommand.create(
+        thread_pool_size=thread_pool_size
+    )
     print(command.execute())
 
 

--- a/tools/test/test_qontract_cli.py
+++ b/tools/test/test_qontract_cli.py
@@ -145,7 +145,7 @@ def test_get_aws_cost_report(env_vars, mock_queries, mock_aws_cost_report_comman
 
     assert result.exit_code == 0
     assert result.output == "some report\n"
-    mock_aws_cost_report_command.create.assert_called_once_with()
+    mock_aws_cost_report_command.create.assert_called_once_with(thread_pool_size=5)
     mock_aws_cost_report_command.create.return_value.execute.assert_called_once_with()
 
 
@@ -169,7 +169,9 @@ def test_get_openshift_cost_report(
 
     assert result.exit_code == 0
     assert result.output == "some report\n"
-    mock_openshift_cost_report_command.create.assert_called_once_with()
+    mock_openshift_cost_report_command.create.assert_called_once_with(
+        thread_pool_size=5
+    )
     mock_openshift_cost_report_command.create.return_value.execute.assert_called_once_with()
 
 
@@ -193,5 +195,7 @@ def test_get_openshift_cost_optimization_report(
 
     assert result.exit_code == 0
     assert result.output == "some report\n"
-    mock_openshift_cost_optimization_report_command.create.assert_called_once_with()
+    mock_openshift_cost_optimization_report_command.create.assert_called_once_with(
+        thread_pool_size=5
+    )
     mock_openshift_cost_optimization_report_command.create.return_value.execute.assert_called_once_with()


### PR DESCRIPTION
This pull request introduces changes to allow the specification of a `thread_pool_size` parameter in various cost report command creation methods and updates the corresponding CLI commands and tests to support this new parameter.

Set default thread pool size to 5 instead of 10 when run in cli to reduce load on server.

[APPSRE-11357](https://issues.redhat.com/browse/APPSRE-11357)