### PR TITLE
APPSRE-11690 AUS max parallel upgrades

### DIFF
--- a/reconcile/aus/advanced_upgrade_service.py
+++ b/reconcile/aus/advanced_upgrade_service.py
@@ -289,6 +289,10 @@ class OrganizationLabelSet(BaseModel):
 
     blocked_versions: CSV | None = Field(alias=aus_label_key("blocked-versions"))
 
+    sector_max_parallel_upgrades: dict[str, str] = labelset_groupfield(
+        group_prefix=aus_label_key("sector-max-parallel-upgrades.")
+    )
+
     sector_deps: dict[str, CSV] = labelset_groupfield(
         group_prefix=aus_label_key("sector-deps.")
     )
@@ -311,6 +315,7 @@ class OrganizationLabelSet(BaseModel):
         return [
             OpenShiftClusterManagerSectorV1(
                 name=s,
+                maxParallelUpgrades=self.sector_max_parallel_upgrades.get(s),
                 dependencies=[
                     OpenShiftClusterManagerSectorDependenciesV1(name=d, ocm=None)
                     for d in self.sector_deps.get(s, [])

--- a/reconcile/aus/aus_label_source.py
+++ b/reconcile/aus/aus_label_source.py
@@ -88,8 +88,12 @@ class AUSOrganizationLabelSource(LabelSource):
             )
         # sector dependencies
         for sector in organization.sectors or []:
+            if sector.max_parallel_upgrades:
+                labels[aus_label_key(f"sector-max-parallel-upgrades.{sector.name}")] = (
+                    sector.max_parallel_upgrades
+                )
             if sector.dependencies:
-                labels[aus_label_key(f"sectors.{sector.name}")] = ",".join(
+                labels[aus_label_key(f"sector-deps.{sector.name}")] = ",".join(
                     sorted([dep.name for dep in sector.dependencies])
                 )
         # version-data sharing

--- a/reconcile/aus/aus_label_source.py
+++ b/reconcile/aus/aus_label_source.py
@@ -92,7 +92,7 @@ class AUSOrganizationLabelSource(LabelSource):
                 labels[aus_label_key(f"sector-max-parallel-upgrades.{sector.name}")] = (
                     sector.max_parallel_upgrades
                 )
-            if sector.dependencies:
+            if sector.dependencies is not None:
                 labels[aus_label_key(f"sector-deps.{sector.name}")] = ",".join(
                     sorted([dep.name for dep in sector.dependencies])
                 )

--- a/reconcile/aus/models.py
+++ b/reconcile/aus/models.py
@@ -137,7 +137,11 @@ class OrganizationUpgradeSpec(BaseModel):
 
         # extract sectors
         self._sectors = {
-            s.name: Sector(org_id=self.org.org_id, name=s.name)
+            s.name: Sector(
+                org_id=self.org.org_id,
+                name=s.name,
+                max_parallel_upgrades=s.max_parallel_upgrades,
+            )
             for s in self.org.sectors or []
         }
 
@@ -223,6 +227,7 @@ class SectorConfigError(Exception):
 
 class Sector(BaseModel):
     name: str
+    max_parallel_upgrades: str | None
     dependencies: list[Sector] = Field(default_factory=list)
     _specs: dict[str, ClusterUpgradeSpec] = PrivateAttr(default_factory=dict)
 

--- a/reconcile/gql_definitions/advanced_upgrade_service/aus_clusters.py
+++ b/reconcile/gql_definitions/advanced_upgrade_service/aus_clusters.py
@@ -66,6 +66,7 @@ fragment AUSOCMOrganization on OpenShiftClusterManager_v1 {
   }
   sectors {
     name
+    maxParallelUpgrades
     dependencies {
       name
       ocm {

--- a/reconcile/gql_definitions/advanced_upgrade_service/aus_organization.py
+++ b/reconcile/gql_definitions/advanced_upgrade_service/aus_organization.py
@@ -65,6 +65,7 @@ fragment AUSOCMOrganization on OpenShiftClusterManager_v1 {
   }
   sectors {
     name
+    maxParallelUpgrades
     dependencies {
       name
       ocm {

--- a/reconcile/gql_definitions/common/clusters.gql
+++ b/reconcile/gql_definitions/common/clusters.gql
@@ -47,6 +47,7 @@ query Clusters($name: String) {
       }
       sectors {
         name
+        maxParallelUpgrades
         dependencies {
           name
           ocm {

--- a/reconcile/gql_definitions/common/clusters.py
+++ b/reconcile/gql_definitions/common/clusters.py
@@ -148,6 +148,7 @@ query Clusters($name: String) {
       }
       sectors {
         name
+        maxParallelUpgrades
         dependencies {
           name
           ocm {
@@ -388,6 +389,7 @@ class OpenShiftClusterManagerSectorDependenciesV1(ConfiguredBaseModel):
 
 class OpenShiftClusterManagerSectorV1(ConfiguredBaseModel):
     name: str = Field(..., alias="name")
+    max_parallel_upgrades: Optional[str] = Field(..., alias="maxParallelUpgrades")
     dependencies: Optional[list[OpenShiftClusterManagerSectorDependenciesV1]] = Field(..., alias="dependencies")
 
 

--- a/reconcile/gql_definitions/fragments/aus_organization.gql
+++ b/reconcile/gql_definitions/fragments/aus_organization.gql
@@ -44,6 +44,7 @@ fragment AUSOCMOrganization on OpenShiftClusterManager_v1 {
   }
   sectors {
     name
+    maxParallelUpgrades
     dependencies {
       name
       ocm {

--- a/reconcile/gql_definitions/fragments/aus_organization.py
+++ b/reconcile/gql_definitions/fragments/aus_organization.py
@@ -67,6 +67,7 @@ class OpenShiftClusterManagerSectorDependenciesV1(ConfiguredBaseModel):
 
 class OpenShiftClusterManagerSectorV1(ConfiguredBaseModel):
     name: str = Field(..., alias="name")
+    max_parallel_upgrades: Optional[str] = Field(..., alias="maxParallelUpgrades")
     dependencies: Optional[list[OpenShiftClusterManagerSectorDependenciesV1]] = Field(..., alias="dependencies")
 
 

--- a/reconcile/gql_definitions/introspection.json
+++ b/reconcile/gql_definitions/introspection.json
@@ -8080,6 +8080,18 @@
                             "deprecationReason": null
                         },
                         {
+                            "name": "maxParallelUpgrades",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "SCALAR",
+                                "name": "String",
+                                "ofType": null
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
                             "name": "dependencies",
                             "description": null,
                             "args": [],

--- a/reconcile/queries.py
+++ b/reconcile/queries.py
@@ -739,6 +739,7 @@ CLUSTERS_QUERY = """
       }
       sectors {
         name
+        maxParallelUpgrades
         dependencies {
           name
         }
@@ -1348,6 +1349,7 @@ OCM_QUERY = """
     }
     sectors {
       name
+      maxParallelUpgrades
       dependencies {
         name
         ocm {

--- a/reconcile/test/ocm/aus/fixtures.py
+++ b/reconcile/test/ocm/aus/fixtures.py
@@ -97,6 +97,7 @@ def build_organization(
     inherit_version_data_from_org_ids: list[tuple[str, str, bool]] | None = None,
     publish_version_data_from_org_ids: list[str] | None = None,
     blocked_versions: list[str] | None = None,
+    sector_max_parallel_upgrades: dict[str, str | None] | None = None,
     sector_dependencies: dict[str, list[str] | None] | None = None,
     addonManagedUpgrades: bool = False,
     disabled_integrations: list[str] | None = None,
@@ -145,6 +146,9 @@ def build_organization(
         sectors=[
             OpenShiftClusterManagerSectorV1(
                 name=sector,
+                maxParallelUpgrades=sector_max_parallel_upgrades.get(sector)
+                if sector_max_parallel_upgrades
+                else None,
                 dependencies=[
                     OpenShiftClusterManagerSectorDependenciesV1(
                         name=dep,

--- a/reconcile/test/ocm/aus/test_aus_label_source.py
+++ b/reconcile/test/ocm/aus/test_aus_label_source.py
@@ -165,7 +165,21 @@ def test_cluster_upgrade_policy_label_source(
                 sector_dependencies={"prod": ["stage-1", "stage-2"], "stage-1": None},
             ),
             {
-                "sre-capabilities.aus.sectors.prod": "stage-1,stage-2",
+                "sre-capabilities.aus.sector-deps.prod": "stage-1,stage-2",
+            },
+        ),
+        # sector maxParallelUpgrades
+        (
+            build_organization(
+                org_id="org-1",
+                org_name="org-1",
+                env_name="ocm-prod",
+                sector_dependencies={"prod": ["stage-1"], "stage-1": None},
+                sector_max_parallel_upgrades={"prod": "2"},
+            ),
+            {
+                "sre-capabilities.aus.sector-deps.prod": "stage-1",
+                "sre-capabilities.aus.sector-max-parallel-upgrades.prod": "2",
             },
         ),
         # inherit
@@ -199,6 +213,7 @@ def test_cluster_upgrade_policy_label_source(
     ids=[
         "blocked versions",
         "sector dependencies",
+        "sector maxParallelUpgrades",
         "inherit",
         "publish",
     ],

--- a/reconcile/test/ocm/aus/test_calculate_diff.py
+++ b/reconcile/test/ocm/aus/test_calculate_diff.py
@@ -554,10 +554,11 @@ def test_calculate_diff_max_parallel_upgrades_set(
         ],
         org=org,
     )
+
     skip = base.verify_max_upgrades_should_skip(
         desired=org_upgrade_spec.specs[-1],
-        desired_state=org_upgrade_spec,
         sector_upgrades={sector: upgrading_cluster_names},
+        sector=org_upgrade_spec.sectors[sector],
     )
     assert skip == expected_skip
 

--- a/reconcile/test/ocm/aus/test_calculate_diff.py
+++ b/reconcile/test/ocm/aus/test_calculate_diff.py
@@ -22,6 +22,7 @@ from reconcile.aus.models import NodePoolSpec
 from reconcile.test.ocm.aus.fixtures import (
     build_cluster_health,
     build_cluster_upgrade_spec,
+    build_organization,
     build_organization_upgrade_spec,
     build_upgrade_policy,
 )
@@ -491,6 +492,74 @@ def test_calculate_diff_implicit_mutex_set(
         ),
     )
     assert not diffs
+
+
+@pytest.mark.parametrize(
+    "max_parallel_upgrades, total_cluster_count, ongoing_cluster_upgrades, expected_skip",
+    [
+        (None, 5, 0, False),
+        (None, 5, 1, False),
+        (None, 5, 4, False),
+        ("1", 5, 0, False),  # 0 ongoing upgrade over 5 clusters, allow a new one
+        ("1", 5, 1, True),  # 1 ongoing upgrade over 5 clusters, skip a new one
+        ("1", 5, 2, True),  # 2 ongoing upgrades over 5 clusters, skip a new one
+        ("2", 5, 0, False),  # 0 ongoing upgrade over 5 clusters, allow a new one
+        ("2", 5, 1, False),  # 1 ongoing upgrade over 5 clusters, allow a new one
+        ("2", 5, 2, True),  # 2 ongoing upgrades over 5 clusters, skip a new one
+        ("2", 5, 3, True),  # 3 ongoing upgrades over 5 clusters, skip a new one
+        ("2%", 5, 1, True),  # 1 ongoing upgrade over 5 clusters, skip a new one
+        ("33%", 5, 0, False),  # 0 ongoing upgrade over 5 clusters, allow a new one
+        ("33%", 5, 1, False),  # 1 ongoing upgrade over 5 clusters, skip a new one
+        ("33%", 5, 2, True),  # 2 ongoing upgrade over 5 clusters, skip a new one
+        ("33%", 5, 3, True),  # 3 ongoing upgrade over 5 clusters, skip a new one
+        ("33%", 5, 4, True),  # 4 ongoing upgrades over 5 clusters, skip a new one
+        ("50%", 5, 1, False),  # 1 ongoing upgrades over 5 clusters, skip a new one
+        ("50%", 5, 2, True),  # 2 ongoing upgrades over 5 clusters, skip a new one
+        ("50%", 5, 3, True),  # 3 ongoing upgrades over 5 clusters, skip a new one
+        ("50%", 5, 4, True),  # 4 ongoing upgrades over 5 clusters, skip a new one
+        ("50%", 6, 1, False),  # 1 ongoing upgrades over 6 clusters, skip a new one
+        ("50%", 6, 2, False),  # 2 ongoing upgrades over 6 clusters, skip a new one
+        ("50%", 6, 3, True),  # 3 ongoing upgrades over 6 clusters, skip a new one
+        ("50%", 6, 4, True),  # 4 ongoing upgrades over 6 clusters, skip a new one
+        ("100%", 6, 5, False),  # 5 ongoing upgrades over 6 clusters, allow a new one
+    ],
+)
+def test_calculate_diff_max_parallel_upgrades_set(
+    max_parallel_upgrades: str,
+    total_cluster_count: int,
+    ongoing_cluster_upgrades: int,
+    expected_skip: bool,
+) -> None:
+    workload = "wl"
+    sector = "sector-1"
+    org = build_organization(
+        sector_max_parallel_upgrades={sector: max_parallel_upgrades},
+        sector_dependencies={sector: []},
+    )
+    clusters = [
+        build_ocm_cluster(name=f"cluster-{id}") for id in range(total_cluster_count)
+    ]
+    upgrading_cluster_names = {
+        f"cluster-{id}" for id in range(ongoing_cluster_upgrades)
+    }
+    org_upgrade_spec = build_organization_upgrade_spec(
+        specs=[
+            (
+                cluster,
+                build_upgrade_policy(workloads=[workload], soak_days=1, sector=sector),
+                build_cluster_health(),
+                [],
+            )
+            for cluster in clusters
+        ],
+        org=org,
+    )
+    skip = base.verify_max_upgrades_should_skip(
+        desired=org_upgrade_spec.specs[-1],
+        desired_state=org_upgrade_spec,
+        sector_upgrades={sector: upgrading_cluster_names},
+    )
+    assert skip == expected_skip
 
 
 def test__calculate_node_pool_diffs(


### PR DESCRIPTION
https://issues.redhat.com/browse/APPSRE-11690

Adding support for limiting the number of parallel upgrades within a sector. The main changes involve adding new fields and methods to handle the `maxParallelUpgrades` attribute for sectors, updating existing functions to consider this new attribute, and adding tests to verify the new functionality.

The new field is added as part of https://github.com/app-sre/qontract-schemas/pull/802

The main change is in commit 4618c40f2c380c460fd4c467bba9e94c8afe8aa8, updating `reconcile/aus/base.py` to introduce the function `verify_max_upgrades_should_skip`