### PR TITLE
APPSRE-11390 store subscription_id in inventory

### DIFF
--- a/reconcile/fleet_labeler/integration.py
+++ b/reconcile/fleet_labeler/integration.py
@@ -104,6 +104,7 @@ class FleetLabelerIntegration(QontractReconcileIntegration[NoParams]):
             {
                 "name": cluster.name,
                 "clusterId": cluster.cluster_id,
+                "subscriptionId": cluster.subscription_id,
                 "serverUrl": cluster.server_url,
                 "subscriptionLabels": cluster.subscription_labels_content,
             }
@@ -128,6 +129,7 @@ class FleetLabelerIntegration(QontractReconcileIntegration[NoParams]):
 
             name: str
             server_url: str
+            subscription_id: str
             label_default: FleetLabelDefaultV1
 
         all_current_cluster_ids = {cluster.cluster_id for cluster in spec.clusters}
@@ -145,6 +147,7 @@ class FleetLabelerIntegration(QontractReconcileIntegration[NoParams]):
                     clusters[cluster.cluster_id].append(
                         ClusterData(
                             label_default=label_default,
+                            subscription_id=cluster.subscription_id,
                             name=cluster.name,
                             server_url=cluster.server_url,
                         )
@@ -172,6 +175,7 @@ class FleetLabelerIntegration(QontractReconcileIntegration[NoParams]):
         clusters_to_add = [
             YamlCluster(
                 cluster_id=cluster_id,
+                subscription_id=cluster_info.subscription_id,
                 name=cluster_info.name,
                 server_url=cluster_info.server_url,
                 subscription_labels_content=self._render_default_labels(

--- a/reconcile/fleet_labeler/merge_request.py
+++ b/reconcile/fleet_labeler/merge_request.py
@@ -13,6 +13,7 @@ class YamlCluster(BaseModel):
     name: str
     server_url: str
     cluster_id: str
+    subscription_id: str
     subscription_labels_content: Any
 
 

--- a/reconcile/fleet_labeler/ocm.py
+++ b/reconcile/fleet_labeler/ocm.py
@@ -31,7 +31,11 @@ class Cluster(BaseModel):
 
     @staticmethod
     def from_cluster_details(cluster: ClusterDetails) -> Cluster:
-        server_url = cluster.ocm_cluster.api_url or ""
+        console_url = (
+            cluster.ocm_cluster.console.url if cluster.ocm_cluster.console else ""
+        )
+        api_url = cluster.ocm_cluster.api_url or ""
+        server_url = api_url or console_url or ""
 
         return Cluster(
             cluster_id=cluster.ocm_cluster.id,

--- a/reconcile/fleet_labeler/ocm.py
+++ b/reconcile/fleet_labeler/ocm.py
@@ -26,16 +26,16 @@ class Cluster(BaseModel):
     cluster_id: str
     server_url: str
     name: str
+    subscription_id: str
     subscription_labels: dict[str, str]
 
     @staticmethod
     def from_cluster_details(cluster: ClusterDetails) -> Cluster:
-        server_url = (
-            cluster.ocm_cluster.console.url if cluster.ocm_cluster.console else ""
-        )
+        server_url = cluster.ocm_cluster.api_url or ""
 
         return Cluster(
             cluster_id=cluster.ocm_cluster.id,
+            subscription_id=cluster.ocm_cluster.subscription.id,
             server_url=server_url,
             name=cluster.ocm_cluster.name,
             subscription_labels={

--- a/reconcile/gql_definitions/fleet_labeler/fleet_labels.gql
+++ b/reconcile/gql_definitions/fleet_labeler/fleet_labels.gql
@@ -30,6 +30,7 @@ query FleetLabelSpecs {
         clusters {
             name
             serverUrl
+            subscriptionId
             clusterId
             subscriptionLabels
         }

--- a/reconcile/gql_definitions/fleet_labeler/fleet_labels.py
+++ b/reconcile/gql_definitions/fleet_labeler/fleet_labels.py
@@ -58,6 +58,7 @@ query FleetLabelSpecs {
         clusters {
             name
             serverUrl
+            subscriptionId
             clusterId
             subscriptionLabels
         }
@@ -103,6 +104,7 @@ class FleetLabelDefaultV1(ConfiguredBaseModel):
 class FleetClusterV1(ConfiguredBaseModel):
     name: str = Field(..., alias="name")
     server_url: str = Field(..., alias="serverUrl")
+    subscription_id: str = Field(..., alias="subscriptionId")
     cluster_id: str = Field(..., alias="clusterId")
     subscription_labels: Json = Field(..., alias="subscriptionLabels")
 

--- a/reconcile/gql_definitions/introspection.json
+++ b/reconcile/gql_definitions/introspection.json
@@ -34633,6 +34633,22 @@
                             "deprecationReason": null
                         },
                         {
+                            "name": "subscriptionId",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "NON_NULL",
+                                "name": null,
+                                "ofType": {
+                                    "kind": "SCALAR",
+                                    "name": "String",
+                                    "ofType": null
+                                }
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
                             "name": "subscriptionLabels",
                             "description": null,
                             "args": [],

--- a/reconcile/test/fixtures/fleet_labeler/1_cluster.yaml
+++ b/reconcile/test/fixtures/fleet_labeler/1_cluster.yaml
@@ -36,7 +36,8 @@ labelDefaults:
 
 clusters:
 - name: cluster_name
-  clusterId: cluster_id
+  clusterId: '123'
+  subscriptionId: '123'
   serverUrl: https://api.test.com
   subscriptionLabels:
     tenant: tenantabc

--- a/reconcile/test/fixtures/fleet_labeler/2_clusters.yaml
+++ b/reconcile/test/fixtures/fleet_labeler/2_clusters.yaml
@@ -36,13 +36,15 @@ labelDefaults:
 
 clusters:
 - name: cluster_name_1
-  clusterId: cluster_id_1
+  clusterId: '456'
+  subscriptionId: '456'
   serverUrl: https://api.test.com
   subscriptionLabels:
     tenant: tenantabc
     tokenSpec: hypershift-management-cluster-v1
 - name: cluster_name_2
-  clusterId: cluster_id_2
+  clusterId: '789'
+  subscriptionId: '789'
   serverUrl: https://api.test.com
   subscriptionLabels:
     tenant: tenantother1

--- a/reconcile/test/fleet_labeler/fixtures.py
+++ b/reconcile/test/fleet_labeler/fixtures.py
@@ -21,12 +21,13 @@ def build_ocm_client(
 
 def build_cluster(
     subscription_labels: dict[str, str],
-    cluster_id: str,
+    uid: str,
     name: str,
     server_url: str = "https://api.test.com",
 ) -> Cluster:
     return Cluster(
-        cluster_id=cluster_id,
+        cluster_id=uid,
+        subscription_id=uid,
         name=name,
         server_url=server_url,
         subscription_labels=subscription_labels,

--- a/reconcile/test/fleet_labeler/test_fleet_labeler_cluster_inventory_lifecycle.py
+++ b/reconcile/test/fleet_labeler/test_fleet_labeler_cluster_inventory_lifecycle.py
@@ -37,7 +37,7 @@ def test_add_new_cluster(
             discover_clusters_by_labels=[
                 build_cluster(
                     name="cluster_name",
-                    cluster_id="cluster_id",
+                    uid="123",
                     subscription_labels={"sre-capabilities.dtp.managed-labels": "true"},
                 ),
             ],
@@ -103,12 +103,12 @@ def test_delete_and_add_cluster_multi_default_labels(
             discover_clusters_by_labels=[
                 build_cluster(
                     name="cluster_name_1",
-                    cluster_id="cluster_id_1",
+                    uid="456",
                     subscription_labels={"sre-capabilities.dtp.managed-labels": "true"},
                 ),
                 build_cluster(
                     name="cluster_name_2",
-                    cluster_id="cluster_id_2",
+                    uid="789",
                     # Note, this is the filter for the 2nd default label
                     subscription_labels={"sre-capabilities.dtp.other-label": "true"},
                 ),
@@ -145,12 +145,12 @@ def test_no_change(
             discover_clusters_by_labels=[
                 build_cluster(
                     name="cluster_name_1",
-                    cluster_id="cluster_id_1",
+                    uid="456",
                     subscription_labels={"sre-capabilities.dtp.managed-labels": "true"},
                 ),
                 build_cluster(
                     name="cluster_name_2",
-                    cluster_id="cluster_id_2",
+                    uid="789",
                     subscription_labels={"sre-capabilities.dtp.other-label": "true"},
                 ),
             ],
@@ -185,7 +185,7 @@ def test_no_reconcile_on_label_change(
             discover_clusters_by_labels=[
                 build_cluster(
                     name="cluster_name",
-                    cluster_id="cluster_id",
+                    uid="123",
                     subscription_labels={"sre-capabilities.dtp.managed-labels": "true"},
                 ),
             ],
@@ -222,18 +222,18 @@ def test_competing_label_matchers(
             discover_clusters_by_labels=[
                 build_cluster(
                     name="cluster_name_1",
-                    cluster_id="cluster_id_1",
+                    uid="456",
                     subscription_labels={"sre-capabilities.dtp.managed-labels": "true"},
                 ),
                 build_cluster(
                     name="cluster_name_2",
-                    cluster_id="cluster_id_2",
+                    uid="789",
                     # Note, this is the filter for the 2nd default label
                     subscription_labels={"sre-capabilities.dtp.other-label": "true"},
                 ),
                 build_cluster(
                     name="cluster_name_3",
-                    cluster_id="cluster_id_3",
+                    uid="1011",
                     # Note, this cluster fits both label matchers
                     subscription_labels={
                         "sre-capabilities.dtp.managed-labels": "true",
@@ -242,7 +242,7 @@ def test_competing_label_matchers(
                 ),
                 build_cluster(
                     name="cluster_name_4",
-                    cluster_id="cluster_id_4",
+                    uid="1213",
                     # Note, this cluster fits both label matchers
                     subscription_labels={
                         "sre-capabilities.dtp.managed-labels": "true",

--- a/reconcile/test/fleet_labeler/test_fleet_labeler_dry_run.py
+++ b/reconcile/test/fleet_labeler/test_fleet_labeler_dry_run.py
@@ -41,7 +41,7 @@ def test_fleet_labeler_dry_run_new_file_spec(
             discover_clusters_by_labels=[
                 build_cluster(
                     name="cluster_name",
-                    cluster_id="cluster_id",
+                    uid="cluster_id",
                     subscription_labels={"sre-capabilities.dtp.managed-labels": "true"},
                 ),
             ],
@@ -76,7 +76,7 @@ def test_fleet_labeler_no_dry_run_new_spec(
             discover_clusters_by_labels=[
                 build_cluster(
                     name="cluster_name",
-                    cluster_id="cluster_id",
+                    uid="cluster_id",
                     subscription_labels={"sre-capabilities.dtp.managed-labels": "true"},
                 ),
             ],
@@ -110,7 +110,7 @@ def test_fleet_labeler_dry_run_other_error(
             discover_clusters_by_labels=[
                 build_cluster(
                     name="cluster_name",
-                    cluster_id="cluster_id",
+                    uid="cluster_id",
                     subscription_labels={"sre-capabilities.dtp.managed-labels": "true"},
                 ),
             ],

--- a/reconcile/test/fleet_labeler/test_fleet_labeler_filters.py
+++ b/reconcile/test/fleet_labeler/test_fleet_labeler_filters.py
@@ -57,12 +57,12 @@ def test_default_label_filter(
             discover_clusters_by_labels=[
                 build_cluster(
                     name="cluster_name",
-                    cluster_id="cluster_id",
+                    uid="123",
                     subscription_labels={"sre-capabilities.dtp.managed-labels": "true"},
                 ),
                 build_cluster(
                     name="cluster_name_2",
-                    cluster_id="cluster_id_2",
+                    uid="456",
                     # Note, the label doesnt match the filter
                     subscription_labels={
                         "sre-capabilities.dtp.managed-labels": "false"


### PR DESCRIPTION
Add `subscriptionId` to clusters inside fleet labelers inventories.

Fleet labeler uses this `subscriptionId` to properly synchronize subscription labels (will be part of follow-up PR).

Schema: https://github.com/app-sre/qontract-schemas/pull/773