### PR TITLE
[FR] create fleet-manager user-pool-client under rosa-authenticator

### DIFF
--- a/reconcile/utils/terrascript_aws_client.py
+++ b/reconcile/utils/terrascript_aws_client.py
@@ -6322,6 +6322,24 @@ class TerrascriptClient:  # pylint: disable=too-many-public-methods
         )
         tf_resources.append(insights_service_account_pool_client_resource)
 
+        # todo: add terrascript equivalent of this:
+#resource "aws_cognito_user_pool_client" "ocm_osdfm_service_account" {
+#  name            = "ocm-appsre-${var.environment}-osdfm-service-account"
+#  user_pool_id    = aws_cognito_user_pool.pool.id
+#  generate_secret = true
+
+#  allowed_oauth_flows = ["client_credentials"]
+#  allowed_oauth_scopes = [
+#    "ocm/OSDFleetManagerService"
+#  ]
+#  allowed_oauth_flows_user_pool_client = true
+#  supported_identity_providers         = ["COGNITO"]
+
+#  depends_on = [
+#    aws_cognito_resource_server.userpool_service_resource_server
+#  ]
+#}
+
         # USER POOL COMPLETE
 
         # rosa-authenticator-vpce provider OR pre-created vpce resources are required for this

--- a/reconcile/utils/terrascript_aws_client.py
+++ b/reconcile/utils/terrascript_aws_client.py
@@ -6322,23 +6322,21 @@ class TerrascriptClient:  # pylint: disable=too-many-public-methods
         )
         tf_resources.append(insights_service_account_pool_client_resource)
 
-        # todo: add terrascript equivalent of this:
-#resource "aws_cognito_user_pool_client" "ocm_osdfm_service_account" {
-#  name            = "ocm-appsre-${var.environment}-osdfm-service-account"
-#  user_pool_id    = aws_cognito_user_pool.pool.id
-#  generate_secret = true
-
-#  allowed_oauth_flows = ["client_credentials"]
-#  allowed_oauth_scopes = [
-#    "ocm/OSDFleetManagerService"
-#  ]
-#  allowed_oauth_flows_user_pool_client = true
-#  supported_identity_providers         = ["COGNITO"]
-
-#  depends_on = [
-#    aws_cognito_resource_server.userpool_service_resource_server
-#  ]
-#}
+        # OSD FLEET MANAGER
+        ocm_osdfm_service_account_pool_client_resource = aws_cognito_user_pool_client(
+            "ocm_osdfm_service_account",
+            name=f"ocm-{identifier}-osdfm-service-account",
+            user_pool_id=f"${{{cognito_user_pool_resource.id}}}",
+            allowed_oauth_scopes=["ocm/OSDFleetManagerService"],
+            depends_on=["aws_cognito_resource_server.userpool_service_resource_server"],
+            **pool_client_service_account_common_args,
+            token_validity_units={
+                "access_token": "minutes",
+                "id_token": "minutes",
+                "refresh_token": "days",
+            },
+        )
+        tf_resources.append(insights_service_account_pool_client_resource)
 
         # USER POOL COMPLETE
 

--- a/reconcile/utils/terrascript_aws_client.py
+++ b/reconcile/utils/terrascript_aws_client.py
@@ -6323,8 +6323,8 @@ class TerrascriptClient:  # pylint: disable=too-many-public-methods
         tf_resources.append(insights_service_account_pool_client_resource)
 
         # OSD FLEET MANAGER
-        ocm_osdfm_service_account_pool_client_resource = aws_cognito_user_pool_client(
-            "ocm_osdfm_service_account",
+        osdfm_service_account_pool_client_resource = aws_cognito_user_pool_client(
+            "osdfm_service_account",
             name=f"ocm-{identifier}-osdfm-service-account",
             user_pool_id=f"${{{cognito_user_pool_resource.id}}}",
             allowed_oauth_scopes=["ocm/OSDFleetManagerService"],
@@ -6336,7 +6336,7 @@ class TerrascriptClient:  # pylint: disable=too-many-public-methods
                 "refresh_token": "days",
             },
         )
-        tf_resources.append(insights_service_account_pool_client_resource)
+        tf_resources.append(osdfm_service_account_pool_client_resource)
 
         # USER POOL COMPLETE
 


### PR DESCRIPTION
Adds a fleet-manager user-pool-client under the rosa-authenticator terraform-resource.

Part of [OCM-12752] as part of the FR HCP buildout.