### PR TITLE
:recycle: jira-boards: common issueFields 

### DIFF
--- a/reconcile/gql_definitions/acs/acs_policies.gql
+++ b/reconcile/gql_definitions/acs/acs_policies.gql
@@ -2,7 +2,7 @@
 
 query AcsPolicy {
   acs_policies: acs_policy_v1 {
-   	name
+    name
     description
     severity
     integrations {
@@ -24,7 +24,10 @@ query AcsPolicy {
                   }
                 }
                 issueType
-                issueSecurityId
+                issueFields {
+                  name
+                  value
+                }
                 disable {
                   integrations
                 }
@@ -40,12 +43,12 @@ query AcsPolicy {
     scope {
       level
       ... on AcsPolicyScopeCluster_v1 {
-				clusters {
+        clusters {
           name
-        }        
+        }
       }
       ... on AcsPolicyScopeNamespace_v1 {
-       	namespaces {
+        namespaces {
           name
           cluster {
             name
@@ -53,7 +56,7 @@ query AcsPolicy {
         }
       }
     }
-	  conditions {
+    conditions {
       policyField
       ... on AcsPolicyConditionsCvss_v1 {
         comparison

--- a/reconcile/gql_definitions/acs/acs_policies.py
+++ b/reconcile/gql_definitions/acs/acs_policies.py
@@ -21,7 +21,7 @@ from pydantic import (  # noqa: F401 # pylint: disable=W0611
 DEFINITION = """
 query AcsPolicy {
   acs_policies: acs_policy_v1 {
-   	name
+    name
     description
     severity
     integrations {
@@ -43,7 +43,10 @@ query AcsPolicy {
                   }
                 }
                 issueType
-                issueSecurityId
+                issueFields {
+                  name
+                  value
+                }
                 disable {
                   integrations
                 }
@@ -59,12 +62,12 @@ query AcsPolicy {
     scope {
       level
       ... on AcsPolicyScopeCluster_v1 {
-				clusters {
+        clusters {
           name
-        }        
+        }
       }
       ... on AcsPolicyScopeNamespace_v1 {
-       	namespaces {
+        namespaces {
           name
           cluster {
             name
@@ -72,7 +75,7 @@ query AcsPolicy {
         }
       }
     }
-	  conditions {
+    conditions {
       policyField
       ... on AcsPolicyConditionsCvss_v1 {
         comparison
@@ -118,6 +121,11 @@ class JiraSeverityPriorityMappingsV1(ConfiguredBaseModel):
     mappings: list[SeverityPriorityMappingV1] = Field(..., alias="mappings")
 
 
+class JiraBoardIssueFieldV1(ConfiguredBaseModel):
+    name: str = Field(..., alias="name")
+    value: str = Field(..., alias="value")
+
+
 class DisableJiraBoardAutomationsV1(ConfiguredBaseModel):
     integrations: Optional[list[str]] = Field(..., alias="integrations")
 
@@ -127,7 +135,7 @@ class JiraBoardV1(ConfiguredBaseModel):
     server: JiraServerV1 = Field(..., alias="server")
     severity_priority_mappings: JiraSeverityPriorityMappingsV1 = Field(..., alias="severityPriorityMappings")
     issue_type: Optional[str] = Field(..., alias="issueType")
-    issue_security_id: Optional[str] = Field(..., alias="issueSecurityId")
+    issue_fields: Optional[list[JiraBoardIssueFieldV1]] = Field(..., alias="issueFields")
     disable: Optional[DisableJiraBoardAutomationsV1] = Field(..., alias="disable")
 
 

--- a/reconcile/gql_definitions/introspection.json
+++ b/reconcile/gql_definitions/introspection.json
@@ -5442,6 +5442,11 @@
                         },
                         {
                             "kind": "OBJECT",
+                            "name": "ExternalUser_v1",
+                            "ofType": null
+                        },
+                        {
+                            "kind": "OBJECT",
                             "name": "GabiInstance_v1",
                             "ofType": null
                         },
@@ -13832,6 +13837,151 @@
                 },
                 {
                     "kind": "OBJECT",
+                    "name": "ExternalUser_v1",
+                    "description": null,
+                    "fields": [
+                        {
+                            "name": "schema",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "NON_NULL",
+                                "name": null,
+                                "ofType": {
+                                    "kind": "SCALAR",
+                                    "name": "String",
+                                    "ofType": null
+                                }
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "path",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "NON_NULL",
+                                "name": null,
+                                "ofType": {
+                                    "kind": "SCALAR",
+                                    "name": "String",
+                                    "ofType": null
+                                }
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "labels",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "SCALAR",
+                                "name": "JSON",
+                                "ofType": null
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "name",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "NON_NULL",
+                                "name": null,
+                                "ofType": {
+                                    "kind": "SCALAR",
+                                    "name": "String",
+                                    "ofType": null
+                                }
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "github_username",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "SCALAR",
+                                "name": "String",
+                                "ofType": null
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "quay_username",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "SCALAR",
+                                "name": "String",
+                                "ofType": null
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "sponsors",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "NON_NULL",
+                                "name": null,
+                                "ofType": {
+                                    "kind": "LIST",
+                                    "name": null,
+                                    "ofType": {
+                                        "kind": "NON_NULL",
+                                        "name": null,
+                                        "ofType": {
+                                            "kind": "OBJECT",
+                                            "name": "User_v1",
+                                            "ofType": null
+                                        }
+                                    }
+                                }
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "roles",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "LIST",
+                                "name": null,
+                                "ofType": {
+                                    "kind": "NON_NULL",
+                                    "name": null,
+                                    "ofType": {
+                                        "kind": "OBJECT",
+                                        "name": "Role_v1",
+                                        "ofType": null
+                                    }
+                                }
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        }
+                    ],
+                    "inputFields": null,
+                    "interfaces": [
+                        {
+                            "kind": "INTERFACE",
+                            "name": "DatafileObject_v1",
+                            "ofType": null
+                        }
+                    ],
+                    "enumValues": null,
+                    "possibleTypes": null
+                },
+                {
+                    "kind": "OBJECT",
                     "name": "CredentialsRequest_v1",
                     "description": null,
                     "fields": [
@@ -19225,18 +19375,6 @@
                             "deprecationReason": null
                         },
                         {
-                            "name": "issueSecurityId",
-                            "description": null,
-                            "args": [],
-                            "type": {
-                                "kind": "SCALAR",
-                                "name": "String",
-                                "ofType": null
-                            },
-                            "isDeprecated": false,
-                            "deprecationReason": null
-                        },
-                        {
                             "name": "wontFixResolution",
                             "description": null,
                             "args": [],
@@ -19268,6 +19406,26 @@
                                 "kind": "OBJECT",
                                 "name": "DisableJiraBoardAutomations_v1",
                                 "ofType": null
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "issueFields",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "LIST",
+                                "name": null,
+                                "ofType": {
+                                    "kind": "NON_NULL",
+                                    "name": null,
+                                    "ofType": {
+                                        "kind": "OBJECT",
+                                        "name": "JiraBoardIssueField_v1",
+                                        "ofType": null
+                                    }
+                                }
                             },
                             "isDeprecated": false,
                             "deprecationReason": null
@@ -19723,6 +19881,49 @@
                                         "name": "String",
                                         "ofType": null
                                     }
+                                }
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        }
+                    ],
+                    "inputFields": null,
+                    "interfaces": [],
+                    "enumValues": null,
+                    "possibleTypes": null
+                },
+                {
+                    "kind": "OBJECT",
+                    "name": "JiraBoardIssueField_v1",
+                    "description": null,
+                    "fields": [
+                        {
+                            "name": "name",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "NON_NULL",
+                                "name": null,
+                                "ofType": {
+                                    "kind": "SCALAR",
+                                    "name": "String",
+                                    "ofType": null
+                                }
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "value",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "NON_NULL",
+                                "name": null,
+                                "ofType": {
+                                    "kind": "SCALAR",
+                                    "name": "String",
+                                    "ofType": null
                                 }
                             },
                             "isDeprecated": false,
@@ -27248,145 +27449,6 @@
                             "ofType": null
                         }
                     ]
-                },
-                {
-                    "kind": "OBJECT",
-                    "name": "ExternalUser_v1",
-                    "description": null,
-                    "fields": [
-                        {
-                            "name": "schema",
-                            "description": null,
-                            "args": [],
-                            "type": {
-                                "kind": "NON_NULL",
-                                "name": null,
-                                "ofType": {
-                                    "kind": "SCALAR",
-                                    "name": "String",
-                                    "ofType": null
-                                }
-                            },
-                            "isDeprecated": false,
-                            "deprecationReason": null
-                        },
-                        {
-                            "name": "path",
-                            "description": null,
-                            "args": [],
-                            "type": {
-                                "kind": "NON_NULL",
-                                "name": null,
-                                "ofType": {
-                                    "kind": "SCALAR",
-                                    "name": "String",
-                                    "ofType": null
-                                }
-                            },
-                            "isDeprecated": false,
-                            "deprecationReason": null
-                        },
-                        {
-                            "name": "labels",
-                            "description": null,
-                            "args": [],
-                            "type": {
-                                "kind": "SCALAR",
-                                "name": "JSON",
-                                "ofType": null
-                            },
-                            "isDeprecated": false,
-                            "deprecationReason": null
-                        },
-                        {
-                            "name": "name",
-                            "description": null,
-                            "args": [],
-                            "type": {
-                                "kind": "NON_NULL",
-                                "name": null,
-                                "ofType": {
-                                    "kind": "SCALAR",
-                                    "name": "String",
-                                    "ofType": null
-                                }
-                            },
-                            "isDeprecated": false,
-                            "deprecationReason": null
-                        },
-                        {
-                            "name": "github_username",
-                            "description": null,
-                            "args": [],
-                            "type": {
-                                "kind": "SCALAR",
-                                "name": "String",
-                                "ofType": null
-                            },
-                            "isDeprecated": false,
-                            "deprecationReason": null
-                        },
-                        {
-                            "name": "quay_username",
-                            "description": null,
-                            "args": [],
-                            "type": {
-                                "kind": "SCALAR",
-                                "name": "String",
-                                "ofType": null
-                            },
-                            "isDeprecated": false,
-                            "deprecationReason": null
-                        },
-                        {
-                            "name": "sponsors",
-                            "description": null,
-                            "args": [],
-                            "type": {
-                                "kind": "NON_NULL",
-                                "name": null,
-                                "ofType": {
-                                    "kind": "LIST",
-                                    "name": null,
-                                    "ofType": {
-                                        "kind": "NON_NULL",
-                                        "name": null,
-                                        "ofType": {
-                                            "kind": "OBJECT",
-                                            "name": "User_v1",
-                                            "ofType": null
-                                        }
-                                    }
-                                }
-                            },
-                            "isDeprecated": false,
-                            "deprecationReason": null
-                        },
-                        {
-                            "name": "roles",
-                            "description": null,
-                            "args": [],
-                            "type": {
-                                "kind": "LIST",
-                                "name": null,
-                                "ofType": {
-                                    "kind": "NON_NULL",
-                                    "name": null,
-                                    "ofType": {
-                                        "kind": "OBJECT",
-                                        "name": "Role_v1",
-                                        "ofType": null
-                                    }
-                                }
-                            },
-                            "isDeprecated": false,
-                            "deprecationReason": null
-                        }
-                    ],
-                    "inputFields": null,
-                    "interfaces": [],
-                    "enumValues": null,
-                    "possibleTypes": null
                 },
                 {
                     "kind": "OBJECT",

--- a/reconcile/gql_definitions/jira_permissions_validator/jira_boards_for_permissions_validator.gql
+++ b/reconcile/gql_definitions/jira_permissions_validator/jira_boards_for_permissions_validator.gql
@@ -13,7 +13,10 @@ query JiraBoardsForPermissionValidation {
     issueType
     issueResolveState
     issueReopenState
-    issueSecurityId
+    issueFields {
+      name
+      value
+    }
     severityPriorityMappings {
       name
       mappings {

--- a/reconcile/gql_definitions/jira_permissions_validator/jira_boards_for_permissions_validator.py
+++ b/reconcile/gql_definitions/jira_permissions_validator/jira_boards_for_permissions_validator.py
@@ -41,7 +41,10 @@ query JiraBoardsForPermissionValidation {
     issueType
     issueResolveState
     issueReopenState
-    issueSecurityId
+    issueFields {
+      name
+      value
+    }
     severityPriorityMappings {
       name
       mappings {
@@ -73,6 +76,11 @@ class JiraServerV1(ConfiguredBaseModel):
     token: VaultSecret = Field(..., alias="token")
 
 
+class JiraBoardIssueFieldV1(ConfiguredBaseModel):
+    name: str = Field(..., alias="name")
+    value: str = Field(..., alias="value")
+
+
 class SeverityPriorityMappingV1(ConfiguredBaseModel):
     priority: str = Field(..., alias="priority")
 
@@ -102,7 +110,7 @@ class JiraBoardV1(ConfiguredBaseModel):
     issue_type: Optional[str] = Field(..., alias="issueType")
     issue_resolve_state: Optional[str] = Field(..., alias="issueResolveState")
     issue_reopen_state: Optional[str] = Field(..., alias="issueReopenState")
-    issue_security_id: Optional[str] = Field(..., alias="issueSecurityId")
+    issue_fields: Optional[list[JiraBoardIssueFieldV1]] = Field(..., alias="issueFields")
     severity_priority_mappings: JiraSeverityPriorityMappingsV1 = Field(..., alias="severityPriorityMappings")
     escalation_policies: Optional[list[AppEscalationPolicyV1]] = Field(..., alias="escalationPolicies")
     disable: Optional[DisableJiraBoardAutomationsV1] = Field(..., alias="disable")

--- a/reconcile/jira_permissions_validator.py
+++ b/reconcile/jira_permissions_validator.py
@@ -114,7 +114,8 @@ def board_is_valid(
                 error |= ValidationError.INVALID_COMPONENT
 
         issue_type = board.issue_type or default_issue_type
-        if not (project_issue_type := jira.get_issue_type(issue_type)):
+        project_issue_type = jira.get_issue_type(issue_type)
+        if not project_issue_type:
             project_issue_types_str = ", ".join(
                 t.name for t in jira.project_issue_types()
             )
@@ -149,11 +150,10 @@ def board_is_valid(
                 error |= ValidationError.INVALID_ISSUE_STATE
 
             for field in board.issue_fields or []:
-                if not (
-                    project_issue_field := jira.project_issue_field(
-                        issue_type_id=project_issue_type.id, field=field.name
-                    )
-                ):
+                project_issue_field = jira.project_issue_field(
+                    issue_type_id=project_issue_type.id, field=field.name
+                )
+                if not project_issue_field:
                     logging.error(
                         f"[{board.name}] {field.name} is not a valid field in project."
                     )

--- a/reconcile/jira_permissions_validator.py
+++ b/reconcile/jira_permissions_validator.py
@@ -115,9 +115,9 @@ def board_is_valid(
 
         issue_type = board.issue_type or default_issue_type
         if not (project_issue_type := jira.get_issue_type(issue_type)):
-            project_issue_types_str = ", ".join([
+            project_issue_types_str = ", ".join(
                 t.name for t in jira.project_issue_types()
-            ])
+            )
             logging.error(
                 f"[{board.name}] {issue_type} is not a valid issue type in project. Valid issue types: {project_issue_types_str}"
             )

--- a/reconcile/jira_permissions_validator.py
+++ b/reconcile/jira_permissions_validator.py
@@ -120,7 +120,7 @@ def board_is_valid(
                 t.name for t in jira.project_issue_types()
             )
             logging.error(
-                f"[{board.name}] {issue_type} is not a valid issue type in project. Valid issue types: {project_issue_types_str}"
+                f"[{board.name}] '{issue_type}' is not a valid issue type in project. Valid issue types: {project_issue_types_str}"
             )
             error |= ValidationError.INVALID_ISSUE_TYPE
 
@@ -128,7 +128,7 @@ def board_is_valid(
             # Check issue attributes
             if not project_issue_type.statuses:
                 logging.error(
-                    f"[{board.name}] {issue_type} doesn't have any status. Choose a different issue type."
+                    f"[{board.name}] '{issue_type}' doesn't have any status. Choose a different issue type."
                 )
                 error |= ValidationError.INVALID_ISSUE_TYPE
 
@@ -155,7 +155,7 @@ def board_is_valid(
                 )
                 if not project_issue_field:
                     logging.error(
-                        f"[{board.name}] {field.name} is not a valid field in project."
+                        f"[{board.name}] '{field.name}' is not a valid field for '{project_issue_type.name}' in this project."
                     )
 
                     error |= ValidationError.INVALID_ISSUE_FIELD
@@ -169,7 +169,7 @@ def board_is_valid(
                 else:
                     # field.value is not in the allowed options
                     logging.error(
-                        f"[{board.name}] {field.name} has an invalid value '{field.value}'. Valid values: {project_issue_field.options}"
+                        f"[{board.name}] '{field.name}' has an invalid value '{field.value}'. Valid values: {project_issue_field.options}"
                     )
                     error |= ValidationError.INVALID_ISSUE_FIELD
                     continue

--- a/reconcile/test/fixtures/jira_permissions_validator/boards.yml
+++ b/reconcile/test/fixtures/jira_permissions_validator/boards.yml
@@ -1,3 +1,4 @@
+---
 
 jira_boards:
 - name: jira-board-default
@@ -9,7 +10,7 @@ jira_boards:
   issueType: null
   issueResolveState: Closed
   issueReopenState: null
-  issueSecurityId: null
+  issueFields: null
   severityPriorityMappings:
     name: major-major
     mappings:
@@ -25,7 +26,9 @@ jira_boards:
   issueType: bug
   issueResolveState: Closed
   issueReopenState: Open
-  issueSecurityId: "32168"
+  issueFields:
+  - name: Security Level
+    value: "fake"
   severityPriorityMappings:
     name: major-major
     mappings:
@@ -42,7 +45,9 @@ jira_boards:
   issueType: bug
   issueResolveState: Closed
   issueReopenState: Open
-  issueSecurityId: "32168"
+  issueFields:
+  - name: Security Level
+    value: "fake"
   severityPriorityMappings:
     name: major-major
     mappings:

--- a/reconcile/test/test_acs_notifiers.py
+++ b/reconcile/test/test_acs_notifiers.py
@@ -78,7 +78,7 @@ def jira_notifier(
         url=jira_credentials.url,
         issue_type="Task",
         severity_priority_mappings=[severity_priority_mapping],
-        custom_fields={"security": {"id": "0"}},
+        custom_fields={"security": {"name": "0"}},
     )
 
 
@@ -98,7 +98,7 @@ def jira_notifier_api_payload(
             "password": jira_credentials.token,
             "issueType": "Task",
             "priorityMappings": [severity_priority_mapping.to_api()],
-            "defaultFieldsJson": '{"security": {"id": "0"}}',
+            "defaultFieldsJson": '{"security": {"name": "0"}}',
         },
     }
 
@@ -264,7 +264,7 @@ def escalation_policy() -> AppEscalationPolicyV1:
                         ],
                     ),
                     issueType="Task",
-                    issueSecurityId="0",
+                    issueFields=[{"name": "Security Level", "value": "0"}],
                     disable=DisableJiraBoardAutomationsV1(integrations=[]),
                 )
             ],

--- a/reconcile/test/test_acs_policies.py
+++ b/reconcile/test/test_acs_policies.py
@@ -66,7 +66,7 @@ def query_data_desired_state() -> AcsPolicyQueryData:
                                                 mappings=[],
                                             ),
                                             issueType="Task",
-                                            issueSecurityId="0",
+                                            issueFields=None,
                                             disable=DisableJiraBoardAutomationsV1(
                                                 integrations=[]
                                             ),

--- a/reconcile/test/test_jira_permissions_validator.py
+++ b/reconcile/test/test_jira_permissions_validator.py
@@ -17,7 +17,13 @@ from reconcile.jira_permissions_validator import (
 )
 from reconcile.test.fixtures import Fixtures
 from reconcile.utils import metrics
-from reconcile.utils.jira_client import IssueType, JiraClient, SecurityLevel
+from reconcile.utils.jira_client import (
+    CustomFieldOption,
+    FieldOption,
+    IssueField,
+    IssueType,
+    JiraClient,
+)
 
 
 @pytest.fixture
@@ -75,7 +81,7 @@ def test_jira_permissions_validator_get_jira_boards(
         "issueType": "bug",
         "issueResolveState": "Closed",
         "issueReopenState": "Open",
-        "issueSecurityId": 32168,
+        "issueFields": [{"name": "Security Level", "value": "fake"}],
         "severityPriorityMappings": {
             "name": "major-major",
             "mappings": [
@@ -100,7 +106,7 @@ def test_jira_permissions_validator_get_jira_boards(
         (ValidationError.CANT_TRANSITION_ISSUES, True, True, False),
         (ValidationError.INVALID_ISSUE_TYPE, True, True, False),
         (ValidationError.INVALID_ISSUE_STATE, True, True, False),
-        (ValidationError.INVALID_SECURITY_LEVEL, True, True, False),
+        (ValidationError.INVALID_ISSUE_FIELD, True, True, False),
         (ValidationError.INVALID_PRIORITY, True, True, False),
         (ValidationError.PUBLIC_PROJECT_NO_SECURITY_LEVEL, True, True, False),
         (ValidationError.PERMISSION_ERROR, True, True, True),
@@ -137,7 +143,7 @@ def test_jira_permissions_validator_validate_boards(
     board_is_valid_mock = mocker.patch(
         "reconcile.jira_permissions_validator.board_is_valid"
     )
-    board_is_valid_mock.return_value = board_is_valid
+    board_is_valid_mock.return_value = (board_is_valid, {})
     metrics_container_mock = mocker.create_autospec(spec=metrics.MetricsContainer)
     jira_client_class = mocker.create_autospec(spec=JiraClient)
     state = s3_state_builder({})
@@ -176,7 +182,10 @@ def test_jira_permissions_validator_board_is_valid_happy_path(
             "issueType": "bug",
             "issueResolveState": "Closed",
             "issueReopenState": "Open",
-            "issueSecurityId": "32168",
+            "issueFields": [
+                {"name": "Security Level", "value": "foo"},
+                {"name": "Another Field", "value": "bar"},
+            ],
             "severityPriorityMappings": {
                 "name": "major-major",
                 "mappings": [
@@ -191,13 +200,20 @@ def test_jira_permissions_validator_board_is_valid_happy_path(
     jira_client.is_archived = False
     jira_client.can_create_issues.return_value = True
     jira_client.can_transition_issues.return_value = True
-    jira_client.project_issue_types.return_value = [
-        IssueType(id="1", name="task", statuses=["open", "closed"]),
-        IssueType(id="2", name="bug", statuses=["open", "closed"]),
-    ]
-    jira_client.security_levels.return_value = [
-        SecurityLevel(id="32168", name="foo"),
-        SecurityLevel(id="1", name="bar"),
+    jira_client.get_issue_type.return_value = IssueType(
+        id="2", name="bug", statuses=["open", "closed"]
+    )
+    jira_client.project_issue_field.side_effect = [
+        IssueField(
+            name="Security Level",
+            id="security",
+            options=[FieldOption(name="foo"), FieldOption(name="foo2")],
+        ),
+        IssueField(
+            name="Another Field",
+            id="field",
+            options=[CustomFieldOption(value="bar"), FieldOption(name="bar2")],
+        ),
     ]
     jira_client.project_priority_scheme.return_value = ["1", "2", "3"]
     assert board_is_valid(
@@ -207,7 +223,7 @@ def test_jira_permissions_validator_board_is_valid_happy_path(
         default_reopen_state="new",
         jira_server_priorities={"Minor": "1", "Major": "2", "Critical": "3"},
         public_projects=[],
-    ) == ValidationError(0)
+    ) == (ValidationError(0), {"security": {"name": "foo"}, "field": {"value": "bar"}})
 
 
 def test_jira_permissions_validator_board_is_valid_all_errors(
@@ -224,7 +240,7 @@ def test_jira_permissions_validator_board_is_valid_all_errors(
             "issueType": "bug",
             "issueResolveState": "Closed",
             "issueReopenState": "Open",
-            "issueSecurityId": "32168",
+            "issueFields": [{"name": "unknown-field", "value": "unknown"}],
             "severityPriorityMappings": {
                 "name": "major-major",
                 "mappings": [
@@ -239,27 +255,116 @@ def test_jira_permissions_validator_board_is_valid_all_errors(
     jira_client.is_archived = False
     jira_client.can_create_issues.return_value = False
     jira_client.can_transition_issues.return_value = False
+    jira_client.get_issue_type.return_value = None
+    jira_client.project_issue_types = Mock()
     jira_client.project_issue_types.return_value = []
-    jira_client.security_levels.return_value = [
-        SecurityLevel(id="1", name="bar"),
-    ]
     jira_client.project_priority_scheme.return_value = ["1", "2"]
-    assert (
-        board_is_valid(
-            jira=jira_client,
-            board=board,
-            default_issue_type="task",
-            default_reopen_state="new",
-            jira_server_priorities={"Minor": "1", "Major": "2", "Critical": "3"},
-            public_projects=[],
-        )
-        == ValidationError.CANT_CREATE_ISSUE
+    assert board_is_valid(
+        jira=jira_client,
+        board=board,
+        default_issue_type="task",
+        default_reopen_state="new",
+        jira_server_priorities={"Minor": "1", "Major": "2", "Critical": "3"},
+        public_projects=[],
+    ) == (
+        ValidationError.CANT_CREATE_ISSUE
         | ValidationError.CANT_TRANSITION_ISSUES
         | ValidationError.INVALID_ISSUE_TYPE
-        | ValidationError.INVALID_ISSUE_STATE
-        | ValidationError.INVALID_SECURITY_LEVEL
-        | ValidationError.INVALID_PRIORITY
+        | ValidationError.INVALID_PRIORITY,
+        {},
     )
+
+
+def test_jira_permissions_validator_board_is_valid_bad_issue_field_name(
+    mocker: MockerFixture, gql_class_factory: Callable
+) -> None:
+    board = gql_class_factory(
+        JiraBoardV1,
+        {
+            "name": "jira-board-default",
+            "server": {
+                "serverUrl": "https://jira-server.com",
+                "token": {"path": "vault/path/token", "field": "token"},
+            },
+            "issueType": "bug",
+            "issueResolveState": "Closed",
+            "issueReopenState": "Open",
+            "issueFields": [{"name": "unknown-field", "value": "fake"}],
+            "severityPriorityMappings": {
+                "name": "major-major",
+                "mappings": [
+                    {"priority": "Minor"},
+                    {"priority": "Major"},
+                    {"priority": "Critical"},
+                ],
+            },
+        },
+    )
+    jira_client = mocker.create_autospec(spec=JiraClient)
+    jira_client.is_archived = False
+    jira_client.can_create_issues.return_value = True
+    jira_client.can_transition_issues.return_value = True
+    jira_client.get_issue_type.return_value = IssueType(
+        id="2", name="bug", statuses=["open", "closed"]
+    )
+    jira_client.project_issue_field.return_value = None
+    jira_client.project_priority_scheme.return_value = ["1", "2", "3"]
+    assert board_is_valid(
+        jira=jira_client,
+        board=board,
+        default_issue_type="task",
+        default_reopen_state="new",
+        jira_server_priorities={"Minor": "1", "Major": "2", "Critical": "3"},
+        public_projects=[],
+    ) == (ValidationError.INVALID_ISSUE_FIELD, {})
+
+
+def test_jira_permissions_validator_board_is_valid_bad_issue_field_value(
+    mocker: MockerFixture, gql_class_factory: Callable
+) -> None:
+    board = gql_class_factory(
+        JiraBoardV1,
+        {
+            "name": "jira-board-default",
+            "server": {
+                "serverUrl": "https://jira-server.com",
+                "token": {"path": "vault/path/token", "field": "token"},
+            },
+            "issueType": "bug",
+            "issueResolveState": "Closed",
+            "issueReopenState": "Open",
+            "issueFields": [{"name": "Security Level", "value": "unknown"}],
+            "severityPriorityMappings": {
+                "name": "major-major",
+                "mappings": [
+                    {"priority": "Minor"},
+                    {"priority": "Major"},
+                    {"priority": "Critical"},
+                ],
+            },
+        },
+    )
+    jira_client = mocker.create_autospec(spec=JiraClient)
+    jira_client.is_archived = False
+    jira_client.can_create_issues.return_value = True
+    jira_client.can_transition_issues.return_value = True
+    jira_client.get_issue_type.return_value = IssueType(
+        id="2", name="bug", statuses=["open", "closed"]
+    )
+    jira_client.project_issue_field.return_value = IssueField(
+        name="Security Level",
+        id="security",
+        options=[FieldOption(name="fake"), FieldOption(name="fake2")],
+    )
+    jira_client.project_priority_scheme.return_value = ["1", "2", "3"]
+    assert board_is_valid(
+        jira=jira_client,
+        board=board,
+        default_issue_type="task",
+        default_reopen_state="new",
+        jira_server_priorities={"Minor": "1", "Major": "2", "Critical": "3"},
+        public_projects=[],
+    ) == (ValidationError.INVALID_ISSUE_FIELD, {})
 
 
 def test_jira_permissions_validator_board_is_valid_bad_issue_status(
@@ -275,8 +380,8 @@ def test_jira_permissions_validator_board_is_valid_bad_issue_status(
             },
             "issueType": "bug",
             "issueResolveState": "Closed",
-            "issueReopenState": "Open",
-            "issueSecurityId": "32168",
+            "issueReopenState": "BadState",
+            "issueFields": None,
             "severityPriorityMappings": {
                 "name": "major-major",
                 "mappings": [
@@ -291,26 +396,19 @@ def test_jira_permissions_validator_board_is_valid_bad_issue_status(
     jira_client.is_archived = False
     jira_client.can_create_issues.return_value = True
     jira_client.can_transition_issues.return_value = True
-    jira_client.project_issue_types.return_value = [
-        IssueType(id="1", name="task", statuses=["not - open", "closed"]),
-        IssueType(id="2", name="bug", statuses=["not - open", "closed"]),
-    ]
-    jira_client.security_levels.return_value = [
-        SecurityLevel(id="32168", name="foo"),
-        SecurityLevel(id="1", name="bar"),
-    ]
-    jira_client.project_priority_scheme.return_value = ["1", "2", "3"]
-    assert (
-        board_is_valid(
-            jira=jira_client,
-            board=board,
-            default_issue_type="task",
-            default_reopen_state="new",
-            jira_server_priorities={"Minor": "1", "Major": "2", "Critical": "3"},
-            public_projects=[],
-        )
-        == ValidationError.INVALID_ISSUE_STATE
+    jira_client.get_issue_type.return_value = IssueType(
+        id="2", name="bug", statuses=["open", "closed"]
     )
+    jira_client._project_issue_fields.return_value = []
+    jira_client.project_priority_scheme.return_value = ["1", "2", "3"]
+    assert board_is_valid(
+        jira=jira_client,
+        board=board,
+        default_issue_type="task",
+        default_reopen_state="new",
+        jira_server_priorities={"Minor": "1", "Major": "2", "Critical": "3"},
+        public_projects=[],
+    ) == (ValidationError.INVALID_ISSUE_STATE, {})
 
 
 def test_jira_permissions_validator_board_is_valid_public_project(
@@ -327,7 +425,7 @@ def test_jira_permissions_validator_board_is_valid_public_project(
             "issueType": "bug",
             "issueResolveState": "Closed",
             "issueReopenState": "Open",
-            "issueSecurityId": None,
+            "issueFields": None,
             "severityPriorityMappings": {
                 "name": "major-major",
                 "mappings": [
@@ -342,26 +440,19 @@ def test_jira_permissions_validator_board_is_valid_public_project(
     jira_client.is_archived = False
     jira_client.can_create_issues.return_value = True
     jira_client.can_transition_issues.return_value = True
-    jira_client.project_issue_types.return_value = [
-        IssueType(id="1", name="task", statuses=["open", "closed"]),
-        IssueType(id="2", name="bug", statuses=["open", "closed"]),
-    ]
-    jira_client.security_levels.return_value = [
-        SecurityLevel(id="32168", name="foo"),
-        SecurityLevel(id="1", name="bar"),
-    ]
-    jira_client.project_priority_scheme.return_value = ["1", "2", "3"]
-    assert (
-        board_is_valid(
-            jira=jira_client,
-            board=board,
-            default_issue_type="task",
-            default_reopen_state="new",
-            jira_server_priorities={"Minor": "1", "Major": "2", "Critical": "3"},
-            public_projects=["jira-board-default"],
-        )
-        == ValidationError.PUBLIC_PROJECT_NO_SECURITY_LEVEL
+    jira_client.get_issue_type.return_value = IssueType(
+        id="2", name="bug", statuses=["open", "closed"]
     )
+    jira_client._project_issue_fields.return_value = []
+    jira_client.project_priority_scheme.return_value = ["1", "2", "3"]
+    assert board_is_valid(
+        jira=jira_client,
+        board=board,
+        default_issue_type="task",
+        default_reopen_state="new",
+        jira_server_priorities={"Minor": "1", "Major": "2", "Critical": "3"},
+        public_projects=["jira-board-default"],
+    ) == (ValidationError.PUBLIC_PROJECT_NO_SECURITY_LEVEL, {})
 
 
 def test_jira_permissions_validator_board_is_valid_permission_error(
@@ -378,7 +469,7 @@ def test_jira_permissions_validator_board_is_valid_permission_error(
             "issueType": "bug",
             "issueResolveState": "Closed",
             "issueReopenState": "Open",
-            "issueSecurityId": "32168",
+            "issueFields": None,
             "severityPriorityMappings": {
                 "name": "major-major",
                 "mappings": [
@@ -392,17 +483,14 @@ def test_jira_permissions_validator_board_is_valid_permission_error(
     jira_client = mocker.create_autospec(spec=JiraClient)
     jira_client.is_archived = False
     jira_client.can_create_issues.side_effect = JIRAError(status_code=403)
-    assert (
-        board_is_valid(
-            jira=jira_client,
-            board=board,
-            default_issue_type="task",
-            default_reopen_state="new",
-            jira_server_priorities={"Minor": "1", "Major": "2", "Critical": "3"},
-            public_projects=[],
-        )
-        == ValidationError.PERMISSION_ERROR
-    )
+    assert board_is_valid(
+        jira=jira_client,
+        board=board,
+        default_issue_type="task",
+        default_reopen_state="new",
+        jira_server_priorities={"Minor": "1", "Major": "2", "Critical": "3"},
+        public_projects=[],
+    ) == (ValidationError.PERMISSION_ERROR, {})
 
 
 def test_jira_permissions_validator_board_is_valid_exception(
@@ -419,7 +507,7 @@ def test_jira_permissions_validator_board_is_valid_exception(
             "issueType": "bug",
             "issueResolveState": "Closed",
             "issueReopenState": "Open",
-            "issueSecurityId": "32168",
+            "issueFields": None,
             "severityPriorityMappings": {
                 "name": "major-major",
                 "mappings": [
@@ -458,7 +546,7 @@ def test_jira_permissions_validator_board_is_valid_exception_401(
             "issueType": "bug",
             "issueResolveState": "Closed",
             "issueReopenState": "Open",
-            "issueSecurityId": "32168",
+            "issueFields": None,
             "severityPriorityMappings": {
                 "name": "major-major",
                 "mappings": [
@@ -497,7 +585,7 @@ def test_jira_permissions_validator_board_is_valid_archived(
             "issueType": "bug",
             "issueResolveState": "Closed",
             "issueReopenState": "Open",
-            "issueSecurityId": "32168",
+            "issueFields": None,
             "severityPriorityMappings": {
                 "name": "major-major",
                 "mappings": [
@@ -510,14 +598,11 @@ def test_jira_permissions_validator_board_is_valid_archived(
     )
     jira_client = mocker.create_autospec(spec=JiraClient)
     jira_client.is_archived = True
-    assert (
-        board_is_valid(
-            jira=jira_client,
-            board=board,
-            default_issue_type="task",
-            default_reopen_state="new",
-            jira_server_priorities={"Minor": "1", "Major": "2", "Critical": "3"},
-            public_projects=[],
-        )
-        == ValidationError.PROJECT_ARCHIVED
-    )
+    assert board_is_valid(
+        jira=jira_client,
+        board=board,
+        default_issue_type="task",
+        default_reopen_state="new",
+        jira_server_priorities={"Minor": "1", "Major": "2", "Critical": "3"},
+        public_projects=[],
+    ) == (ValidationError.PROJECT_ARCHIVED, {})

--- a/reconcile/utils/acs/notifiers.py
+++ b/reconcile/utils/acs/notifiers.py
@@ -82,8 +82,10 @@ class JiraNotifier(BaseModel):
         jira_board = escalation_policy.channels.jira_board[0]
 
         custom_fields: dict[str, Any] = {}
-        if jira_board.issue_security_id:
-            custom_fields["security"] = {"id": jira_board.issue_security_id}
+        for field in jira_board.issue_fields or []:
+            if field.name == "Security Level":
+                custom_fields["security"] = {"name": field.value}
+
         if escalation_policy.channels.jira_component:
             custom_fields["components"] = [
                 {"name": escalation_policy.channels.jira_component}

--- a/reconcile/utils/jira_client.py
+++ b/reconcile/utils/jira_client.py
@@ -125,12 +125,8 @@ class JiraClient:
         self.priorities = functools.lru_cache(maxsize=None)(self._priorities)
         self.public_projects = functools.lru_cache(maxsize=None)(self._public_projects)
         self.my_permissions = functools.lru_cache(maxsize=None)(self._my_permissions)
-        self.project_issue_types = functools.lru_cache(maxsize=None)(
-            self._project_issue_types
-        )
-        self.project_issue_fields = functools.lru_cache(maxsize=None)(
-            self._project_issue_fields
-        )
+        self.project_issue_types = functools.cache(self._project_issue_types)
+        self.project_issue_fields = functools.cache(self._project_issue_fields)
 
     def _deprecated_init(
         self, jira_board: Mapping[str, Any], settings: Mapping | None

--- a/reconcile/utils/jira_client.py
+++ b/reconcile/utils/jira_client.py
@@ -16,6 +16,8 @@ from jira import (
     Issue,
 )
 from jira.client import ResultList
+from jira.resources import CustomFieldOption as JiraCustomFieldOption
+from jira.resources import Resource
 from pydantic import BaseModel
 
 from reconcile.utils.secret_reader import SecretReader
@@ -24,13 +26,6 @@ from reconcile.utils.secret_reader import SecretReader
 class JiraWatcherSettings(Protocol):
     read_timeout: int
     connect_timeout: int
-
-
-class SecurityLevel(BaseModel):
-    """Jira security level."""
-
-    id: str
-    name: str
 
 
 class Priority(BaseModel):
@@ -46,6 +41,50 @@ class IssueType(BaseModel):
     id: str
     name: str
     statuses: list[str]
+
+
+class FieldOption(BaseModel):
+    """A standard buildin issue field option."""
+
+    name: str
+
+    def __eq__(self, value: Any) -> bool:
+        """Compare the field option with a string value."""
+        if isinstance(value, str):
+            return self.name == value
+        return False
+
+    def __str__(self) -> str:
+        return self.name
+
+    def __repr__(self) -> str:
+        return self.__str__()
+
+
+class CustomFieldOption(BaseModel):
+    """A custom issue field option."""
+
+    value: str
+
+    def __eq__(self, value: Any) -> bool:
+        """Compare the custom field option with a string value."""
+        if isinstance(value, str):
+            return self.value == value
+        return False
+
+    def __str__(self) -> str:
+        return self.value
+
+    def __repr__(self) -> str:
+        return self.__str__()
+
+
+class IssueField(BaseModel):
+    """Jira issue field."""
+
+    id: str
+    name: str
+    options: list[FieldOption | CustomFieldOption]
 
 
 class JiraClient:
@@ -86,6 +125,12 @@ class JiraClient:
         self.priorities = functools.lru_cache(maxsize=None)(self._priorities)
         self.public_projects = functools.lru_cache(maxsize=None)(self._public_projects)
         self.my_permissions = functools.lru_cache(maxsize=None)(self._my_permissions)
+        self.project_issue_types = functools.lru_cache(maxsize=None)(
+            self._project_issue_types
+        )
+        self.project_issue_fields = functools.lru_cache(maxsize=None)(
+            self._project_issue_fields
+        )
 
     def _deprecated_init(
         self, jira_board: Mapping[str, Any], settings: Mapping | None
@@ -199,19 +244,57 @@ class JiraClient:
     def can_transition_issues(self) -> bool:
         return self.can_i("TRANSITION_ISSUES")
 
-    def project_issue_types(self) -> list[IssueType]:
+    def _project_issue_types(self) -> list[IssueType]:
         return [
             IssueType(id=t.id, name=t.name, statuses=[s.name for s in t.statuses])
             for t in self.jira.issue_types_for_project(self.project)
         ]
 
-    def security_levels(self) -> list[SecurityLevel]:
-        """Return a list of all available security levels for the project.
+    def get_issue_type(self, issue_type: str) -> IssueType | None:
+        for _issue_type in self.project_issue_types():
+            if _issue_type.name == issue_type:
+                return _issue_type
+        return None
 
-        This API endpoint needs admin/owner project permissions.
+    @staticmethod
+    def _get_allowed_issue_field_options(
+        allowed_values: list[Resource],
+    ) -> list[FieldOption | CustomFieldOption]:
+        """Return a list of allowed values for a field."""
+        return [
+            CustomFieldOption(value=v.value)
+            if isinstance(v, JiraCustomFieldOption)
+            else FieldOption(name=v.name)
+            for v in allowed_values
+        ]
+
+    def _project_issue_fields(self, issue_type_id: str) -> list[IssueField]:
+        """Return all available issue fields for the project.
+
+        This API endpoint needs createIssue project permissions.
         """
-        scheme = self.jira.project_issue_security_level_scheme(self.project)
-        return [SecurityLevel(id=level.id, name=level.name) for level in scheme.levels]
+        return [
+            IssueField(
+                name=field.name,
+                id=field.fieldId,
+                options=self._get_allowed_issue_field_options(
+                    getattr(field, "allowedValues", [])
+                ),
+            )
+            for field in self.jira.project_issue_fields(
+                project=self.project, issue_type=issue_type_id, maxResults=9999
+            )
+        ]
+
+    def project_issue_field(self, issue_type_id: str, field: str) -> IssueField | None:
+        """Return a issue field for the project if it exists.
+
+        This API endpoint needs createIssue project permissions.
+        """
+        for _field in self.project_issue_fields(issue_type_id=issue_type_id):
+            if _field.name == field:
+                return _field
+        return None
 
     def _priorities(self) -> list[Priority]:
         """Return a list of all available Jira priorities."""

--- a/reconcile/utils/jira_client.py
+++ b/reconcile/utils/jira_client.py
@@ -240,14 +240,15 @@ class JiraClient:
     def can_transition_issues(self) -> bool:
         return self.can_i("TRANSITION_ISSUES")
 
-    def _project_issue_types(self) -> list[IssueType]:
+    def _project_issue_types(self, project: str) -> list[IssueType]:
+        # Don't use self.project here, because of function.cache usage
         return [
             IssueType(id=t.id, name=t.name, statuses=[s.name for s in t.statuses])
-            for t in self.jira.issue_types_for_project(self.project)
+            for t in self.jira.issue_types_for_project(project)
         ]
 
     def get_issue_type(self, issue_type: str) -> IssueType | None:
-        for _issue_type in self.project_issue_types():
+        for _issue_type in self.project_issue_types(self.project):
             if _issue_type.name == issue_type:
                 return _issue_type
         return None
@@ -264,11 +265,14 @@ class JiraClient:
             for v in allowed_values
         ]
 
-    def _project_issue_fields(self, issue_type_id: str) -> list[IssueField]:
+    def _project_issue_fields(
+        self, project: str, issue_type_id: str
+    ) -> list[IssueField]:
         """Return all available issue fields for the project.
 
         This API endpoint needs createIssue project permissions.
         """
+        # Don't use self.project here, because of function.cache usage
         return [
             IssueField(
                 name=field.name,
@@ -278,7 +282,7 @@ class JiraClient:
                 ),
             )
             for field in self.jira.project_issue_fields(
-                project=self.project, issue_type=issue_type_id, maxResults=9999
+                project=project, issue_type=issue_type_id, maxResults=9999
             )
         ]
 
@@ -287,7 +291,9 @@ class JiraClient:
 
         This API endpoint needs createIssue project permissions.
         """
-        for _field in self.project_issue_fields(issue_type_id=issue_type_id):
+        for _field in self.project_issue_fields(
+            project=self.project, issue_type_id=issue_type_id
+        ):
             if _field.name == field:
                 return _field
         return None


### PR DESCRIPTION
Adapt `jira-permissions-validator` and `acs-notifiers` to verify and use the common `jira-board.issueFields` as a replacement for `issueSecurityId`.

This allows any arbitrary issue field definitions for our tenants, such as the new `Work Type` one.

Ticket: [APPSRE-12034](https://issues.redhat.com/browse/APPSRE-12034)
Depends on: https://github.com/app-sre/qontract-schemas/pull/828