### PR TITLE
fix selectorsyncset_managed_resources

### DIFF
--- a/tools/qontract_cli.py
+++ b/tools/qontract_cli.py
@@ -2510,7 +2510,7 @@ def selectorsyncset_managed_resources(ctx: click.Context, use_jump_host: bool) -
             try:
                 for resource in sss["spec"]["resources"]:
                     kind = resource["kind"]
-                    namespace = resource["metadata"].get("namespace")
+                    namespace = resource["metadata"].get("namespace", "")
                     name = resource["metadata"]["name"]
                     item = {
                         "cluster": c_name,


### PR DESCRIPTION
The namespace field is None for namespace resources and results in 
```
16:43:46   File "/work/reconcile/utils/output.py", line 15, in print_output
16:43:46     content = sorted(content, key=lambda c: tuple(c.values()))
16:43:46               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
16:43:46 TypeError: '<' not supported between instances of 'str' and 'NoneType'
```