### PR TITLE
:sparkles: aws-account-manager: enable/disable regions

### DIFF
--- a/reconcile/aws_account_manager/integration.py
+++ b/reconcile/aws_account_manager/integration.py
@@ -227,6 +227,7 @@ class AwsAccountMgmtIntegration(
             alias=account.alias,
             quotas=[q for ql in account.quota_limits or [] for q in ql.quotas],
             security_contact=account.security_contact,
+            regions=account.supported_deployment_regions or [],
         )
 
     def reconcile_payer_accounts(

--- a/reconcile/aws_account_manager/reconciler.py
+++ b/reconcile/aws_account_manager/reconciler.py
@@ -4,6 +4,7 @@ from textwrap import dedent
 from typing import Any, Protocol
 
 from reconcile.aws_account_manager.utils import state_key
+from reconcile.utils.aws_api_typed.account import OptStatus
 from reconcile.utils.aws_api_typed.api import AWSApi
 from reconcile.utils.aws_api_typed.iam import (
     AWSAccessKey,
@@ -26,6 +27,7 @@ TASK_CHECK_SERVICE_QUOTA_STATUS = "check-service-quota-status"
 TASK_ENABLE_ENTERPRISE_SUPPORT = "enable-enterprise-support"
 TASK_CHECK_ENTERPRISE_SUPPORT_STATUS = "check-enterprise-support-status"
 TASK_SET_SECURITY_CONTACT = "set-security-contact"
+TASK_SET_SUPPORTED_REGIONS = "set-supported-regions"
 
 
 class Quota(Protocol):
@@ -62,7 +64,7 @@ class AWSReconciler:
                 # account already exists, nothing to do
                 return _state.value
 
-            logging.info(f"Creating account {name}")
+            logging.info(f"{name}: Creating account")
             if self.dry_run:
                 raise AbortStateTransaction("Dry run")
 
@@ -83,7 +85,7 @@ class AWSReconciler:
                 # account checked and exists, nothing to do
                 return _state.value
 
-            logging.info(f"Checking account creation status {name}")
+            logging.info(f"{name}: Checking account creation status")
             status = aws_api.organizations.describe_create_account_status(
                 create_account_request_id=create_account_request_id
             )
@@ -110,7 +112,7 @@ class AWSReconciler:
                 # account already tagged, nothing to do
                 return
 
-            logging.info(f"Tagging account {name}: {tags}")
+            logging.info(f"{name}: Setting tags {tags}")
             _state.value = tags
             if self.dry_run:
                 raise AbortStateTransaction("Dry run")
@@ -133,7 +135,7 @@ class AWSReconciler:
                 # account already moved, nothing to do
                 return
 
-            logging.info(f"Moving account {name} to {ou}")
+            logging.info(f"{name}: Moving account to OU {ou}")
             destination = self._get_destination_ou(aws_api, destination_path=ou)
             if self.dry_run:
                 raise AbortStateTransaction("Dry run")
@@ -153,7 +155,7 @@ class AWSReconciler:
             if _state.exists and _state.value == new_alias:
                 return
 
-            logging.info(f"Set account alias '{new_alias}' for {name}")
+            logging.info(f"{name}: Set account alias '{new_alias}'")
             if self.dry_run:
                 raise AbortStateTransaction("Dry run")
 
@@ -179,7 +181,7 @@ class AWSReconciler:
                 if quota.value > q.value:
                     # a quota can be already higher than requested, because it was may set manually or enforced by the payer account
                     logging.info(
-                        f"Cannot lower quota {q.service_code=}, {q.quota_code=}: {quota.value} -> {q.value}. Skipping."
+                        f"{name}: Cannot lower quota {q.service_code=}, {q.quota_code=}: {quota.value} -> {q.value}. Skipping."
                     )
                 elif quota.value < q.value:
                     quota.value = q.value
@@ -187,7 +189,7 @@ class AWSReconciler:
 
             for q in new_quotas:
                 logging.info(
-                    f"Setting quota for {name}: {q.service_name}/{q.quota_name} ({q.service_code}/{q.quota_code}) -> {q.value}"
+                    f"{name}: Setting quota: {q.service_name}/{q.quota_name} ({q.service_code}/{q.quota_code}) -> {q.value}"
                 )
 
             if self.dry_run:
@@ -203,7 +205,7 @@ class AWSReconciler:
                     )
                 except AWSResourceAlreadyExistsException:
                     raise AbortStateTransaction(
-                        f"A quota increase for this {new_quota.service_code}/{new_quota.quota_code} already exists. Try it again later."
+                        f"{name}: A quota increase for this {new_quota.service_code}/{new_quota.quota_code} already exists. Try it again later."
                     ) from None
                 ids.append(req.id)
 
@@ -223,7 +225,7 @@ class AWSReconciler:
             if _state.exists and _state.value == request_ids:
                 return
 
-            logging.info(f"Checking quota change requests for {name}")
+            logging.info(f"{name}: Checking quota change requests")
             if self.dry_run:
                 raise AbortStateTransaction("Dry run")
 
@@ -258,7 +260,7 @@ class AWSReconciler:
                     raise AbortStateTransaction("Dry run")
                 return None
 
-            logging.info(f"Enabling enterprise support for {name}")
+            logging.info(f"{name}: Enabling enterprise support")
             if self.dry_run:
                 raise AbortStateTransaction("Dry run")
 
@@ -277,7 +279,9 @@ class AWSReconciler:
             _state.value = case_id
             return case_id
 
-    def _check_enterprise_support_status(self, aws_api: AWSApi, case_id: str) -> None:
+    def _check_enterprise_support_status(
+        self, aws_api: AWSApi, name: str, case_id: str
+    ) -> None:
         """Check the status of the enterprise support case."""
         with self.state.transaction(
             state_key(case_id, TASK_CHECK_ENTERPRISE_SUPPORT_STATUS), True
@@ -285,7 +289,7 @@ class AWSReconciler:
             if _state.exists:
                 return
 
-            logging.info(f"Checking enterprise support case {case_id}")
+            logging.info(f"{name}: Checking enterprise support case {case_id}")
             if self.dry_run:
                 raise AbortStateTransaction("Dry run")
 
@@ -316,7 +320,7 @@ class AWSReconciler:
             if _state.exists and _state.value == security_contact:
                 return
 
-            logging.info(f"Setting security contact for {account}")
+            logging.info(f"{name}: Setting security contact")
             if self.dry_run:
                 raise AbortStateTransaction("Dry run")
 
@@ -324,6 +328,47 @@ class AWSReconciler:
                 name=name, title=title, email=email, phone_number=phone_number
             )
             _state.value = security_contact
+
+    def _set_supported_regions(
+        self,
+        aws_api: AWSApi,
+        name: str,
+        regions: Iterable[str],
+    ) -> None:
+        """Set the supported regions for the account."""
+        with self.state.transaction(
+            state_key(name, TASK_SET_SUPPORTED_REGIONS)
+        ) as _state:
+            if _state.exists and _state.value == regions:
+                return
+
+            logging.info(f"{name}: Setting regions {regions}")
+            aws_regions = aws_api.account.list_regions()
+            if invalid_regions := set(regions) - {r.name for r in aws_regions}:
+                raise RuntimeError(
+                    f"Regions {invalid_regions} are not available in the account {name}"
+                )
+
+            if self.dry_run:
+                raise AbortStateTransaction("Dry run")
+
+            for aws_region in aws_regions:
+                # ATTENTION: Regions can be enabled by default.
+                # That means we cannot enable or disable them manually. We just gently ignore them!
+                if (
+                    aws_region.status == OptStatus.ENABLED
+                    and aws_region.name not in regions
+                ):
+                    logging.info(f"Disabling region {aws_region.name} in {name}")
+                    aws_api.account.disable_region(aws_region.name)
+                if (
+                    aws_region.status == OptStatus.DISABLED
+                    and aws_region.name in regions
+                ):
+                    logging.info(f"Enabling region {aws_region.name} in {name}")
+                    aws_api.account.enable_region(aws_region.name)
+
+            _state.value = regions
 
     #
     # Public methods
@@ -353,7 +398,7 @@ class AWSReconciler:
             if _state.exists and _state.value == user_name:
                 return None
 
-            logging.info(f"Creating IAM user '{user_name}' for {name}")
+            logging.info(f"{name}: Creating IAM user '{user_name}'")
             if self.dry_run:
                 raise AbortStateTransaction("Dry run")
 
@@ -379,7 +424,7 @@ class AWSReconciler:
         if enterprise_support and (
             case_id := self._enable_enterprise_support(aws_api, name, uid)
         ):
-            self._check_enterprise_support_status(aws_api, case_id)
+            self._check_enterprise_support_status(aws_api, name, case_id)
 
     def reconcile_account(
         self,
@@ -388,6 +433,7 @@ class AWSReconciler:
         alias: str | None,
         quotas: Iterable[Quota],
         security_contact: Contact,
+        regions: Iterable[str],
     ) -> None:
         """Reconcile/update the AWS account. Return the initial user access key if a new user was created."""
         self._set_account_alias(aws_api, name, alias)
@@ -401,3 +447,4 @@ class AWSReconciler:
             email=security_contact.email,
             phone_number=security_contact.phone_number,
         )
