### PR TITLE
APPSRE-11142 DTP allow multiple specs per cluster

### DIFF
--- a/reconcile/dynatrace_token_provider/integration.py
+++ b/reconcile/dynatrace_token_provider/integration.py
@@ -13,12 +13,15 @@ from reconcile.dynatrace_token_provider.metrics import (
     DTPOrganizationErrorRate,
     DTPTokensManagedGauge,
 )
-from reconcile.dynatrace_token_provider.model import DynatraceAPIToken, K8sSecret
-from reconcile.dynatrace_token_provider.ocm import (
-    DTP_LABEL_SEARCH,
-    DTP_TENANT_V2_LABEL,
+from reconcile.dynatrace_token_provider.model import (
     Cluster,
+    DynatraceAPIToken,
+    K8sSecret,
+    TokenSpecTenantBinding,
+)
+from reconcile.dynatrace_token_provider.ocm import (
     OCMClient,
+    OCMCluster,
 )
 from reconcile.dynatrace_token_provider.validate import validate_token_specs
 from reconcile.gql_definitions.dynatrace_token_provider.token_specs import (
@@ -37,6 +40,7 @@ from reconcile.utils.ocm.base import (
     OCMServiceLogSeverity,
 )
 from reconcile.utils.ocm.labels import subscription_label_filter
+from reconcile.utils.ocm.sre_capability_labels import sre_capability_label_key
 from reconcile.utils.openshift_resource import (
     QONTRACT_ANNOTATION_INTEGRATION,
     QONTRACT_ANNOTATION_INTEGRATION_VERSION,
@@ -50,6 +54,9 @@ from reconcile.utils.semver_helper import make_semver
 QONTRACT_INTEGRATION_VERSION = make_semver(2, 0, 1)
 QONTRACT_INTEGRATION = "dynatrace-token-provider"
 SYNCSET_AND_MANIFEST_ID = "ext-dynatrace-tokens-dtp"
+DTP_LABEL_SEARCH = sre_capability_label_key("dtp", "%")
+DTP_TENANT_V2_LABEL = sre_capability_label_key("dtp.v2", "tenant")
+DTP_SPEC_V2_LABEL = sre_capability_label_key("dtp.v2", "token-spec")
 
 
 class ReconcileErrorSummary(Exception):
@@ -103,6 +110,27 @@ class DynatraceTokenProviderIntegration(QontractReconcileIntegration[NoParams]):
                     cnt,
                 )
 
+    def _parse_ocm_data_to_cluster(self, ocm_cluster: OCMCluster) -> Cluster | None:
+        dt_tenant = ocm_cluster.labels.get(DTP_TENANT_V2_LABEL)
+        token_spec_name = ocm_cluster.labels.get(DTP_SPEC_V2_LABEL)
+        if not dt_tenant or not token_spec_name:
+            logging.warning(
+                f"[Missing DTP labels] {ocm_cluster.id=} {ocm_cluster.subscription_id=} {dt_tenant=} {token_spec_name=}"
+            )
+            return None
+        return Cluster(
+            id=ocm_cluster.id,
+            external_id=ocm_cluster.external_id,
+            organization_id=ocm_cluster.organization_id,
+            is_hcp=ocm_cluster.is_hcp,
+            dt_token_bindings=[
+                TokenSpecTenantBinding(
+                    spec_name=token_spec_name,
+                    tenant_id=dt_tenant,
+                )
+            ],
+        )
+
     def _filter_clusters(
         self,
         clusters: Iterable[Cluster],
@@ -110,18 +138,19 @@ class DynatraceTokenProviderIntegration(QontractReconcileIntegration[NoParams]):
     ) -> list[Cluster]:
         filtered_clusters = []
         for cluster in clusters:
-            token_spec = token_spec_by_name.get(cluster.token_spec_name)
-            if not token_spec:
-                logging.debug(
-                    f"[{cluster.id=}] Skipping cluster. {cluster.token_spec_name=} does not exist."
-                )
-                continue
-            if cluster.organization_id in token_spec.ocm_org_ids:
-                filtered_clusters.append(cluster)
-            else:
-                logging.debug(
-                    f"[{cluster.id=}] Skipping cluster for {token_spec.name=}. {cluster.organization_id=} is not defined in {token_spec.ocm_org_ids=}."
-                )
+            for token_binding in cluster.dt_token_bindings:
+                token_spec = token_spec_by_name.get(token_binding.spec_name)
+                if not token_spec:
+                    logging.debug(
+                        f"[{cluster.id=}] Skipping cluster. {token_binding.spec_name=} does not exist."
+                    )
+                    continue
+                if cluster.organization_id in token_spec.ocm_org_ids:
+                    filtered_clusters.append(cluster)
+                else:
+                    logging.debug(
+                        f"[{cluster.id=}] Skipping cluster for {token_spec.name=}. {cluster.organization_id=} is not defined in {token_spec.ocm_org_ids=}."
+                    )
         return filtered_clusters
 
     def reconcile(self, dry_run: bool, dependencies: Dependencies) -> None:
@@ -131,17 +160,26 @@ class DynatraceTokenProviderIntegration(QontractReconcileIntegration[NoParams]):
         with metrics.transactional_metrics(self.name):
             unhandled_exceptions = []
             for ocm_env_name, ocm_client in dependencies.ocm_client_by_env_name.items():
-                clusters: list[Cluster] = []
+                ocm_clusters: list[OCMCluster] = []
                 try:
-                    clusters = ocm_client.discover_clusters_by_labels(
+                    ocm_clusters = ocm_client.discover_clusters_by_labels(
                         label_filter=subscription_label_filter().like(
                             "key", DTP_LABEL_SEARCH
                         ),
                     )
                 except Exception as e:
                     unhandled_exceptions.append(f"{ocm_env_name}: {e}")
-                if not clusters:
+                if not ocm_clusters:
                     continue
+                clusters: list[Cluster] = [
+                    cluster
+                    for ocm_cluster in ocm_clusters
+                    if (
+                        cluster := self._parse_ocm_data_to_cluster(
+                            ocm_cluster=ocm_cluster
+                        )
+                    )
+                ]
                 filtered_clusters = self._filter_clusters(
                     clusters=clusters,
                     token_spec_by_name=dependencies.token_spec_by_name,
@@ -157,79 +195,80 @@ class DynatraceTokenProviderIntegration(QontractReconcileIntegration[NoParams]):
                     len(clusters),
                 )
                 for cluster in filtered_clusters:
-                    try:
-                        with DTPOrganizationErrorRate(
-                            integration=self.name,
-                            ocm_env=ocm_env_name,
-                            org_id=cluster.organization_id,
-                        ):
-                            tenant_id = cluster.dt_tenant
-                            if not tenant_id:
-                                _expose_errors_as_service_log(
-                                    ocm_client,
-                                    cluster_uuid=cluster.external_id,
-                                    error=f"Missing label {DTP_TENANT_V2_LABEL}",
-                                )
-                                logging.warn(
-                                    f"[{cluster.id=}] Missing value for label {DTP_TENANT_V2_LABEL}"
-                                )
-                                continue
-                            if (
-                                tenant_id
-                                not in dependencies.dynatrace_client_by_tenant_id
+                    for token_binding in cluster.dt_token_bindings:
+                        try:
+                            with DTPOrganizationErrorRate(
+                                integration=self.name,
+                                ocm_env=ocm_env_name,
+                                org_id=cluster.organization_id,
                             ):
-                                _expose_errors_as_service_log(
-                                    ocm_client,
-                                    cluster_uuid=cluster.external_id,
-                                    error=f"Dynatrace tenant {tenant_id} does not exist",
-                                )
-                                logging.warn(
-                                    f"[{cluster.id=}] Dynatrace {tenant_id=} does not exist"
-                                )
-                                continue
-                            dt_client = dependencies.dynatrace_client_by_tenant_id[
-                                tenant_id
-                            ]
-
-                            token_spec = dependencies.token_spec_by_name.get(
-                                cluster.token_spec_name
-                            )
-                            if not token_spec:
-                                _expose_errors_as_service_log(
-                                    ocm_client,
-                                    cluster_uuid=cluster.external_id,
-                                    error=f"Token spec {cluster.token_spec_name} does not exist",
-                                )
-                                logging.warn(
-                                    f"[{cluster.id=}] Token spec '{cluster.token_spec_name}' does not exist"
-                                )
-                                continue
-                            if tenant_id not in existing_dtp_tokens:
-                                existing_dtp_tokens[tenant_id] = (
-                                    dt_client.get_token_ids_map_for_name_prefix(
-                                        prefix="dtp"
+                                tenant_id = token_binding.tenant_id
+                                if not tenant_id:
+                                    _expose_errors_as_service_log(
+                                        ocm_client,
+                                        cluster_uuid=cluster.external_id,
+                                        error=f"Missing label {DTP_TENANT_V2_LABEL}",
                                     )
-                                )
+                                    logging.warning(
+                                        f"[{cluster.id=}] Missing value for label {DTP_TENANT_V2_LABEL}"
+                                    )
+                                    continue
+                                if (
+                                    tenant_id
+                                    not in dependencies.dynatrace_client_by_tenant_id
+                                ):
+                                    _expose_errors_as_service_log(
+                                        ocm_client,
+                                        cluster_uuid=cluster.external_id,
+                                        error=f"Dynatrace tenant {tenant_id} does not exist",
+                                    )
+                                    logging.warning(
+                                        f"[{cluster.id=}] Dynatrace {tenant_id=} does not exist"
+                                    )
+                                    continue
+                                dt_client = dependencies.dynatrace_client_by_tenant_id[
+                                    tenant_id
+                                ]
 
-                            """
-                            Note, that we consciously do not parallelize cluster processing
-                            for now. We want to keep stress on OCM at a minimum. The amount
-                            of tagged clusters is currently feasible to be processed sequentially.
-                            """
-                            self.process_cluster(
-                                dry_run=dry_run,
-                                cluster=cluster,
-                                dt_client=dt_client,
-                                ocm_client=ocm_client,
-                                existing_dtp_tokens=existing_dtp_tokens[tenant_id],
-                                tenant_id=tenant_id,
-                                token_spec=token_spec,
-                                ocm_env_name=ocm_env_name,
+                                token_spec = dependencies.token_spec_by_name.get(
+                                    token_binding.spec_name
+                                )
+                                if not token_spec:
+                                    _expose_errors_as_service_log(
+                                        ocm_client,
+                                        cluster_uuid=cluster.external_id,
+                                        error=f"Token spec {token_binding.spec_name} does not exist",
+                                    )
+                                    logging.warning(
+                                        f"[{cluster.id=}] Token spec '{token_binding.spec_name}' does not exist"
+                                    )
+                                    continue
+                                if tenant_id not in existing_dtp_tokens:
+                                    existing_dtp_tokens[tenant_id] = (
+                                        dt_client.get_token_ids_map_for_name_prefix(
+                                            prefix="dtp"
+                                        )
+                                    )
+
+                                """
+                                Note, that we consciously do not parallelize cluster processing
+                                for now. We want to keep stress on OCM at a minimum. The amount
+                                of tagged clusters is currently feasible to be processed sequentially.
+                                """
+                                self.process_cluster(
+                                    dry_run=dry_run,
+                                    cluster=cluster,
+                                    dt_client=dt_client,
+                                    ocm_client=ocm_client,
+                                    existing_dtp_tokens=existing_dtp_tokens[tenant_id],
+                                    tenant_id=tenant_id,
+                                    token_spec=token_spec,
+                                    ocm_env_name=ocm_env_name,
+                                )
+                        except Exception as e:
+                            unhandled_exceptions.append(
+                                f"{ocm_env_name}/{cluster.organization_id}/{cluster.id}: {e}"
                             )
-                    except Exception as e:
-                        unhandled_exceptions.append(
-                            f"{ocm_env_name}/{cluster.organization_id}/{cluster.id}: {e}"
-                        )
                 self._expose_token_metrics()
 
         if unhandled_exceptions:

--- a/reconcile/dynatrace_token_provider/model.py
+++ b/reconcile/dynatrace_token_provider/model.py
@@ -12,3 +12,16 @@ class K8sSecret(BaseModel):
     namespace_name: str
     secret_name: str
     tokens: list[DynatraceAPIToken]
+
+
+class TokenSpecTenantBinding(BaseModel):
+    spec_name: str
+    tenant_id: str
+
+
+class Cluster(BaseModel):
+    id: str
+    external_id: str
+    organization_id: str
+    is_hcp: bool
+    dt_token_bindings: list[TokenSpecTenantBinding]

--- a/reconcile/test/dynatrace_token_provider/conftest.py
+++ b/reconcile/test/dynatrace_token_provider/conftest.py
@@ -7,7 +7,7 @@ from reconcile.dynatrace_token_provider.integration import (
     DynatraceTokenProviderIntegration,
 )
 from reconcile.dynatrace_token_provider.model import DynatraceAPIToken
-from reconcile.dynatrace_token_provider.ocm import Cluster
+from reconcile.dynatrace_token_provider.ocm import OCMCluster
 from reconcile.gql_definitions.dynatrace_token_provider.token_specs import (
     DynatraceTokenProviderTokenSpecV1,
 )
@@ -92,24 +92,30 @@ def default_ingestion_token() -> DynatraceAPIToken:
 
 
 @pytest.fixture
-def default_cluster() -> Cluster:
-    return Cluster(
+def default_cluster() -> OCMCluster:
+    return OCMCluster(
         id="cluster_a",
         external_id="external_id_a",
         organization_id="ocm_org_id_a",
-        dt_tenant="dt_tenant_a",
-        token_spec_name="default",
+        subscription_id="sub_id",
         is_hcp=False,
+        labels={
+            "sre-capabilities.dtp.v2.tenant": "dt_tenant_a",
+            "sre-capabilities.dtp.v2.token-spec": "default",
+        },
     )
 
 
 @pytest.fixture
-def default_hcp_cluster() -> Cluster:
-    return Cluster(
+def default_hcp_cluster() -> OCMCluster:
+    return OCMCluster(
         id="cluster_a",
         external_id="external_id_a",
         organization_id="ocm_org_id_a",
-        dt_tenant="dt_tenant_a",
-        token_spec_name="default",
+        subscription_id="sub_id",
         is_hcp=True,
+        labels={
+            "sre-capabilities.dtp.v2.tenant": "dt_tenant_a",
+            "sre-capabilities.dtp.v2.token-spec": "default",
+        },
     )

--- a/reconcile/test/dynatrace_token_provider/fixtures.py
+++ b/reconcile/test/dynatrace_token_provider/fixtures.py
@@ -11,7 +11,7 @@ from reconcile.dynatrace_token_provider.integration import (
     QONTRACT_INTEGRATION_VERSION,
 )
 from reconcile.dynatrace_token_provider.model import K8sSecret
-from reconcile.dynatrace_token_provider.ocm import Cluster, OCMClient
+from reconcile.dynatrace_token_provider.ocm import OCMClient, OCMCluster
 from reconcile.utils.dynatrace.client import DynatraceAPITokenCreated, DynatraceClient
 from reconcile.utils.openshift_resource import (
     QONTRACT_ANNOTATION_INTEGRATION,
@@ -90,7 +90,7 @@ def build_manifest(
 
 
 def build_ocm_client(
-    discover_clusters_by_labels: Iterable[Cluster],
+    discover_clusters_by_labels: Iterable[OCMCluster],
     get_syncset: Mapping[str, Mapping],
     get_manifest: Mapping[str, Mapping],
 ) -> OCMClient:

--- a/reconcile/test/dynatrace_token_provider/test_create_manifest.py
+++ b/reconcile/test/dynatrace_token_provider/test_create_manifest.py
@@ -1,9 +1,10 @@
 from reconcile.dynatrace_token_provider.dependencies import Dependencies
 from reconcile.dynatrace_token_provider.integration import (
+    DTP_TENANT_V2_LABEL,
     DynatraceTokenProviderIntegration,
 )
 from reconcile.dynatrace_token_provider.model import DynatraceAPIToken, K8sSecret
-from reconcile.dynatrace_token_provider.ocm import Cluster
+from reconcile.dynatrace_token_provider.ocm import OCMCluster
 from reconcile.gql_definitions.dynatrace_token_provider.token_specs import (
     DynatraceTokenProviderTokenSpecV1,
 )
@@ -21,13 +22,14 @@ def test_single_hcp_cluster_create_tokens(
     default_token_spec: DynatraceTokenProviderTokenSpecV1,
     default_operator_token: DynatraceAPIToken,
     default_ingestion_token: DynatraceAPIToken,
-    default_hcp_cluster: Cluster,
+    default_hcp_cluster: OCMCluster,
     default_integration: DynatraceTokenProviderIntegration,
 ) -> None:
     """
     We have a single HCP cluster that does not have a manifest/token yet.
     New tokens in a new manifest should be created.
     """
+    tenant_id = default_hcp_cluster.labels[DTP_TENANT_V2_LABEL]
     ocm_client = build_ocm_client(
         discover_clusters_by_labels=[default_hcp_cluster],
         get_syncset={},
@@ -108,7 +110,7 @@ def test_single_hcp_cluster_create_tokens(
                     ],
                 )
             ],
-            tenant_id=default_hcp_cluster.dt_tenant,
+            tenant_id=tenant_id,
             with_id=True,
         ),
     )

--- a/reconcile/test/dynatrace_token_provider/test_create_syncset.py
+++ b/reconcile/test/dynatrace_token_provider/test_create_syncset.py
@@ -1,9 +1,10 @@
 from reconcile.dynatrace_token_provider.dependencies import Dependencies
 from reconcile.dynatrace_token_provider.integration import (
+    DTP_TENANT_V2_LABEL,
     DynatraceTokenProviderIntegration,
 )
 from reconcile.dynatrace_token_provider.model import DynatraceAPIToken, K8sSecret
-from reconcile.dynatrace_token_provider.ocm import Cluster
+from reconcile.dynatrace_token_provider.ocm import OCMCluster
 from reconcile.gql_definitions.dynatrace_token_provider.token_specs import (
     DynatraceTokenProviderTokenSpecV1,
 )
@@ -21,13 +22,14 @@ def test_single_non_hcp_cluster_create_tokens(
     default_token_spec: DynatraceTokenProviderTokenSpecV1,
     default_operator_token: DynatraceAPIToken,
     default_ingestion_token: DynatraceAPIToken,
-    default_cluster: Cluster,
+    default_cluster: OCMCluster,
     default_integration: DynatraceTokenProviderIntegration,
 ) -> None:
     """
     We have a single non-HCP cluster that does not have a syncset/token yet.
     New tokens in a new syncset should be created.
     """
+    tenant_id = default_cluster.labels[DTP_TENANT_V2_LABEL]
     ocm_client = build_ocm_client(
         discover_clusters_by_labels=[default_cluster],
         get_syncset={},
@@ -108,7 +110,7 @@ def test_single_non_hcp_cluster_create_tokens(
                     ],
                 )
             ],
-            tenant_id=default_cluster.dt_tenant,
+            tenant_id=tenant_id,
             with_id=True,
         ),
     )

--- a/reconcile/test/dynatrace_token_provider/test_dry_run.py
+++ b/reconcile/test/dynatrace_token_provider/test_dry_run.py
@@ -3,7 +3,7 @@ from reconcile.dynatrace_token_provider.integration import (
     DynatraceTokenProviderIntegration,
 )
 from reconcile.dynatrace_token_provider.model import DynatraceAPIToken, K8sSecret
-from reconcile.dynatrace_token_provider.ocm import Cluster
+from reconcile.dynatrace_token_provider.ocm import OCMCluster
 from reconcile.gql_definitions.dynatrace_token_provider.token_specs import (
     DynatraceTokenProviderTokenSpecV1,
 )
@@ -26,21 +26,25 @@ def test_dry_run(
     In this case we have 2 clusters, one that needs a new (create)
     syncset and one that needs a patch for an existing syncset.
     """
-    cluster_a = Cluster(
+    cluster_a = OCMCluster(
         id="cluster_a",
         external_id="external_id_a",
         organization_id="ocm_org_id_a",
+        subscription_id="sub_id",
         dt_tenant="dt_tenant_a",
         token_spec_name="default",
         is_hcp=False,
+        labels={},
     )
-    cluster_b = Cluster(
+    cluster_b = OCMCluster(
         id="cluster_b",
         external_id="external_id_b",
         organization_id="ocm_org_id_a",
+        subscription_id="sub_id",
         dt_tenant="dt_tenant_a",
         token_spec_name="default",
         is_hcp=False,
+        labels={},
     )
     given_clusters = [cluster_a, cluster_b]
     ocm_client = build_ocm_client(

--- a/reconcile/test/dynatrace_token_provider/test_no_change_manifest.py
+++ b/reconcile/test/dynatrace_token_provider/test_no_change_manifest.py
@@ -1,9 +1,10 @@
 from reconcile.dynatrace_token_provider.dependencies import Dependencies
 from reconcile.dynatrace_token_provider.integration import (
+    DTP_TENANT_V2_LABEL,
     DynatraceTokenProviderIntegration,
 )
 from reconcile.dynatrace_token_provider.model import DynatraceAPIToken, K8sSecret
-from reconcile.dynatrace_token_provider.ocm import Cluster
+from reconcile.dynatrace_token_provider.ocm import OCMCluster
 from reconcile.gql_definitions.dynatrace_token_provider.token_specs import (
     DynatraceTokenProviderTokenSpecV1,
 )
@@ -21,7 +22,7 @@ def test_no_change_hcp_cluster(
     default_token_spec: DynatraceTokenProviderTokenSpecV1,
     default_operator_token: DynatraceAPIToken,
     default_ingestion_token: DynatraceAPIToken,
-    default_hcp_cluster: Cluster,
+    default_hcp_cluster: OCMCluster,
     default_integration: DynatraceTokenProviderIntegration,
 ) -> None:
     """
@@ -29,6 +30,7 @@ def test_no_change_hcp_cluster(
     The token ids match with the token ids in Dynatrace.
     We expect no changes.
     """
+    tenant_id = default_hcp_cluster.labels[DTP_TENANT_V2_LABEL]
     ocm_client = build_ocm_client(
         discover_clusters_by_labels=[default_hcp_cluster],
         get_syncset={},
@@ -44,7 +46,7 @@ def test_no_change_hcp_cluster(
                         ],
                     )
                 ],
-                tenant_id=default_hcp_cluster.dt_tenant,
+                tenant_id=tenant_id,
                 with_id=True,
             )
         },

--- a/reconcile/test/dynatrace_token_provider/test_no_change_syncset.py
+++ b/reconcile/test/dynatrace_token_provider/test_no_change_syncset.py
@@ -1,9 +1,10 @@
 from reconcile.dynatrace_token_provider.dependencies import Dependencies
 from reconcile.dynatrace_token_provider.integration import (
+    DTP_TENANT_V2_LABEL,
     DynatraceTokenProviderIntegration,
 )
 from reconcile.dynatrace_token_provider.model import DynatraceAPIToken, K8sSecret
-from reconcile.dynatrace_token_provider.ocm import Cluster
+from reconcile.dynatrace_token_provider.ocm import OCMCluster
 from reconcile.gql_definitions.dynatrace_token_provider.token_specs import (
     DynatraceTokenProviderTokenSpecV1,
 )
@@ -21,7 +22,7 @@ def test_no_change_non_hcp_cluster(
     default_token_spec: DynatraceTokenProviderTokenSpecV1,
     default_operator_token: DynatraceAPIToken,
     default_ingestion_token: DynatraceAPIToken,
-    default_cluster: Cluster,
+    default_cluster: OCMCluster,
     default_integration: DynatraceTokenProviderIntegration,
 ) -> None:
     """
@@ -29,6 +30,7 @@ def test_no_change_non_hcp_cluster(
     The token ids match with the token ids in Dynatrace.
     We expect no changes.
     """
+    tenant_id = default_cluster.labels[DTP_TENANT_V2_LABEL]
     ocm_client = build_ocm_client(
         discover_clusters_by_labels=[default_cluster],
         get_manifest={},
@@ -44,7 +46,7 @@ def test_no_change_non_hcp_cluster(
                         ],
                     )
                 ],
-                tenant_id=default_cluster.dt_tenant,
+                tenant_id=tenant_id,
                 with_id=True,
             )
         },

--- a/reconcile/test/dynatrace_token_provider/test_ocm_org_filters.py
+++ b/reconcile/test/dynatrace_token_provider/test_ocm_org_filters.py
@@ -3,7 +3,7 @@ from reconcile.dynatrace_token_provider.integration import (
     DynatraceTokenProviderIntegration,
 )
 from reconcile.dynatrace_token_provider.model import DynatraceAPIToken, K8sSecret
-from reconcile.dynatrace_token_provider.ocm import Cluster
+from reconcile.dynatrace_token_provider.ocm import OCMCluster
 from reconcile.gql_definitions.dynatrace_token_provider.token_specs import (
     DynatraceTokenProviderTokenSpecV1,
 )
@@ -27,13 +27,15 @@ def test_ocm_org_filters(
     There is a diff to desired state (patch + create).
     However, we expect the cluster to be filtered.
     """
-    cluster_a = Cluster(
+    cluster_a = OCMCluster(
         id="cluster_a",
         external_id="external_id_b",
         organization_id="does-not-exist",
+        subscription_id="sub_id",
         dt_tenant="dt_tenant_a",
         token_spec_name="default",
         is_hcp=False,
+        labels={},
     )
     given_clusters = [cluster_a]
     ocm_client = build_ocm_client(

--- a/reconcile/test/dynatrace_token_provider/test_patch_manifest.py
+++ b/reconcile/test/dynatrace_token_provider/test_patch_manifest.py
@@ -1,9 +1,10 @@
 from reconcile.dynatrace_token_provider.dependencies import Dependencies
 from reconcile.dynatrace_token_provider.integration import (
+    DTP_TENANT_V2_LABEL,
     DynatraceTokenProviderIntegration,
 )
 from reconcile.dynatrace_token_provider.model import DynatraceAPIToken, K8sSecret
-from reconcile.dynatrace_token_provider.ocm import Cluster
+from reconcile.dynatrace_token_provider.ocm import OCMCluster
 from reconcile.gql_definitions.dynatrace_token_provider.token_specs import (
     DynatraceTokenProviderTokenSpecV1,
 )
@@ -21,7 +22,7 @@ def test_single_hcp_cluster_patch_tokens(
     default_token_spec: DynatraceTokenProviderTokenSpecV1,
     default_operator_token: DynatraceAPIToken,
     default_ingestion_token: DynatraceAPIToken,
-    default_hcp_cluster: Cluster,
+    default_hcp_cluster: OCMCluster,
     default_integration: DynatraceTokenProviderIntegration,
 ) -> None:
     """
@@ -29,6 +30,7 @@ def test_single_hcp_cluster_patch_tokens(
     However, one of the token ids does not match with the token ids in Dynatrace.
     We expect a new token to be created and the syncset to be patched.
     """
+    tenant_id = default_hcp_cluster.labels[DTP_TENANT_V2_LABEL]
     ocm_client = build_ocm_client(
         discover_clusters_by_labels=[default_hcp_cluster],
         get_syncset={},
@@ -44,7 +46,7 @@ def test_single_hcp_cluster_patch_tokens(
                         ],
                     )
                 ],
-                tenant_id=default_hcp_cluster.dt_tenant,
+                tenant_id=tenant_id,
                 with_id=True,
             )
         },
@@ -114,7 +116,7 @@ def test_single_hcp_cluster_patch_tokens(
                     ],
                 )
             ],
-            tenant_id=default_hcp_cluster.dt_tenant,
+            tenant_id=tenant_id,
             with_id=False,
         ),
     )

--- a/reconcile/test/dynatrace_token_provider/test_patch_syncset.py
+++ b/reconcile/test/dynatrace_token_provider/test_patch_syncset.py
@@ -1,9 +1,10 @@
 from reconcile.dynatrace_token_provider.dependencies import Dependencies
 from reconcile.dynatrace_token_provider.integration import (
+    DTP_TENANT_V2_LABEL,
     DynatraceTokenProviderIntegration,
 )
 from reconcile.dynatrace_token_provider.model import DynatraceAPIToken, K8sSecret
-from reconcile.dynatrace_token_provider.ocm import Cluster
+from reconcile.dynatrace_token_provider.ocm import OCMCluster
 from reconcile.gql_definitions.dynatrace_token_provider.token_specs import (
     DynatraceTokenProviderTokenSpecV1,
 )
@@ -21,7 +22,7 @@ def test_single_non_hcp_cluster_patch_tokens(
     default_token_spec: DynatraceTokenProviderTokenSpecV1,
     default_operator_token: DynatraceAPIToken,
     default_ingestion_token: DynatraceAPIToken,
-    default_cluster: Cluster,
+    default_cluster: OCMCluster,
     default_integration: DynatraceTokenProviderIntegration,
 ) -> None:
     """
@@ -29,6 +30,7 @@ def test_single_non_hcp_cluster_patch_tokens(
     However, one of the token ids does not match with the token ids in Dynatrace.
     We expect a new token to be created and the syncset to be patched.
     """
+    tenant_id = default_cluster.labels[DTP_TENANT_V2_LABEL]
     ocm_client = build_ocm_client(
         discover_clusters_by_labels=[default_cluster],
         get_manifest={},
@@ -44,7 +46,7 @@ def test_single_non_hcp_cluster_patch_tokens(
                         ],
                     )
                 ],
-                tenant_id=default_cluster.dt_tenant,
+                tenant_id=tenant_id,
                 with_id=True,
             )
         },
