### PR TITLE
Proper DTP resource labels

### DIFF
--- a/reconcile/dynatrace_token_provider/integration.py
+++ b/reconcile/dynatrace_token_provider/integration.py
@@ -37,6 +37,7 @@ from reconcile.utils.ocm.base import (
     OCMServiceLogSeverity,
 )
 from reconcile.utils.ocm.labels import subscription_label_filter
+from reconcile.utils.openshift_resource import QONTRACT_ANNOTATION_INTEGRATION
 from reconcile.utils.runtime.integration import (
     NoParams,
     QontractReconcileIntegration,
@@ -574,6 +575,9 @@ class DynatraceTokenProviderIntegration(QontractReconcileIntegration[NoParams]):
                 "metadata": {
                     "name": secret.secret_name,
                     "namespace": secret.namespace_name,
+                    "annotations": {
+                        QONTRACT_ANNOTATION_INTEGRATION: QONTRACT_INTEGRATION,
+                    },
                 },
                 "data": data,
             })

--- a/reconcile/test/dynatrace_token_provider/fixtures.py
+++ b/reconcile/test/dynatrace_token_provider/fixtures.py
@@ -6,9 +6,11 @@ from unittest.mock import (
     create_autospec,
 )
 
+from reconcile.dynatrace_token_provider.integration import QONTRACT_INTEGRATION
 from reconcile.dynatrace_token_provider.model import K8sSecret
 from reconcile.dynatrace_token_provider.ocm import Cluster, OCMClient
 from reconcile.utils.dynatrace.client import DynatraceAPITokenCreated, DynatraceClient
+from reconcile.utils.openshift_resource import QONTRACT_ANNOTATION_INTEGRATION
 
 
 def tobase64(s: str) -> str:
@@ -35,6 +37,9 @@ def _build_secret_data(
             "metadata": {
                 "name": secret.secret_name,
                 "namespace": secret.namespace_name,
+                "annotations": {
+                    QONTRACT_ANNOTATION_INTEGRATION: QONTRACT_INTEGRATION,
+                },
             },
             "data": data,
         })


### PR DESCRIPTION
Follow-up on https://github.com/app-sre/qontract-reconcile/pull/4223

> to be a little consistent with standard qontract resource annotation, and to provide a hint on the Secret that lands on clusters as to what owns it.