+        self._set_supported_regions(aws_api, name, regions)

--- a/reconcile/gql_definitions/aws_account_manager/aws_accounts.py
+++ b/reconcile/gql_definitions/aws_account_manager/aws_accounts.py
@@ -45,6 +45,7 @@ fragment AWSAccountManaged on AWSAccount_v1 {
     email
     phoneNumber
   }
+  supportedDeploymentRegions
 }
 
 fragment VaultSecret on VaultSecret_v1 {

--- a/reconcile/gql_definitions/fragments/aws_account_managed.gql
+++ b/reconcile/gql_definitions/fragments/aws_account_managed.gql
@@ -23,4 +23,5 @@ fragment AWSAccountManaged on AWSAccount_v1 {
     email
     phoneNumber
   }
+  supportedDeploymentRegions
 }

--- a/reconcile/gql_definitions/fragments/aws_account_managed.py
+++ b/reconcile/gql_definitions/fragments/aws_account_managed.py
@@ -55,3 +55,4 @@ class AWSAccountManaged(ConfiguredBaseModel):
     organization: Optional[AWSOrganizationV1] = Field(..., alias="organization")
     quota_limits: Optional[list[AWSQuotaLimitsV1]] = Field(..., alias="quotaLimits")
     security_contact: Optional[AWSContactV1] = Field(..., alias="securityContact")
