### PR TITLE
Handle immutable field changes in Recreate type deployments

### DIFF
--- a/reconcile/openshift_base.py
+++ b/reconcile/openshift_base.py
@@ -443,6 +443,11 @@ def apply(
             # spec.selector changes
             current_resource = oc.get(namespace, resource_type, resource.name)
 
+            if current_resource["spec"]["strategy"]["type"] == "Recreate":
+                oc.delete(namespace, resource_type, resource.name)
+                oc.create(namespace, resource=annotated)
+                return
+
             # check update strategy
             if current_resource["spec"]["strategy"]["type"] != "RollingUpdate":
                 logging.error(


### PR DESCRIPTION
Handle immutable field deployment changes by recreating the deployment objects. 
* This only happens when immutable fields are changed. 
* This rollout strategy has an intrinsic downtime when this behavior happens, this code only automates it. 

