### PR TITLE
skip target if deleted while assembling channels for promotion

### DIFF
--- a/reconcile/utils/saasherder/saasherder.py
+++ b/reconcile/utils/saasherder/saasherder.py
@@ -1023,6 +1023,8 @@ class SaasHerder:  # pylint: disable=too-many-public-methods
                 for target in tmpl.targets:
                     if not target.promotion:
                         continue
+                    if target.delete:
+                        continue
                     for publish in target.promotion.publish or []:
                         publisher_uid = target.uid(
                             parent_saas_file_name=saas_file.name,


### PR DESCRIPTION
In case of target marked as deleted and having a publish promotion..all the upcoming subscribe promotion will be blocked..as `_assemble_channels` will still consider the deleted target
fixes : https://issues.redhat.com/browse/APPSRE-11364