### PR TITLE
APPSRE-11886: Add support to migrate HCL/terraform modules

### DIFF
--- a/tools/cli_commands/erv2.py
+++ b/tools/cli_commands/erv2.py
@@ -232,20 +232,28 @@ class Erv2Cli:
 
         try:
             with task(self.progress_spinner, "-- Running terraform"):
-                # now spin up your ERv2 image in DRY_RUN=“True” ACTION=“Apply”
-                run([
-                  "docker", "pull", self.image
-                ], check=True)
-                run([
-                  "docker", "run", "--name", "erv2",
-                  "-v", f"{input_file!s}:/inputs/input.json:Z",
-                  "-v", f"{credentials!s}:/credentials:Z",
-                  "-v", f"{self.temp}:/work:Z",
-                  "-e", "AWS_SHARED_CREDENTIALS_FILE=/credentials",
-                  "-e", f"TERRAFORM_MODULE_WORK_DIR=/tmp/{tf_module}",
-                  self.image
-                ], check=True,
-                capture_output=True)
+                run(["docker", "pull", self.image], check=True)
+                run(
+                    [
+                        "docker",
+                        "run",
+                        "--name",
+                        "erv2",
+                        "-v",
+                        f"{input_file!s}:/inputs/input.json:Z",
+                        "-v",
+                        f"{credentials!s}:/credentials:Z",
+                        "-v",
+                        f"{self.temp}:/work:Z",
+                        "-e",
+                        "AWS_SHARED_CREDENTIALS_FILE=/credentials",
+                        "-e",
+                        f"TERRAFORM_MODULE_WORK_DIR=/tmp/{tf_module}",
+                        self.image,
+                    ],
+                    check=True,
+                    capture_output=True,
+                )
 
             with task(self.progress_spinner, "-- Copying the terraform module"):
                 run(

--- a/tools/cli_commands/erv2.py
+++ b/tools/cli_commands/erv2.py
@@ -123,6 +123,7 @@ class Erv2Cli:
                 m_inventory.get_from_spec(spec), spec, self._er_settings
             )
         )
+        self.module_type = m_inventory.get_from_spec(spec).module_type
         self._resource = f.create_external_resource(spec, self._module_configuration)
         f.validate_external_resource(self._resource, self._module_configuration)
 
@@ -214,6 +215,68 @@ class Erv2Cli:
                     check=True,
                     capture_output=True,
                 )
+        except CalledProcessError as e:
+            if e.stderr:
+                print(e.stderr.decode("utf-8"))
+            if e.stdout:
+                print(e.stdout.decode("utf-8"))
+            raise
+
+    def build_terraform(self, credentials: Path) -> None:
+        input_file = self.temp / "input.json"
+        input_file.write_text(self.input_data)
+        tf_module = "tfmodule"
+
+        # delete previous ERv2 container
+        run(["docker", "rm", "-f", "erv2"], capture_output=True, check=True)
+
+        try:
+            with task(self.progress_spinner, "-- Running terraform"):
+                # now spin up your ERv2 image in DRY_RUN=“True” ACTION=“Apply”
+                run([
+                  "docker", "pull", self.image
+                ], check=True)
+                run([
+                  "docker", "run", "--name", "erv2",
+                  "-v", f"{input_file!s}:/inputs/input.json:Z",
+                  "-v", f"{credentials!s}:/credentials:Z",
+                  "-v", f"{self.temp}:/work:Z",
+                  "-e", "AWS_SHARED_CREDENTIALS_FILE=/credentials",
+                  "-e", f"TERRAFORM_MODULE_WORK_DIR=/tmp/{tf_module}",
+                  self.image
+                ], check=True,
+                capture_output=True)
+
+            with task(self.progress_spinner, "-- Copying the terraform module"):
+                run(
+                    [
+                        "docker",
+                        "cp",
+                        f"erv2:/tmp/{tf_module}",
+                        str(self.temp),
+                    ],
+                    check=True,
+                    capture_output=True,
+                )
+
+            # move all assets to local workdir
+            src_dir = self.temp / tf_module
+            for item in src_dir.iterdir():
+                if item.name != ".terraform":
+                    item.rename(self.temp / item.name)
+
+            # overwrite path set while within container
+            backend_tf = Path(self.temp) / "backend.tf"
+            backend_tf.write_text(
+                f'''
+            terraform {{
+              backend "local" {{
+                path = "{self.temp}/terraform.tfstate"
+              }}
+            }}
+            '''.lstrip()
+            )
+
         except CalledProcessError as e:
             if e.stderr:
                 print(e.stderr.decode("utf-8"))

--- a/tools/cli_commands/erv2.py
+++ b/tools/cli_commands/erv2.py
@@ -249,6 +249,8 @@ class Erv2Cli:
                         "AWS_SHARED_CREDENTIALS_FILE=/credentials",
                         "-e",
                         f"TERRAFORM_MODULE_WORK_DIR=/tmp/{tf_module}",
+                        "-e",
+                        "LOCAL_STATE=False",
                         self.image,
                     ],
                     check=True,
@@ -272,18 +274,6 @@ class Erv2Cli:
             for item in src_dir.iterdir():
                 if item.name != ".terraform":
                     item.rename(self.temp / item.name)
-
-            # overwrite path set while within container
-            backend_tf = Path(self.temp) / "backend.tf"
-            backend_tf.write_text(
-                f'''
-            terraform {{
-              backend "local" {{
-                path = "{self.temp}/terraform.tfstate"
-              }}
-            }}
-            '''.lstrip()
-            )
 
         except CalledProcessError as e:
             if e.stderr:

--- a/tools/qontract_cli.py
+++ b/tools/qontract_cli.py
@@ -4381,8 +4381,10 @@ def migrate(ctx: click.Context, dry_run: bool, skip_build: bool) -> None:
 
         with task(progress, "(erv2) Building the terraform configuration"):
             if not skip_build:
-                # build the CDKTF output
-                erv2cli.build_cdktf(credentials_file)
+                if erv2cli.module_type == "cdktf":
+                    erv2cli.build_cdktf(credentials_file)
+                else:
+                    erv2cli.build_terraform(credentials_file)
             erv2_tf_cli = TerraformCli(
                 temp_erv2, dry_run=dry_run, progress_spinner=progress
             )


### PR DESCRIPTION
## Summary

Currently, `external-resources` integration `migrate` functionality only supports modules of type `cdktf`. `cdktf` has been deprecated in favor of HCL(type `terraform`) modules. This PR adds state migration support for HCL modules.

Depends on ERv2 modules built on base image that includes change in https://github.com/app-sre/er-base-terraform/pull/27