### PR TITLE
Add a qontract-cli command for getting logGroup usage from CloudWatch

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -1699,7 +1699,7 @@ wheels = [
 
 [[package]]
 name = "qontract-reconcile"
-version = "0.10.1.dev1235"
+version = "0.10.1.dev1251"
 source = { editable = "." }
 dependencies = [
     { name = "anymarkup" },


### PR DESCRIPTION
[APPSRE-11480](https://issues.redhat.com/browse/APPSRE-11480)

I tried fetching log group data via CloudWatch metrics but ran into limitations due to the vast number of log groups we have in our accounts. This is another approach which fetches the data from the AWS API and outputs it with the command.