### PR TITLE
🐛  BugFix: Force destroy access_logs buckets

### DIFF
--- a/reconcile/utils/terrascript_aws_client.py
+++ b/reconcile/utils/terrascript_aws_client.py
@@ -5295,6 +5295,7 @@ class TerrascriptClient:  # pylint: disable=too-many-public-methods
             lb_access_logs_s3_bucket_values = {
                 "provider": provider,
                 "bucket": bucket_identifier,
+                "force_destroy": True,
             }
             lb_access_logs_s3_bucket_tf_resource = aws_s3_bucket(
                 bucket_identifier, **lb_access_logs_s3_bucket_values


### PR DESCRIPTION
When the tenant removes the `access_lotg: true` from the ALB resource in `app-interface` the integration fails to remove the bucket because the log files are still present.

This forces the deletion of the bucket along with all the log files.