+    supported_deployment_regions: Optional[list[str]] = Field(..., alias="supportedDeploymentRegions")

--- a/reconcile/test/aws_account_manager/test_aws_account_manager_integration.py
+++ b/reconcile/test/aws_account_manager/test_aws_account_manager_integration.py
@@ -239,6 +239,7 @@ def test_aws_account_manager_utils_integration_reconcile_account(
             email="security@example.com",
             phoneNumber="+1234567890",
         ),
+        regions=["ca-east-1", "ca-west-2"],
     )
 
 

--- a/reconcile/test/aws_account_manager/test_aws_account_manager_reconciler.py
+++ b/reconcile/test/aws_account_manager/test_aws_account_manager_reconciler.py
@@ -594,7 +594,7 @@ def test_aws_account_manager_reconcile_check_enterprise_support_status(
     aws_api.support.describe_case.return_value = AWSCase(
         caseId="case-id", subject="foobar", status="resolved"
     )
-    reconciler._check_enterprise_support_status(aws_api, "case-id")
+    reconciler._check_enterprise_support_status(aws_api, "name", "case-id")
     aws_api.support.describe_case.assert_called_once()
 
 
@@ -602,7 +602,7 @@ def test_aws_account_manager_reconcile_check_enterprise_support_status_state_exi
     aws_api: MagicMock, reconciler: AWSReconciler, state_exists: Callable
 ) -> None:
     state_exists(state_key("case-id", TASK_CHECK_ENTERPRISE_SUPPORT_STATUS), True)
