### PR TITLE
[FR] Fix cognito token-duration units (ocm-ams client only)

### DIFF
--- a/reconcile/utils/terrascript_aws_client.py
+++ b/reconcile/utils/terrascript_aws_client.py
@@ -5927,6 +5927,7 @@ class TerrascriptClient:  # pylint: disable=too-many-public-methods
         self.add_resources(account, tf_resources)
 
     def populate_tf_resource_rosa_authenticator(self, spec):
+        
         account = spec.provisioner_name
         identifier = spec.identifier
         common_values = self.init_values(spec)

--- a/reconcile/utils/terrascript_aws_client.py
+++ b/reconcile/utils/terrascript_aws_client.py
@@ -6138,15 +6138,11 @@ class TerrascriptClient:  # pylint: disable=too-many-public-methods
             callback_urls=[f"{bucket_url}/token.html"],
             depends_on=["aws_cognito_resource_server.userpool_gateway_resource_server"],
             **pool_client_args,
-
-            #refresh_token_validity = 30
-            #access_token_validity = 60
-            #id_token_validity = 60
-            #token_validity_units {
-            #    refresh_token = "days"
-            #    access_token = "minutes"
-            #    id_token = "minutes"
-            #}
+            #token_validity_units={
+            #    "access_token":  "minutes",
+            #    "id_token":      "minutes",
+            #    "refresh_token": "days"
+            #},
         )
         tf_resources.append(cognito_user_pool_client)
 
@@ -6158,18 +6154,15 @@ class TerrascriptClient:  # pylint: disable=too-many-public-methods
                 user_pool_id=f"${{{cognito_user_pool_resource.id}}}",
                 callback_urls=insights_callback_urls,
                 **pool_client_args,
-
-                #refresh_token_validity = 30
-                #access_token_validity = 60
-                #id_token_validity = 60
-                #token_validity_units {
-                #    refresh_token = "days"
-                #    access_token = "minutes"
-                #    id_token = "minutes"
-                #}
+                #token_validity_units={
+                #    "access_token":  "minutes",
+                #    "id_token":      "minutes",
+                #    "refresh_token": "days"
+                #},
             )
             tf_resources.append(insights_cognito_user_pool_client)
 
+        # todo: these scopes should be defined in an external resource file
         # POOL RESOURCE SERVER
         cognito_resource_server_resource = aws_cognito_resource_server(
             "userpool_service_resource_server",
@@ -6233,15 +6226,11 @@ class TerrascriptClient:  # pylint: disable=too-many-public-methods
             allowed_oauth_scopes=["ocm/AccountManagement"],
             depends_on=["aws_cognito_resource_server.userpool_service_resource_server"],
             **pool_client_service_account_common_args,
-
-            refresh_token_validity = 30
-            access_token_validity = 60
-            id_token_validity = 60
-            token_validity_units {
-                refresh_token = "days"
-                access_token = "minutes"
-                id_token = "minutes"
-            }
+            token_validity_units={
+                "access_token":  "minutes",
+                "id_token":      "minutes",
+                "refresh_token": "days"
+            },
         )
         tf_resources.append(ams_service_account_pool_client_resource)
 
@@ -6253,15 +6242,11 @@ class TerrascriptClient:  # pylint: disable=too-many-public-methods
             allowed_oauth_scopes=["ocm/ClusterService"],
             depends_on=["aws_cognito_resource_server.userpool_service_resource_server"],
             **pool_client_service_account_common_args,
-
-            #refresh_token_validity = 30
-            #access_token_validity = 60
-            #id_token_validity = 60
-            #token_validity_units {
-            #    refresh_token = "days"
-            #    access_token = "minutes"
-            #    id_token = "minutes"
-            #}
+            #token_validity_units={
+            #    "access_token":  "minutes",
+            #    "id_token":      "minutes",
+            #    "refresh_token": "days"
+            #},
         )
         tf_resources.append(cs_service_account_pool_client_resource)
 
@@ -6273,15 +6258,11 @@ class TerrascriptClient:  # pylint: disable=too-many-public-methods
             allowed_oauth_scopes=["ocm/ServiceLogService"],
             depends_on=["aws_cognito_resource_server.userpool_service_resource_server"],
             **pool_client_service_account_common_args,
-
-            #refresh_token_validity = 30
-            #access_token_validity = 60
-            #id_token_validity = 60
-            #token_validity_units {
-            #    refresh_token = "days"
-            #    access_token = "minutes"
-            #    id_token = "minutes"
-            #}
+            #token_validity_units={
+            #    "access_token":  "minutes",
+            #    "id_token":      "minutes",
+            #    "refresh_token": "days"
+            #},
         )
         tf_resources.append(osl_service_account_pool_client_resource)
 
