### PR TITLE
[gitlab] Use archive api to download dir

### DIFF
--- a/reconcile/dashdotdb_dora.py
+++ b/reconcile/dashdotdb_dora.py
@@ -34,6 +34,7 @@ from reconcile.typed_queries.saas_files import get_saas_files
 from reconcile.utils.github_api import GithubRepositoryApi
 from reconcile.utils.gitlab_api import GitLabApi
 from reconcile.utils.secret_reader import create_secret_reader
+from reconcile.utils.vcs import GITHUB_BASE_URL
 
 QONTRACT_INTEGRATION = "dashdotdb-dora"
 
@@ -421,7 +422,7 @@ class DashdotdbDORA(DashdotdbBase):
             return rc, []
 
         LOG.info("Fetching commits %s", rc)
-        if rc.repo_url.startswith("https://github.com"):
+        if rc.repo_url.startswith(GITHUB_BASE_URL):
             try:
                 commits = self._github_compare_commits(rc)
             except GithubException as e:
@@ -476,8 +477,7 @@ class DashdotdbDORA(DashdotdbBase):
         if not rc.repo_url:
             return []
 
-        prefix = "https://github.com/"
-        repo = rc.repo_url[rc.repo_url.startswith(prefix) and len(prefix) :]
+        repo = rc.repo_url.removeprefix(GITHUB_BASE_URL).rstrip("/")
 
         return [
             Commit(rc.repo_url, commit.sha, commit.commit.committer.date)

--- a/reconcile/github_repo_permissions_validator.py
+++ b/reconcile/github_repo_permissions_validator.py
@@ -11,6 +11,7 @@ from reconcile.jenkins_job_builder import init_jjb
 from reconcile.utils.jjb_client import JJB
 from reconcile.utils.secret_reader import SecretReader
 from reconcile.utils.semver_helper import make_semver
+from reconcile.utils.vcs import GITHUB_BASE_URL
 
 QONTRACT_INTEGRATION = "github-repo-permissions-validator"
 QONTRACT_INTEGRATION_VERSION = make_semver(0, 1, 0)
@@ -45,7 +46,7 @@ def run(dry_run: bool, instance_name: str) -> None:
     error = False
     for job in pr_check_jobs:
         repo_url = jjb.get_repo_url(job)
-        repo_name = repo_url.rstrip("/").replace("https://github.com/", "")
+        repo_name = repo_url.removeprefix(GITHUB_BASE_URL).rstrip("/")
         repo = gh.get_repo(repo_name)
         permissions = repo.permissions
         if not permissions.push and repo_url not in invitations:

--- a/reconcile/integrations_manager.py
+++ b/reconcile/integrations_manager.py
@@ -47,6 +47,7 @@ from reconcile.utils.runtime.sharding import (
     StaticShardingStrategy,
 )
 from reconcile.utils.semver_helper import make_semver
+from reconcile.utils.vcs import GITHUB_BASE_URL
 
 QONTRACT_INTEGRATION = "integrations-manager"
 QONTRACT_INTEGRATION_VERSION = make_semver(0, 1, 0)
@@ -58,8 +59,7 @@ INTEGRATION_UPSTREAM_REPOS_PARAM = "INTEGRATION_UPSTREAM_REPOS"
 
 
 def get_image_tag_from_ref(ref: str, upstream: str) -> str:
-    gh_prefix = "https://github.com/"
-    upstream = upstream.removeprefix(gh_prefix)
+    upstream = upstream.removeprefix(GITHUB_BASE_URL)
     settings = queries.get_app_interface_settings()
     gh_token = get_default_config()["token"]
     github = Github(gh_token, base_url=GH_BASE_URL)

--- a/reconcile/service_dependencies.py
+++ b/reconcile/service_dependencies.py
@@ -16,6 +16,7 @@ from reconcile.gql_definitions.service_dependencies.service_dependencies import 
     SaasResourceTemplateV2,
 )
 from reconcile.utils import gql
+from reconcile.utils.vcs import GITHUB_BASE_URL
 
 QONTRACT_INTEGRATION = "service-dependencies"
 
