### PR TITLE
[AUS] new cluster_missing_version_gate_agreements metric

### DIFF
--- a/reconcile/aus/base.py
+++ b/reconcile/aus/base.py
@@ -1169,11 +1169,11 @@ def calculate_diff(
                     },
                 )
                 if gates_with_missing_agreements:
-                    missing_gate_ids = [
-                        gate.id for gate in gates_with_missing_agreements
+                    missing_gate_labels = [
+                        gate.label for gate in gates_with_missing_agreements
                     ]
                     logging.info(
-                        f"[{spec.org.org_id}/{spec.org.name}/{spec.cluster.name}] found gates with missing agreements for {target_version_prefix} - {missing_gate_ids} "
+                        f"[{spec.org.org_id}/{spec.org.name}/{spec.cluster.name}] found gates with missing agreements for {target_version_prefix} - {missing_gate_labels} "
                         "Skip creation of an upgrade policy until all of them have been acked by the version-gate-approver integration or a user."
                     )
                     continue

--- a/reconcile/aus/metrics.py
+++ b/reconcile/aus/metrics.py
@@ -56,6 +56,18 @@ class AUSClusterHealthStateGauge(AUSBaseMetric, GaugeMetric):
         return "aus_cluster_health_state"
 
 
+class AUSClusterMissingVersionGateAgreementsGauge(AUSBaseMetric, GaugeMetric):
+    "The number of missing version gate agreements for a cluster and a target version prefix."
+
+    org_id: str
+    cluster_uuid: str
+    version_prefix: str
+
+    @classmethod
+    def name(cls) -> str:
+        return "aus_cluster_missing_version_gate_agreements"
+
+
 class AUSAddonVersionRemainingSoakDaysGauge(AUSClusterVersionRemainingSoakDaysGauge):
     "Remaining days a version needs to soak for an addon on a cluster"
 

--- a/reconcile/aus/ocm_addons_upgrade_scheduler_org.py
+++ b/reconcile/aus/ocm_addons_upgrade_scheduler_org.py
@@ -250,6 +250,7 @@ def calculate_diff(
         ocm_api,
         version_data,
         addon_id,
+        integration=QONTRACT_INTEGRATION,
     )
     for current in addon_current_state:
         if addon_id == current.addon_id and (

--- a/reconcile/aus/ocm_upgrade_scheduler.py
+++ b/reconcile/aus/ocm_upgrade_scheduler.py
@@ -76,7 +76,11 @@ class OCMClusterUpgradeSchedulerIntegration(
             )
 
             diffs = aus.calculate_diff(
-                current_state, org_upgrade_spec, ocm_api, version_data
+                current_state,
+                org_upgrade_spec,
+                ocm_api,
+                version_data,
+                integration=self.name,
             )
             aus.act(dry_run, diffs, ocm_api)
 


### PR DESCRIPTION
https://issues.redhat.com/browse/APPSRE-11140

Will allow to inform (dashboard or alert) users on missing version gate agreements

copilot summary:

This pull request introduces a new metric to track missing version gate agreements during cluster upgrades and updates related functionality to improve clarity and consistency. The most significant changes include adding a new gauge metric, modifying how missing gates are logged, and updating method signatures to support integration identification.

### Metrics Enhancements:
* Added a new gauge metric `AUSClusterMissingVersionGateAgreementsGauge` to track the number of missing version gate agreements for a cluster and a target version prefix. (`reconcile/aus/metrics.py`, [reconcile/aus/metrics.pyR59-R70](diffhunk://#diff-6d929caa7ce45dabb9f7f13fb859dfccfe166af3da59f2d8dbec4028dd008ca3R59-R70))
* Integrated the new gauge metric into the `set_upgrading` function to record missing gate agreements when they are encountered. (`reconcile/aus/base.py`, [reconcile/aus/base.pyL1172-R1192](diffhunk://#diff-1116e0b2a36737253acab520cca7b58ded278ae79b94d06027fe4b60e4b88624L1172-R1192))

### Logging Improvements:
* Updated the `set_upgrading` function to log missing gate agreements using `gate.label` instead of `gate.id` for improved readability. (`reconcile/aus/base.py`, [reconcile/aus/base.pyL1172-R1192](diffhunk://#diff-1116e0b2a36737253acab520cca7b58ded278ae79b94d06027fe4b60e4b88624L1172-R1192))

### API Changes:
* Added a new `integration` parameter to the `calculate_diff` function to identify the integration triggering the calculation. (`reconcile/aus/base.py`, [reconcile/aus/base.pyR1070](diffhunk://#diff-1116e0b2a36737253acab520cca7b58ded278ae79b94d06027fe4b60e4b88624R1070))
* Updated calls to `calculate_diff` in `ocm_addons_upgrade_scheduler_org.py` and `ocm_upgrade_scheduler.py` to include the `integration` parameter. (`reconcile/aus/ocm_addons_upgrade_scheduler_org.py`, [[1]](diffhunk://#diff-51c04f924792315a54e6bea1ca7ab24757f56fa78b4f44410f002899f896e437R253); `reconcile/aus/ocm_upgrade_scheduler.py`, [[2]](diffhunk://#diff-991714a85390cca75015e337cccaa6e46fddcbe7dc128776b13bb664a9b428b8L79-R83)