@@ -6296,15 +6277,11 @@ class TerrascriptClient:  # pylint: disable=too-many-public-methods
                     "aws_cognito_resource_server.userpool_service_resource_server"
                 ],
                 **pool_client_service_account_common_args,
-
-                #refresh_token_validity = 30
-                #access_token_validity = 60
-                #id_token_validity = 60
-                #token_validity_units {
-                #    refresh_token = "days"
-                #    access_token = "minutes"
-                #    id_token = "minutes"
-                #}
+                #token_validity_units={
+                #    "access_token":  "minutes",
+                #    "id_token":      "minutes",
+                #    "refresh_token": "days"
+                #},
             )
         )
         tf_resources.append(backplane_cli_service_account_pool_client_resource)
@@ -6320,15 +6297,11 @@ class TerrascriptClient:  # pylint: disable=too-many-public-methods
                     "aws_cognito_resource_server.userpool_service_resource_server"
                 ],
                 **pool_client_service_account_common_args,
-
-                #refresh_token_validity = 30
-                #access_token_validity = 60
-                #id_token_validity = 60
-                #token_validity_units {
-                #    refresh_token = "days"
-                #    access_token = "minutes"
-                #    id_token = "minutes"
-                #}
+                #token_validity_units={
+                #    "access_token":  "minutes",
+                #    "id_token":      "minutes",
+                #    "refresh_token": "days"
+                #},
             )
         )
         tf_resources.append(backplane_api_service_account_pool_client_resource)
@@ -6341,15 +6314,11 @@ class TerrascriptClient:  # pylint: disable=too-many-public-methods
             allowed_oauth_scopes=["ocm/InsightsServiceAccount"],
             depends_on=["aws_cognito_resource_server.userpool_service_resource_server"],
             **pool_client_service_account_common_args,
-
-            #refresh_token_validity = 30
-            #access_token_validity = 60
-            #id_token_validity = 60
-            #token_validity_units {
-            #    refresh_token = "days"
-            #    access_token = "minutes"
-            #    id_token = "minutes"
-            #}
+            #token_validity_units={
+            #    "access_token":  "minutes",
+            #    "id_token":      "minutes",
+            #    "refresh_token": "days"
+            #},
         )
         tf_resources.append(insights_service_account_pool_client_resource)
 

--- a/reconcile/utils/terrascript_aws_client.py
+++ b/reconcile/utils/terrascript_aws_client.py
@@ -5927,7 +5927,7 @@ class TerrascriptClient:  # pylint: disable=too-many-public-methods
         self.add_resources(account, tf_resources)
 
     def populate_tf_resource_rosa_authenticator(self, spec):
-        
+
         account = spec.provisioner_name
         identifier = spec.identifier
         common_values = self.init_values(spec)
@@ -6139,6 +6139,15 @@ class TerrascriptClient:  # pylint: disable=too-many-public-methods
             callback_urls=[f"{bucket_url}/token.html"],
             depends_on=["aws_cognito_resource_server.userpool_gateway_resource_server"],
             **pool_client_args,
+
+            #refresh_token_validity = 30
+            #access_token_validity = 60
+            #id_token_validity = 60
+            #token_validity_units {
+            #    refresh_token = "days"
+            #    access_token = "minutes"
+            #    id_token = "minutes"
+            #}
         )
         tf_resources.append(cognito_user_pool_client)
 
@@ -6150,6 +6159,15 @@ class TerrascriptClient:  # pylint: disable=too-many-public-methods
                 user_pool_id=f"${{{cognito_user_pool_resource.id}}}",
                 callback_urls=insights_callback_urls,
                 **pool_client_args,
+
+                #refresh_token_validity = 30
+                #access_token_validity = 60
+                #id_token_validity = 60
+                #token_validity_units {
+                #    refresh_token = "days"
+                #    access_token = "minutes"
+                #    id_token = "minutes"
+                #}
             )
             tf_resources.append(insights_cognito_user_pool_client)
 
@@ -6216,6 +6234,15 @@ class TerrascriptClient:  # pylint: disable=too-many-public-methods
             allowed_oauth_scopes=["ocm/AccountManagement"],
             depends_on=["aws_cognito_resource_server.userpool_service_resource_server"],
             **pool_client_service_account_common_args,
