### PR TITLE
:sparkles: aws-account-manager: customizable AWS account file path

### DIFF
--- a/reconcile/gql_definitions/aws_account_manager/aws_accounts.gql
+++ b/reconcile/gql_definitions/aws_account_manager/aws_accounts.gql
@@ -36,6 +36,7 @@ query AWSAccountManagerAccounts {
       supportedDeploymentRegions
       uid
       additionalFeatures
+      accountFileTargetPath
     }
     organization_accounts {
       ... AWSAccountManaged

--- a/reconcile/gql_definitions/aws_account_manager/aws_accounts.py
+++ b/reconcile/gql_definitions/aws_account_manager/aws_accounts.py
@@ -90,6 +90,7 @@ query AWSAccountManagerAccounts {
       supportedDeploymentRegions
       uid
       additionalFeatures
+      accountFileTargetPath
     }
     organization_accounts {
       ... AWSAccountManaged
@@ -143,6 +144,7 @@ class AWSAccountRequestV1(ConfiguredBaseModel):
     supported_deployment_regions: Optional[list[str]] = Field(..., alias="supportedDeploymentRegions")
     uid: Optional[str] = Field(..., alias="uid")
     additional_features: Optional[Json] = Field(..., alias="additionalFeatures")
+    account_file_target_path: Optional[str] = Field(..., alias="accountFileTargetPath")
 
 
 class AWSAccountV1(AWSAccountManaged):

--- a/reconcile/gql_definitions/introspection.json
+++ b/reconcile/gql_definitions/introspection.json
@@ -15396,6 +15396,18 @@
                             },
                             "isDeprecated": false,
                             "deprecationReason": null
+                        },
+                        {
+                            "name": "accountFileTargetPath",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "SCALAR",
+                                "name": "String",
+                                "ofType": null
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
                         }
                     ],
                     "inputFields": null,


### PR DESCRIPTION
The resulting account file path in app-interface must be configurable. This PR adds `accountFileTargetPath` to customize the path.

Ticket: [APPSRE-11540](https://issues.redhat.com/browse/APPSRE-11540)