### PR TITLE
feat(erv2): expose blue_green_deployment in replica_source

### DIFF
--- a/reconcile/external_resources/aws.py
+++ b/reconcile/external_resources/aws.py
@@ -180,13 +180,10 @@ class AWSRdsFactory(AWSDefaultResourceFactory):
                 sourcedb.get("region", None)
                 or sourcedb_spec.provisioner["resources_default_region"]
             )
-            blue_green_deployment_enabled = sourcedb.get(
-                "blue_green_deployment", {}
-            ).get("enabled", False)
             data["replica_source"] = {
                 "identifier": sourcedb["identifier"],
                 "region": sourcedb_region,
-                "blue_green_deployment_enabled": blue_green_deployment_enabled,
+                "blue_green_deployment": sourcedb.get("blue_green_deployment"),
             }
         # If AZ is set, but not the region, the region is got from the AZ
         if "availability_zone" in data and "region" not in data:

--- a/reconcile/test/external_resources/test_rds_factory.py
+++ b/reconcile/test/external_resources/test_rds_factory.py
@@ -185,8 +185,12 @@ def test_resolve_replica_source(
         "region": "us-east-1",
         "blue_green_deployment": {
             "enabled": True,
+            "target": {
+                "parameter_group": "/path/to/new_parameter_group",
+            },
         },
     }
+    rvr_2._get_values.return_value = {"k": "v"}
     spec = ExternalResourceSpec(
         provision_provider="aws",
         provisioner={"name": "test"},
@@ -205,7 +209,12 @@ def test_resolve_replica_source(
         "replica_source": {
             "identifier": "test-rds",
             "region": "us-east-1",
-            "blue_green_deployment_enabled": True,
+            "blue_green_deployment": {
+                "enabled": True,
+                "target": {
+                    "parameter_group": {"k": "v"},
+                },
+            },
         },
         "output_prefix": "test-rds-read-replica-rds",
         "timeouts": DEFAULT_EXPECTED_TIMEOUTS,


### PR DESCRIPTION
Expose the whole `blue_green_deployment` in `replica_source` to support more validations in https://github.com/app-sre/er-aws-rds/pull/139

[APPSRE-11714](https://issues.redhat.com/browse/APPSRE-11714)