### PR TITLE
Skip pipeline setup on deleted namespaces

### DIFF
--- a/reconcile/openshift_tekton_resources.py
+++ b/reconcile/openshift_tekton_resources.py
@@ -139,6 +139,9 @@ def fetch_desired_resources(
     while we are migrating from the current system to this integration"""
     desired_resources = []
     for tknp in tkn_providers.values():
+        if tknp["namespace"]["delete"]:
+            continue
+
         namespace = tknp["namespace"]["name"]
         cluster = tknp["namespace"]["cluster"]["name"]
         deploy_resources = tknp.get("deployResources") or DEFAULT_DEPLOY_RESOURCES

--- a/reconcile/queries.py
+++ b/reconcile/queries.py
@@ -2068,6 +2068,7 @@ PIPELINES_PROVIDERS_QUERY = """
       }
       namespace {
         name
+        delete
         cluster {
           name
           serverUrl

--- a/reconcile/test/fixtures/openshift_tekton_resources/provider1.json
+++ b/reconcile/test/fixtures/openshift_tekton_resources/provider1.json
@@ -31,6 +31,7 @@
   },
   "namespace": {
     "name": "provider1",
+    "delete": null,
     "cluster": {
       "name": "appsres03ue1",
       "serverUrl": "",

--- a/reconcile/test/fixtures/openshift_tekton_resources/provider2-with-resources.json
+++ b/reconcile/test/fixtures/openshift_tekton_resources/provider2-with-resources.json
@@ -32,6 +32,7 @@
   },
   "namespace": {
     "name": "provider2-with-resources",
+    "delete": null,
     "cluster": {
       "name": "appsres03ue1",
       "serverUrl": "",

--- a/reconcile/test/fixtures/openshift_tekton_resources/provider5-with-unknown-task.json
+++ b/reconcile/test/fixtures/openshift_tekton_resources/provider5-with-unknown-task.json
@@ -31,6 +31,7 @@
   },
   "namespace": {
     "name": "provider1",
+    "delete": null,
     "cluster": {
       "name": "appsres03ue1",
       "serverUrl": "",

--- a/reconcile/test/fixtures/openshift_tekton_resources/provider6-too-long-pipeline-name.yaml
+++ b/reconcile/test/fixtures/openshift_tekton_resources/provider6-too-long-pipeline-name.yaml
@@ -31,6 +31,7 @@
   },
   "namespace": {
     "name": "provider1",
+    "delete": null,
     "cluster": {
       "name": "appsres03ue1",
       "serverUrl": "",

--- a/reconcile/test/fixtures/openshift_tekton_resources/provider7-deleted-namespace.json
+++ b/reconcile/test/fixtures/openshift_tekton_resources/provider7-deleted-namespace.json
@@ -1,5 +1,5 @@
 {
-  "name": "provider4-with-task-duplicates",
+  "name": "provider7-deleted-namespace",
   "provider": "tekton",
   "defaults": {
     "retention": {
@@ -31,7 +31,7 @@
   },
   "namespace": {
     "name": "provider1",
-    "delete": null,
+    "delete": true,
     "cluster": {
       "name": "appsres03ue1",
       "serverUrl": "",
@@ -44,25 +44,5 @@
       "internal": true,
       "disable": null
     }
-  },
-  "taskTemplates": [
-    {
-      "name": "openshift-saas-deploy",
-      "type": "onePerSaasFile",
-      "path": "openshift-saas-deploy.task.yaml.j2",
-      "variables": "{\"qontract_reconcile_image_tag\":\"latest\"}"
-    },
-    {
-      "name": "openshift-saas-deploy",
-      "type": "onePerSaasFile",
-      "path": "openshift-saas-deploy.task.yaml.j2",
-      "variables": "{\"qontract_reconcile_image_tag\":\"latest\"}"
-    },
-    {
-      "name": "push-gateway-openshift-saas-deploy-task-status-metric",
-      "type": "onePerNamespace",
-      "path": "push-gateway-task-status-metric.task.yaml.j2",
-      "variables": "{\"ubi8_ubi_minimal_image_tag\":\"latest\"}"
-    }
-  ]
+  }
 }

--- a/reconcile/test/fixtures/openshift_tekton_resources/saas7-deleted-namespace.json
+++ b/reconcile/test/fixtures/openshift_tekton_resources/saas7-deleted-namespace.json
@@ -1,0 +1,9 @@
+{
+  "path": "saas7-deleted-namespace.yaml",
+  "name": "saas7-deleted-namespace",
+  "pipelinesProvider": {
+    "name": "provider7-deleted-namespace",
+    "provider": "tekton"
+  },
+  "deployResources": null
+}

--- a/reconcile/test/test_openshift_tekton_resources.py
+++ b/reconcile/test/test_openshift_tekton_resources.py
@@ -96,8 +96,12 @@ class TestOpenshiftTektonResources:
         self.saas1 = self.fxt.get_json("saas1.json")
         self.saas2 = self.fxt.get_json("saas2.json")
         self.saas2_wr = self.fxt.get_json("saas2-with-resources.json")
+        self.saas7_deleted_namespace = self.fxt.get_json("saas7-deleted-namespace.json")
         self.provider1 = self.fxt.get_json("provider1.json")
         self.provider2_wr = self.fxt.get_json("provider2-with-resources.json")
+        self.provider7_deleted_ns = self.fxt.get_json(
+            "provider7-deleted-namespace.json"
+        )
 
         # Patcher for GqlApi methods
         self.gql_patcher = patch.object(gql, "get_api", autospec=True)
@@ -140,6 +144,15 @@ class TestOpenshiftTektonResources:
 
         # we have one task per namespace and a pipeline + task per saas file
         assert len(desired_resources) == 8
+
+    def test_fetch_desired_resources_skip_deleted_namespace(self) -> None:
+        self.test_data.saas_files = [self.saas7_deleted_namespace]
+        self.test_data.providers = [self.provider7_deleted_ns]
+
+        desired_resources = otr.fetch_desired_resources(otr.fetch_tkn_providers(None))
+
+        # we have one task per namespace and a pipeline + task per saas file
+        assert len(desired_resources) == 0
 
     def test_fetch_desired_resources_names(self) -> None:
         self.test_data.saas_files = [self.saas1]


### PR DESCRIPTION
https://issues.redhat.com/browse/APPSRE-11857

Avoids continuous logs like
```
[openshift-tekton-resources] [<cluster>/<namespace>] namespace does not exist (yet).
```