### PR TITLE
APPSRE-11551 ALB health checks

### DIFF
--- a/reconcile/gql_definitions/introspection.json
+++ b/reconcile/gql_definitions/introspection.json
@@ -46575,6 +46575,77 @@
                             },
                             "isDeprecated": false,
                             "deprecationReason": null
+                        },
+                        {
+                            "name": "health_check",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "OBJECT",
+                                "name": "NamespaceTerraformResourceALBTargetHealthcheck_v1",
+                                "ofType": null
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        }
+                    ],
+                    "inputFields": null,
+                    "interfaces": [],
+                    "enumValues": null,
+                    "possibleTypes": null
+                },
+                {
+                    "kind": "OBJECT",
+                    "name": "NamespaceTerraformResourceALBTargetHealthcheck_v1",
+                    "description": null,
+                    "fields": [
+                        {
+                            "name": "unhealthy_threshold",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "SCALAR",
+                                "name": "Int",
+                                "ofType": null
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "timeout",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "SCALAR",
+                                "name": "Int",
+                                "ofType": null
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "interval",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "SCALAR",
+                                "name": "Int",
+                                "ofType": null
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "healthy_threshold",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "SCALAR",
+                                "name": "Int",
+                                "ofType": null
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
                         }
                     ],
                     "inputFields": null,

--- a/reconcile/gql_definitions/terraform_resources/terraform_resources_namespaces.gql
+++ b/reconcile/gql_definitions/terraform_resources/terraform_resources_namespaces.gql
@@ -262,6 +262,12 @@ query TerraformResourcesNamespaces {
                     openshift_service
                     protocol
                     protocol_version
+                    health_check {
+                        unhealthy_threshold
+                        timeout
+                        interval
+                        healthy_threshold
+                    }
                 }
                 rules {
                     condition {

--- a/reconcile/gql_definitions/terraform_resources/terraform_resources_namespaces.py
+++ b/reconcile/gql_definitions/terraform_resources/terraform_resources_namespaces.py
@@ -319,6 +319,12 @@ query TerraformResourcesNamespaces {
                     openshift_service
                     protocol
                     protocol_version
+                    health_check {
+                        unhealthy_threshold
+                        timeout
+                        interval
+                        healthy_threshold
+                    }
                 }
                 rules {
                     condition {
@@ -799,6 +805,13 @@ class NamespaceTerraformResourceS3CloudFrontPublicKeyV1(NamespaceTerraformResour
     annotations: Optional[str] = Field(..., alias="annotations")
 
 
+class NamespaceTerraformResourceALBTargetHealthcheckV1(ConfiguredBaseModel):
+    unhealthy_threshold: Optional[int] = Field(..., alias="unhealthy_threshold")
+    timeout: Optional[int] = Field(..., alias="timeout")
+    interval: Optional[int] = Field(..., alias="interval")
+    healthy_threshold: Optional[int] = Field(..., alias="healthy_threshold")
+
+
 class NamespaceTerraformResourceALBTargetsV1(ConfiguredBaseModel):
     name: str = Field(..., alias="name")
     default: bool = Field(..., alias="default")
@@ -806,6 +819,7 @@ class NamespaceTerraformResourceALBTargetsV1(ConfiguredBaseModel):
     openshift_service: Optional[str] = Field(..., alias="openshift_service")
     protocol: Optional[str] = Field(..., alias="protocol")
     protocol_version: Optional[str] = Field(..., alias="protocol_version")
+    health_check: Optional[NamespaceTerraformResourceALBTargetHealthcheckV1] = Field(..., alias="health_check")
 
 
 class NamespaceTerraformResourceALBConditionV1(ConfiguredBaseModel):

--- a/reconcile/utils/terrascript_aws_client.py
+++ b/reconcile/utils/terrascript_aws_client.py
@@ -5376,6 +5376,25 @@ class TerrascriptClient:  # pylint: disable=too-many-public-methods
                 f"{identifier}-{target_name}", **lbt_random_id_values
             )
             tf_resources.append(lbt_random_id)
+            health_check_interval = 10
+            health_check_timeout = 5
+            health_check_unhealthy_threshold = 3
+            health_check_healthy_threshold = 3
+            if health_check := t.get("health_check"):
+                health_check_interval = (
+                    health_check.get("interval") or health_check_interval
+                )
+                health_check_timeout = (
+                    health_check.get("timeout") or health_check_timeout
+                )
+                health_check_unhealthy_threshold = (
+                    health_check.get("unhealthy_threshold")
+                    or health_check_unhealthy_threshold
+                )
+                health_check_healthy_threshold = (
+                    health_check.get("healthy_threshold")
+                    or health_check_healthy_threshold
+                )
 
             # https://www.terraform.io/docs/providers/aws/r/
             # lb_target_group.html
@@ -5388,7 +5407,10 @@ class TerrascriptClient:  # pylint: disable=too-many-public-methods
                 "target_type": "ip",
                 "vpc_id": vpc_id,
                 "health_check": {
-                    "interval": 10,
+                    "interval": health_check_interval,
+                    "timeout": health_check_timeout,
+                    "unhealthy_threshold": health_check_unhealthy_threshold,
+                    "healthy_threshold": health_check_healthy_threshold,
                     "path": "/",
                     "protocol": "HTTPS",
                     "port": 443,


### PR DESCRIPTION
ALB health checks should be configurable. The defaults are taken from currently provisioned ALB instances.

schema: https://github.com/app-sre/qontract-schemas/pull/783

Verified locally by changing only a few target groups

```
qontract-reconcile-terraform-resources  | [2025-03-18 10:15:17] [INFO] [DRY-RUN] [terraform_client.py:log_plan_diff:374] - ['update', 'quayio-prod', 'aws_lb_target_group', 'quayio-production-alb01-quay-pull', {'health_check'}]
qontract-reconcile-terraform-resources  | [2025-03-18 10:15:17] [INFO] [DRY-RUN] [terraform_client.py:log_plan_diff:374] - ['update', 'quayio-prod', 'aws_lb_target_group', 'quayio-production-alb01-quay-push', {'health_check'}]
qontract-reconcile-terraform-resources  | [2025-03-18 10:15:17] [INFO] [DRY-RUN] [terraform_client.py:log_plan_diff:374] - ['update', 'quayio-prod', 'aws_lb_target_group', 'quayio-production-alb01-quayio-prod-ak', {'health_check'}]
qontract-reconcile-terraform-resources  | [2025-03-18 10:15:17] [INFO] [DRY-RUN] [terraform_client.py:log_plan_diff:374] - ['update', 'quayio-prod', 'aws_lb_target_group', 'quayio-production-alb01-quayio-production-py3', {'health_check'}]
```

Other ALB target groups are not affected and keep their defaults