### PR TITLE
[maintenance] update uv to 0.6.11

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,6 +1,6 @@
 # this file is used by asdf to automatically select the correct tool versions
 # but it also serves as a reference for non-asdf users
-uv
 terraform 1.6.6
 oc 4.12.46
 helm 3.11.1
+uv 0.6.10

--- a/dockerfiles/Dockerfile
+++ b/dockerfiles/Dockerfile
@@ -2,7 +2,7 @@
 # STAGE 1 - build-image
 ###############################################################################
 FROM quay.io/app-sre/qontract-reconcile-builder:0.9.3 AS build-image
-COPY --from=ghcr.io/astral-sh/uv:0.5.7@sha256:23272999edd22e78195509ea3fe380e7632ab39a4c69a340bedaba7555abe20a /uv /bin/uv
+COPY --from=ghcr.io/astral-sh/uv:0.6.10@sha256:sha256:57da96c4557243fc0a732817854084e81af9393f64dc7d172f39c16465b5e2ba /uv /bin/uv
 
 WORKDIR /work
 
@@ -25,7 +25,7 @@ RUN UV_DYNAMIC_VERSIONING_BYPASS="0.0.0" uv sync --frozen --no-group dev --pytho
 # STAGE 2 - dev-image
 ###############################################################################
 FROM quay.io/app-sre/qontract-reconcile-base:0.15.3 AS dev-image
-COPY --from=ghcr.io/astral-sh/uv:0.5.7@sha256:23272999edd22e78195509ea3fe380e7632ab39a4c69a340bedaba7555abe20a /uv /bin/uv
+COPY --from=ghcr.io/astral-sh/uv:0.6.10@sha256:sha256:57da96c4557243fc0a732817854084e81af9393f64dc7d172f39c16465b5e2ba /uv /bin/uv
 
 ARG CONTAINER_UID=1000
 RUN useradd --uid ${CONTAINER_UID} reconcile && \
@@ -90,7 +90,7 @@ COPY --chown=0:0 --from=quay.io/app-sre/qontract-reconcile-oc:0.3.1 \
 # STAGE 5 - unittest image
 ###############################################################################
 FROM prod-image AS test-image
-COPY --from=ghcr.io/astral-sh/uv:0.5.7@sha256:23272999edd22e78195509ea3fe380e7632ab39a4c69a340bedaba7555abe20a /uv /bin/uv
+COPY --from=ghcr.io/astral-sh/uv:0.6.10@sha256:sha256:57da96c4557243fc0a732817854084e81af9393f64dc7d172f39c16465b5e2ba /uv /bin/uv
 
 RUN microdnf install -y make
 

--- a/uv.lock
+++ b/uv.lock
@@ -1,4 +1,5 @@
 version = 1
+revision = 1
 requires-python = "==3.11.*"
 
 [[package]]
@@ -1493,7 +1494,6 @@ wheels = [
 
 [[package]]
 name = "qontract-reconcile"
-version = "0.10.2.dev69"
 source = { editable = "." }
 dependencies = [
     { name = "anymarkup" },


### PR DESCRIPTION
Update uv to 0.6.11 in Dockerfile & the `.tool-versions`. 

Reason: the lockfile format changed between recent versions of uv so we should update to the latest version and ensure devs are using the same if they use ASDF for version management.