-    reconciler._check_enterprise_support_status(aws_api, "case-id")
+    reconciler._check_enterprise_support_status(aws_api, "name", "case-id")
     aws_api.support.describe_case.assert_not_called()
 
 
@@ -610,14 +610,14 @@ def test_aws_account_manager_reconcile_check_enterprise_support_status_state_exi
     aws_api: MagicMock, reconciler: AWSReconciler, state_exists: Callable
 ) -> None:
     state_exists(state_key("another-id", TASK_CHECK_ENTERPRISE_SUPPORT_STATUS), True)
-    reconciler._check_enterprise_support_status(aws_api, "case-id")
+    reconciler._check_enterprise_support_status(aws_api, "name", "case-id")
     aws_api.support.describe_case.assert_called_once()
 
 
 def test_aws_account_manager_reconcile_check_enterprise_support_status_dry_run(
     aws_api: MagicMock, reconciler_dry_run: AWSReconciler
 ) -> None:
-    reconciler_dry_run._check_enterprise_support_status(aws_api, "case-id")
+    reconciler_dry_run._check_enterprise_support_status(aws_api, "name", "case-id")
     aws_api.support.describe_case.assert_not_called()
 
 
@@ -842,6 +842,7 @@ def test_aws_account_manager_reconcile_reconcile_account(
         security_contact=AWSContactV1(
             name="name", title="title", email="email", phoneNumber="phone"
         ),
+        regions=[],
     )
     reconciler._set_account_alias.assert_called_once()
     reconciler._request_quotas.assert_called_once()
@@ -865,6 +866,7 @@ def test_aws_account_manager_reconcile_reconcile_account_no_initial_user(
         security_contact=AWSContactV1(
             name="name", title="title", email="email", phoneNumber="phone"
         ),
+        regions=[],
     )
     reconciler._set_account_alias.assert_called_once()
     reconciler._request_quotas.assert_called_once()

--- a/reconcile/test/fixtures/aws_account_manager/accounts.yml
+++ b/reconcile/test/fixtures/aws_account_manager/accounts.yml
@@ -4,7 +4,6 @@ accounts:
 - name: jeanluc
   alias: captain-picard
   uid: '111111111111'
-  alias: null
   premiumSupport: false
   organization:
     ou: /Root/alpha quadrant/uss enterprise/ncc-1701-d
@@ -19,6 +18,9 @@ accounts:
       quotaCode: L-1194D53C
       value: 102
   resourcesDefaultRegion: us-east-1
+  supportedDeploymentRegions:
+  - ca-east-1
+  - ca-west-2
   securityContact:
     name: security contact name
     email: security@example.com
@@ -42,6 +44,9 @@ accounts:
       quotaCode: L-1194D53C
       value: 102
   resourcesDefaultRegion: us-east-1
+  supportedDeploymentRegions:
+  - ca-east-1
+  - ca-west-2
   securityContact:
     name: security contact name
     email: security@example.com

--- a/reconcile/test/utils/aws_api_typed/test_aws_api_typed_account.py
+++ b/reconcile/test/utils/aws_api_typed/test_aws_api_typed_account.py
@@ -4,7 +4,7 @@ from unittest.mock import MagicMock
 import pytest
 from pytest_mock import MockerFixture
 
-from reconcile.utils.aws_api_typed.account import AWSApiAccount
+from reconcile.utils.aws_api_typed.account import AWSApiAccount, OptStatus, Region
 
 if TYPE_CHECKING:
     from mypy_boto3_account import AccountClient
@@ -32,3 +32,61 @@ def test_aws_api_typed_account_set_security_contact(
         email="email",
         phone_number="phone_number",
     )
