### PR TITLE
APPSRE-11390 fleet labeler - fix filter

### DIFF
--- a/reconcile/fleet_labeler/integration.py
+++ b/reconcile/fleet_labeler/integration.py
@@ -105,9 +105,13 @@ class FleetLabelerIntegration(QontractReconcileIntegration[NoParams]):
         for label_default in spec.label_defaults:
             match_subscription_labels = dict(label_default.match_subscription_labels)
             for cluster in ocm.discover_clusters_by_labels(
-                labels=match_subscription_labels
+                labels=match_subscription_labels,
+                managed_prefix=spec.managed_subscription_label_prefix,
             ):
-                # TODO: ideally we filter on server side - see TODO in ocm.py
+                # Note, due to the nature of how our label filtering works (see ocm.py), we
+                # also fetch clusters that do not match the filter label.
+                # Here, we filter the clusters on client side.
+                # TODO: move this into utils.ocm module
                 if (
                     match_subscription_labels.items()
                     <= cluster.subscription_labels.items()

--- a/reconcile/test/fleet_labeler/test_fleet_labeler_filters.py
+++ b/reconcile/test/fleet_labeler/test_fleet_labeler_filters.py
@@ -22,6 +22,7 @@ def test_subscription_label_filter(
     default_label_spec: FleetLabelsSpecV1,
 ) -> None:
     default_label_spec.name = "spec"
+    default_label_spec.managed_subscription_label_prefix = "test.prefix"
     dependencies.label_specs_by_name = {"spec": default_label_spec}
 
     ocm_client = build_ocm_client(
@@ -33,6 +34,7 @@ def test_subscription_label_filter(
 
     ocm_client.discover_clusters_by_labels.assert_called_once_with(
         labels={"test": "true"},
+        managed_prefix="test.prefix",
     )
 
 


### PR DESCRIPTION
The `discover_clusters_by_labels()` function currently only populates labels into the result that are part of the filter. Our desired labels are not part of the default label matchers.

To circumvent this, we for now widen the filter by an `OR {spec.managed_prefix}.%` query. This will lead to all managed labels being populated into the `ClusterDetails` result.

Note, that the API call overhead here is neglectable, since we anyways most of the times have to fetch subscription labels for the whole inventory and our currently managed prefixes are very exclusive. Still, longterm, we should fix this by extending the utils.ocm module to provide this functionality.