### PR TITLE
use qr oc base image 0.3.1 for FIPS

### DIFF
--- a/dockerfiles/Dockerfile
+++ b/dockerfiles/Dockerfile
@@ -78,11 +78,11 @@ CMD ["run-integration"]
 # STAGE 4 - fips-prod-image
 ###############################################################################
 FROM prod-image AS fips-prod-image
-ENV OC_VERSION=4.10.15
+ENV OC_VERSION=4.16.2
 
 # oc versions sometimes have issues with FIPS enabled systems requiring us to use specific
 # versions in these environments so in this case we extract an older version of oc and kubectl
-COPY --chown=0:0 --from=quay.io/app-sre/qontract-reconcile-oc:0.1.0 \
+COPY --chown=0:0 --from=quay.io/app-sre/qontract-reconcile-oc:0.3.1 \
     /work/${OC_VERSION}/ /usr/local/bin/
 
 


### PR DESCRIPTION
Use oc binary from 4.16 release.

https://docs.openshift.com/container-platform/4.16/release_notes/ocp-4-16-release-notes.html

Previously, when running a cluster with FIPS enabled, you might have received the following error when running the OpenShift CLI (oc) on a RHEL 9 system: FIPS mode is enabled, but the required OpenSSL backend is unavailable. With this release, the default version of OpenShift CLI (oc) is compiled with Red Hat Enterprise Linux (RHEL) 9 and works properly when running a cluster with FIPS enabled on RHEL 9. Additionally, a version of oc compiled with RHEL 8 is also provided, which must be used if you are running a cluster with FIPS enabled on RHEL 8. ([OCPBUGS-23386](https://issues.redhat.com/browse/OCPBUGS-23386), [OCPBUGS-28540](https://issues.redhat.com/browse/OCPBUGS-28540))