### PR TITLE
APPSRE-11389 annotate DTP version in secret too

### DIFF
--- a/reconcile/dynatrace_token_provider/integration.py
+++ b/reconcile/dynatrace_token_provider/integration.py
@@ -37,12 +37,17 @@ from reconcile.utils.ocm.base import (
     OCMServiceLogSeverity,
 )
 from reconcile.utils.ocm.labels import subscription_label_filter
-from reconcile.utils.openshift_resource import QONTRACT_ANNOTATION_INTEGRATION
+from reconcile.utils.openshift_resource import (
+    QONTRACT_ANNOTATION_INTEGRATION,
+    QONTRACT_ANNOTATION_INTEGRATION_VERSION,
+)
 from reconcile.utils.runtime.integration import (
     NoParams,
     QontractReconcileIntegration,
 )
+from reconcile.utils.semver_helper import make_semver
 
+QONTRACT_INTEGRATION_VERSION = make_semver(2, 0, 1)
 QONTRACT_INTEGRATION = "dynatrace-token-provider"
 SYNCSET_AND_MANIFEST_ID = "ext-dynatrace-tokens-dtp"
 
@@ -65,10 +70,11 @@ class DynatraceTokenProviderIntegration(QontractReconcileIntegration[NoParams]):
     def get_early_exit_desired_state(self, *args: Any, **kwargs: Any) -> dict[str, Any]:
         """Return the desired state for early exit."""
         return {
+            "version": QONTRACT_INTEGRATION_VERSION,
             "specs": {
                 spec.name: spec.dict()
                 for spec in get_dynatrace_token_provider_token_specs()
-            }
+            },
         }
 
     @property
@@ -577,6 +583,7 @@ class DynatraceTokenProviderIntegration(QontractReconcileIntegration[NoParams]):
                     "namespace": secret.namespace_name,
                     "annotations": {
                         QONTRACT_ANNOTATION_INTEGRATION: QONTRACT_INTEGRATION,
+                        QONTRACT_ANNOTATION_INTEGRATION_VERSION: QONTRACT_INTEGRATION_VERSION,
                     },
                 },
                 "data": data,

--- a/reconcile/test/dynatrace_token_provider/fixtures.py
+++ b/reconcile/test/dynatrace_token_provider/fixtures.py
@@ -6,11 +6,17 @@ from unittest.mock import (
     create_autospec,
 )
 
-from reconcile.dynatrace_token_provider.integration import QONTRACT_INTEGRATION
+from reconcile.dynatrace_token_provider.integration import (
+    QONTRACT_INTEGRATION,
+    QONTRACT_INTEGRATION_VERSION,
+)
 from reconcile.dynatrace_token_provider.model import K8sSecret
 from reconcile.dynatrace_token_provider.ocm import Cluster, OCMClient
 from reconcile.utils.dynatrace.client import DynatraceAPITokenCreated, DynatraceClient
-from reconcile.utils.openshift_resource import QONTRACT_ANNOTATION_INTEGRATION
+from reconcile.utils.openshift_resource import (
+    QONTRACT_ANNOTATION_INTEGRATION,
+    QONTRACT_ANNOTATION_INTEGRATION_VERSION,
+)
 
 
 def tobase64(s: str) -> str:
@@ -39,6 +45,7 @@ def _build_secret_data(
                 "namespace": secret.namespace_name,
                 "annotations": {
                     QONTRACT_ANNOTATION_INTEGRATION: QONTRACT_INTEGRATION,
+                    QONTRACT_ANNOTATION_INTEGRATION_VERSION: QONTRACT_INTEGRATION_VERSION,
                 },
             },
             "data": data,


### PR DESCRIPTION
Follow up on https://github.com/app-sre/qontract-reconcile/pull/4807

Lets also add the DTP version. This helps us to compare if a change actually lead to a reconcile in a secret.

Also adding version to early_exit dict. Not sure if it makes sense, as we always reconcile anyways on version bump w/o early_exit. But at the same time it doesnt harm to have it here.