### PR TITLE
feat(gitlab): use keyset pagination as default

### DIFF
--- a/reconcile/gitlab_members.py
+++ b/reconcile/gitlab_members.py
@@ -68,9 +68,7 @@ def get_current_state(
     """Get current gitlab group members for all managed groups."""
     return {
         g: CurrentStateSpec(
-            members={
-                u.username: u for u in gl.get_group_members(gitlab_groups_map.get(g))
-            },
+            members={u.username: u for u in gl.get_group_members(gitlab_groups_map[g])},
         )
         for g in instance.managed_groups
     }

--- a/reconcile/test/test_gitlab_permissions.py
+++ b/reconcile/test/test_gitlab_permissions.py
@@ -77,10 +77,6 @@ def test_run_share_with_group(
     group.name = "app-sre"
     group.projects = create_autospec(GroupProjectManager)
     group.shared_projects = create_autospec(SharedProjectManager)
-    mocked_gl.get_items.side_effect = [
-        [],
-        [],
-    ]
     mocked_gl.get_group.return_value = group
     mocked_gl.get_access_level.return_value = 40
     project = create_autospec(Project, web_url="https://test.com")
@@ -110,10 +106,6 @@ def test_run_managed_repo_not_created_yet(
     group.name = "app-sre"
     group.projects = create_autospec(GroupProjectManager)
     group.shared_projects = create_autospec(SharedProjectManager)
-    mocked_gl.get_items.side_effect = [
-        [],
-        [],
-    ]
     mocked_gl.get_group.return_value = group
     mocked_gl.get_access_level.return_value = 40
     project = None
@@ -133,22 +125,18 @@ def test_run_reshare_with_group(
     group.name = "app-sre"
     group.projects = create_autospec(GroupProjectManager)
     group.shared_projects = create_autospec(SharedProjectManager)
-    mocked_gl.get_items.side_effect = [
-        [],
-        [
-            create_autospec(
-                SharedProject,
-                web_url=GITLAB_TEST_URL,
-                shared_with_groups=[
-                    {
-                        "group_access_level": 30,
-                        "group_name": "app-sre",
-                        "group_id": 1234,
-                    }
-                ],
-            )
+    shared_project = create_autospec(
+        SharedProject,
+        web_url=GITLAB_TEST_URL,
+        shared_with_groups=[
+            {
+                "group_access_level": 30,
+                "group_name": "app-sre",
+                "group_id": 1234,
+            }
         ],
-    ]
+    )
+    group.shared_projects.list.return_value = [shared_project]
     mocked_gl.get_group.return_value = group
     mocked_gl.get_access_level.return_value = 40
     project = create_autospec(Project, web_url=GITLAB_TEST_URL)
@@ -176,22 +164,18 @@ def test_run_share_with_group_failed(
     group.shared_projects = create_autospec(SharedProjectManager)
     group.projects = create_autospec(GroupProjectManager)
     group.shared_projects = create_autospec(SharedProjectManager)
-    mocked_gl.get_items.side_effect = [
-        [],
-        [
-            create_autospec(
-                SharedProject,
-                web_url="https://test-gitlab.com",
-                shared_with_groups=[
-                    {
-                        "group_access_level": 30,
-                        "group_name": "app-sre",
-                        "group_id": 134,
-                    }
-                ],
-            )
+    shared_project = create_autospec(
+        SharedProject,
+        web_url="https://test-gitlab.com",
+        shared_with_groups=[
+            {
+                "group_access_level": 30,
+                "group_name": "app-sre",
+                "group_id": 134,
+            }
         ],
-    ]
+    )
+    group.shared_projects.list.return_value = [shared_project]
     mocked_gl.get_group.return_value = group
     mocked_gl.get_access_level.return_value = 40
     project = create_autospec(Project)

--- a/reconcile/test/utils/test_gitlab_api.py
+++ b/reconcile/test/utils/test_gitlab_api.py
@@ -10,6 +10,10 @@ from gitlab.v4.objects import (
     GroupManager,
     GroupMember,
     GroupMemberManager,
+    GroupProject,
+    GroupProjectManager,
+    PersonalAccessToken,
+    PersonalAccessTokenManager,
     Project,
     ProjectIssue,
     ProjectIssueManager,
@@ -17,10 +21,16 @@ from gitlab.v4.objects import (
     ProjectLabel,
     ProjectLabelManager,
     ProjectManager,
+    ProjectMember,
+    ProjectMemberManager,
     ProjectMergeRequest,
     ProjectMergeRequestManager,
     ProjectMergeRequestNote,
     ProjectMergeRequestNoteManager,
+    ProjectMergeRequestPipeline,
+    ProjectMergeRequestPipelineManager,
+    ProjectMergeRequestResourceLabelEvent,
+    ProjectMergeRequestResourceLabelEventManager,
 )
 from pytest_mock import MockerFixture
 from requests.exceptions import ConnectTimeout
@@ -60,6 +70,8 @@ def mocked_gl(mocker: MockerFixture) -> Mock:
     ).return_value
     mocked_gl.user = create_autospec(CurrentUser)
     mocked_gl.projects = create_autospec(ProjectManager)
+    mocked_gl.groups = create_autospec(GroupManager)
+    mocked_gl.personal_access_tokens = create_autospec(PersonalAccessTokenManager)
     mocker.patch("reconcile.utils.gitlab_api.SecretReader", autospec=True)
     return mocked_gl
 
@@ -102,6 +114,8 @@ def test_gitlab_api_init(
         ssl_verify=False,
         timeout=30,
         session=mocked_session.return_value,
+        per_page=100,
+        pagination="keyset",
     )
     assert gitlab_api.server == instance["url"]
     assert gitlab_api.ssl_verify is False
@@ -302,6 +316,7 @@ def test_get_merge_request_comments() -> None:
         },
     ]
     assert comments == expected_comments
+    mr.notes.list.assert_called_once_with(iterator=True)
 
 
 def test_delete_comment() -> None:
@@ -348,6 +363,7 @@ def test_get_project_labels(
     labels = mocked_gitlab_api.get_project_labels()
 
     assert labels == {"a"}
+    project.labels.list.assert_called_once_with(iterator=True)
 
 
 def test_get_merge_request_changed_paths() -> None:
@@ -454,6 +470,7 @@ def test_get_group_members(
     mocked_gl.groups = groups
 
     assert mocked_gitlab_api.get_group_members(group) == [user]
+    group.members.list.assert_called_once_with(iterator=True)
 
 
 def test_share_project_with_group_positive(
@@ -462,3 +479,239 @@ def test_share_project_with_group_positive(
     project = create_autospec(Project)
     mocked_gitlab_api.share_project_with_group(project, 1111, 40)
     project.share.assert_called_once_with(1111, 40)
+
+
+def test_get_project_maintainers(
+    mocked_gitlab_api: GitLabApi,
+    mocked_gl: Mock,
+) -> None:
+    mocked_project = mocked_gl.projects.get.return_value
+    mocked_project.members = create_autospec(ProjectMemberManager)
+    member = create_autospec(
+        ProjectMember,
+        id="1",
+        username="m",
+        access_level=40,
+    )
+    mocked_project.members.list.return_value = [member]
+    query = {
+        "user_ids": "1",
+    }
+
+    result = mocked_gitlab_api.get_project_maintainers(query=query)
+
+    assert result == ["m"]
+    mocked_project.members.list.assert_called_once_with(
+        iterator=True,
+        query_parameters=query,
+    )
+
+
+def test_get_app_sre_group_users(
+    mocked_gitlab_api: GitLabApi,
+    mocked_gl: Mock,
+) -> None:
+    mocked_group = mocked_gl.groups.get.return_value
+    mocked_group.members = create_autospec(GroupMemberManager)
+    expected_members = [
+        create_autospec(GroupMember, id="1", username="m1"),
+    ]
+    mocked_group.members.list.return_value = expected_members
+
+    members = mocked_gitlab_api.get_app_sre_group_users()
+
+    assert members == expected_members
+    mocked_gl.groups.get.assert_called_once_with("app-sre")
+    mocked_group.members.list.assert_called_once_with(get_all=True)
+
+
+def test_get_group_id_and_projects(
+    mocked_gitlab_api: GitLabApi,
+    mocked_gl: Mock,
+) -> None:
+    group = create_autospec(Group, id="1")
+    mocked_gl.groups.get.return_value = group
+    group.projects = create_autospec(GroupProjectManager)
+    project = create_autospec(GroupProject)
+    project.name = "project_name"
+    group.projects.list.return_value = [project]
+
+    group_id, project_names = mocked_gitlab_api.get_group_id_and_projects("group_name")
+
+    assert group_id == "1"
+    assert project_names == {"project_name"}
+
+
+def test_get_issues(
+    mocked_gitlab_api: GitLabApi,
+    mocked_gl: Mock,
+) -> None:
+    project = mocked_gl.projects.get.return_value
+    project.issues = create_autospec(ProjectIssueManager)
+    expected_issue = create_autospec(ProjectIssue)
+    project.issues.list.return_value = [expected_issue]
+
+    issue = mocked_gitlab_api.get_issues(state="opened")
+
+    assert issue == [expected_issue]
+    project.issues.list.assert_called_once_with(state="opened", get_all=True)
+
+
+def test_get_merge_requests(
+    mocked_gitlab_api: GitLabApi,
+    mocked_gl: Mock,
+) -> None:
+    project = mocked_gl.projects.get.return_value
+    project.mergerequests = create_autospec(ProjectMergeRequestManager)
+    expected_mr = create_autospec(ProjectMergeRequest)
+    project.mergerequests.list.return_value = [expected_mr]
+
+    mr = mocked_gitlab_api.get_merge_requests(state="opened")
+
+    assert mr == [expected_mr]
+    project.mergerequests.list.assert_called_once_with(state="opened", get_all=True)
+
+
+def test_get_merge_request_label_events() -> None:
+    mr = create_autospec(ProjectMergeRequest)
+    mr.resourcelabelevents = create_autospec(
+        ProjectMergeRequestResourceLabelEventManager
+    )
+    expected_event = create_autospec(ProjectMergeRequestResourceLabelEvent)
+    mr.resourcelabelevents.list.return_value = [expected_event]
+
+    events = GitLabApi.get_merge_request_label_events(mr)
+
+    assert events == [expected_event]
+    mr.resourcelabelevents.list.assert_called_once_with(get_all=True)
+
+
+def test_get_merge_request_pipelines() -> None:
+    mr = create_autospec(ProjectMergeRequest)
+    mr.pipelines = create_autospec(ProjectMergeRequestPipelineManager)
+
+    pipeline_1 = create_autospec(ProjectMergeRequestPipeline)
+    expected_pipeline_1 = {
+        "created_at": "2025-01-01T00:00:00Z",
+        "id": 1,
+    }
+    pipeline_1.asdict.return_value = expected_pipeline_1
+
+    pipeline_2 = create_autospec(ProjectMergeRequestPipeline)
+    expected_pipeline_2 = {
+        "created_at": "2025-01-02T00:00:00Z",
+        "id": 2,
+    }
+    pipeline_2.asdict.return_value = expected_pipeline_2
+
+    mr.pipelines.list.return_value = [pipeline_1, pipeline_2]
+
+    pipelines = GitLabApi.get_merge_request_pipelines(mr)
+
+    assert pipelines == [expected_pipeline_2, expected_pipeline_1]
+    mr.pipelines.list.assert_called_once_with(iterator=True)
+
+
+def test_get_repository_tree_as_git_cli_interface(
+    mocked_gitlab_api: GitLabApi,
+    mocked_gl: Mock,
+) -> None:
+    project = mocked_gl.projects.get.return_value
+    expected_result = [
+        {
+            "id": "a1e8f8d745cc87e3a9248358d9352bb7f9a0aeba",
+            "name": "html",
+            "type": "tree",
+            "path": "files/html",
+            "mode": "040000",
+        }
+    ]
+    project.repository_tree.return_value = expected_result
+
+    result = mocked_gitlab_api.get_repository_tree(
+        ref="main",
+        recursive=True,
+    )
+
+    assert result == expected_result
+    project.repository_tree.assert_called_once_with(
+        ref="main",
+        recursive=True,
+        pagination="keyset",
+        get_all=True,
+        path="",
+    )
+
+
+def test_get_repository_tree_with_project(
+    mocked_gitlab_api: GitLabApi,
+    mocked_gl: Mock,
+) -> None:
+    project = create_autospec(Project)
+    expected_result = [
+        {
+            "id": "a1e8f8d745cc87e3a9248358d9352bb7f9a0aeba",
+            "name": "html",
+            "type": "tree",
+            "path": "files/html",
+            "mode": "040000",
+        }
+    ]
+    project.repository_tree.return_value = expected_result
+
+    result = mocked_gitlab_api.get_repository_tree(
+        ref="main",
+        recursive=False,
+        project=project,
+        path="some/path",
+    )
+
+    assert result == expected_result
+    project.repository_tree.assert_called_once_with(
+        ref="main",
+        recursive=False,
+        pagination="keyset",
+        get_all=True,
+        path="some/path",
+    )
+
+
+def test_last_assignment() -> None:
+    mr = create_autospec(ProjectMergeRequest)
+    mr.notes = create_autospec(ProjectMergeRequestNoteManager)
+
+    note_1 = create_autospec(ProjectMergeRequestNote)
+    note_1.system = True
+    note_1.body = "assigned to @assignee_1"
+    note_1.author = {"username": "author_1"}
+
+    note_2 = create_autospec(ProjectMergeRequestNote)
+    note_2.system = True
+    note_2.body = "assigned to @assignee_2"
+    note_2.author = {"username": "author_2"}
+
+    mr.notes.list.return_value = [note_1, note_2]
+
+    result = GitLabApi.last_assignment(mr)
+
+    assert result == ("author_1", "assignee_1")
+
+    mr.notes.list.assert_called_once_with(
+        sort="desc",
+        order_by="created_at",
+        iterator=True,
+    )
+
+
+def test_get_personal_access_tokens(
+    mocked_gitlab_api: GitLabApi,
+    mocked_gl: Mock,
+) -> None:
+    manager = mocked_gl.personal_access_tokens
+    expected_pat = create_autospec(PersonalAccessToken)
+    manager.list.return_value = [expected_pat]
+
+    pats = mocked_gitlab_api.get_personal_access_tokens()
+
+    assert pats == [expected_pat]
+    manager.list.assert_called_once_with(get_all=True)

--- a/reconcile/test/utils/test_gitlab_api.py
+++ b/reconcile/test/utils/test_gitlab_api.py
@@ -638,6 +638,7 @@ def test_get_repository_tree_as_git_cli_interface(
         ref="main",
         recursive=True,
         pagination="keyset",
+        per_page=100,
         get_all=True,
         path="",
     )
@@ -671,6 +672,7 @@ def test_get_repository_tree_with_project(
         ref="main",
         recursive=False,
         pagination="keyset",
+        per_page=100,
         get_all=True,
         path="some/path",
     )

--- a/reconcile/utils/github_api.py
+++ b/reconcile/utils/github_api.py
@@ -54,9 +54,14 @@ class GithubRepositoryApi:
         Align with GitLabApi
         """
 
-    def get_repository_tree(self, ref: str = "master") -> list[dict[str, str]]:
+    def get_repository_tree(
+        self,
+        *,
+        ref: str = "master",
+        recursive: bool = False,
+    ) -> list[dict[str, str]]:
         tree_items = []
-        for item in self._repo.get_git_tree(sha=ref, recursive=True).tree:
+        for item in self._repo.get_git_tree(sha=ref, recursive=recursive).tree:
             tree_item = {"path": item.path, "name": Path(item.path).name}
             tree_items.append(tree_item)
         return tree_items

--- a/reconcile/utils/gitlab_api.py
+++ b/reconcile/utils/gitlab_api.py
@@ -668,7 +668,14 @@ class GitLabApi:
         path: str = "",
     ) -> list[dict]:
         """
-        Wrapper around Gitlab.repository_tree() with pagination enabled.
+        Get a list of repository files and directories in a project.
+
+        :param ref: The name of a repository branch or tag or, if not given, the default branch.
+        :param recursive: Boolean value used to get a recursive tree. Default is false.
+        :param project: The project to get the tree from, if None, use the current project
+        :param path: The path inside the repository. Used to get content of subdirectories.
+
+        :return: list of tree objects
         """
         target_project = self.project if project is None else project
         return cast(

--- a/reconcile/utils/gitlab_api.py
+++ b/reconcile/utils/gitlab_api.py
@@ -685,6 +685,7 @@ class GitLabApi:
                 path=path,
                 recursive=recursive,
                 pagination="keyset",
+                per_page=MAX_PER_PAGE,
                 get_all=True,
             ),
         )

--- a/reconcile/utils/repo_owners.py
+++ b/reconcile/utils/repo_owners.py
@@ -120,7 +120,7 @@ class RepoOwners:
         aliases = self._get_aliases()
 
         if self._recursive:
-            repo_tree = self._git_cli.get_repository_tree(ref=self._ref)
+            repo_tree = self._git_cli.get_repository_tree(ref=self._ref, recursive=True)
             owner_files = [item for item in repo_tree if item["name"] == "OWNERS"]
         else:
             owner_files = [{"path": "OWNERS"}]

--- a/reconcile/utils/saasherder/saasherder.py
+++ b/reconcile/utils/saasherder/saasherder.py
@@ -798,8 +798,11 @@ class SaasHerder:  # pylint: disable=too-many-public-methods
             if not self.gitlab:
                 raise Exception("gitlab is not initialized")
             project = self.gitlab.get_project(url)
-            for item in self.gitlab.get_items(
-                project.repository_tree, path=path.lstrip("/"), ref=commit_sha
+            for item in self.gitlab.get_repository_tree(
+                project=project,
+                path=path.lstrip("/"),
+                ref=commit_sha,
+                recursive=False,
             ):
                 file_contents = project.files.get(
                     file_path=item["path"], ref=commit_sha


### PR DESCRIPTION
deprecate old `get_items`, use [keyset pagination](https://docs.gitlab.com/api/rest/#keyset-based-pagination) by default, follow [python-gitlab doc](https://python-gitlab.readthedocs.io/en/stable/api-usage.html#pagination).

[APPSRE-10450](https://issues.redhat.com/browse/APPSRE-10450)

### GitLab API Enhancements:
* Replaced `get_items` utility with direct use of iterators (`iterator=True`) for API calls in methods like `get_group_members`, `get_project_maintainers`, and `get_group_id_and_projects`. This improves efficiency and aligns with GitLab's pagination model. [[1]](diffhunk://#diff-1d5ab1abb6ecb1d8c243a9e8c04d4cf6505e6be2c8932df654ea9a11c6c1b64bL270-R279) [[2]](diffhunk://#diff-1d5ab1abb6ecb1d8c243a9e8c04d4cf6505e6be2c8932df654ea9a11c6c1b64bL312-R316) [[3]](diffhunk://#diff-1d5ab1abb6ecb1d8c243a9e8c04d4cf6505e6be2c8932df654ea9a11c6c1b64bL377-R376)
* Introduced constants `MAX_PER_PAGE` and `pagination="keyset"` to standardize API pagination settings. [[1]](diffhunk://#diff-1d5ab1abb6ecb1d8c243a9e8c04d4cf6505e6be2c8932df654ea9a11c6c1b64bR67) [[2]](diffhunk://#diff-1d5ab1abb6ecb1d8c243a9e8c04d4cf6505e6be2c8932df654ea9a11c6c1b64bR137-R138)

### Code Simplification:
* Simplified `get_group_members` and related methods by removing unnecessary error handling and casting directly to the expected types.
* Updated the `get_group_id_and_projects` method to return a `set` instead of a `list` for project names, ensuring uniqueness.

### Test Updates:
* Enhanced test coverage for GitLab API methods, adding new test cases for scenarios like fetching project maintainers, group users, and repository trees.
* Updated existing tests to replace `mocked_gl.get_items` with the new iterator-based API calls. [[1]](diffhunk://#diff-c19c452e84a3c92f93e41b4c727ef82eb466aa3982b1dfed923c1f773cb58bc3L136-R128) [[2]](diffhunk://#diff-c19c452e84a3c92f93e41b4c727ef82eb466aa3982b1dfed923c1f773cb58bc3L150-R139)
