### PR TITLE
[elasticsearch] allow additional keys in admin credentials

### DIFF
--- a/reconcile/utils/terrascript_aws_client.py
+++ b/reconcile/utils/terrascript_aws_client.py
@@ -4883,10 +4883,11 @@ class TerrascriptClient:  # pylint: disable=too-many-public-methods
             es_values["provider"] = provider
 
         auth_options = values.get("auth", {})
+        advanced_security_options = None
         # TODO: @fishi0x01 make mandatory after migration APPSRE-3409
         if auth_options:
-            es_values["advanced_security_options"] = (
-                self._build_es_advanced_security_options(auth_options)
+            advanced_security_options = self._build_es_advanced_security_options(
+                auth_options
             )
 
         # TODO: @fishi0x01 remove after migration APPSRE-3409
@@ -4900,6 +4901,81 @@ class TerrascriptClient:  # pylint: disable=too-many-public-methods
                     )
                 )
         # ++++++++ END: REMOVE ++++++++++
+        # add master user creds to output and secretsmanager if internal_user_database_enabled
+        if advanced_security_options:
+            if advanced_security_options.get("internal_user_database_enabled", False):
+                master_user = advanced_security_options["master_user_options"]
+                secret_name = f"qrtf/es/{identifier}"
+                secret_identifier = secret_name.replace("/", "-")
+                secret_values = {"name": secret_name, "tags": tags}
+                if provider:
+                    secret_values["provider"] = provider
+                aws_secret_resource = aws_secretsmanager_secret(
+                    secret_identifier, **secret_values
+                )
+                tf_resources.append(aws_secret_resource)
+
+                version_values = {
+                    "secret_id": "${" + aws_secret_resource.id + "}",
+                    "secret_string": json.dumps(master_user, sort_keys=True),
+                }
+                if provider:
+                    version_values["provider"] = provider
+                aws_version_resource = aws_secretsmanager_secret_version(
+                    secret_identifier, **version_values
+                )
+                tf_resources.append(aws_version_resource)
+
+                policy = {
+                    "Version": "2012-10-17",
+                    "Statement": [
+                        {
+                            "Effect": "Allow",
+                            "Action": [
+                                "secretsmanager:GetResourcePolicy",
+                                "secretsmanager:GetSecretValue",
+                                "secretsmanager:DescribeSecret",
+                                "secretsmanager:ListSecretVersionIds",
+                            ],
+                            "Resource": "${" + aws_secret_resource.id + "}",
+                        }
+                    ],
+                }
+                iam_policy_resource = aws_iam_policy(
+                    secret_identifier,
+                    name=f"{identifier}-secretsmanager-policy",
+                    policy=json.dumps(policy, sort_keys=True),
+                    tags=tags,
+                )
+                tf_resources.append(iam_policy_resource)
+
+                output_name = output_prefix + "__secret_name"
+                output_value = secret_name
+                tf_resources.append(Output(output_name, value=output_value))
+                output_name = output_prefix + "__secret_policy_arn"
+                output_value = "${" + iam_policy_resource.arn + "}"
+                tf_resources.append(Output(output_name, value=output_value))
+                # master_user_name
+                output_name = output_prefix + "__master_user_name"
+                output_value = master_user["master_user_name"]
+                tf_resources.append(
+                    Output(output_name, value=output_value, sensitive=True)
+                )
+                # master_user_password
+                output_name = output_prefix + "__master_user_password"
+                output_value = master_user["master_user_password"]
+                tf_resources.append(
+                    Output(output_name, value=output_value, sensitive=True)
+                )
+            # this secret can include additional values which are then saved to secrets manager in AWS
+            # however this step strips those extra values from `master_user_options` which only expects
+            # 2 fields https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/elasticsearch_domain#master_user_options-1
+            advanced_security_options["master_user_options"] = {
+                k: v
+                for k, v in advanced_security_options["master_user_options"].items()
+                if k in {"master_user_name", "master_user_password"}
+            }
+            es_values["advanced_security_options"] = advanced_security_options
 
         es_tf_resource = aws_elasticsearch_domain(identifier, **es_values)
         tf_resources.append(es_tf_resource)
@@ -4931,70 +5007,6 @@ class TerrascriptClient:  # pylint: disable=too-many-public-methods
             "${aws_elasticsearch_domain." + identifier + ".vpc_options.0.vpc_id}"
         )
         tf_resources.append(Output(output_name, value=output_value))
-        # add master user creds to output and secretsmanager if internal_user_database_enabled
-        security_options = es_values.get("advanced_security_options")
-        if security_options and security_options.get(
-            "internal_user_database_enabled", False
-        ):
-            master_user = security_options["master_user_options"]
-            secret_name = f"qrtf/es/{identifier}"
-            secret_identifier = secret_name.replace("/", "-")
-            secret_values = {"name": secret_name, "tags": tags}
-            if provider:
-                secret_values["provider"] = provider
-            aws_secret_resource = aws_secretsmanager_secret(
-                secret_identifier, **secret_values
-            )
-            tf_resources.append(aws_secret_resource)
-
-            version_values = {
-                "secret_id": "${" + aws_secret_resource.id + "}",
-                "secret_string": json.dumps(master_user, sort_keys=True),
-            }
-            if provider:
-                version_values["provider"] = provider
-            aws_version_resource = aws_secretsmanager_secret_version(
-                secret_identifier, **version_values
-            )
-            tf_resources.append(aws_version_resource)
-
-            policy = {
-                "Version": "2012-10-17",
-                "Statement": [
-                    {
-                        "Effect": "Allow",
-                        "Action": [
-                            "secretsmanager:GetResourcePolicy",
-                            "secretsmanager:GetSecretValue",
-                            "secretsmanager:DescribeSecret",
-                            "secretsmanager:ListSecretVersionIds",
-                        ],
-                        "Resource": "${" + aws_secret_resource.id + "}",
-                    }
-                ],
-            }
-            iam_policy_resource = aws_iam_policy(
-                secret_identifier,
-                name=f"{identifier}-secretsmanager-policy",
-                policy=json.dumps(policy, sort_keys=True),
-                tags=tags,
-            )
-            tf_resources.append(iam_policy_resource)
-
-            output_name = output_prefix + "__secret_name"
-            output_value = secret_name
-            tf_resources.append(Output(output_name, value=output_value))
-            output_name = output_prefix + "__secret_policy_arn"
-            output_value = "${" + iam_policy_resource.arn + "}"
-            tf_resources.append(Output(output_name, value=output_value))
-            # master_user_name
-            output_name = output_prefix + "__master_user_name"
-            output_value = master_user["master_user_name"]
-            tf_resources.append(Output(output_name, value=output_value, sensitive=True))
-            # master_user_password
-            output_name = output_prefix + "__master_user_password"
-            output_value = master_user["master_user_password"]
-            tf_resources.append(Output(output_name, value=output_value, sensitive=True))
 
         self.add_resources(account, tf_resources)
 


### PR DESCRIPTION
Follow-up from #4961

[APPSRE-11853](https://issues.redhat.com/browse/APPSRE-11853)

This PR allows users to add additional secrets to their Elasticsearch `admin_user_credentials` secret which can then be used when setting up a Kinesis lambda (https://github.com/app-sre/qontract-reconcile/blob/master/reconcile/utils/terrascript_aws_client.py#L3994). The additional values are stripped out when provisioning the Elasticache domain to meet the expected schema from AWS.

```yaml
$schema: /aws/elasticsearch-defaults-1.yml
ebs_options:
  ebs_enabled: true
  volume_size: 350

auth:
  admin_user_credentials:
    path: <your_vault_path_here>
```