### PR TITLE
fix(openshift_serviceaccount_tokens): handle secret without data

### DIFF
--- a/reconcile/openshift_serviceaccount_tokens.py
+++ b/reconcile/openshift_serviceaccount_tokens.py
@@ -149,17 +149,17 @@ def write_outputs_to_vault(
     integration_name = QONTRACT_INTEGRATION.replace("_", "-")
     for cluster, namespace, _, data in ri:
         for name, d_item in data["desired"].items():
-            body_data = d_item.body["data"]
-            # write secret to per-namespace location
-            secret_path = (
-                f"{vault_path}/{integration_name}/{cluster}/{namespace}/{name}"
-            )
-            secret = {"path": secret_path, "data": body_data}
-            vault_client.write(secret)  # type: ignore
-            # write secret to shared-resources location
-            secret_path = f"{vault_path}/{integration_name}/shared-resources/{name}"
-            secret = {"path": secret_path, "data": body_data}
-            vault_client.write(secret)  # type: ignore
+            if body_data := d_item.body.get("data"):
+                # write secret to per-namespace location
+                secret_path = (
+                    f"{vault_path}/{integration_name}/{cluster}/{namespace}/{name}"
+                )
+                secret = {"path": secret_path, "data": body_data}
+                vault_client.write(secret)  # type: ignore
+                # write secret to shared-resources location
+                secret_path = f"{vault_path}/{integration_name}/shared-resources/{name}"
+                secret = {"path": secret_path, "data": body_data}
+                vault_client.write(secret)  # type: ignore
 
 
 def canonicalize_namespaces(namespaces: Iterable[NamespaceV1]) -> list[NamespaceV1]:

--- a/reconcile/test/test_openshift_serviceaccount_tokens.py
+++ b/reconcile/test/test_openshift_serviceaccount_tokens.py
@@ -1,6 +1,6 @@
 from collections.abc import Callable, Mapping
 from typing import Any
-from unittest.mock import call
+from unittest.mock import call, create_autospec
 
 import pytest
 from pytest_mock import MockerFixture
@@ -136,6 +136,21 @@ def test_openshift_serviceaccount_tokens__write_outputs_to_vault(
             "data": {"token": "token"},
         }),
     ])
+
+
+def test_openshift_serviceaccount_tokens__write_outputs_to_vault_with_service_account_token_request(
+    ri: ResourceInventory,
+) -> None:
+    vault_client = create_autospec(_VaultClient)
+    ri.add_desired_resource(
+        cluster="cluster",
+        namespace="namespace",
+        resource=service_account_token_request("grafana"),
+    )
+
+    write_outputs_to_vault(vault_client, "path/to/secrets", ri)
+
+    vault_client.write.assert_not_called()
 
 
 def test_openshift_serviceaccount_tokens__get_namespaces_with_serviceaccount_tokens(


### PR DESCRIPTION
secret without data (created by `service_account_token_request`) should be ignored when write to vault.

[APPSRE-11650](https://issues.redhat.com/browse/APPSRE-11650)