### PR TITLE
:bug: service-dependencies: fix KeyError

### DIFF
--- a/reconcile/service_dependencies.py
+++ b/reconcile/service_dependencies.py
@@ -22,7 +22,7 @@ QONTRACT_INTEGRATION = "service-dependencies"
 
 def get_dependency_names(dependency_map: Mapping[Any, Any], dep_type: str) -> list[str]:
     dependency_maps = (dm for dm in dependency_map if dm["type"] == dep_type)
-    return [service["name"] for service in dependency_maps]
+    return [service["name"] for service in dependency_maps if "name" in service]
 
 
 def get_desired_dependency_names(


### PR DESCRIPTION
Fix

```
Traceback (most recent call last):
  File "/work/reconcile/cli.py", line 609, in run_class_integration
    run_integration_cfg(
  File "/work/reconcile/utils/runtime/runner.py", line 155, in run_integration_cfg
    _integration_dry_run(run_cfg.integration, desired_state_diff)
  File "/work/reconcile/utils/runtime/runner.py", line 226, in _integration_dry_run
    integration.run(True)
  File "/work/reconcile/utils/runtime/integration.py", line 315, in run
    self.params.module.run(dry_run, *self.params.args, **self.params.kwargs)
  File "/work/reconcile/service_dependencies.py", line 103, in run
    desired_deps = get_desired_dependency_names(app, dependency_map)
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/work/reconcile/service_dependencies.py", line 37, in get_desired_dependency_names
    required_dep_names.update(get_dependency_names(dependency_map, "gitlab"))
                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/work/reconcile/service_dependencies.py", line 25, in get_dependency_names
    return [service["name"] for service in dependency_maps]
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/work/reconcile/service_dependencies.py", line 25, in <listcomp>
    return [service["name"] for service in dependency_maps]
            ~~~~~~~^^^^^^^^
KeyError: 'name'
```