### PR TITLE
fix(jjb): validate job name

### DIFF
--- a/reconcile/utils/jjb_client.py
+++ b/reconcile/utils/jjb_client.py
@@ -186,7 +186,11 @@ class JJB:  # pylint: disable=too-many-public-methods
                 if equal:
                     continue
 
-            instance, item, _ = f.replace(replace_path + "/", "").split("/")
+            instance, *items, _ = f.replace(replace_path + "/", "").split("/")
+            if len(items) != 1:
+                name = "/".join(items)
+                raise ValueError(f"Invalid job name contains '/' in {instance}: {name}")
+            item = items[0]
             item_type = et.parse(f).getroot().tag
             item_type = item_type.replace("hudson.model.ListView", "view")
             item_type = item_type.replace("project", "job")


### PR DESCRIPTION
If jenkins job name contains `/` such as `group/subgroup-project-xxx`, generated jenkins `config.xml` is in nested dir, causing error

```
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/work/reconcile/jenkins_job_builder.py", line 103, in run
    jjb.print_diffs(io_dir, instance_name)
  File "/work/reconcile/utils/jjb_client.py", line 177, in print_diffs
    self.print_diff(create, desired_path, "create")
  File "/work/reconcile/utils/jjb_client.py", line 189, in print_diff
    instance, item, _ = f.replace(replace_path + "/", "").split("/")
    ^^^^^^^^^^^^^^^^^
ValueError: too many values to unpack (expected 3)
```

This PR validates job to ensure no `/` in name.

[APPSRE-11502](https://issues.redhat.com/browse/APPSRE-11502)