### PR TITLE
APPSRE-11583 FleetLabeler use OCMEnvironment

### DIFF
--- a/reconcile/fleet_labeler/dependencies.py
+++ b/reconcile/fleet_labeler/dependencies.py
@@ -61,10 +61,10 @@ def _ocm_clients(secret_reader: SecretReaderBase) -> dict[str, OCMClient]:
     for spec in get_fleet_label_specs():
         ocm_base_client = init_ocm_base_client(
             cfg=OCMClientConfig(
-                url=spec.ocm.environment.url,
-                access_token_client_id=spec.ocm.access_token_client_id,
-                access_token_url=spec.ocm.access_token_url,
-                access_token_client_secret=spec.ocm.access_token_client_secret,
+                url=spec.ocm_env.url,
+                access_token_client_id=spec.ocm_env.access_token_client_id,
+                access_token_url=spec.ocm_env.access_token_url,
+                access_token_client_secret=spec.ocm_env.access_token_client_secret,
             ),
             secret_reader=secret_reader,
         )

--- a/reconcile/fleet_labeler/integration.py
+++ b/reconcile/fleet_labeler/integration.py
@@ -257,7 +257,7 @@ class FleetLabelerIntegration(QontractReconcileIntegration[NoParams]):
                 f"[{spec.name}] Cluster ID {cluster_id} is matched multiple times by different label matchers:\n{label_matches}"
             )
         metrics.set_duplicate_cluster_matches_gauge(
-            ocm_name=spec.ocm.name,
+            ocm_name=spec.ocm_env.name,
             spec_name=spec.name,
             value=len(clusters_with_duplicate_matches),
         )
@@ -291,7 +291,7 @@ class FleetLabelerIntegration(QontractReconcileIntegration[NoParams]):
                     )
                 )
         metrics.set_label_rendering_error_gauge(
-            ocm_name=spec.ocm.name,
+            ocm_name=spec.ocm_env.name,
             spec_name=spec.name,
             value=label_rendering_errors_cnt,
         )

--- a/reconcile/fleet_labeler/validate.py
+++ b/reconcile/fleet_labeler/validate.py
@@ -3,20 +3,7 @@ from collections.abc import Mapping
 
 from reconcile.gql_definitions.fleet_labeler.fleet_labels import (
     FleetLabelsSpecV1,
-    OpenShiftClusterManagerV1,
 )
-
-
-class OCMAccessTokenClientIdMissing(Exception):
-    pass
-
-
-class OCMAccessTokenClientSecretMissing(Exception):
-    pass
-
-
-class OCMAccessTokenUrlMissing(Exception):
-    pass
 
 
 class MatchLabelsNotUniqueError(Exception):
