### PR TITLE
fix(gitlab_fork_compliance): use members_all instead of members

### DIFF
--- a/reconcile/test/utils/test_gitlab_api.py
+++ b/reconcile/test/utils/test_gitlab_api.py
@@ -21,8 +21,8 @@ from gitlab.v4.objects import (
     ProjectLabel,
     ProjectLabelManager,
     ProjectManager,
-    ProjectMember,
-    ProjectMemberManager,
+    ProjectMemberAll,
+    ProjectMemberAllManager,
     ProjectMergeRequest,
     ProjectMergeRequestManager,
     ProjectMergeRequestNote,
@@ -486,14 +486,14 @@ def test_get_project_maintainers(
     mocked_gl: Mock,
 ) -> None:
     mocked_project = mocked_gl.projects.get.return_value
-    mocked_project.members = create_autospec(ProjectMemberManager)
+    mocked_project.members_all = create_autospec(ProjectMemberAllManager)
     member = create_autospec(
-        ProjectMember,
+        ProjectMemberAll,
         id="1",
         username="m",
         access_level=40,
     )
-    mocked_project.members.list.return_value = [member]
+    mocked_project.members_all.list.return_value = [member]
     query = {
         "user_ids": "1",
     }
@@ -501,7 +501,7 @@ def test_get_project_maintainers(
     result = mocked_gitlab_api.get_project_maintainers(query=query)
 
     assert result == ["m"]
-    mocked_project.members.list.assert_called_once_with(
+    mocked_project.members_all.list.assert_called_once_with(
         iterator=True,
         query_parameters=query,
     )

--- a/reconcile/utils/gitlab_api.py
+++ b/reconcile/utils/gitlab_api.py
@@ -268,7 +268,7 @@ class GitLabApi:
         project = self.project if repo_url is None else self.get_project(repo_url)
         if project is None:
             return None
-        members = project.members.list(iterator=True, query_parameters=query or {})
+        members = project.members_all.list(iterator=True, query_parameters=query or {})
         return [m.username for m in members if m.access_level >= 40]
 
     def get_app_sre_group_users(self) -> list[GroupMember]:


### PR DESCRIPTION
Fix wrong methods replace in https://github.com/app-sre/qontract-reconcile/pull/4981/files#diff-1d5ab1abb6ecb1d8c243a9e8c04d4cf6505e6be2c8932df654ea9a11c6c1b64bR271.

Should use `members_all` instead of just `members`.

[APPSRE-10450](https://issues.redhat.com/browse/APPSRE-10450)