### PR TITLE
APPSRE-11584 fleet-labeler: optional disable label synch

### DIFF
--- a/reconcile/fleet_labeler/integration.py
+++ b/reconcile/fleet_labeler/integration.py
@@ -92,11 +92,12 @@ class FleetLabelerIntegration(QontractReconcileIntegration[NoParams]):
                 metrics=dependencies.metrics,
                 dry_run=dependencies.dry_run,
             )
+            synch_labels = spec.dry_run_label_synchronization or dependencies.dry_run
             self._sync_subscription_labels(
                 spec=spec,
                 desired_clusters=all_desired_clusters,
                 ocm=ocm,
-                dry_run=dependencies.dry_run,
+                dry_run=synch_labels,
             )
 
     def _discover_desired_clusters(

--- a/reconcile/gql_definitions/fleet_labeler/fleet_labels.gql
+++ b/reconcile/gql_definitions/fleet_labeler/fleet_labels.gql
@@ -5,6 +5,7 @@ query FleetLabelSpecs {
         name
         path
         managedSubscriptionLabelPrefix
+        dryRunLabelSynchronization
         ocm {
             name
             environment {

--- a/reconcile/gql_definitions/fleet_labeler/fleet_labels.py
+++ b/reconcile/gql_definitions/fleet_labeler/fleet_labels.py
@@ -33,6 +33,7 @@ query FleetLabelSpecs {
         name
         path
         managedSubscriptionLabelPrefix
+        dryRunLabelSynchronization
         ocm {
             name
             environment {
@@ -113,6 +114,7 @@ class FleetLabelsSpecV1(ConfiguredBaseModel):
     name: str = Field(..., alias="name")
     path: str = Field(..., alias="path")
     managed_subscription_label_prefix: str = Field(..., alias="managedSubscriptionLabelPrefix")
+    dry_run_label_synchronization: Optional[bool] = Field(..., alias="dryRunLabelSynchronization")
     ocm: OpenShiftClusterManagerV1 = Field(..., alias="ocm")
     label_defaults: list[FleetLabelDefaultV1] = Field(..., alias="labelDefaults")
     clusters: list[FleetClusterV1] = Field(..., alias="clusters")

--- a/reconcile/gql_definitions/introspection.json
+++ b/reconcile/gql_definitions/introspection.json
@@ -34398,6 +34398,18 @@
                             "deprecationReason": null
                         },
                         {
+                            "name": "dryRunLabelSynchronization",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "SCALAR",
+                                "name": "Boolean",
+                                "ofType": null
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
                             "name": "managedSubscriptionLabelPrefix",
                             "description": null,
                             "args": [],

--- a/reconcile/test/fixtures/fleet_labeler/2_clusters-alternative.yaml
+++ b/reconcile/test/fixtures/fleet_labeler/2_clusters-alternative.yaml
@@ -1,0 +1,51 @@
+$schema: /openshift/fleet-labels-spec-1.yml
+
+name: hypershift-cluster-subscription-labels-integration
+ocm:
+  $ref: /dependencies/ocm/orgs/osd-fleet-manager/integration.yml
+
+managedSubscriptionLabelPrefix: sre-capabilities.dtp.spec
+
+labelDefaults:
+- name: first
+  matchSubscriptionLabels:
+    sre-capabilities.dtp.managed-labels: "true"
+  subscriptionLabelTemplate:
+    path: /dynatrace-token-provider-labels-1.yaml.j2
+    type: jinja2
+    variables:
+      tenants:
+        default: tenantabc
+        other: tenantdef
+      tokenSpecs:
+        default: hypershift-management-cluster-v1
+        other: hypershift-service-cluster-v1
+- name: second
+  matchSubscriptionLabels:
+    sre-capabilities.dtp.other-label: "true"
+  subscriptionLabelTemplate:
+    path: /dynatrace-token-provider-labels-2.yaml.j2
+    type: jinja2
+    variables:
+      tenants:
+        default: tenantother1
+        other: tenantother2
+      tokenSpecs:
+        default: specother1
+        other: specother2
+
+clusters:
+- name: cluster_name_1
+  clusterId: '456'
+  subscriptionId: '456'
+  serverUrl: https://api.test.com
+  subscriptionLabels:
+    tenant: tenantabc
+    tokenSpec: hypershift-management-cluster-v1
+- name: cluster_name_3
+  clusterId: '123'
+  subscriptionId: '123'
+  serverUrl: https://api.test.com
+  subscriptionLabels:
+    tenant: tenantother1
+    tokenSpec: specother1


### PR DESCRIPTION
Extra flag to disable label synchronization for a spec.

This is especially useful for prod environments, if you want to let fleet labeler render the inventory first and investigate/change any desired labels manually before the first synchronization starts.

Schema: https://github.com/app-sre/qontract-schemas/pull/778