### PR TITLE
Temporary workaround for github 404 issues

### DIFF
--- a/reconcile/utils/github_api.py
+++ b/reconcile/utils/github_api.py
@@ -3,11 +3,7 @@ from pathlib import Path
 from types import TracebackType
 from urllib.parse import urlparse
 
-from github import (
-    Commit,
-    Github,
-    UnknownObjectException,
-)
+from github import Commit, Github, GithubException, UnknownObjectException
 from sretoolbox.utils import retry
 
 GH_BASE_URL = os.environ.get("GITHUB_API", "https://api.github.com")
@@ -75,6 +71,13 @@ class GithubRepositoryApi:
                 # -> for now staying backwards compatible
                 return None
             return content.decoded_content
+        except GithubException as e:
+            # handling a bug in the upstream GH library
+            # https://github.com/PyGithub/PyGithub/issues/3179
+            if e.status == 404:
+                return None
+            else:
+                raise e
         except UnknownObjectException:
             return None
 

--- a/uv.lock
+++ b/uv.lock
@@ -309,7 +309,7 @@ name = "click"
 version = "8.1.7"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "colorama", marker = "platform_system == 'Windows'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/96/d3/f04c7bfcf5c1862a2a5b845c6b2b360488cf47af55dfa79c98f6a6bf98b5/click-8.1.7.tar.gz", hash = "sha256:ca9853ad459e787e2192211578cc907e7594e294c7ccc834310722b41b9ca6de", size = 336121 }
 wheels = [
@@ -1699,7 +1699,7 @@ wheels = [
 
 [[package]]
 name = "qontract-reconcile"
-version = "0.10.2.dev25"
+version = "0.10.1.dev1229"
 source = { editable = "." }
 dependencies = [
     { name = "anymarkup" },
@@ -2539,7 +2539,7 @@ name = "tzlocal"
 version = "5.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "tzdata", marker = "sys_platform == 'win32'" },
+    { name = "tzdata", marker = "platform_system == 'Windows'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/04/d3/c19d65ae67636fe63953b20c2e4a8ced4497ea232c43ff8d01db16de8dc0/tzlocal-5.2.tar.gz", hash = "sha256:8d399205578f1a9342816409cc1e46a93ebd5755e39ea2d85334bea911bf0e6e", size = 30201 }
 wheels = [


### PR DESCRIPTION
Ref: https://redhat-internal.slack.com/archives/GGC2A0MS8/p1737664565157489

GitHub made an API change that broke PyGithub and thus caused lots of 404 errors that were unhandled by our code, see https://github.com/PyGithub/PyGithub/issues/3179

To resolve this, I did a temporary workaround that just checks the generic exception status to see if its a 404 and return `None`, keeping up the same return behavior our functions expect.