@@ -114,7 +116,7 @@ def test_single_non_hcp_cluster_patch_tokens(
                     ],
                 )
             ],
-            tenant_id=default_cluster.dt_tenant,
+            tenant_id=tenant_id,
             with_id=False,
         ),
     )

--- a/reconcile/test/dynatrace_token_provider/test_spec_token_diff.py
+++ b/reconcile/test/dynatrace_token_provider/test_spec_token_diff.py
@@ -1,9 +1,10 @@
 from reconcile.dynatrace_token_provider.dependencies import Dependencies
 from reconcile.dynatrace_token_provider.integration import (
+    DTP_TENANT_V2_LABEL,
     DynatraceTokenProviderIntegration,
 )
 from reconcile.dynatrace_token_provider.model import DynatraceAPIToken, K8sSecret
-from reconcile.dynatrace_token_provider.ocm import Cluster
+from reconcile.dynatrace_token_provider.ocm import OCMCluster
 from reconcile.gql_definitions.dynatrace_token_provider.token_specs import (
     DynatraceTokenProviderTokenSpecV1,
 )
@@ -20,13 +21,14 @@ def test_spec_to_existing_token_diff(
     default_token_spec: DynatraceTokenProviderTokenSpecV1,
     default_operator_token: DynatraceAPIToken,
     default_ingestion_token: DynatraceAPIToken,
-    default_cluster: Cluster,
+    default_cluster: OCMCluster,
     default_integration: DynatraceTokenProviderIntegration,
 ) -> None:
     """
     We have an existing token in Dynatrace that does not match the spec.
     We expect DTP to update the token to match the given spec.
     """
+    tenant_id = default_cluster.labels[DTP_TENANT_V2_LABEL]
     ocm_client = build_ocm_client(
         discover_clusters_by_labels=[default_cluster],
         get_manifest={},
@@ -42,7 +44,7 @@ def test_spec_to_existing_token_diff(
                         ],
                     )
                 ],
-                tenant_id=default_cluster.dt_tenant,
+                tenant_id=tenant_id,
                 with_id=True,
             )
         },


### PR DESCRIPTION
This is in preparation for DTP `v3` labeling. The new labeling will allow multiple `tenant:spec` label pairs for every cluster.

This PR is mainly a refactor for:
- Preparing structure to allow multiple `Tenant:Spec` pairs for clusters
- moving label parsing logic out of ocm abstraction layer and into integration logic, because it will grow more complex with `v3` -> this makes it part of the test logic now
- adjusting tests to properly harbor label parsing logic

Note, that we still keep the old `v2` labeling in place. **The functionality does not change in this PR.**

In follow a follow up PR we will address the new DTP `v3` labeling itself.