### PR TITLE
APPSRE-11584 DTP enforce v2 labels

### DIFF
--- a/reconcile/dynatrace_token_provider/integration.py
+++ b/reconcile/dynatrace_token_provider/integration.py
@@ -16,7 +16,7 @@ from reconcile.dynatrace_token_provider.metrics import (
 from reconcile.dynatrace_token_provider.model import DynatraceAPIToken, K8sSecret
 from reconcile.dynatrace_token_provider.ocm import (
     DTP_LABEL_SEARCH,
-    DTP_TENANT_LABEL,
+    DTP_TENANT_V2_LABEL,
     Cluster,
     OCMClient,
 )
@@ -172,10 +172,10 @@ class DynatraceTokenProviderIntegration(QontractReconcileIntegration[NoParams]):
                                 _expose_errors_as_service_log(
                                     ocm_client,
                                     cluster_uuid=cluster.external_id,
-                                    error=f"Missing label {DTP_TENANT_LABEL}",
+                                    error=f"Missing label {DTP_TENANT_V2_LABEL}",
                                 )
                                 logging.warn(
-                                    f"[{cluster.id=}] Missing value for label {DTP_TENANT_LABEL}"
+                                    f"[{cluster.id=}] Missing value for label {DTP_TENANT_V2_LABEL}"
                                 )
                                 continue
                             if (


### PR DESCRIPTION
Our fleet labeler capability is now managing DTP subscription labels. Lets enforce the v2 labeling schema and drop backwards compatibility with old schemas. Since fleet labeler is managing the labels, all the labels for the new schema already exist on the subscriptions.

Note, that for now we log a warning if expected labels are missing. During the DTPv3 transition, we will expose this as a metric. If we run into this case, it is likely that fleet-labeler didnt label the cluster yet - however, it should do so soon - thus we shouldnt fail here.