### PR TITLE
fix/Exclude deleted specs when finding linked resources

### DIFF
--- a/reconcile/external_resources/aws.py
+++ b/reconcile/external_resources/aws.py
@@ -264,6 +264,7 @@ class AWSRdsFactory(AWSDefaultResourceFactory):
             if s.provision_provider == "aws"
             and s.provider == "rds"
             and s.resource["replica_source"] == spec.identifier
+            and not s.marked_to_delete
         }
 
 


### PR DESCRIPTION
Linked resources need to be reconciled when the parent is reconciled. For example, when an RDS main instance is reconciled, the replicas are also reconciled later. This is needed for password updates, for example. 

This fix excludes deleted or marked-to-delete linked resources. Without this, the Erv2 state is being updated with partial data