+
+
+def test_aws_api_typed_account_list_regions(
+    aws_api_account: AWSApiAccount, account_client: MagicMock
+) -> None:
+    paginator_mock = MagicMock()
+    paginator_mock.paginate.side_effect = [
+        [
+            {
+                "Regions": [
+                    {
+                        "RegionOptStatus": "ENABLED",
+                        "RegionName": "region-enabled",
+                    },
+                    {
+                        "RegionOptStatus": "ENABLING",
+                        "RegionName": "region-enabling",
+                    },
+                    {
+                        "RegionOptStatus": "DISABLED",
+                        "RegionName": "region-disabled",
+                    },
+                    {
+                        "RegionOptStatus": "DISABLING",
+                        "RegionName": "region-disabling",
+                    },
+                    {
+                        "RegionOptStatus": "ENABLED_BY_DEFAULT",
+                        "RegionName": "region-enabled-by-default",
+                    },
+                ]
+            }
+        ],
+        [],
+    ]
+    account_client.get_paginator.return_value = paginator_mock
+
+    assert aws_api_account.list_regions() == [
+        Region(name="region-enabled", status=OptStatus.ENABLED),
+        Region(name="region-enabling", status=OptStatus.ENABLED),
+        Region(name="region-disabled", status=OptStatus.DISABLED),
+        Region(name="region-disabling", status=OptStatus.DISABLED),
+        Region(name="region-enabled-by-default", status=OptStatus.ENABLED_BY_DEFAULT),
+    ]
+
+
+def test_aws_api_typed_account_enable_region(
+    aws_api_account: AWSApiAccount, account_client: MagicMock
+) -> None:
+    aws_api_account.enable_region("region")
+    account_client.enable_region.assert_called_once_with(RegionName="region")
+
+
+def test_aws_api_typed_account_disable_region(
+    aws_api_account: AWSApiAccount, account_client: MagicMock
+) -> None:
+    aws_api_account.disable_region("region")
+    account_client.disable_region.assert_called_once_with(RegionName="region")

--- a/reconcile/utils/aws_api_typed/account.py
+++ b/reconcile/utils/aws_api_typed/account.py
@@ -1,9 +1,25 @@
+from enum import StrEnum
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from mypy_boto3_account import AccountClient
 else:
     AccountClient = object
+
+from pydantic import BaseModel
+
+
+class OptStatus(StrEnum):
+    """Optional status enum."""
+
+    ENABLED = "ENABLED"
+    DISABLED = "DISABLED"
+    ENABLED_BY_DEFAULT = "ENABLED_BY_DEFAULT"
+
+
+class Region(BaseModel):
+    name: str
+    status: OptStatus
 
 
 class AWSApiAccount:
@@ -21,3 +37,29 @@ class AWSApiAccount:
             Title=title,
             PhoneNumber=phone_number,
         )
+
+    def list_regions(self) -> list[Region]:
+        """List all regions in the account."""
+        regions = []
+        paginator = self.client.get_paginator("list_regions")
+        for page in paginator.paginate():
+            for region in page["Regions"]:
+                match region["RegionOptStatus"]:
+                    case "DISABLED" | "DISABLING":
+                        status = OptStatus.DISABLED
+                    case "ENABLED" | "ENABLING":
+                        status = OptStatus.ENABLED
+                    case "ENABLED_BY_DEFAULT":
+                        status = OptStatus.ENABLED_BY_DEFAULT
+                    case _:
+                        raise ValueError(f"Unknown status: {region['RegionOptStatus']}")
+                regions.append(Region(name=region["RegionName"], status=status))
+        return regions
+
+    def enable_region(self, region: str) -> None:
+        """Enable a region in the account."""
+        self.client.enable_region(RegionName=region)
+
+    def disable_region(self, region: str) -> None:
+        """Disable a region in the account."""
+        self.client.disable_region(RegionName=region)


### PR DESCRIPTION
This PR adds region support to the `aws-account-manager`. Users can enable and disable AWS regions for an account via the `/aws/account-1/supportedDeploymentRegions` attribute. 
The 15 default-enabled AWS regions can't be enabled/disabled and are ignored by the integration.
Additionally, this PR enhances the log messages.


Ticket: [APPSRE-11624](https://issues.redhat.com/browse/APPSRE-11624)
