### PR TITLE
fix(aus): expose matching remaining soak days for addon

### DIFF
--- a/reconcile/aus/ocm_addons_upgrade_scheduler_org.py
+++ b/reconcile/aus/ocm_addons_upgrade_scheduler_org.py
@@ -88,7 +88,8 @@ class OCMAddonsUpgradeSchedulerOrgIntegration(
                     addon_id=addon_id,
                     integration=self.name,
                 ).get(
-                    org_upgrade_spec.org.environment.name, org_upgrade_spec.org.org_id
+                    addon_org_upgrade_spec.org.environment.name,
+                    addon_org_upgrade_spec.org.org_id,
                 )
 
                 addon_current_state: list[AddonUpgradePolicy] = [
@@ -98,13 +99,13 @@ class OCMAddonsUpgradeSchedulerOrgIntegration(
                 ]
 
                 self.expose_remaining_soak_day_metrics(
-                    org_upgrade_spec=org_upgrade_spec,
+                    org_upgrade_spec=addon_org_upgrade_spec,
                     version_data=version_data,
                     current_state=addon_current_state,
                     metrics_builder=functools.partial(
                         AUSAddonVersionRemainingSoakDaysGauge,
                         integration=self.name,
-                        ocm_env=org_upgrade_spec.org.environment.name,
+                        ocm_env=addon_org_upgrade_spec.org.environment.name,
                         addon=addon_id,
                     ),
                 )


### PR DESCRIPTION
`aus_addon_version_remaining_soak_days` metric is broken when multiple addons in one cluster, when exposing metrics, `org_upgrade_spec` (with all addons) was used, expect to expose per addon (`addon_org_upgrade_spec`).

This PR changes all usages in addons iteration to use `addon_org_upgrade_spec` to avoid confusion.

[APPSRE-11549](https://issues.redhat.com/browse/APPSRE-11549)

