### PR TITLE
:sparkles: qontract-cli erv2: force-unlock subcommand

### DIFF
--- a/tools/cli_commands/erv2.py
+++ b/tools/cli_commands/erv2.py
@@ -269,7 +269,6 @@ class Erv2Cli:
                     "--name",
                     "erv2-unlock",
                     "--rm",
-                    "-it",
                     "--mount",
                     f"type=bind,source={input_file!s},target=/inputs/input.json",
                     "--mount",


### PR DESCRIPTION
`qontract-cli external-resources force-unlock` subcommand to easily unlock an ERv2 terraform state.

Example usage:

```
$ qontract-cli --config config.prod.toml external-resources --provision-provider aws --provisioner app-sre --provider elasticache --identifier error-tracking-production force-unlock --lock-id 1234-1234-1234

  Preparing environment ... 0:00:01
Generated Terraform code for the stacks: CDKTF

Initializing the backend...

Successfully configured the backend "s3"! Terraform will automatically
use this backend unless the backend configuration changes.

...

The state has been unlocked, and Terraform commands should now be able to
obtain a new lock on the remote state.
```

Ticket: [APPSRE-11400](https://issues.redhat.com/browse/APPSRE-11400)