### PR TITLE
APPSRE-11390 fleet labeler - handle new spec files

### DIFF
--- a/reconcile/fleet_labeler/dependencies.py
+++ b/reconcile/fleet_labeler/dependencies.py
@@ -27,10 +27,12 @@ class Dependencies:
         label_specs_by_name: Mapping[str, FleetLabelsSpecV1],
         ocm_clients_by_label_spec_name: Mapping[str, OCMClient],
         vcs: VCS,
+        dry_run: bool,
     ):
         self.label_specs_by_name = label_specs_by_name
         self.ocm_clients_by_label_spec_name = ocm_clients_by_label_spec_name
         self.vcs = vcs
+        self.dry_run = dry_run
 
     @classmethod
     def create(
@@ -42,6 +44,7 @@ class Dependencies:
             label_specs_by_name=_label_specs(),
             ocm_clients_by_label_spec_name=_ocm_clients(secret_reader=secret_reader),
             vcs=_vcs(secret_reader=secret_reader, dry_run=dry_run),
+            dry_run=dry_run,
         )
 
 

--- a/reconcile/fleet_labeler/integration.py
+++ b/reconcile/fleet_labeler/integration.py
@@ -203,7 +203,7 @@ class FleetLabelerIntegration(QontractReconcileIntegration[NoParams]):
         # If the content exists in main, then it doesnt harm to also run the rendering procedure.
         try:
             current_content = vcs.get_file_content_from_main(path=spec.path)