@@ -28,7 +15,6 @@ def validate_label_specs(specs: Mapping[str, FleetLabelsSpecV1]) -> None:
     We cannot catch all potential errors through json schema definition.
     """
     for spec in specs.values():
-        _validate_ocm_token_spec(spec.ocm)
         _validate_match_labels(spec)
         _validate_unique_ocm_managed_label_combo(spec)
 
@@ -63,21 +49,3 @@ def _validate_match_labels(spec: FleetLabelsSpecV1) -> None:
             raise MatchLabelsNotUniqueError(
                 f"The 'matchSubscriptionLabels' combinations must be unique within a spec. Found duplicates in spec {spec.name} for matchers: {duplicates}"
             )
-
-
-def _validate_ocm_token_spec(ocm: OpenShiftClusterManagerV1) -> None:
-    """
-    OCM tokens are optional in the schema. Lets verify they exist.
-    """
-    if not ocm.access_token_client_id:
-        raise OCMAccessTokenClientIdMissing(
-            f"accessTokenClientId missing in ocm spec '{ocm.name}'"
-        )
-    if not ocm.access_token_client_secret:
-        raise OCMAccessTokenClientSecretMissing(
-            f"accessTokenClientSecret missing in ocm spec '{ocm.name}'"
-        )
-    if not ocm.access_token_url:
-        raise OCMAccessTokenUrlMissing(
-            f"accessTokenUrl missing in ocm spec '{ocm.name}'"
-        )

--- a/reconcile/gql_definitions/fleet_labeler/fleet_labels.gql
+++ b/reconcile/gql_definitions/fleet_labeler/fleet_labels.gql
@@ -6,11 +6,9 @@ query FleetLabelSpecs {
         path
         managedSubscriptionLabelPrefix
         dryRunLabelSynchronization
-        ocm {
+        ocmEnv {
             name
-            environment {
-                url
-            }
+            url
             accessTokenClientId
             accessTokenClientSecret {
                 ... VaultSecret

--- a/reconcile/gql_definitions/fleet_labeler/fleet_labels.py
+++ b/reconcile/gql_definitions/fleet_labeler/fleet_labels.py
@@ -34,11 +34,9 @@ query FleetLabelSpecs {
         path
         managedSubscriptionLabelPrefix
         dryRunLabelSynchronization
-        ocm {
+        ocmEnv {
             name
-            environment {
-                url
-            }
+            url
             accessTokenClientId
             accessTokenClientSecret {
                 ... VaultSecret
@@ -75,15 +73,11 @@ class ConfiguredBaseModel(BaseModel):
 
 
 class OpenShiftClusterManagerEnvironmentV1(ConfiguredBaseModel):
-    url: str = Field(..., alias="url")
-
-
-class OpenShiftClusterManagerV1(ConfiguredBaseModel):
     name: str = Field(..., alias="name")
-    environment: OpenShiftClusterManagerEnvironmentV1 = Field(..., alias="environment")
-    access_token_client_id: Optional[str] = Field(..., alias="accessTokenClientId")
-    access_token_client_secret: Optional[VaultSecret] = Field(..., alias="accessTokenClientSecret")
-    access_token_url: Optional[str] = Field(..., alias="accessTokenUrl")
+    url: str = Field(..., alias="url")
+    access_token_client_id: str = Field(..., alias="accessTokenClientId")
+    access_token_client_secret: VaultSecret = Field(..., alias="accessTokenClientSecret")
+    access_token_url: str = Field(..., alias="accessTokenUrl")
 
 
 class ResourceV1(ConfiguredBaseModel):
@@ -115,7 +109,7 @@ class FleetLabelsSpecV1(ConfiguredBaseModel):
     path: str = Field(..., alias="path")
     managed_subscription_label_prefix: str = Field(..., alias="managedSubscriptionLabelPrefix")
     dry_run_label_synchronization: Optional[bool] = Field(..., alias="dryRunLabelSynchronization")
-    ocm: OpenShiftClusterManagerV1 = Field(..., alias="ocm")
+    ocm_env: OpenShiftClusterManagerEnvironmentV1 = Field(..., alias="ocmEnv")
     label_defaults: list[FleetLabelDefaultV1] = Field(..., alias="labelDefaults")
     clusters: list[FleetClusterV1] = Field(..., alias="clusters")
 

--- a/reconcile/gql_definitions/introspection.json
+++ b/reconcile/gql_definitions/introspection.json
@@ -34382,7 +34382,7 @@
                             "deprecationReason": null
                         },
                         {
-                            "name": "ocm",
+                            "name": "ocmEnv",
                             "description": null,
                             "args": [],
                             "type": {
@@ -34390,7 +34390,7 @@
                                 "name": null,
                                 "ofType": {
                                     "kind": "OBJECT",
-                                    "name": "OpenShiftClusterManager_v1",
+                                    "name": "OpenShiftClusterManagerEnvironment_v1",
                                     "ofType": null
                                 }
                             },

--- a/reconcile/test/fixtures/fleet_labeler/0_clusters.yaml
+++ b/reconcile/test/fixtures/fleet_labeler/0_clusters.yaml
@@ -1,8 +1,8 @@
 $schema: /openshift/fleet-labels-spec-1.yml
 
 name: hypershift-cluster-subscription-labels-integration
-ocm:
-  $ref: /dependencies/ocm/orgs/osd-fleet-manager/integration.yml
+ocmEnv:
+  $ref: /dependencies/ocm/environments/integration.yml
 
 managedSubscriptionLabelPrefix: sre-capabilities.dtp.spec
 

--- a/reconcile/test/fixtures/fleet_labeler/0_clusters_no_defaults.yaml
+++ b/reconcile/test/fixtures/fleet_labeler/0_clusters_no_defaults.yaml
@@ -1,8 +1,8 @@
 $schema: /openshift/fleet-labels-spec-1.yml
 
 name: hypershift-cluster-subscription-labels-integration
-ocm:
-  $ref: /dependencies/ocm/orgs/osd-fleet-manager/integration.yml
+ocmEnv:
+  $ref: /dependencies/ocm/environments/integration.yml
 
 managedSubscriptionLabelPrefix: sre-capabilities.dtp.spec
 

--- a/reconcile/test/fixtures/fleet_labeler/1_cluster.yaml
+++ b/reconcile/test/fixtures/fleet_labeler/1_cluster.yaml
@@ -1,8 +1,8 @@
 $schema: /openshift/fleet-labels-spec-1.yml
 
 name: hypershift-cluster-subscription-labels-integration
-ocm:
-  $ref: /dependencies/ocm/orgs/osd-fleet-manager/integration.yml
+ocmEnv:
+  $ref: /dependencies/ocm/environments/integration.yml
 
 managedSubscriptionLabelPrefix: sre-capabilities.dtp.spec
 

--- a/reconcile/test/fixtures/fleet_labeler/1_cluster_no_defaults.yaml
+++ b/reconcile/test/fixtures/fleet_labeler/1_cluster_no_defaults.yaml
@@ -1,8 +1,8 @@
 $schema: /openshift/fleet-labels-spec-1.yml
 
 name: hypershift-cluster-subscription-labels-integration
-ocm:
-  $ref: /dependencies/ocm/orgs/osd-fleet-manager/integration.yml
+ocmEnv:
+  $ref: /dependencies/ocm/environments/integration.yml
 
 managedSubscriptionLabelPrefix: sre-capabilities.dtp.spec
 

--- a/reconcile/test/fixtures/fleet_labeler/2_clusters-alternative.yaml
+++ b/reconcile/test/fixtures/fleet_labeler/2_clusters-alternative.yaml
@@ -1,8 +1,8 @@
 $schema: /openshift/fleet-labels-spec-1.yml
 
 name: hypershift-cluster-subscription-labels-integration
-ocm:
-  $ref: /dependencies/ocm/orgs/osd-fleet-manager/integration.yml
+ocmEnv:
+  $ref: /dependencies/ocm/environments/integration.yml
 
 managedSubscriptionLabelPrefix: sre-capabilities.dtp.spec
 

--- a/reconcile/test/fixtures/fleet_labeler/2_clusters.yaml
+++ b/reconcile/test/fixtures/fleet_labeler/2_clusters.yaml
@@ -1,8 +1,8 @@
 $schema: /openshift/fleet-labels-spec-1.yml
 
 name: hypershift-cluster-subscription-labels-integration
-ocm:
-  $ref: /dependencies/ocm/orgs/osd-fleet-manager/integration.yml
+ocmEnv:
+  $ref: /dependencies/ocm/environments/integration.yml
 
 managedSubscriptionLabelPrefix: sre-capabilities.dtp.spec
 

--- a/reconcile/test/fleet_labeler/conftest.py
+++ b/reconcile/test/fleet_labeler/conftest.py
@@ -26,11 +26,9 @@ def default_label_spec(
         {
             "path": "/test.yaml",
             "name": "default-spec",
-            "ocm": {
+            "ocmEnv": {
                 "name": "ocm_test",
-                "environment": {
-                    "url": "https://api.test.com",
-                },
+                "url": "https://api.test.com",
                 "accessTokenClientId": "client_id",
                 "accessTokenUrl": "https://test.com",
                 "accessTokenClientSecret": {},

--- a/reconcile/test/fleet_labeler/fixtures.py
+++ b/reconcile/test/fleet_labeler/fixtures.py
@@ -70,11 +70,9 @@ def label_spec_data_from_fixture(file_name: str) -> dict[str, Any]:
     data = fxt.get_anymarkup(file_name)
     del data["$schema"]
     data["path"] = "/test.yaml"
-    data["ocm"] = {
+    data["ocmEnv"] = {
         "name": "ocm_test",
-        "environment": {
-            "url": "https://api.test.com",
-        },
+        "url": "https://api.test.com",
         "accessTokenClientId": "client_id",
         "accessTokenUrl": "https://test.com",
         "accessTokenClientSecret": {},

--- a/reconcile/test/fleet_labeler/test_fleet_labeler_spec_validation.py
+++ b/reconcile/test/fleet_labeler/test_fleet_labeler_spec_validation.py
@@ -6,9 +6,6 @@ from reconcile.fleet_labeler.integration import (
 )
 from reconcile.fleet_labeler.validate import (
     MatchLabelsNotUniqueError,
-    OCMAccessTokenClientIdMissing,
-    OCMAccessTokenClientSecretMissing,
-    OCMAccessTokenUrlMissing,
 )
 from reconcile.gql_definitions.fleet_labeler.fleet_labels import (
     FleetLabelsSpecV1,
@@ -22,39 +19,6 @@ def test_valid_spec(
 ) -> None:
     dependencies.label_specs_by_name = {default_label_spec.name: default_label_spec}
     integration.reconcile(dependencies=dependencies)
-
-
-def test_missing_client_id(
-    integration: FleetLabelerIntegration,
-    dependencies: Dependencies,
-    default_label_spec: FleetLabelsSpecV1,
-) -> None:
-    default_label_spec.ocm.access_token_client_id = None
-    dependencies.label_specs_by_name = {default_label_spec.name: default_label_spec}
-    with pytest.raises(OCMAccessTokenClientIdMissing):
-        integration.reconcile(dependencies=dependencies)
-
-
-def test_missing_client_secret(
-    integration: FleetLabelerIntegration,
-    dependencies: Dependencies,
-    default_label_spec: FleetLabelsSpecV1,
-) -> None:
-    default_label_spec.ocm.access_token_client_secret = None
-    dependencies.label_specs_by_name = {default_label_spec.name: default_label_spec}
-    with pytest.raises(OCMAccessTokenClientSecretMissing):
-        integration.reconcile(dependencies=dependencies)
-
-
-def test_missing_token_url(
-    integration: FleetLabelerIntegration,
-    dependencies: Dependencies,
-    default_label_spec: FleetLabelsSpecV1,
-) -> None:
-    default_label_spec.ocm.access_token_url = None
-    dependencies.label_specs_by_name = {default_label_spec.name: default_label_spec}
-    with pytest.raises(OCMAccessTokenUrlMissing):
-        integration.reconcile(dependencies=dependencies)
 
 
 def test_non_unique_match_labels(


### PR DESCRIPTION
Fleet Labeler should use `OCMEnvironment` directly instead of going via `ClusterManager`. We currently have no need for any `ClusterManager` attributes.
This also makes it easier to align Fleet Labeler with DTP, as currently both are using different OCM tokens, which leads to different cluster discovery results.

Using `OCMEnvironment` directly eases spec validation as most things are covered at schema check. Further, we require use of our sre-capa tokens in the environments to see more clusters.

Schema: https://github.com/app-sre/qontract-schemas/pull/781