### PR TITLE
:sparkles: external-resources: elasticache service updates

### DIFF
--- a/reconcile/external_resources/aws.py
+++ b/reconcile/external_resources/aws.py
@@ -58,6 +58,8 @@ class AWSElasticacheFactory(AWSDefaultResourceFactory):
         if "replication_group_id" not in data:
             data["replication_group_id"] = spec.identifier
 
+        data["environment"] = spec.environment_type
+
         if cluster_mode := data.pop("cluster_mode", {}):
             for k, v in cluster_mode.items():
                 data[k] = v

--- a/reconcile/gql_definitions/external_resources/external_resources_namespaces.gql
+++ b/reconcile/gql_definitions/external_resources/external_resources_namespaces.gql
@@ -448,6 +448,7 @@ query ExternalResourcesNamespaces {
     }
     environment {
       name
+      labels
     }
     app {
       path

--- a/reconcile/gql_definitions/external_resources/external_resources_namespaces.py
+++ b/reconcile/gql_definitions/external_resources/external_resources_namespaces.py
@@ -505,6 +505,7 @@ query ExternalResourcesNamespaces {
     }
     environment {
       name
+      labels
     }
     app {
       path
@@ -1071,6 +1072,7 @@ class NamespaceTerraformProviderResourceAWSV1(NamespaceExternalResourceV1):
 
 class EnvironmentV1(ConfiguredBaseModel):
     name: str = Field(..., alias="name")
+    labels: str = Field(..., alias="labels")
 
 
 class AppV1(ConfiguredBaseModel):

--- a/reconcile/gql_definitions/fragments/saas_target_namespace.py
+++ b/reconcile/gql_definitions/fragments/saas_target_namespace.py
@@ -34,7 +34,7 @@ class SaasSecretParametersV1(ConfiguredBaseModel):
 
 class EnvironmentV1(ConfiguredBaseModel):
     name: str = Field(..., alias="name")
-    labels: Optional[Json] = Field(..., alias="labels")
+    labels: Json = Field(..., alias="labels")
     parameters: Optional[Json] = Field(..., alias="parameters")
     secret_parameters: Optional[list[SaasSecretParametersV1]] = Field(..., alias="secretParameters")
 

--- a/reconcile/gql_definitions/introspection.json
+++ b/reconcile/gql_definitions/introspection.json
@@ -16224,9 +16224,13 @@
                             "description": null,
                             "args": [],
                             "type": {
-                                "kind": "SCALAR",
-                                "name": "JSON",
-                                "ofType": null
+                                "kind": "NON_NULL",
+                                "name": null,
+                                "ofType": {
+                                    "kind": "SCALAR",
+                                    "name": "JSON",
+                                    "ofType": null
+                                }
                             },
                             "isDeprecated": false,
                             "deprecationReason": null

--- a/reconcile/gql_definitions/status_board/status_board.py
+++ b/reconcile/gql_definitions/status_board/status_board.py
@@ -119,7 +119,7 @@ class NamespaceV1(ConfiguredBaseModel):
 
 class EnvironmentV1(ConfiguredBaseModel):
     name: str = Field(..., alias="name")
-    labels: Optional[Json] = Field(..., alias="labels")
+    labels: Json = Field(..., alias="labels")
     product: ProductV1 = Field(..., alias="product")
     namespaces: Optional[list[NamespaceV1]] = Field(..., alias="namespaces")
 

--- a/reconcile/utils/external_resource_spec.py
+++ b/reconcile/utils/external_resource_spec.py
@@ -118,10 +118,8 @@ class ExternalResourceSpec:
 
     @property
     def environment_type(self) -> str:
-        try:
-            return json.loads(self.namespace["environment"]["labels"])["type"]
-        except KeyError:
-            return "production"
+        labels = json.loads(self.namespace["environment"]["labels"])
+        return labels.get("type", "production")
 
     @property
     def output_prefix(self) -> str:

--- a/reconcile/utils/external_resource_spec.py
+++ b/reconcile/utils/external_resource_spec.py
@@ -117,6 +117,13 @@ class ExternalResourceSpec:
         return self.namespace["cluster"]["name"]
 
     @property
+    def environment_type(self) -> str:
+        try:
+            return json.loads(self.namespace["environment"]["labels"])["type"]
+        except KeyError:
+            return "production"
+
+    @property
     def output_prefix(self) -> str:
         # Adhere to DNS-1123 subdomain names spec. It's reasonable to have provider
         # names that have underscores, but without replacing them with hyphens we run


### PR DESCRIPTION
Add service updates related fields to ERv2 AWS elasticache settings.

Depends on:
* https://github.com/app-sre/qontract-schemas/pull/760
* https://github.com/app-sre/er-aws-elasticache/pull/103

Ticket: [APPSRE-11432](https://issues.redhat.com/browse/APPSRE-11432)