### PR TITLE
Module overrides should trigger reconciliations

### DIFF
--- a/reconcile/external_resources/manager.py
+++ b/reconcile/external_resources/manager.py
@@ -145,10 +145,10 @@ class ExternalResourcesManager:
             reconciliation.module_configuration.reconcile_drift_interval_minutes * 60
         )
 
-    def _reconciliation_module_config_overriden(
+    def _reconciliation_module_config_overridden(
         self, reconciliation: Reconciliation, state: ExternalResourceState
     ) -> bool:
-        return reconciliation.module_configuration.overriden and (
+        return reconciliation.module_configuration.overridden and (
             reconciliation.module_configuration.image_version
             != state.reconciliation.module_configuration.image_version
         )
@@ -160,7 +160,7 @@ class ExternalResourcesManager:
             reconciliation.action == Action.APPLY
             and (
                 self._resource_spec_changed(reconciliation, state)
-                or self._reconciliation_module_config_overriden(reconciliation, state)
+                or self._reconciliation_module_config_overridden(reconciliation, state)
             )
         ) or (
             reconciliation.action == Action.DESTROY
@@ -185,10 +185,10 @@ class ExternalResourcesManager:
                         reconciliation, state
                     ):
                         return ReconcileAction.APPLY_DRIFT_DETECTION
-                    elif self._reconciliation_module_config_overriden(
+                    elif self._reconciliation_module_config_overridden(
                         reconciliation, state
                     ):
-                        return ReconcileAction.APPLY_MODULE_CONFIG_OVERRIDEN
+                        return ReconcileAction.APPLY_MODULE_CONFIG_OVERRIDDEN
         elif reconciliation.action == Action.DESTROY:
             match state.resource_status:
                 case ResourceStatus.CREATED:

--- a/reconcile/external_resources/model.py
+++ b/reconcile/external_resources/model.py
@@ -263,7 +263,7 @@ class ExternalResourceModuleConfiguration(BaseModel, frozen=True):
     outputs_secret_image: str = ""
     outputs_secret_version: str = ""
     resources: Resources = Resources()
-    overriden: bool = Field(default=False, exclude=True)
+    overridden: bool = Field(default=False, exclude=True)
 
     @property
     def image_version(self) -> str:
@@ -280,7 +280,7 @@ class ExternalResourceModuleConfiguration(BaseModel, frozen=True):
         settings: ExternalResourcesSettingsV1,
     ) -> "ExternalResourceModuleConfiguration":
         module_overrides = spec.metadata.get("module_overrides")
-        overriden = module_overrides is not None
+        overridden = module_overrides is not None
 
         if module_overrides is None:
             module_overrides = ExternalResourcesModuleOverrides(
@@ -310,7 +310,7 @@ class ExternalResourceModuleConfiguration(BaseModel, frozen=True):
                 or module.resources
                 or settings.module_default_resources
             ),
-            overriden=overriden,
+            overridden=overridden,
         )
 
 
@@ -362,7 +362,7 @@ class ReconcileAction(StrEnum):
     APPLY_SPEC_CHANGED = "Resource spec has changed"
     APPLY_DRIFT_DETECTION = "Resource drift detection run"
     APPLY_USER_REQUESTED = "Resource reconciliation requested"
-    APPLY_MODULE_CONFIG_OVERRIDEN = "Module configuration overriden"
+    APPLY_MODULE_CONFIG_OVERRIDDEN = "Module configuration overridden"
     DESTROY_CREATED = "Resource no longer exists in the configuration"
     DESTROY_ERROR = "Resource status in ERROR state"
 

--- a/reconcile/external_resources/model.py
+++ b/reconcile/external_resources/model.py
@@ -7,7 +7,7 @@ from collections.abc import ItemsView, Iterable, Iterator, MutableMapping
 from enum import StrEnum
 from typing import Any
 
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 from reconcile.external_resources.meta import (
     FLAG_DELETE_RESOURCE,
@@ -263,6 +263,7 @@ class ExternalResourceModuleConfiguration(BaseModel, frozen=True):
     outputs_secret_image: str = ""
     outputs_secret_version: str = ""
     resources: Resources = Resources()
+    overriden: bool = Field(default=False, exclude=True)
 
     @property
     def image_version(self) -> str:
@@ -278,17 +279,19 @@ class ExternalResourceModuleConfiguration(BaseModel, frozen=True):
         spec: ExternalResourceSpec,
         settings: ExternalResourcesSettingsV1,
     ) -> "ExternalResourceModuleConfiguration":
-        module_overrides = spec.metadata.get(
-            "module_overrides"
-        ) or ExternalResourcesModuleOverrides(
-            module_type=None,
-            image=None,
-            version=None,
-            reconcile_timeout_minutes=None,
-            outputs_secret_image=None,
-            outputs_secret_version=None,
-            resources=None,
-        )
+        module_overrides = spec.metadata.get("module_overrides")
+        overriden = module_overrides is not None
+
+        if module_overrides is None:
+            module_overrides = ExternalResourcesModuleOverrides(
+                module_type=None,
+                image=None,
+                version=None,
+                reconcile_timeout_minutes=None,
+                outputs_secret_image=None,
+                outputs_secret_version=None,
+                resources=None,
+            )
 
         return ExternalResourceModuleConfiguration(
             image=module_overrides.image or module.image,
@@ -307,6 +310,7 @@ class ExternalResourceModuleConfiguration(BaseModel, frozen=True):
                 or module.resources
                 or settings.module_default_resources
             ),
+            overriden=overriden,
         )
 
 
@@ -358,6 +362,7 @@ class ReconcileAction(StrEnum):
     APPLY_SPEC_CHANGED = "Resource spec has changed"
     APPLY_DRIFT_DETECTION = "Resource drift detection run"
     APPLY_USER_REQUESTED = "Resource reconciliation requested"
+    APPLY_MODULE_CONFIG_OVERRIDEN = "Module configuration overriden"
     DESTROY_CREATED = "Resource no longer exists in the configuration"
     DESTROY_ERROR = "Resource status in ERROR state"
 


### PR DESCRIPTION
When overriding a module configuration: 
* The associated MR must run the DRY_RUN reconciliation. 
* When merged, the resource must be reconciled.  

This only applies with module_overrides, not when updating the default module versions. 