### PR TITLE
APPSRE-12023 - expand ACS permission set mappings

### DIFF
--- a/reconcile/acs_rbac.py
+++ b/reconcile/acs_rbac.py
@@ -29,6 +29,7 @@ PERMISSION_SET_NAMES = {
     "admin": "Admin",
     "analyst": "Analyst",
     "vuln-admin": "Vulnerability Management Admin",
+    "vuln-report-creator": "Vulnerability Report Creator",
 }
 
 


### PR DESCRIPTION
A gap in permissions provided by the `vuln-admin` permission set has been uncovered: `vuln-admin` allows **generating** reports using existing report templates but does not allow **creation** of new report templates.  

depends on https://github.com/app-sre/qontract-schemas/pull/827