### PR TITLE
update tf-repo dashboard to sort log lines oldest first

### DIFF
--- a/grafana-dashboards/grafana-dashboard-terraform-repo.yaml
+++ b/grafana-dashboards/grafana-dashboard-terraform-repo.yaml
@@ -181,7 +181,7 @@ data:
             "showCommonLabels": false,
             "showLabels": false,
             "showTime": true,
-            "sortOrder": "Descending",
+            "sortOrder": "Ascending",
             "wrapLogMessage": true
           },
           "targets": [
@@ -433,7 +433,7 @@ data:
         "list": [
           {
             "current": {
-              "selected": true,
+              "selected": false,
               "text": "appsrep09ue1-prometheus",
               "value": "P7B77307D2CE073BC"
             },
@@ -452,9 +452,9 @@ data:
           {
             "allValue": ".+",
             "current": {
-              "selected": true,
-              "text": "tf-repo-push-deploy-pipelinerungn2k9",
-              "value": "tf-repo-push-deploy-pipelinerungn2k9"
+              "selected": false,
+              "text": "All",
+              "value": "$__all"
             },
             "datasource": {
               "type": "prometheus",
@@ -471,7 +471,7 @@ data:
               "query": "label_values(kube_pod_info{namespace=\"terraform-repo-production\", pod=~\"tf-repo.+\"},pod)",
               "refId": "PrometheusVariableQueryEditor-VariableQuery"
             },
-            "refresh": 1,
+            "refresh": 2,
             "regex": "/(tf-repo-push-deploy-pipelinerun.+)-tf-executor/",
             "skipUrlSync": false,
             "sort": 1,


### PR DESCRIPTION
Updates the Grafana dashboard from Terraform Repo to display log lines as oldest first and update the pipelinerun variable to refresh on dashboard time range update:
![image](https://github.com/user-attachments/assets/ff2def98-e9b8-462a-802e-932c2de22e30)

Thanks @hemslo for the tip!