+
+            refresh_token_validity = 30
+            access_token_validity = 60
+            id_token_validity = 60
+            token_validity_units {
+                refresh_token = "days"
+                access_token = "minutes"
+                id_token = "minutes"
+            }
         )
         tf_resources.append(ams_service_account_pool_client_resource)
 
@@ -6227,6 +6254,15 @@ class TerrascriptClient:  # pylint: disable=too-many-public-methods
             allowed_oauth_scopes=["ocm/ClusterService"],
             depends_on=["aws_cognito_resource_server.userpool_service_resource_server"],
             **pool_client_service_account_common_args,
+
+            #refresh_token_validity = 30
+            #access_token_validity = 60
+            #id_token_validity = 60
+            #token_validity_units {
+            #    refresh_token = "days"
+            #    access_token = "minutes"
+            #    id_token = "minutes"
+            #}
         )
         tf_resources.append(cs_service_account_pool_client_resource)
 
@@ -6238,6 +6274,15 @@ class TerrascriptClient:  # pylint: disable=too-many-public-methods
             allowed_oauth_scopes=["ocm/ServiceLogService"],
             depends_on=["aws_cognito_resource_server.userpool_service_resource_server"],
             **pool_client_service_account_common_args,
+
+            #refresh_token_validity = 30
+            #access_token_validity = 60
+            #id_token_validity = 60
+            #token_validity_units {
+            #    refresh_token = "days"
+            #    access_token = "minutes"
+            #    id_token = "minutes"
+            #}
         )
         tf_resources.append(osl_service_account_pool_client_resource)
 
@@ -6252,6 +6297,15 @@ class TerrascriptClient:  # pylint: disable=too-many-public-methods
                     "aws_cognito_resource_server.userpool_service_resource_server"
                 ],
                 **pool_client_service_account_common_args,
+
+                #refresh_token_validity = 30
+                #access_token_validity = 60
+                #id_token_validity = 60
+                #token_validity_units {
+                #    refresh_token = "days"
+                #    access_token = "minutes"
+                #    id_token = "minutes"
+                #}
             )
         )
         tf_resources.append(backplane_cli_service_account_pool_client_resource)
@@ -6267,6 +6321,15 @@ class TerrascriptClient:  # pylint: disable=too-many-public-methods
                     "aws_cognito_resource_server.userpool_service_resource_server"
                 ],
                 **pool_client_service_account_common_args,
+
+                #refresh_token_validity = 30
+                #access_token_validity = 60
+                #id_token_validity = 60
+                #token_validity_units {
+                #    refresh_token = "days"
+                #    access_token = "minutes"
+                #    id_token = "minutes"
+                #}
             )
         )
         tf_resources.append(backplane_api_service_account_pool_client_resource)
@@ -6279,6 +6342,15 @@ class TerrascriptClient:  # pylint: disable=too-many-public-methods
             allowed_oauth_scopes=["ocm/InsightsServiceAccount"],
             depends_on=["aws_cognito_resource_server.userpool_service_resource_server"],
             **pool_client_service_account_common_args,
+
+            #refresh_token_validity = 30
+            #access_token_validity = 60
+            #id_token_validity = 60
+            #token_validity_units {
+            #    refresh_token = "days"
+            #    access_token = "minutes"
+            #    id_token = "minutes"
+            #}
         )
         tf_resources.append(insights_service_account_pool_client_resource)
 

--- a/reconcile/utils/terrascript_aws_client.py
+++ b/reconcile/utils/terrascript_aws_client.py
@@ -5927,7 +5927,6 @@ class TerrascriptClient:  # pylint: disable=too-many-public-methods
         self.add_resources(account, tf_resources)
 
     def populate_tf_resource_rosa_authenticator(self, spec):
-
         account = spec.provisioner_name
         identifier = spec.identifier
         common_values = self.init_values(spec)

--- a/reconcile/utils/terrascript_aws_client.py
+++ b/reconcile/utils/terrascript_aws_client.py
@@ -6138,11 +6138,11 @@ class TerrascriptClient:  # pylint: disable=too-many-public-methods
             callback_urls=[f"{bucket_url}/token.html"],
             depends_on=["aws_cognito_resource_server.userpool_gateway_resource_server"],
             **pool_client_args,
-            #token_validity_units={
+            # token_validity_units={
             #    "access_token":  "minutes",
             #    "id_token":      "minutes",
             #    "refresh_token": "days"
-            #},
+            # },
         )
         tf_resources.append(cognito_user_pool_client)
 
@@ -6154,11 +6154,11 @@ class TerrascriptClient:  # pylint: disable=too-many-public-methods
                 user_pool_id=f"${{{cognito_user_pool_resource.id}}}",
                 callback_urls=insights_callback_urls,
                 **pool_client_args,