@@ -35,7 +36,9 @@ def get_desired_dependency_names(
         gitlab_urls = [cc for cc in code_components if "gitlab" in cc.url]
         if gitlab_urls:
             required_dep_names.update(get_dependency_names(dependency_map, "gitlab"))
-        github_urls = [cc for cc in code_components if "github.com" in cc.url]
+        github_urls = [
+            cc for cc in code_components if cc.url.startswith(GITHUB_BASE_URL)
+        ]
         if github_urls:
             required_dep_names.update(get_dependency_names(dependency_map, "github"))
 

--- a/reconcile/test/utils/test_terrascript_aws_client.py
+++ b/reconcile/test/utils/test_terrascript_aws_client.py
@@ -317,7 +317,7 @@ class MockProjectCommit:
     "repo_info, expected",
     [
         ({"url": "http://fake", "ref": 40 * "1"}, 40 * "1"),
-        ({"url": "http://github.com/foo/bar", "ref": "main"}, "sha-12345"),
+        ({"url": "https://github.com/foo/bar", "ref": "main"}, "sha-12345"),
         (
             {"url": "http://gitlab.com/foo/bar", "ref": "master"},
             "sha-67890",

--- a/reconcile/utils/gitlab_api.py
+++ b/reconcile/utils/gitlab_api.py
@@ -849,9 +849,10 @@ class GitLabApi:
         tar_bytes = io.BytesIO(archive)
         with tarfile.open(fileobj=tar_bytes, mode="r:gz") as tar:
             return {
-                path: file.read()
+                file_path: file.read()
                 for member in tar.getmembers()
                 if member.isfile()
-                and (path := member.name.split("/", 1)[-1])  # skip leading prefix xxx/
+                # skip leading prefix xxx/
+                and (file_path := member.name.split("/", 1)[-1])
                 and (file := tar.extractfile(member))
             }

--- a/reconcile/utils/gitlab_api.py
+++ b/reconcile/utils/gitlab_api.py
@@ -1,6 +1,8 @@
+import io
 import logging
 import os
 import re
+import tarfile
 from collections.abc import (
     Iterable,
     Mapping,
@@ -828,3 +830,28 @@ class GitLabApi:
             list[PersonalAccessToken],
             self.gl.personal_access_tokens.list(get_all=True),
         )
+
+    @staticmethod
+    def get_directory_contents(
+        project: Project,
+        ref: str | None = None,
+        path: str | None = None,
+    ) -> dict[str, bytes]:
+        """
+        Get the contents of a directory in a project.
+
+        :param project: The project to get the contents from.
+        :param ref: The commit SHA to download. A tag, branch reference, or SHA can be used. If not specified, defaults to the tip of the default branch.
+        :param path: The subpath of the repository to download. If an empty string, defaults to the whole repository.
+        :return: A dictionary with the file path as keys and the file content bytes as values.
+        """
+        archive = project.repository_archive(format="tar.gz", sha=ref, path=path)
+        tar_bytes = io.BytesIO(archive)
+        with tarfile.open(fileobj=tar_bytes, mode="r:gz") as tar:
+            return {
+                path: file.read()
+                for member in tar.getmembers()
+                if member.isfile()
+                and (path := member.name.split("/", 1)[-1])  # skip leading prefix xxx/
+                and (file := tar.extractfile(member))
+            }

--- a/reconcile/utils/jjb_client.py
+++ b/reconcile/utils/jjb_client.py
@@ -25,6 +25,7 @@ from sretoolbox.utils import retry
 
 from reconcile.utils import throughput
 from reconcile.utils.helpers import toggle_logger
+from reconcile.utils.vcs import GITHUB_BASE_URL
 
 JJB_INI = "[jenkins]\nurl = https://JENKINS_URL"
 
@@ -290,7 +291,7 @@ class JJB:  # pylint: disable=too-many-public-methods
             for job in jobs:
                 try:
                     project_url_raw = job["properties"][0]["github"]["url"]
-                    if "https://github.com" in project_url_raw:
+                    if project_url_raw.startswith(GITHUB_BASE_URL):
                         continue
                     if str(job.get("disabled")).lower() == "true":
                         continue

--- a/reconcile/utils/saasherder/saasherder.py
+++ b/reconcile/utils/saasherder/saasherder.py
@@ -798,17 +798,14 @@ class SaasHerder:  # pylint: disable=too-many-public-methods
             if not self.gitlab:
                 raise Exception("gitlab is not initialized")
             project = self.gitlab.get_project(url)
-            for item in self.gitlab.get_repository_tree(
-                project=project,
-                path=path.lstrip("/"),
+            dir_contents = self.gitlab.get_directory_contents(
+                project,
                 ref=commit_sha,
-                recursive=False,
-            ):
-                file_contents = project.files.get(
-                    file_path=item["path"], ref=commit_sha
-                )
-                resource = yaml.safe_load(file_contents.decode())
-                resources.append(resource)
+                path=path,
+            )
+            for content in dir_contents.values():
+                result_resources = yaml.safe_load_all(content)
+                resources.extend(result_resources)
         else:
             raise Exception(f"Only GitHub and GitLab are supported: {url}")
 

--- a/reconcile/utils/saasherder/saasherder.py
+++ b/reconcile/utils/saasherder/saasherder.py
@@ -83,6 +83,7 @@ from reconcile.utils.saasherder.models import (
 )
 from reconcile.utils.secret_reader import SecretReaderBase
 from reconcile.utils.state import State
+from reconcile.utils.vcs import GITHUB_BASE_URL
 
 TARGET_CONFIG_HASH = "target_config_hash"
 
@@ -742,7 +743,7 @@ class SaasHerder:  # pylint: disable=too-many-public-methods
         [url, sha] = trigger_reason.split(" ")[0].split("/commit/")
         repo_name = urlparse(url).path.strip("/")
         file_name = f"{repo_name.replace('/', '-')}-{sha}.tar.gz"
-        if "github" in url:
+        if url.startswith(GITHUB_BASE_URL):
             github = self._initiate_github(saas_file, base_url="https://api.github.com")
             repo = github.get_repo(repo_name)
             # get_archive_link get redirect url form header, it does not work with github-mirror
@@ -760,8 +761,8 @@ class SaasHerder:  # pylint: disable=too-many-public-methods
     ) -> tuple[Any, str]:
         commit_sha = self._get_commit_sha(url, ref, github)
 
-        if "github" in url:
-            repo_name = url.rstrip("/").replace("https://github.com/", "")
+        if url.startswith(GITHUB_BASE_URL):
+            repo_name = url.removeprefix(GITHUB_BASE_URL).rstrip("/")
             repo = github.get_repo(repo_name)
             content = self._get_file_contents_github(repo, path, commit_sha)
         elif "gitlab" in url:
@@ -781,8 +782,8 @@ class SaasHerder:  # pylint: disable=too-many-public-methods
     ) -> tuple[list[Any], str]:
         commit_sha = self._get_commit_sha(url, ref, github)
         resources: list[Any] = []
-        if "github" in url:
-            repo_name = url.rstrip("/").replace("https://github.com/", "")
+        if url.startswith(GITHUB_BASE_URL):
+            repo_name = url.removeprefix(GITHUB_BASE_URL).rstrip("/")
             repo = github.get_repo(repo_name)
             directory = repo.get_contents(path, commit_sha)
             if isinstance(directory, ContentFile):
@@ -814,8 +815,8 @@ class SaasHerder:  # pylint: disable=too-many-public-methods
     @retry()
     def _get_commit_sha(self, url: str, ref: str, github: Github) -> str:
         commit_sha = ""
-        if "github" in url:
-            repo_name = url.rstrip("/").replace("https://github.com/", "")
+        if url.startswith(GITHUB_BASE_URL):
+            repo_name = url.removeprefix(GITHUB_BASE_URL).rstrip("/")
             repo = github.get_repo(repo_name)
             commit = repo.get_commit(sha=ref)
             commit_sha = commit.sha

--- a/reconcile/utils/terrascript_aws_client.py
+++ b/reconcile/utils/terrascript_aws_client.py
@@ -186,6 +186,7 @@ from reconcile.utils.password_validator import (
 )
 from reconcile.utils.secret_reader import SecretReader, SecretReaderBase
 from reconcile.utils.terraform import safe_resource_id
+from reconcile.utils.vcs import GITHUB_BASE_URL
 
 GH_BASE_URL = os.environ.get("GITHUB_API", "https://api.github.com")
 LOGTOES_RELEASE = "repos/app-sre/logs-to-elasticsearch-lambda/releases/latest"
@@ -5685,9 +5686,9 @@ class TerrascriptClient:  # pylint: disable=too-many-public-methods
             return ref
 
         # get commit_sha from branch
-        if "github" in url:
+        if url.startswith(GITHUB_BASE_URL):
             github = self.init_github()
-            repo_name = url.rstrip("/").replace("https://github.com/", "")
+            repo_name = url.removeprefix(GITHUB_BASE_URL).rstrip("/")
             repo = github.get_repo(repo_name)
             commit = repo.get_commit(sha=ref)
             return commit.sha

--- a/reconcile/utils/vcs.py
+++ b/reconcile/utils/vcs.py
@@ -22,6 +22,8 @@ from reconcile.utils.secret_reader import (
     SecretReaderBase,
 )
 
+GITHUB_BASE_URL = "https://github.com/"
+
 
 class MRCheckStatus(Enum):
     NONE = 0
@@ -158,7 +160,7 @@ class VCS:
     ) -> str:
         if bool(self._is_commit_sha_regex.search(ref)):
             return ref
