### PR TITLE
APPSRE-11390 fleet labeler synchronize subscription labels

### DIFF
--- a/reconcile/fleet_labeler/integration.py
+++ b/reconcile/fleet_labeler/integration.py
@@ -26,12 +26,25 @@ from reconcile.typed_queries.fleet_labels import get_fleet_label_specs
 from reconcile.utils import (
     metrics,
 )
+from reconcile.utils.differ import diff_mappings
 from reconcile.utils.jinja2.utils import process_jinja2_template
 from reconcile.utils.ruamel import create_ruamel_instance
 from reconcile.utils.runtime.integration import (
     NoParams,
     QontractReconcileIntegration,
 )
+
+
+class ClusterData(BaseModel):
+    """
+    Helper structure for synching process
+    """
+
+    name: str
+    server_url: str
+    subscription_id: str
+    desired_label_default: FleetLabelDefaultV1
+    current_subscription_labels: dict[str, str]
 
 
 class FleetLabelerIntegration(QontractReconcileIntegration[NoParams]):
@@ -59,12 +72,56 @@ class FleetLabelerIntegration(QontractReconcileIntegration[NoParams]):
     def reconcile(self, dependencies: Dependencies) -> None:
         validate_label_specs(specs=dependencies.label_specs_by_name)
         for spec_name, ocm in dependencies.ocm_clients_by_label_spec_name.items():
+            spec = dependencies.label_specs_by_name[spec_name]
+            discovered_clusters = self._discover_desired_clusters(
+                spec=spec,
+                ocm=ocm,
+            )
+            all_desired_clusters = {
+                k: v[0] for k, v in discovered_clusters.items() if len(v) == 1
+            }
+            clusters_with_duplicate_matches = {
+                k: v for k, v in discovered_clusters.items() if len(v) > 1
+            }
             self._sync_cluster_inventory(
                 ocm=ocm,
                 spec=dependencies.label_specs_by_name[spec_name],
                 vcs=dependencies.vcs,
+                all_desired_clusters=all_desired_clusters,
+                clusters_with_duplicate_matches=clusters_with_duplicate_matches,
                 dry_run=dependencies.dry_run,
             )