-                #token_validity_units={
+                # token_validity_units={
                 #    "access_token":  "minutes",
                 #    "id_token":      "minutes",
                 #    "refresh_token": "days"
-                #},
+                # },
             )
             tf_resources.append(insights_cognito_user_pool_client)
 
@@ -6227,9 +6227,9 @@ class TerrascriptClient:  # pylint: disable=too-many-public-methods
             depends_on=["aws_cognito_resource_server.userpool_service_resource_server"],
             **pool_client_service_account_common_args,
             token_validity_units={
-                "access_token":  "minutes",
-                "id_token":      "minutes",
-                "refresh_token": "days"
+                "access_token": "minutes",
+                "id_token": "minutes",
+                "refresh_token": "days",
             },
         )
         tf_resources.append(ams_service_account_pool_client_resource)
@@ -6242,11 +6242,11 @@ class TerrascriptClient:  # pylint: disable=too-many-public-methods
             allowed_oauth_scopes=["ocm/ClusterService"],
             depends_on=["aws_cognito_resource_server.userpool_service_resource_server"],
             **pool_client_service_account_common_args,
-            #token_validity_units={
+            # token_validity_units={
             #    "access_token":  "minutes",
             #    "id_token":      "minutes",
             #    "refresh_token": "days"
-            #},
+            # },
         )
         tf_resources.append(cs_service_account_pool_client_resource)
 
@@ -6258,11 +6258,11 @@ class TerrascriptClient:  # pylint: disable=too-many-public-methods
             allowed_oauth_scopes=["ocm/ServiceLogService"],
             depends_on=["aws_cognito_resource_server.userpool_service_resource_server"],
             **pool_client_service_account_common_args,
-            #token_validity_units={
+            # token_validity_units={
             #    "access_token":  "minutes",
             #    "id_token":      "minutes",
             #    "refresh_token": "days"
-            #},
+            # },
         )
         tf_resources.append(osl_service_account_pool_client_resource)
 
@@ -6277,11 +6277,11 @@ class TerrascriptClient:  # pylint: disable=too-many-public-methods
                     "aws_cognito_resource_server.userpool_service_resource_server"
                 ],
                 **pool_client_service_account_common_args,
-                #token_validity_units={
+                # token_validity_units={
                 #    "access_token":  "minutes",
                 #    "id_token":      "minutes",
                 #    "refresh_token": "days"
-                #},
+                # },
             )
         )
         tf_resources.append(backplane_cli_service_account_pool_client_resource)
@@ -6297,11 +6297,11 @@ class TerrascriptClient:  # pylint: disable=too-many-public-methods
                     "aws_cognito_resource_server.userpool_service_resource_server"
                 ],
                 **pool_client_service_account_common_args,
-                #token_validity_units={
+                # token_validity_units={
                 #    "access_token":  "minutes",
                 #    "id_token":      "minutes",
                 #    "refresh_token": "days"
-                #},
+                # },
             )
         )
         tf_resources.append(backplane_api_service_account_pool_client_resource)
@@ -6314,11 +6314,11 @@ class TerrascriptClient:  # pylint: disable=too-many-public-methods
             allowed_oauth_scopes=["ocm/InsightsServiceAccount"],
             depends_on=["aws_cognito_resource_server.userpool_service_resource_server"],
             **pool_client_service_account_common_args,
-            #token_validity_units={
+            # token_validity_units={
             #    "access_token":  "minutes",
             #    "id_token":      "minutes",
             #    "refresh_token": "days"
-            #},
+            # },
         )
         tf_resources.append(insights_service_account_pool_client_resource)
 


### PR DESCRIPTION
Fixes a bug/quirk with aws-terraform-provider when cognito token expiration units are not defined.

Starting with just the ocm-ams client to reduce blast radius.

Issue explained here: https://github.com/hashicorp/terraform-provider-aws/issues/32504

AWS console UI appears to apply "default" token duration units as follows when saving changes to cognito clients:

```
 token_validity_units={
       "access_token":  "minutes",
       "id_token":      "minutes",
       "refresh_token": "days"
    }
```

This conflicts with terraform-aws-provider's default units. For `access_token` and `id_token`, AWS console seems to default to `minutes`, while terraform-aws-provider defaults these to `hours`. Both default `refresh_token` to `days`.

By making QR and the AWS console UI use the same "default" unit types, we reduce the chances of a terraform state mismatch happening as a result of someone viewing settings in the AWS console UI.    