### PR TITLE
APPSRE9086 - Error handling on rds upgrades

### DIFF
--- a/reconcile/utils/terraform_client.py
+++ b/reconcile/utils/terraform_client.py
@@ -716,6 +716,14 @@ class TerraformClient:  # pylint: disable=too-many-public-methods
                 response = self._aws_api.describe_rds_db_instance(
                     account_name, resource_name, region_name=region_name
                 )
+                if len(response["DBInstances"][0].get("ReadReplicaDBInstanceIdentifiers")) > 0:
+                    replica_db = response["DBInstances"][0].get("ReadReplicaDBInstanceIdentifiers")[0]
+                    replica_db_response = self._aws_api.describe_rds_db_instance(
+                        account_name, replica_db, region_name=region_name
+                    )
+                    replica_db_engine_version = replica_db_response["DBInstances"][0].get("EngineVersion")
+                    if after.get("engine_version") > replica_db_engine_version:
+                        raise RdsUpgradeValidationError("The replica database is running a previous version from the primary and needs to have an upgrade first.")
             except ClientError as e:
                 # The RDS database might have been already removed, or there was
                 # a resource name change, and we no longer use valid references.


### PR DESCRIPTION
This is to catch a DB upgrade dependency error that isn't caught until after an upgrade MR is made: `DBUpgradeDependencyFailure: One or more of the DB Instance's read replicas need to be upgraded`