### PR TITLE
[gitlab-owners] support groups

### DIFF
--- a/reconcile/gitlab_owners.py
+++ b/reconcile/gitlab_owners.py
@@ -94,6 +94,13 @@ class MRApproval:
             lgtms.append(comment["username"])
         return lgtms
 
+    def expand_groups(self, owners: list[str]) -> list[str]:
+        members: set[str] = set()
+        for name in owners:
+            if group := self.gitlab.get_group_if_exists(name):
+                members.update(m.username for m in self.gitlab.get_group_members(group))
+        return list(members.union(owners))
+
     def get_approval_status(self):
         approval_status = {"approved": False, "report": None}
 
@@ -116,6 +123,11 @@ class MRApproval:
             for approver in change_owners["approvers"]:
                 if approver in lgtms:
                     change_approved = True
+
+            if not change_approved:
+                for approver in self.expand_groups(change_owners["approvers"]):
+                    if approver in lgtms:
+                        change_approved = True
 
             # Each change that was not yet approved will generate
             # a report message

--- a/reconcile/gitlab_owners.py
+++ b/reconcile/gitlab_owners.py
@@ -124,9 +124,12 @@ class MRApproval:
                 if approver in lgtms:
                     change_approved = True
 
-            if lgtms and not change_approved:
-                if self.expand_groups(change_owners["approvers"]).intersection(lgtms):
-                    change_approved = True
+            if (
+                not change_approved
+                and lgtms
+                and self.expand_groups(change_owners["approvers"]).intersection(lgtms)
+            ):
+                change_approved = True
 
             # Each change that was not yet approved will generate
             # a report message

--- a/reconcile/gitlab_owners.py
+++ b/reconcile/gitlab_owners.py
@@ -124,7 +124,7 @@ class MRApproval:
                 if approver in lgtms:
                     change_approved = True
 
-            if not change_approved:
+            if lgtms and not change_approved:
                 for approver in self.expand_groups(change_owners["approvers"]):
                     if approver in lgtms:
                         change_approved = True


### PR DESCRIPTION
this PR adds support to use a gitlab group in an OWNERS file.

the implementation is to iterate over each name, and if it's a group - add it's members to the list of approvers.

required to support a self-service onboarding, for example: https://gitlab.cee.redhat.com/service/managed-tenants/-/merge_requests/4870