### PR TITLE
add trigger information to pipelinerun annotations

### DIFF
--- a/reconcile/openshift_saas_deploy_trigger_base.py
+++ b/reconcile/openshift_saas_deploy_trigger_base.py
@@ -378,6 +378,10 @@ def _construct_tekton_trigger_resource(
         "kind": "PipelineRun",
         "metadata": {
             "generateName": f"{name}-",
+            "annotations": {
+                "qontract.trigger_integration": integration,
+                "qontract.trigger_reason": reason or "",
+            },
             "labels": {
                 "qontract.saas_file_name": saas_file_name,
                 "qontract.env_name": env_name,


### PR DESCRIPTION
https://issues.redhat.com/browse/APPSRE-11873

This will trickle down to the pods as well, and it will appear in cloudwatch logs as a filterable field. This means we can filter logs in cloudwatch per commitref