### PR TITLE
feat(cost-optimization-report): skip json table if no items

### DIFF
--- a/tools/cli_commands/cost_report/view.py
+++ b/tools/cli_commands/cost_report/view.py
@@ -127,6 +127,10 @@ TOTAL_COST = """\
 Total Cost: {total}
 """
 
+EMPTY_OPTIMIZATION = """\
+## {app_name}
+"""
+
 OPTIMIZATION = """\
 ## {app_name}
 
@@ -442,6 +446,10 @@ def render_openshift_cost_report(
 def render_optimization(
     report: OptimizationReport,
 ) -> str:
+    if not report.items:
+        return EMPTY_OPTIMIZATION.format(
+            app_name=report.app_name,
+        )
     items = [
         ViewOptimizationReportItem(
             namespace=f"{i.cluster}/{i.project}",

--- a/tools/cli_commands/test/fixtures/openshift_cost_optimization_report_without_items.md
+++ b/tools/cli_commands/test/fixtures/openshift_cost_optimization_report_without_items.md
@@ -1,0 +1,14 @@
+[TOC]
+
+# OpenShift Cost Optimization Report
+
+Report is generated for optimization enabled namespaces
+(`insights_cost_management_optimizations='true'` in namespace `labels`).
+
+In Cost optimizations, recommendations get generated when
+CPU usage is at or above the 60th percentile and
+memory usage is at the 100th percentile.
+
+View details in [Cost Management Optimizations](https://console.redhat.com/openshift/cost-management/optimizations).
+
+## app

--- a/tools/cli_commands/test/test_openshift_cost_optimization_report.py
+++ b/tools/cli_commands/test/test_openshift_cost_optimization_report.py
@@ -253,3 +253,20 @@ def test_openshift_cost_report_render(
     output = openshift_cost_optimization_report_command.render(reports)
 
     assert output == expected_output
+
+
+def test_openshift_cost_report_render_no_items(
+    openshift_cost_optimization_report_command: OpenShiftCostOptimizationReportCommand,
+    fx: Callable,
+) -> None:
+    expected_output = fx("openshift_cost_optimization_report_without_items.md")
+    reports = [
+        OptimizationReport(
+            app_name=APP.name,
+            items=[],
+        )
+    ]
+
+    output = openshift_cost_optimization_report_command.render(reports)
+
+    assert output == expected_output


### PR DESCRIPTION
This pull request introduces changes to handle cases where there are no items in the OpenShift cost optimization report. To save space and use less scrolls when reading report, render no table for app without actual items.

[APPSRE-10233](https://issues.redhat.com/browse/APPSRE-10233)