### PR TITLE
fix blue_green_deployment target parameter_group

### DIFF
--- a/reconcile/external_resources/aws.py
+++ b/reconcile/external_resources/aws.py
@@ -168,7 +168,9 @@ class AWSRdsFactory(AWSDefaultResourceFactory):
             and (target := blue_green_deployment.get("target"))
             and (parameter_group := target.get("parameter_group"))
         ):
-            target["parameter_group"] = rvr._get_values(parameter_group)
+            data["blue_green_deployment"] = blue_green_deployment | {
+                "target": target | {"parameter_group": rvr._get_values(parameter_group)}
+            }
         if "replica_source" in data:
             sourcedb_spec = self._get_source_db_spec(
                 spec.provisioner_name, data["replica_source"]


### PR DESCRIPTION
Use deepcopy to generate resolved data to ensure that we don’t modify the date in ExternalResourceSpec.resource. This prevents issues when resolving sourcedb [here](https://github.com/app-sre/qontract-reconcile/blob/aa32044ed8d80e20751c80486f63a8e801cc2315/reconcile/external_resources/aws.py#L176), where we might find that target["parameter_group"] has been replaced by a dictionary. e.g https://gitlab.cee.redhat.com/service/app-interface/-/merge_requests/137521