### PR TITLE
:sparkles: automated-actions-config: throttling support

### DIFF
--- a/reconcile/automated_actions/config/integration.py
+++ b/reconcile/automated_actions/config/integration.py
@@ -53,6 +53,7 @@ class AutomatedActionsUser(BaseModel):
 class AutomatedActionsPolicy(BaseModel):
     sub: str
     obj: str
+    max_ops: int
     params: dict[str, str] = {}
 
 
@@ -142,7 +143,7 @@ class AutomatedActionsConfigIntegration(
         roles: AutomatedActionRoles = {}
 
         for permission in permissions or []:
-            obj = permission.action.operation_id
+            action = permission.action
 
             parameters: list[dict[str, str]] = [] if permission.arguments else [{}]
             for arg in permission.arguments or []:
@@ -163,7 +164,12 @@ class AutomatedActionsConfigIntegration(
             for role in permission.roles or []:
                 aa_role = roles.setdefault(role.name, [])
                 aa_role.extend(
-                    AutomatedActionsPolicy(sub=role.name, obj=obj, params=params)
+                    AutomatedActionsPolicy(
+                        sub=role.name,
+                        obj=action.operation_id,
+                        max_ops=action.max_ops,
+                        params=params,
+                    )
                     for params in parameters
                 )
         return roles

--- a/reconcile/test/automated_actions/conftest.py
+++ b/reconcile/test/automated_actions/conftest.py
@@ -109,7 +109,7 @@ def permissions() -> list[PermissionAutomatedActionsV1]:
                     ),
                 )
             ],
-            action=AutomatedActionV1(operationId="action", retries=1, maxOps=1),
+            action=AutomatedActionV1(operationId="action", retries=1, maxOps=5),
         ),
     ]
 
@@ -128,12 +128,13 @@ def automated_actions_users() -> list[AutomatedActionsUser]:
 def automated_actions_roles() -> AutomatedActionRoles:
     return {
         "role": [
-            AutomatedActionsPolicy(sub="role", obj="action", params={}),
+            AutomatedActionsPolicy(sub="role", obj="action", max_ops=1, params={}),
         ],
         "another-role-with-args": [
             AutomatedActionsPolicy(
                 sub="another-role-with-args",
                 obj="action",
+                max_ops=5,
                 params={
                     "cluster": "^cluster$",
                     "namespace": "^namespace$",
@@ -149,7 +150,8 @@ def automated_actions_roles() -> AutomatedActionRoles:
 def policy_file() -> str:
     return """roles:
   another-role-with-args:
-  - obj: action
+  - max_ops: 5
+    obj: action
     params:
       cluster: ^cluster$
       kind: Deployment|Pod
@@ -157,7 +159,8 @@ def policy_file() -> str:
       namespace: ^namespace$
     sub: another-role-with-args
   role:
-  - obj: action
+  - max_ops: 1
+    obj: action
     params: {}
     sub: role
 users:


### PR DESCRIPTION
Persist the `maxOps` action attribute in the automated-action config to enable throttling support.

Ticket: [APPSRE-12021](https://issues.redhat.com/browse/APPSRE-12021)