### PR TITLE
fix(terraform_tgw_attachments): use correct shard name

### DIFF
--- a/reconcile/terraform_tgw_attachments.py
+++ b/reconcile/terraform_tgw_attachments.py
@@ -550,7 +550,7 @@ def run(
             integration_version=QONTRACT_INTEGRATION_VERSION,
             dry_run=dry_run,
             cache_source=cache_source,
-            shard="_".join(account_name) if account_name else "",
+            shard=account_name or "",
             ttl_seconds=extended_early_exit_cache_ttl_seconds,
             logger=logging.getLogger(),
             runner=runner,


### PR DESCRIPTION
`account_name` is a `str | None`, join by `_` will lead to unexpected result. For example, `'_'.join("app-sre")` will return `a_p_p_-_s_r_e`.