### PR TITLE
ERv2: RuntimeError when dry_run without dry_run_job_suffix

### DIFF
--- a/reconcile/external_resources/integration.py
+++ b/reconcile/external_resources/integration.py
@@ -143,6 +143,9 @@ def run(
     workers_cluster: str | None = None,
     workers_namespace: str | None = None,
 ) -> None:
+    if dry_run and not dry_run_job_suffix:
+        raise RuntimeError("dry_run needs a dry_run_job_suffix")
+
     vault_settings = get_app_interface_vault_settings()
     secret_reader = create_secret_reader(use_vault=vault_settings.vault)
     er_settings = get_settings()


### PR DESCRIPTION
I observed cases where DRY_RUN  runs are made with `dry_run_job_suffix = ""`.  This parameter contains the MR number to identify the MR on the job pods. I think Jenkins launches these runs under certain circumstances. 

DRY_RUN runs must always run under an MR context. Therefore, these runs will be terminated with a RuntimeException. 