### PR TITLE
move sync_tag to shared file for GCP sync + quay mirror

### DIFF
--- a/reconcile/test/test_quay_mirror.py
+++ b/reconcile/test/test_quay_mirror.py
@@ -11,6 +11,7 @@ from reconcile.quay_mirror import (
     QuayMirror,
     queries,
 )
+from reconcile.utils.quay_mirror import sync_tag
 
 from .fixtures import Fixtures
 
@@ -108,7 +109,7 @@ class TestIsCompareTags:
     ],
 )
 def test_sync_tag(tags, tags_exclude, candidate, result):
-    assert QuayMirror.sync_tag(tags, tags_exclude, candidate) == result
+    assert sync_tag(tags, tags_exclude, candidate) == result
 
 
 def test_process_repos_query_ok(mocker):

--- a/reconcile/utils/quay_mirror.py
+++ b/reconcile/utils/quay_mirror.py
@@ -21,23 +21,22 @@ def sync_tag(
     :param candidate: tag to check
     :return: bool, True means to sync, False means not to sync
     """
-    if not tags and not tags_exclude:
-        return True
-
-    if not tags:
+    if tags:
+        if tags_exclude:
+            # both tags and tags_exclude provided
+            return not match_patterns(
+                tags_exclude,
+                candidate,
+            ) and match_patterns(
+                tags,
+                candidate,
+            )
+        else:
+            # only tags provided
+            return match_patterns(tags, candidate)
+    elif tags_exclude:
         # only tags_exclude provided
-        assert tags_exclude  # mypy can't infer not None
         return not match_patterns(tags_exclude, candidate)
-
-    if not tags_exclude:
-        # only tags provided
-        return match_patterns(tags, candidate)
-
-    # both tags and tags_exclude provided
-    return not match_patterns(
-        tags_exclude,
-        candidate,
-    ) and match_patterns(
-        tags,
-        candidate,
-    )
+    else:
+        # neither tags nor tags_exclude provided
+        return True

--- a/reconcile/utils/quay_mirror.py
+++ b/reconcile/utils/quay_mirror.py
@@ -1,0 +1,43 @@
+import time
+from collections.abc import Iterable
+
+from reconcile.utils.helpers import match_patterns
+
+
+def record_timestamp(path: str) -> None:
+    with open(path, "w", encoding="locale") as file_object:
+        file_object.write(str(time.time()))
+
+
+def sync_tag(
+    tags: Iterable[str] | None,
+    tags_exclude: Iterable[str] | None,
+    candidate: str,
+) -> bool:
+    """
+    Determine if the candidate tag should sync, tags_exclude check take precedence.
+    :param tags: regex patterns to filter, match means to sync, None means no filter
+    :param tags_exclude: regex patterns to filter, match means not to sync, None means no filter
+    :param candidate: tag to check
+    :return: bool, True means to sync, False means not to sync
+    """
+    if not tags and not tags_exclude:
+        return True
+
+    if not tags:
+        # only tags_exclude provided
+        assert tags_exclude  # mypy can't infer not None
+        return not match_patterns(tags_exclude, candidate)
+
+    if not tags_exclude:
+        # only tags provided
+        return match_patterns(tags, candidate)
+
+    # both tags and tags_exclude provided
+    return not match_patterns(
+        tags_exclude,
+        candidate,
+    ) and match_patterns(
+        tags,
+        candidate,
+    )


### PR DESCRIPTION
Moves `sync_tag` function from a class method in quay_mirror.py to a shared method so that gcp_image_mirror can use the same logic.

The reason for this change is because this prior MR https://github.com/app-sre/qontract-reconcile/pull/4740 was only applied to one integration and not the other. Longer term we should look into doing class inheritence with the integrations to cut down on duplicated code (https://issues.redhat.com/browse/APPSRE-12007).

[APPSRE-11221](https://issues.redhat.com/browse/APPSRE-11221?filter=-1)