-        if repo_url.startswith("https://github.com/"):
+        if repo_url.startswith(GITHUB_BASE_URL):
             github = self._init_github(repo_url=repo_url, auth_code=auth_code)
             return github.get_commit_sha(ref=ref)
         # assume gitlab by default
@@ -175,7 +177,7 @@ class VCS:
         Return a list of commits between two commits.
         Note, that the commit_to is included in the result list, whereas commit_from is not included.
         """
-        if repo_url.startswith("https://github.com/"):
+        if repo_url.startswith(GITHUB_BASE_URL):
             github = self._init_github(repo_url=repo_url, auth_code=auth_code)
             data = github.compare(commit_from=commit_from, commit_to=commit_to)
             return [


### PR DESCRIPTION
Use [Get file archive](https://docs.gitlab.com/api/repositories/#get-file-archive) to download tar.gz file for a dir instead of iterate repo tree then download files one by one.

Also refactor determine if a repo is for GitHub or GitLab by extract `GITHUB_BASE_URL` and do strict prefix match to avoid gitlab repo name contains `github` to be classified as GitHub repo.

[APPSRE-12038](https://issues.redhat.com/browse/APPSRE-12038)

### Refactoring for GitHub URL Handling:
* Added `GITHUB_BASE_URL` constant in `reconcile/utils/vcs.py` to centralize the GitHub base URL.
* Replaced hardcoded GitHub URL strings with `GITHUB_BASE_URL` in various files and functions, such as `compare`, `_github_compare_commits`, and `_get_directory_contents`. [[1]](diffhunk://#diff-a1ca374a2cf09b0d017bff4299973c839cdc1380b48f5332350204abf7c43feeL424-R425) [[2]](diffhunk://#diff-a1ca374a2cf09b0d017bff4299973c839cdc1380b48f5332350204abf7c43feeL479-R480) [[3]](diffhunk://#diff-52a815feb4bcd8276212403b5f0ae22e3a3d9508acb5b7a75a5134dcf2657bbcL763-R765) and others)
* Updated logic in multiple modules, including `dashdotdb_dora.py`, `github_repo_permissions_validator.py`, and `saasherder.py`, to use `GITHUB_BASE_URL` for URL manipulation and comparisons. [[1]](diffhunk://#diff-a1ca374a2cf09b0d017bff4299973c839cdc1380b48f5332350204abf7c43feeR37) [[2]](diffhunk://#diff-178b0eea2ebeecaca9755b66defe43f0bd821dd1b266f3d9f433f670c2193759R14) [[3]](diffhunk://#diff-52a815feb4bcd8276212403b5f0ae22e3a3d9508acb5b7a75a5134dcf2657bbcL745-R746)

### Enhancements to GitLab API:
* Added a new static method, `get_directory_contents`, in `reconcile/utils/gitlab_api.py` to retrieve directory contents from a GitLab repository archive.
* Implemented a corresponding test case, `test_get_directory_contents`, in `test_gitlab_api.py` to validate the new functionality.

### Other Changes:
* Updated test data to use HTTPS for GitHub URLs in `test_terrascript_aws_client.py`.
* Modified `get_commit_sha` and `get_commits_between` in `vcs.py` to leverage `GITHUB_BASE_URL` for GitHub-specific logic. [[1]](diffhunk://#diff-16325b334e8516b40446197896257fa343843be90eb3b23c90e6f8f0027888f2L161-R163) [[2]](diffhunk://#diff-16325b334e8516b40446197896257fa343843be90eb3b23c90e6f8f0027888f2L178-R180)