### PR TITLE
fix(dev): update config to make dev-reconcile-loop works with uv setup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -67,7 +67,7 @@ test: print-host-versions test-app test-container-image
 dev-reconcile-loop: build-dev ## Trigger the reconcile loop inside a container for an integration
 	@$(CONTAINER_ENGINE) run --rm -it \
 		--add-host=host.docker.internal:host-gateway \
-		-v "$(CURDIR)":/work \
+		-v "$(CURDIR)":/work:z \
 		-p 5678:5678 \
 		-e INTEGRATION_NAME="$(INTEGRATION_NAME)" \
 		-e INTEGRATION_EXTRA_ARGS="$(INTEGRATION_EXTRA_ARGS)" \

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
+# qontract-reconcile
+
 [![Ruff](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/v2.json)](https://github.com/astral-sh/ruff)
 [![uv](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/uv/main/assets/badge/v0.json)](https://github.com/astral-sh/uv)
 [![PyPI](https://img.shields.io/pypi/v/qontract-reconcile)][pypi-link]
 [![PyPI platforms][pypi-platforms]][pypi-link]
 ![PyPI - License](https://img.shields.io/pypi/l/qontract-reconcile)
 [![Checked with mypy](https://www.mypy-lang.org/static/mypy_badge.svg)](https://mypy-lang.org/)
-
-# qontract-reconcile
 
 A tool to reconcile services with their desired state as defined in app-interface.
 Additional tools that use the libraries created by the reconciliations are also hosted here.
@@ -357,29 +357,25 @@ For more flexible way to run in container, please see [qontract-development-cli]
 Make sure the file `./config.dev.toml` exists and contains your current configuration.
 Your `config.dev.toml` should point to the following qontract-server address:
 
-```
-
+```toml
 [graphql]
-server = "<http://host.docker.internal:4000/graphql>"
-
+server = "http://host.docker.internal:4000/graphql"
 ```
 
 ### Run qontract-server
 
 Start the [qontract-server](https://github.com/app-sre/qontract-server) in a different window, e.g., via:
 
-```
+Run this in the root dir of `qontract-server` repo:
 
-qontract-server$ make dev
-
+```shell
+make dev
 ```
 
 ### Trigger integration
 
-```
-
-make dev-reconcile-loop INTEGRATION_NAME=terraform-resources DRY_RUN=--dry-run INTEGRATION_EXTRA_ARGS=--light SLEEP_DURATION_SECS=100
-
+```shell
+make dev-reconcile-loop INTEGRATION_NAME=terraform-resources DRY_RUN=--dry-run LOG_LEVEL=DEBUG INTEGRATION_EXTRA_ARGS=--light SLEEP_DURATION_SECS=100
 ```
 
 ## Query Classes
@@ -403,7 +399,7 @@ GQL definitions and generated classes can be found [here](reconcile/gql_definiti
 ## Code style guide
 
 Qontract-reconcile uses [PEP8](https://peps.python.org/pep-0008/) as the code style guide.
-The style is enforced via [PR checks](#ci-tooling) with the help of the following utilities:
+The style is enforced via PR checks (`make test`) with the help of the following utilities:
 
 - [Ruff - An extremely fast Python linter and code formatter, written in Rust.](https://docs.astral.sh/ruff/)
 - [Mypy](https://mypy.readthedocs.io/en/stable/)
@@ -417,7 +413,7 @@ Release version are calculated from git tags of the form X.Y.Z.
 - If the current commit has such a tag, it will be used as is
 - Otherwise the latest tag of that format is used and:
   - the patch label (Z) is incremented
-  - the string `.pre<count>+<commitid>` is appended. `<count>` is the number of commits since the X.Y.Z tag. `<commitid> is... the current commitid.
+  - the string `.pre<count>+<commitid>` is appended. `<count>` is the number of commits since the X.Y.Z tag. `<commitid>` is... the current commit id.
 
 After the PR is merged, a CI job will be triggered that will publish the package to pypi: <https://pypi.org/project/qontract-reconcile>.
 

--- a/dockerfiles/Dockerfile
+++ b/dockerfiles/Dockerfile
@@ -31,17 +31,17 @@ ARG CONTAINER_UID=1000
 RUN useradd --uid ${CONTAINER_UID} reconcile && \
     chown -R reconcile /.terraform.d
 
-WORKDIR /work
+# Use a different workdir so venv can't be overwritten by volume mount
+WORKDIR /opt/app-root/src
 
 COPY --from=build-image --chown=reconcile:root /work/ ./
 RUN UV_DYNAMIC_VERSIONING_BYPASS="0.0.0" uv sync --frozen --no-cache --group debugger --no-group dev
-# Move .venv out of the workdir so it can't be overwritten by volume mount
-RUN mv .venv /venv
 
+WORKDIR /work
 USER reconcile
 VOLUME ["/work", "/config"]
 # Set the PATH to include the virtualenv
-ENV PATH="/venv/bin:${PATH}"
+ENV PATH="/opt/app-root/src/.venv/bin:${PATH}"
 ENTRYPOINT ["/work/dev/run.sh"]
 
 


### PR DESCRIPTION
`run-integration` script created by `uv sync` has shebang `#!/work/.venv/bin/python3`, can't simply move `.venv` to `/venv`, have to run `uv sync` under the new location.

Now use `/opt/app-root/src` as code dir in `dev-image` to hold `.venv`.