### PR TITLE
fix(erv2): set WORK env for debug-shell

### DIFF
--- a/tools/cli_commands/erv2.py
+++ b/tools/cli_commands/erv2.py
@@ -222,7 +222,7 @@ class Erv2Cli:
             raise
 
     def enter_shell(self, credentials: Path) -> None:
-        """Run the CDKTF container and enter the shell."""
+        """Run the ERv2 container and enter the shell."""
         input_file = self.temp / "input.json"
         input_file.write_text(self.input_data)
 
@@ -242,6 +242,8 @@ class Erv2Cli:
                     f"{credentials!s}:/credentials:Z",
                     "-e",
                     "AWS_SHARED_CREDENTIALS_FILE=/credentials",
+                    "-e",
+                    "WORK=/tmp/work",
                     "--entrypoint",
                     "/bin/bash",
                     self.image,


### PR DESCRIPTION
By default `WORK` not set then script will use `/work`, it's not exist as should be mounted as volume in real run, no permission to create it in container, so use `/tmp/work` when debug.

Updates to docstrings and environment variables:

* [`tools/cli_commands/erv2.py`](diffhunk://#diff-d751b0b90dc403eba502fee7947218c9887f5ce4b3dc2d0c4236b4b8f5a12fccL225-R225): Updated the docstring in the `enter_shell` method to refer to the ERv2 container instead of the CDKTF container.
* [`tools/cli_commands/erv2.py`](diffhunk://#diff-d751b0b90dc403eba502fee7947218c9887f5ce4b3dc2d0c4236b4b8f5a12fccR245-R246): Added the `WORK=/tmp/work` environment variable in the `enter_shell` method.