### PR TITLE
:bug: aws-version-sync: compare final engine version strings

### DIFF
--- a/reconcile/aws_version_sync/integration.py
+++ b/reconcile/aws_version_sync/integration.py
@@ -359,8 +359,8 @@ class AVSIntegration(QontractReconcileIntegration[AVSIntegrationParams]):
             desired=external_resources_aws,
             key=lambda r: r.key,
             equal=lambda external_resources_app_interface,
-            external_resources_aws: external_resources_app_interface.resource_engine_version
-            == external_resources_aws.resource_engine_version,
+            external_resources_aws: external_resources_app_interface.resource_engine_version_string
+            == external_resources_aws.resource_engine_version_string,
         )
         for diff_pair in diff.change.values():
             aws_resource = diff_pair.desired


### PR DESCRIPTION
AVS needs to compare the formatted engine version strings and not the "raw" values. For example, ElastiCache 6+ reports `MAJOR.MINOR.PATCH` but the AWS API (and app-interface) must use `MAJOR.MINOR`.
This will avoid those [MRs](https://gitlab.cee.redhat.com/service/app-interface/-/merge_requests/133434)

Ticket: [APPSRE-11542](https://issues.redhat.com/browse/APPSRE-11542)