### PR TITLE
APPSRE-11390 get cluster labels

### DIFF
--- a/reconcile/utils/ocm/labels.py
+++ b/reconcile/utils/ocm/labels.py
@@ -202,3 +202,15 @@ def get_org_labels(
 
 def build_organization_labels_href(org_id: str) -> str:
     return f"/api/accounts_mgmt/v1/organizations/{org_id}/labels"
+
+
+def get_cluster_labels_for_cluster_id(
+    ocm_api: OCMBaseClient,
+    id: str,
+) -> dict[str, str]:
+    data = ocm_api.get(
+        api_path=f"/api/clusters_mgmt/v1/clusters/{id}/external_configuration/labels"
+    )
+    return {
+        key: d.get("value") for d in data.get("items") or [] if (key := d.get("key"))
+    }


### PR DESCRIPTION
Simple call to get a dict of cluster labels via OCM client.

Note, that cluster label is very different from our existing labels. Cluster label does not contain any timestamp or type attribute. I.e., adding it as an `OCMLabel`, would require substantial change in the base class which might not be worth it for this effort.