### PR TITLE
:bug: honor jira board cache if dry-run mode runs over all boards

### DIFF
--- a/reconcile/jira_permissions_validator.py
+++ b/reconcile/jira_permissions_validator.py
@@ -217,7 +217,7 @@ def validate_boards(
                 continue
             # dry-run mode
             elif len(jira_boards) > 1:
-                # skip for MR checks if there are more than one board to test
+                logging.info(f"[{board.name}] Use cache results. Skipping ...")
                 continue
 
         logging.debug(f"[{board.name}] checking ...")

--- a/reconcile/jira_permissions_validator.py
+++ b/reconcile/jira_permissions_validator.py
@@ -2,7 +2,7 @@ import logging
 import random
 import sys
 import time
-from collections.abc import Callable, Iterable
+from collections.abc import Callable, Iterable, Sequence
 from enum import IntFlag, auto
 from typing import Any, TypedDict
 
@@ -199,7 +199,7 @@ def validate_boards(
     metrics_container: metrics.MetricsContainer,
     secret_reader: SecretReaderBase,
     jira_client_settings: JiraWatcherSettings | None,
-    jira_boards: Iterable[JiraBoardV1],
+    jira_boards: Sequence[JiraBoardV1],
     default_issue_type: str,
     default_reopen_state: str,
     board_check_interval_sec: int,
@@ -211,9 +211,14 @@ def validate_boards(
     jira_clients: dict[str, JiraClient] = {}
     for board in jira_boards:
         next_run_time = state.get(board.name, 0)
-        if not dry_run and time.time() <= next_run_time:
-            logging.debug(f"[{board.name}] Skipping board")
-            continue
+        if time.time() <= next_run_time:
+            if not dry_run:
+                # always skip for non-dry-run mode
+                continue
+            # dry-run mode
+            elif len(jira_boards) > 1:
+                # skip for MR checks if there are more than one board to test
+                continue
 
         logging.debug(f"[{board.name}] checking ...")
         if board.server.server_url not in jira_clients:


### PR DESCRIPTION
Typically, the MR checks run only for the new/updated Jira board. Use the Jira board cache in case of running the MR checks for all boards, e.g., during `qontract-reconcile` promotions.

This will avoid hitting the Jira rate limit during our promotions.