### PR TITLE
perf(aws-api): init users using cached session client

### DIFF
--- a/reconcile/utils/aws_api.py
+++ b/reconcile/utils/aws_api.py
@@ -165,8 +165,6 @@ class AWSApi:
         self.init_sessions_and_resources(accounts)
         if init_ecr_auth_tokens:
             self.init_ecr_auth_tokens(accounts)
-        if init_users:
-            self.init_users()
         self._lock = Lock()
         self.resource_types: list[RESOURCE_TYPE] = [
             "s3",
@@ -196,6 +194,9 @@ class AWSApi:
         self.get_vpc_route_tables = lru_cache()(self.get_vpc_route_tables)  # type: ignore[method-assign]
         self.get_vpc_subnets = lru_cache()(self.get_vpc_subnets)  # type: ignore[method-assign]
         self._get_vpc_endpoints = lru_cache()(self._get_vpc_endpoints)  # type: ignore[method-assign]
+
+        if init_users:
+            self.init_users()
 
     def init_sessions_and_resources(self, accounts: Iterable[awsh.Account]) -> None:
         results = threaded.run(


### PR DESCRIPTION
`init_users` will call `get_session_client`, but cached version `get_session_client` was set after `init_users` call, which means all `iam` clients are not cached. This change moves it to the end of `__init__` to use cached methods.

Compare memory usage for `aws-support-cases-sos` integration:

[memray](https://github.com/bloomberg/memray) profile result compare:

before: 89.4 MiB

<img width="1707" alt="before" src="https://github.com/user-attachments/assets/c4ff4db7-1519-4bbb-9fd5-3d6bd7c2a4f6" />

after: 7.3 MiB

<img width="1708" alt="after" src="https://github.com/user-attachments/assets/3929c775-12e0-4096-9167-2bd1a6bbd6a5" />

Other integrations using aws api with `init_users=True` (default `True`) will also benefit from caching if `iam` client used later.

[APPSRE-11506](https://issues.redhat.com/browse/APPSRE-11506) 