### PR TITLE
:zap: external-resource: specify memory limits for outputs-secret container

### DIFF
--- a/reconcile/external_resources/reconciler.py
+++ b/reconcile/external_resources/reconciler.py
@@ -130,6 +130,10 @@ class ReconciliationK8sJob(K8sJob, BaseModel, frozen=True):
             name="outputs",
             image=self.reconciliation.module_configuration.outputs_secret_image_version,
             image_pull_policy="Always",
+            resources=V1ResourceRequirements(
+                requests={"memory": "128Mi"},
+                limits={"memory": "128Mi"},
+            ),
             env=[
                 V1EnvVar(
                     name="NAMESPACE",


### PR DESCRIPTION
We want to introduce memory-based quotas to avoid killing the k8s node. If needed, we can replace the hardcoded values with app-interface settings in the future

```
Error creating: pods "er-dry-run-mr-132420-02db23c11d-qhk6p" is forbidden: failed quota: external-resources-quota: must specify limits.memory for: outputs; requests.memory for: outputs
```

Ticket: [APPSRE-11514](https://issues.redhat.com/browse/APPSRE-11514)