### PR TITLE
:sparkles: aws-account-manager: tag org accounts

### DIFF
--- a/reconcile/aws_account_manager/integration.py
+++ b/reconcile/aws_account_manager/integration.py
@@ -195,6 +195,7 @@ class AwsAccountMgmtIntegration(
         aws_api: AWSApi,
         reconciler: AWSReconciler,
         organization_accounts: Iterable[AWSAccountManaged],
+        default_tags: dict[str, str],
     ) -> None:
         """Reconcile organization accounts."""
         for account in organization_accounts:
@@ -204,7 +205,7 @@ class AwsAccountMgmtIntegration(
                 name=account.name,
                 uid=account.uid,
                 ou=account.organization.ou,
-                tags=self.params.default_tags
+                tags=default_tags
                 | account.organization.tags
                 | {"app-interface-name": account.name},
                 enterprise_support=account.premium_support,
@@ -276,6 +277,8 @@ class AwsAccountMgmtIntegration(
                     acct_manager_role_aws_api,
                     reconciler,
                     payer_account.organization_accounts or [],
+                    default_tags=self.params.default_tags
+                    | (payer_account.organization_account_tags or {}),
                 )
 
     def reconcile_non_organization_accounts(

--- a/reconcile/gql_definitions/aws_account_manager/aws_accounts.gql
+++ b/reconcile/gql_definitions/aws_account_manager/aws_accounts.gql
@@ -41,5 +41,6 @@ query AWSAccountManagerAccounts {
     organization_accounts {
       ... AWSAccountManaged
     }
+    organizationAccountTags
   }
 }

--- a/reconcile/gql_definitions/aws_account_manager/aws_accounts.py
+++ b/reconcile/gql_definitions/aws_account_manager/aws_accounts.py
@@ -95,6 +95,7 @@ query AWSAccountManagerAccounts {
     organization_accounts {
       ... AWSAccountManaged
     }
+    organizationAccountTags
   }
 }
 """
@@ -154,6 +155,7 @@ class AWSAccountV1(AWSAccountManaged):
     automation_role: Optional[AWSAutomationRoleV1] = Field(..., alias="automationRole")
     account_requests: Optional[list[AWSAccountRequestV1]] = Field(..., alias="account_requests")
     organization_accounts: Optional[list[AWSAccountManaged]] = Field(..., alias="organization_accounts")
+    organization_account_tags: Optional[Json] = Field(..., alias="organizationAccountTags")
 
 
 class AWSAccountManagerAccountsQueryData(ConfiguredBaseModel):

--- a/reconcile/gql_definitions/introspection.json
+++ b/reconcile/gql_definitions/introspection.json
@@ -10409,6 +10409,18 @@
                             "deprecationReason": null
                         },
                         {
+                            "name": "organizationAccountTags",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "SCALAR",
+                                "name": "JSON",
+                                "ofType": null
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
                             "name": "account_requests",
                             "description": null,
                             "args": [],

--- a/reconcile/test/aws_account_manager/test_aws_account_manager_integration.py
+++ b/reconcile/test/aws_account_manager/test_aws_account_manager_integration.py
@@ -203,7 +203,9 @@ def test_aws_account_manager_utils_integration_reconcile_organization_accounts(
     intg: AwsAccountMgmtIntegration,
 ) -> None:
     intg.reconcile_account = MagicMock()  # type: ignore
-    intg.reconcile_organization_accounts(aws_api, reconciler, [org_account])
+    intg.reconcile_organization_accounts(
+        aws_api, reconciler, [org_account], default_tags={"ship": "USS Enterprise"}
+    )
     reconciler.reconcile_organization_account.assert_called_once_with(
         aws_api=aws_api,
         enterprise_support=False,


### PR DESCRIPTION
This PR enhances the `aws-account-manager` integration to be able to tag all organization accounts with tags based on the payer account (`/aws/account-1/organizationAccountTags`).

Depends on: https://github.com/app-sre/qontract-schemas/pull/785
Ticket: [APPSRE-11633](https://issues.redhat.com/browse/APPSRE-11633)