### PR TITLE
fix(quay_mirror_org): update util function usages

### DIFF
--- a/reconcile/quay_mirror_org.py
+++ b/reconcile/quay_mirror_org.py
@@ -18,6 +18,7 @@ from sretoolbox.container.skopeo import SkopeoCmdError
 
 from reconcile.quay_base import get_quay_api_store
 from reconcile.quay_mirror import QuayMirror
+from reconcile.utils.quay_mirror import record_timestamp, sync_tag
 
 _LOG = logging.getLogger(__name__)
 
@@ -80,7 +81,7 @@ class QuayMirrorOrg:
                     _LOG.error("skopeo command error message: '%s'", details)
 
         if self.is_compare_tags and not self.dry_run:
-            QuayMirror.record_timestamp(self.control_file_path)
+            record_timestamp(self.control_file_path)
 
     def process_org_mirrors(self, summary):
         """adds new keys to the summary dict with information about mirrored
@@ -183,7 +184,7 @@ class QuayMirrorOrg:
                     upstream = image_mirror[tag]
                     downstream = image[tag]
 
-                    if not QuayMirror.sync_tag(
+                    if not sync_tag(
                         tags=tags, tags_exclude=tags_exclude, candidate=tag
                     ):
                         _LOG.debug(

--- a/uv.lock
+++ b/uv.lock
@@ -1597,7 +1597,7 @@ requires-dist = [
     { name = "dateparser", specifier = "~=1.1.7" },
     { name = "deepdiff", specifier = "==6.7.1" },
     { name = "dnspython", specifier = "~=2.1" },
-    { name = "dt", specifier = "==1.1.61" },
+    { name = "dt", specifier = "==1.1.73" },
     { name = "filetype", specifier = "~=1.2.0" },
     { name = "gql", specifier = "==3.1.0" },
     { name = "hvac", specifier = ">=0.7.0,<0.8.0" },


### PR DESCRIPTION
`quay_mirror_org` is also using the same function, updates usage after function move from https://github.com/app-sre/qontract-reconcile/pull/4974.

Also sync uv.lock file, not sure why it's missed in https://github.com/app-sre/qontract-reconcile/pull/4969.