-        except Gitlab404Error as e:
+        except Gitlab404Error:
             if dry_run:
                 logging.info(
                     f"The file data{spec.path} does not exist in main branch yet. This is likely because it is being created with this MR. We are skipping rendering steps."
@@ -211,7 +211,7 @@ class FleetLabelerIntegration(QontractReconcileIntegration[NoParams]):
                 return
             # 404 must never happen on non-dry-run, as the file must have already passed
             # MR check and must have been merged to main
-            raise e
+            raise
 
         # Lets make sure we are deterministic when adding new clusters
         # The overhead is neglectable and it makes testing easier

--- a/reconcile/fleet_labeler/integration.py
+++ b/reconcile/fleet_labeler/integration.py
@@ -16,7 +16,7 @@ from reconcile.fleet_labeler.meta import (
 from reconcile.fleet_labeler.metrics import FleetLabelerDuplicateClusterMatchesGauge
 from reconcile.fleet_labeler.ocm import OCMClient
 from reconcile.fleet_labeler.validate import validate_label_specs
-from reconcile.fleet_labeler.vcs import VCS
+from reconcile.fleet_labeler.vcs import VCS, Gitlab404Error
 from reconcile.gql_definitions.fleet_labeler.fleet_labels import (
     FleetLabelDefaultV1,
     FleetLabelsSpecV1,
@@ -60,7 +60,10 @@ class FleetLabelerIntegration(QontractReconcileIntegration[NoParams]):
         validate_label_specs(specs=dependencies.label_specs_by_name)
         for spec_name, ocm in dependencies.ocm_clients_by_label_spec_name.items():
             self._sync_cluster_inventory(
-                ocm, dependencies.label_specs_by_name[spec_name], dependencies.vcs
+                ocm=ocm,
+                spec=dependencies.label_specs_by_name[spec_name],
+                vcs=dependencies.vcs,
+                dry_run=dependencies.dry_run,
             )
 
     def _render_default_labels(
@@ -112,7 +115,11 @@ class FleetLabelerIntegration(QontractReconcileIntegration[NoParams]):
             return stream.getvalue()
 
     def _sync_cluster_inventory(
-        self, ocm: OCMClient, spec: FleetLabelsSpecV1, vcs: VCS
+        self,
+        ocm: OCMClient,
+        spec: FleetLabelsSpecV1,
+        vcs: VCS,
+        dry_run: bool,
     ) -> None:
         class ClusterData(BaseModel):
             """
@@ -189,7 +196,23 @@ class FleetLabelerIntegration(QontractReconcileIntegration[NoParams]):
                 f"[{spec.name}] Deleting cluster {cluster_id=} from inventory."
             )
 
-        current_content = vcs.get_file_content_from_main(path=spec.path)
+        # When adding a new label spec file, then we dont have any existing content in main yet.
+        # This is a chicken-egg problem, but if we are in dry-run we can skip these steps on 404s.
+        # Note, that the diff is already printed above, so we can make a good decision if desired
+        # content fits.
+        # If the content exists in main, then it doesnt harm to also run the rendering procedure.
+        try:
+            current_content = vcs.get_file_content_from_main(path=spec.path)
+        except Gitlab404Error as e:
+            if dry_run:
+                logging.info(
+                    f"The file data{spec.path} does not exist in main branch yet. This is likely because it is being created with this MR. We are skipping rendering steps."
+                )
+                return
+            # 404 must never happen on non-dry-run, as the file must have already passed
+            # MR check and must have been merged to main
+            raise e
+
         # Lets make sure we are deterministic when adding new clusters
         # The overhead is neglectable and it makes testing easier
         sorted_clusters_to_add = sorted(clusters_to_add, key=lambda c: c.name)

--- a/reconcile/fleet_labeler/vcs.py
+++ b/reconcile/fleet_labeler/vcs.py
@@ -23,7 +23,7 @@ class VCS:
             )
         except GitlabGetError as e:
             if e.response_code != 404:
-                raise e
+                raise
             raise Gitlab404Error(
                 f"File at ${path} does not exist yet in main branch. Maybe it is just being created with this MR?"
             ) from e

--- a/reconcile/fleet_labeler/vcs.py
+++ b/reconcile/fleet_labeler/vcs.py
@@ -1,5 +1,11 @@
+from gitlab.exceptions import GitlabGetError
+
 from reconcile.fleet_labeler.merge_request import FleetLabelerUpdates
 from reconcile.utils.vcs import VCS as VCSBase
+
+
+class Gitlab404Error(Exception):
+    pass
 
 
 class VCS:
@@ -11,9 +17,16 @@ class VCS:
         self._vcs = vcs
 
     def get_file_content_from_main(self, path: str) -> str:
-        return self._vcs.get_file_content_from_app_interface_ref(
-            file_path=path, ref="main"
-        )
+        try:
+            return self._vcs.get_file_content_from_app_interface_ref(
+                file_path=path, ref="main"
+            )
+        except GitlabGetError as e:
+            if e.response_code != 404:
+                raise e
+            raise Gitlab404Error(
+                f"File at ${path} does not exist yet in main branch. Maybe it is just being created with this MR?"
+            ) from e
 
     def open_merge_request(self, path: str, content: str) -> None:
         mr = FleetLabelerUpdates(path=path, content=content)

--- a/reconcile/test/fleet_labeler/conftest.py
+++ b/reconcile/test/fleet_labeler/conftest.py
@@ -62,4 +62,5 @@ def dependencies(secret_reader: SecretReaderBase) -> Dependencies:
         label_specs_by_name={},
         ocm_clients_by_label_spec_name={},
         vcs=create_autospec(spec=VCS),
+        dry_run=False,
     )

--- a/reconcile/test/fleet_labeler/fixtures.py
+++ b/reconcile/test/fleet_labeler/fixtures.py
@@ -33,9 +33,12 @@ def build_cluster(
     )
 
 
-def build_vcs(content: str = "") -> Mock:
+def build_vcs(content: str = "", error: Exception | None = None) -> Mock:
     vcs = create_autospec(spec=VCS)
-    vcs.get_file_content_from_main.return_value = content
+    if error:
+        vcs.get_file_content_from_main.side_effect = error
+    else:
+        vcs.get_file_content_from_main.return_value = content
     return vcs
 
 

--- a/reconcile/test/fleet_labeler/test_fleet_labeler_dry_run.py
+++ b/reconcile/test/fleet_labeler/test_fleet_labeler_dry_run.py
@@ -1,0 +1,121 @@
+from collections.abc import Callable
+
+import pytest
+
+from reconcile.fleet_labeler.dependencies import Dependencies
+from reconcile.fleet_labeler.integration import (
+    FleetLabelerIntegration,
+)
+from reconcile.fleet_labeler.vcs import Gitlab404Error
+from reconcile.gql_definitions.fleet_labeler.fleet_labels import (
+    FleetLabelsSpecV1,
+)
+from reconcile.test.fleet_labeler.fixtures import (
+    build_cluster,
+    build_ocm_client,
+    build_vcs,
+    label_spec_data_from_fixture,
+)
+
+
+def test_fleet_labeler_dry_run_new_file_spec(
+    integration: FleetLabelerIntegration,
+    dependencies: Dependencies,
+    gql_class_factory: Callable[..., FleetLabelsSpecV1],
+) -> None:
+    """
+    We are in dry-run mode.
+    OCM API returns 1 cluster.
+    The VCS returns 404 for current content, because the file is new and not in main yet.
+
+    We expect the MR to pass gently, without calling further VCS operations.
+    """
+    dependencies.vcs = build_vcs(error=Gitlab404Error())
+    dependencies.dry_run = True
+    spec = gql_class_factory(
+        FleetLabelsSpecV1, label_spec_data_from_fixture("0_clusters.yaml")
+    )
+    dependencies.label_specs_by_name = {spec.name: spec}
+    dependencies.ocm_clients_by_label_spec_name = {
+        spec.name: build_ocm_client(
+            discover_clusters_by_labels=[
+                build_cluster(
+                    name="cluster_name",
+                    cluster_id="cluster_id",
+                    subscription_labels={"sre-capabilities.dtp.managed-labels": "true"},
+                ),
+            ],
+        )
+    }
+
+    integration.reconcile(dependencies=dependencies)
+
+    dependencies.vcs.open_merge_request.assert_not_called()
+
+
+def test_fleet_labeler_no_dry_run_new_spec(
+    integration: FleetLabelerIntegration,
+    dependencies: Dependencies,
+    gql_class_factory: Callable[..., FleetLabelsSpecV1],
+) -> None:
+    """
+    We are not in dry-run mode.
+    OCM API returns 1 cluster.
+    The VCS returns 404 for current content.
+
+    We expect the run to fail, since in no dry-run mode we should never see 404.
+    """
+    dependencies.vcs = build_vcs(error=Gitlab404Error())
+    dependencies.dry_run = False
+    spec = gql_class_factory(
+        FleetLabelsSpecV1, label_spec_data_from_fixture("0_clusters.yaml")
+    )
+    dependencies.label_specs_by_name = {spec.name: spec}
+    dependencies.ocm_clients_by_label_spec_name = {
+        spec.name: build_ocm_client(
+            discover_clusters_by_labels=[
+                build_cluster(
+                    name="cluster_name",
+                    cluster_id="cluster_id",
+                    subscription_labels={"sre-capabilities.dtp.managed-labels": "true"},
+                ),
+            ],
+        )
+    }
+
+    with pytest.raises(Gitlab404Error):
+        integration.reconcile(dependencies=dependencies)
+
+
+def test_fleet_labeler_dry_run_other_error(
+    integration: FleetLabelerIntegration,
+    dependencies: Dependencies,
+    gql_class_factory: Callable[..., FleetLabelsSpecV1],
+) -> None:
+    """
+    We are in dry-run mode.
+    OCM API returns 1 cluster.
+    The VCS returns some none 404 error for current content.
+
+    We expect the run to fail, since we should only catch 404s in dry-run mode.
+    """
+    dependencies.vcs = build_vcs(error=Exception())
+    dependencies.dry_run = True
+    spec = gql_class_factory(
+        FleetLabelsSpecV1, label_spec_data_from_fixture("0_clusters.yaml")
+    )
+    dependencies.label_specs_by_name = {spec.name: spec}
+    dependencies.ocm_clients_by_label_spec_name = {
+        spec.name: build_ocm_client(
+            discover_clusters_by_labels=[
+                build_cluster(
+                    name="cluster_name",
+                    cluster_id="cluster_id",
+                    subscription_labels={"sre-capabilities.dtp.managed-labels": "true"},
+                ),
+            ],
+        )
+    }
+
+    with pytest.raises(Exception):
+        integration.reconcile(dependencies=dependencies)


### PR DESCRIPTION
We must handle newly created fleet labeler spec files, which are not in main branch yet.

Since these files are not in main branch, we cannot fetch their current content from VCS. If we are in dry-run and hit a 404 on a vcs fetch, then this is very likely because we are adding a new spec file. In that case we can skip the rendering steps, as the desired diff has already been printed before.
We could also skip the rendering altogether in dry-run, however, most MRs will be on existing files. Having the rendering procedure run on those adds extra certainty in MR check, which is why we should keep it for dry-run.

If we are not in dry-run or receive any other non 404 error, then the integration should still fail.