+            self._sync_subscription_labels(
+                spec=spec,
+                desired_clusters=all_desired_clusters,
+                ocm=ocm,
+                dry_run=dependencies.dry_run,
+            )
+
+    def _discover_desired_clusters(
+        self, spec: FleetLabelsSpecV1, ocm: OCMClient
+    ) -> dict[str, list[ClusterData]]:
+        clusters: dict[str, list[ClusterData]] = defaultdict(list)
+        for label_default in spec.label_defaults:
+            match_subscription_labels = dict(label_default.match_subscription_labels)
+            for cluster in ocm.discover_clusters_by_labels(
+                labels=match_subscription_labels
+            ):
+                # TODO: ideally we filter on server side - see TODO in ocm.py
+                if (
+                    match_subscription_labels.items()
+                    <= cluster.subscription_labels.items()
+                ):
+                    clusters[cluster.cluster_id].append(
+                        ClusterData(
+                            subscription_id=cluster.subscription_id,
+                            desired_label_default=label_default,
+                            name=cluster.name,
+                            server_url=cluster.server_url,
+                            current_subscription_labels=cluster.subscription_labels,
+                        )
+                    )
+        return clusters
 
     def _render_default_labels(
         self,
@@ -115,63 +172,96 @@ class FleetLabelerIntegration(QontractReconcileIntegration[NoParams]):
             yml.dump(content, stream)
             return stream.getvalue()
 
+    def _sync_subscription_labels(
+        self,
+        spec: FleetLabelsSpecV1,
+        desired_clusters: dict[str, ClusterData],
+        ocm: OCMClient,
+        dry_run: bool,
+    ) -> None:
+        """
+        Synchronize subscription labels for clusters in the spec's inventory.
+        Note, that we only update labels for clusters which are also part of the
+        discovered desired state.
+        I.e., we only operate on clusters that are in both, current state and desired state.
+        That way we ensure we do not work on deleted clusters and still synch only on
+        whats written in the rendered spec yet.
+        """
+        for cluster in spec.clusters:
+            desired_cluster = desired_clusters.get(cluster.cluster_id)
+            if not desired_cluster:
+                # The cluster is not part of the desired inventory (will be updated with MR soon)
+                continue
+            # Ensure we only handle labels for our managed prefix
+            current_subscription_labels = {
+                k: v
+                for k, v in desired_clusters[
+                    cluster.cluster_id
+                ].current_subscription_labels.items()
+                if k.startswith(spec.managed_subscription_label_prefix)
+            }
+            desired_subscription_labels = {
+                f"{spec.managed_subscription_label_prefix}.{k}": v
+                for k, v in dict(cluster.subscription_labels).items()
+            }
+            diff = diff_mappings(
+                current=current_subscription_labels,
+                desired=desired_subscription_labels,
+            )
+            # Lets run in sorted order for tests
+            for key in sorted(diff.add):
+                value = desired_subscription_labels[key]
+                logging.info(
+                    f"[{spec.name}] Adding label '{key}={value}' for cluster '{cluster.cluster_id}' in subscription '{desired_cluster.subscription_id}'."
+                )
+                if not dry_run:
+                    ocm.add_subscription_label(
+                        # TODO: add subscription_id to cluster yaml
+                        subscription_id=desired_cluster.subscription_id,
+                        key=key,
+                        value=value,
+                    )
+            # Lets run in sorted order for tests
+            for key in sorted(diff.change):
+                value = desired_subscription_labels[key]
+                logging.info(
+                    f"[{spec.name}] Updating label '{key}={value}' for cluster '{cluster.cluster_id}' in subscription '{desired_cluster.subscription_id}'."
+                )
+                if not dry_run:
+                    ocm.update_subscription_label(
+                        # TODO: add subscription_id to cluster yaml
+                        subscription_id=desired_cluster.subscription_id,
+                        key=key,
+                        value=value,
+                    )
+            # Note, we dont want to enable removal for now - its too dangerous on a broad managed prefix
+            # However, if it is needed in the future, we could easily add it here.
+
     def _sync_cluster_inventory(
         self,
         ocm: OCMClient,
         spec: FleetLabelsSpecV1,
         vcs: VCS,
+        clusters_with_duplicate_matches: dict[str, list[ClusterData]],
+        all_desired_clusters: dict[str, ClusterData],
         dry_run: bool,
     ) -> None:
-        class ClusterData(BaseModel):
-            """
-            Helper structure for synching process
-            """
-
-            name: str
-            server_url: str
-            subscription_id: str
-            label_default: FleetLabelDefaultV1
-
         all_current_cluster_ids = {cluster.cluster_id for cluster in spec.clusters}
-        clusters: dict[str, list[ClusterData]] = defaultdict(list)
-        for label_default in spec.label_defaults:
-            match_subscription_labels = dict(label_default.match_subscription_labels)
-            for cluster in ocm.discover_clusters_by_labels(
-                labels=match_subscription_labels
-            ):
-                # TODO: ideally we filter on server side - see TODO in ocm.py
-                if (
-                    match_subscription_labels.items()
-                    <= cluster.subscription_labels.items()
-                ):
-                    clusters[cluster.cluster_id].append(
-                        ClusterData(
-                            label_default=label_default,
-                            subscription_id=cluster.subscription_id,
-                            name=cluster.name,
-                            server_url=cluster.server_url,
-                        )
-                    )
-
-        cluster_with_duplicate_matches = {
-            k: v for k, v in clusters.items() if len(v) > 1
-        }
-        for cluster_id, matches in cluster_with_duplicate_matches.items():
+        for cluster_id, matches in clusters_with_duplicate_matches.items():
             label_matches = "\n".join(
-                str(m.label_default.match_subscription_labels) for m in matches
+                str(m.desired_label_default.match_subscription_labels) for m in matches
             )
             logging.error(
-                f"Spec '{spec.name}': Cluster ID {cluster_id} is matched multiple times by different label matchers:\n{label_matches}"
+                f"[{spec.name}] Cluster ID {cluster_id} is matched multiple times by different label matchers:\n{label_matches}"
             )
         metrics.set_gauge(
             FleetLabelerDuplicateClusterMatchesGauge(
                 integration=self.name,
                 ocm_name=spec.ocm.name,
             ),
-            len(cluster_with_duplicate_matches),
+            len(clusters_with_duplicate_matches),
         )
 
-        all_desired_clusters = {k: v[0] for k, v in clusters.items() if len(v) == 1}
         clusters_to_add = [
             YamlCluster(
                 cluster_id=cluster_id,
@@ -179,7 +269,7 @@ class FleetLabelerIntegration(QontractReconcileIntegration[NoParams]):
                 name=cluster_info.name,
                 server_url=cluster_info.server_url,
                 subscription_labels_content=self._render_default_labels(
-                    template=cluster_info.label_default.subscription_label_template,
+                    template=cluster_info.desired_label_default.subscription_label_template,
                     labels=ocm.get_cluster_labels(cluster_id=cluster_id),
                 ),
             )

--- a/reconcile/fleet_labeler/meta.py
+++ b/reconcile/fleet_labeler/meta.py
@@ -1,4 +1,4 @@
 from reconcile.utils.semver_helper import make_semver
 
 QONTRACT_INTEGRATION = "fleet-labeler"
-QONTRACT_INTEGRATION_VERSION = make_semver(0, 1, 0)
+QONTRACT_INTEGRATION_VERSION = make_semver(1, 0, 0)

--- a/reconcile/fleet_labeler/ocm.py
+++ b/reconcile/fleet_labeler/ocm.py
@@ -29,7 +29,6 @@ class Cluster(BaseModel):
     subscription_id: str
     server_url: str
     name: str
-    subscription_id: str
     subscription_labels: dict[str, str]
 
     @staticmethod
@@ -92,6 +91,7 @@ class OCMClient:
     def add_subscription_label(
         self, subscription_id: str, key: str, value: str
     ) -> None:
+        # TODO: move href into a utils function
         add_label(
             ocm_api=self._ocm_client,
             label_container_href=f"/api/accounts_mgmt/v1/subscriptions/{subscription_id}/labels",
@@ -102,6 +102,7 @@ class OCMClient:
     def update_subscription_label(
         self, subscription_id: str, key: str, value: str
     ) -> None:
+        # TODO: move href into a utils function
         update_label(
             ocm_api=self._ocm_client,
             label_container_href=f"/api/accounts_mgmt/v1/subscriptions/{subscription_id}/labels",

--- a/reconcile/fleet_labeler/ocm.py
+++ b/reconcile/fleet_labeler/ocm.py
@@ -10,7 +10,9 @@ from reconcile.utils.ocm.clusters import (
     discover_clusters_by_labels,
 )
 from reconcile.utils.ocm.labels import (
+    add_label,
     get_cluster_labels_for_cluster_id,
+    update_label,
 )
 from reconcile.utils.ocm.search_filters import Filter, FilterMode
 from reconcile.utils.ocm_base_client import (
@@ -24,6 +26,7 @@ Thin abstractions of reconcile.ocm module to reduce coupling.
 
 class Cluster(BaseModel):
     cluster_id: str
+    subscription_id: str
     server_url: str
     name: str
     subscription_id: str
@@ -85,3 +88,23 @@ class OCMClient:
 
     def get_cluster_labels(self, cluster_id: str) -> dict[str, str]:
         return get_cluster_labels_for_cluster_id(self._ocm_client, cluster_id)
+
+    def add_subscription_label(
+        self, subscription_id: str, key: str, value: str
+    ) -> None:
+        add_label(
+            ocm_api=self._ocm_client,
+            label_container_href=f"/api/accounts_mgmt/v1/subscriptions/{subscription_id}/labels",
+            label=key,
+            value=value,
+        )
+
+    def update_subscription_label(
+        self, subscription_id: str, key: str, value: str
+    ) -> None:
+        update_label(
+            ocm_api=self._ocm_client,
+            label_container_href=f"/api/accounts_mgmt/v1/subscriptions/{subscription_id}/labels",
+            label=key,
+            value=value,
+        )

--- a/reconcile/test/fleet_labeler/test_fleet_labeler_dry_run.py
+++ b/reconcile/test/fleet_labeler/test_fleet_labeler_dry_run.py
@@ -14,6 +14,7 @@ from reconcile.test.fleet_labeler.fixtures import (
     build_cluster,
     build_ocm_client,
     build_vcs,
+    get_fixture_content,
     label_spec_data_from_fixture,
 )
 
@@ -36,21 +37,74 @@ def test_fleet_labeler_dry_run_new_file_spec(
         FleetLabelsSpecV1, label_spec_data_from_fixture("0_clusters.yaml")
     )
     dependencies.label_specs_by_name = {spec.name: spec}
+    ocm_client = build_ocm_client(
+        discover_clusters_by_labels=[
+            build_cluster(
+                name="cluster_name",
+                uid="cluster_id",
+                subscription_labels={"sre-capabilities.dtp.managed-labels": "true"},
+            ),
+        ],
+    )
     dependencies.ocm_clients_by_label_spec_name = {
-        spec.name: build_ocm_client(
-            discover_clusters_by_labels=[
-                build_cluster(
-                    name="cluster_name",
-                    uid="cluster_id",
-                    subscription_labels={"sre-capabilities.dtp.managed-labels": "true"},
-                ),
-            ],
-        )
+        spec.name: ocm_client,
     }
 
     integration.reconcile(dependencies=dependencies)
 
     dependencies.vcs.open_merge_request.assert_not_called()
+    ocm_client.add_subscription_label.assert_not_called()
+    ocm_client.update_subscription_label.assert_not_called()
+
+
+def test_fleet_labeler_dry_run_existing_file_spec(
+    integration: FleetLabelerIntegration,
+    dependencies: Dependencies,
+    gql_class_factory: Callable[..., FleetLabelsSpecV1],
+) -> None:
+    """
+    We are in dry-run mode.
+    Labels and cluster inventory are not in synch.
+
+    We expect that there are no calls to update/add labels since we are in dry-run.
+    We expect no calls to update the inventory.
+    """
+    dependencies.vcs = build_vcs(content=get_fixture_content("1_cluster.yaml"))
+    dependencies.dry_run = True
+    spec = gql_class_factory(
+        FleetLabelsSpecV1, label_spec_data_from_fixture("1_cluster.yaml")
+    )
+    dependencies.label_specs_by_name = {spec.name: spec}
+    ocm_client = build_ocm_client(
+        discover_clusters_by_labels=[
+            build_cluster(
+                name="cluster_name",
+                uid="123",
+                subscription_labels={
+                    "sre-capabilities.dtp.managed-labels": "true",
+                    # Note, this value is not in synch with the spec
+                    "sre-capabilities.dtp.tenant": "BadValue",
+                },
+            ),
+            # A new cluster that is not part of inventory yet
+            build_cluster(
+                name="new_cluster_name",
+                uid="456",
+                subscription_labels={
+                    "sre-capabilities.dtp.managed-labels": "true",
+                },
+            ),
+        ],
+    )
+    dependencies.ocm_clients_by_label_spec_name = {
+        spec.name: ocm_client,
+    }
+
+    integration.reconcile(dependencies=dependencies)
+
+    dependencies.vcs.open_merge_request.assert_not_called()
+    ocm_client.add_subscription_label.assert_not_called()
+    ocm_client.update_subscription_label.assert_not_called()
 
 
 def test_fleet_labeler_no_dry_run_new_spec(

--- a/reconcile/test/fleet_labeler/test_fleet_labeler_label_synch.py
+++ b/reconcile/test/fleet_labeler/test_fleet_labeler_label_synch.py
@@ -1,0 +1,207 @@
+from collections.abc import Callable
+from unittest.mock import call
+
+from reconcile.fleet_labeler.dependencies import Dependencies
+from reconcile.fleet_labeler.integration import (
+    FleetLabelerIntegration,
+)
+from reconcile.gql_definitions.fleet_labeler.fleet_labels import (
+    FleetLabelsSpecV1,
+)
+from reconcile.test.fleet_labeler.fixtures import (
+    build_cluster,
+    build_ocm_client,
+    build_vcs,
+    get_fixture_content,
+    label_spec_data_from_fixture,
+)
+
+
+def test_add_new_labels(
+    integration: FleetLabelerIntegration,
+    dependencies: Dependencies,
+    gql_class_factory: Callable[..., FleetLabelsSpecV1],
+) -> None:
+    """
+    Our cluster inventory has 1 cluster and is in synch.
+    The desired clusters labels do not exist.
+
+    We expect calls to add new subscription labels for the cluster.
+    """
+    dependencies.vcs = build_vcs(content=get_fixture_content("1_cluster.yaml"))
+    spec = gql_class_factory(
+        FleetLabelsSpecV1, label_spec_data_from_fixture("1_cluster.yaml")
+    )
+    dependencies.label_specs_by_name = {spec.name: spec}
+    ocm_client = build_ocm_client(
+        discover_clusters_by_labels=[
+            build_cluster(
+                name="cluster_name",
+                uid="123",
+                subscription_labels={
+                    "sre-capabilities.dtp.managed-labels": "true",
+                },
+            ),
+        ],
+    )
+    dependencies.ocm_clients_by_label_spec_name = {
+        spec.name: ocm_client,
+    }
+
+    integration.reconcile(dependencies=dependencies)
+
+    dependencies.vcs.open_merge_request.assert_not_called()
+    expected_label_calls = [
+        call(
+            subscription_id="123",
+            key="sre-capabilities.dtp.spec.tenant",
+            value="tenantabc",
+        ),
+        call(
+            subscription_id="123",
+            key="sre-capabilities.dtp.spec.tokenSpec",
+            value="hypershift-management-cluster-v1",
+        ),
+    ]
+    ocm_client.add_subscription_label.assert_has_calls(
+        expected_label_calls, any_order=True
+    )
+    assert ocm_client.add_subscription_label.call_count == 2
+    ocm_client.update_subscription_label.assert_not_called()
+
+
+def test_update_existing_labels(
+    integration: FleetLabelerIntegration,
+    dependencies: Dependencies,
+    gql_class_factory: Callable[..., FleetLabelsSpecV1],
+) -> None:
+    """
+    Our cluster inventory has 1 cluster and is in synch.
+    The desired clusters labels exist but the values dont match.
+
+    We expect calls to update existing subscription labels for the cluster.
+    """
+    dependencies.vcs = build_vcs(content=get_fixture_content("1_cluster.yaml"))
+    spec = gql_class_factory(
+        FleetLabelsSpecV1, label_spec_data_from_fixture("1_cluster.yaml")
+    )
+    dependencies.label_specs_by_name = {spec.name: spec}
+    ocm_client = build_ocm_client(
+        discover_clusters_by_labels=[
+            build_cluster(
+                name="cluster_name",
+                uid="123",
+                subscription_labels={
+                    "sre-capabilities.dtp.managed-labels": "true",
+                    "sre-capabilities.dtp.spec.tenant": "badvalue",
+                    "sre-capabilities.dtp.spec.tokenSpec": "badvalue",
+                },
+            ),
+        ],
+    )
+    dependencies.ocm_clients_by_label_spec_name = {
+        spec.name: ocm_client,
+    }
+
+    integration.reconcile(dependencies=dependencies)
+
+    dependencies.vcs.open_merge_request.assert_not_called()
+    expected_label_calls = [
+        call(
+            subscription_id="123",
+            key="sre-capabilities.dtp.spec.tenant",
+            value="tenantabc",
+        ),
+        call(
+            subscription_id="123",
+            key="sre-capabilities.dtp.spec.tokenSpec",
+            value="hypershift-management-cluster-v1",
+        ),
+    ]
+    ocm_client.update_subscription_label.assert_has_calls(
+        expected_label_calls, any_order=True
+    )
+    assert ocm_client.update_subscription_label.call_count == 2
+    ocm_client.add_subscription_label.assert_not_called()
+
+
+def test_update_and_add_labels_on_multiple_clusters(
+    integration: FleetLabelerIntegration,
+    dependencies: Dependencies,
+    gql_class_factory: Callable[..., FleetLabelsSpecV1],
+) -> None:
+    """
+    Our cluster inventory has 2 clusters and is in synch.
+    The desired clusters labels part-wise exist but the values dont match.
+
+    We expect calls to update existing subscription labels for the cluster.
+    We also expect calls to add new missing subscription labels.
+    """
+    dependencies.vcs = build_vcs(content=get_fixture_content("2_clusters.yaml"))
+    spec = gql_class_factory(
+        FleetLabelsSpecV1, label_spec_data_from_fixture("2_clusters.yaml")
+    )
+    dependencies.label_specs_by_name = {spec.name: spec}
+    ocm_client = build_ocm_client(
+        discover_clusters_by_labels=[
+            build_cluster(
+                name="cluster_name_1",
+                uid="456",
+                subscription_labels={
+                    "sre-capabilities.dtp.managed-labels": "true",
+                    "sre-capabilities.dtp.spec.tenant": "badvalue",
+                    # Note, missing tokenSpec label
+                },
+            ),
+            build_cluster(
+                name="cluster_name_2",
+                uid="789",
+                subscription_labels={
+                    "sre-capabilities.dtp.managed-labels": "true",
+                    "sre-capabilities.dtp.spec.tokenSpec": "badvalue",
+                    # Note, missing tenant label
+                },
+            ),
+        ],
+    )
+    dependencies.ocm_clients_by_label_spec_name = {
+        spec.name: ocm_client,
+    }
+
+    integration.reconcile(dependencies=dependencies)
+
+    dependencies.vcs.open_merge_request.assert_not_called()
+
+    expected_add_label_calls = [
+        call(
+            subscription_id="789",
+            key="sre-capabilities.dtp.spec.tenant",
+            value="tenantother1",
+        ),
+        call(
+            subscription_id="456",
+            key="sre-capabilities.dtp.spec.tokenSpec",
+            value="hypershift-management-cluster-v1",
+        ),
+    ]
+    ocm_client.add_subscription_label.assert_has_calls(
+        expected_add_label_calls, any_order=True
+    )
+    assert ocm_client.add_subscription_label.call_count == 2
+
+    expected_update_label_calls = [
+        call(
+            subscription_id="456",
+            key="sre-capabilities.dtp.spec.tenant",
+            value="tenantabc",
+        ),
+        call(
+            subscription_id="789",
+            key="sre-capabilities.dtp.spec.tokenSpec",
+            value="specother1",
+        ),
+    ]
+    ocm_client.update_subscription_label.assert_has_calls(
+        expected_update_label_calls, any_order=True
+    )
+    assert ocm_client.update_subscription_label.call_count == 2


### PR DESCRIPTION
The Fleet Labeler integration already has the ability to synchronize cluster inventories and declare desired subscription label state.

In this PR, we leverage the existing desired subscription label state and make the actual OCM API calls to create/update subscription labels to have them in synch with the fleet-labeler-spec.

Note, that we intentionally do not remove labels under the managed prefix. This might lead to unwanted removals on prefixes with many sub keys, which might not be managed by fleet labeler. However, if desired, this could easily be added later (maybe with an optional flag in the spec).