### PR TITLE
[ERv2] add new commands to get credentials for debug

### DIFF
--- a/tools/qontract_cli.py
+++ b/tools/qontract_cli.py
@@ -4271,6 +4271,29 @@ def get_input(ctx: click.Context) -> None:
     print(erv2cli.input_data)
 
 
+def _get_external_resources_credentials(
+    secret_reader: SecretReader,
+    provisioner: str,
+) -> str:
+    return secret_reader.read_with_parameters(
+        path=f"app-sre/external-resources/{provisioner}",
+        field="credentials",
+        format=None,
+        version=None,
+    )
+
+
+@external_resources.command()
+@click.pass_context
+def get_credentials(ctx: click.Context) -> None:
+    """Gets credentials file used in external-resources as AWS_SHARED_CREDENTIALS_FILE"""
+    credentials = _get_external_resources_credentials(
+        secret_reader=ctx.obj["secret_reader"],
+        provisioner=ctx.obj["provisioner"],
+    )
+    print(credentials)
+
+
 @external_resources.command()
 @click.pass_context
 def request_reconciliation(ctx: click.Context) -> None:
@@ -4333,11 +4356,9 @@ def migrate(ctx: click.Context, dry_run: bool, skip_build: bool) -> None:
             # prepare AWS credentials for CDKTF and local terraform
             credentials_file = tempdir / "credentials"
             credentials_file.write_text(
-                ctx.obj["secret_reader"].read_with_parameters(
-                    path=f"app-sre/external-resources/{ctx.obj['provisioner']}",
-                    field="credentials",
-                    format=None,
-                    version=None,
+                _get_external_resources_credentials(
+                    secret_reader=ctx.obj["secret_reader"],
+                    provisioner=ctx.obj["provisioner"],
                 )
             )
         os.environ["AWS_SHARED_CREDENTIALS_FILE"] = str(credentials_file)
@@ -4415,11 +4436,9 @@ def debug_shell(ctx: click.Context) -> None:
             with task(progress, "Preparing environment ..."):
                 credentials_file = tempdir / "credentials"
                 credentials_file.write_text(
-                    ctx.obj["secret_reader"].read_with_parameters(
-                        path=f"app-sre/external-resources/{ctx.obj['provisioner']}",
-                        field="credentials",
-                        format=None,
-                        version=None,
+                    _get_external_resources_credentials(
+                        secret_reader=ctx.obj["secret_reader"],
+                        provisioner=ctx.obj["provisioner"],
                     )
                 )
             os.environ["AWS_SHARED_CREDENTIALS_FILE"] = str(credentials_file)
@@ -4456,11 +4475,9 @@ def force_unlock(ctx: click.Context, lock_id: str) -> None:
             with task(progress, "Preparing environment ..."):
                 credentials_file = tempdir / "credentials"
                 credentials_file.write_text(
-                    ctx.obj["secret_reader"].read_with_parameters(
-                        path=f"app-sre/external-resources/{ctx.obj['provisioner']}",
-                        field="credentials",
-                        format=None,
-                        version=None,
+                    _get_external_resources_credentials(
+                        secret_reader=ctx.obj["secret_reader"],
+                        provisioner=ctx.obj["provisioner"],
                     )
                 )
             os.environ["AWS_SHARED_CREDENTIALS_FILE"] = str(credentials_file)


### PR DESCRIPTION
This pull request to `tools/qontract_cli.py` and `tools/test/test_qontract_cli.py` introduces a new function for fetching external resource credentials and refactors existing code to use this new function. Additionally, new tests are added to ensure the functionality works as expected.

Example usage

```shell
qontract-cli --config $CONFIG external-resources --provisioner $PROVISIONER --provider $PROVIDER --identifier $IDENTIFIER get-credentials
```

### New Functionality:
* Added `_get_external_resources_credentials` function to fetch external resource credentials.

### Refactoring:
* Refactored `migrate`, `debug_shell`, and `force_unlock` functions to use the new `_get_external_resources_credentials` function instead of directly reading credentials. [[1]](diffhunk://#diff-b578cd66cb4dad72a0138f86ff8b6e4c241eb0850381f1d8cf3133a651c281f9L4336-R4361) [[2]](diffhunk://#diff-b578cd66cb4dad72a0138f86ff8b6e4c241eb0850381f1d8cf3133a651c281f9L4418-R4441) [[3]](diffhunk://#diff-b578cd66cb4dad72a0138f86ff8b6e4c241eb0850381f1d8cf3133a651c281f9L4459-R4480)

### Testing:
* Added new fixtures `mock_get_app_interface_vault_settings` and `mock_create_secret_reader` to `tools/test/test_qontract_cli.py`.
* Added a new test `test_external_resources_get_credentials` to verify the `get_credentials` command functionality.