### PR TITLE
[vcs] use raw file api to get file

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -427,7 +427,6 @@ module = [
     "reconcile.test.utils.test_expiration",
     "reconcile.test.utils.test_external_resource_spec",
     "reconcile.test.utils.test_external_resources",
-    "reconcile.test.utils.test_github_api",
     "reconcile.test.utils.test_gpg",
     "reconcile.test.utils.test_gql",
     "reconcile.test.utils.test_grouping",

--- a/reconcile/dashdotdb_dora.py
+++ b/reconcile/dashdotdb_dora.py
@@ -402,7 +402,7 @@ class DashdotdbDORA(DashdotdbBase):
             if not saas_file_yaml:
                 LOG.info(f"failed to fetch saas file {saastarget.path} at {sha}")
                 return (None, None)
-            saas_file = yaml.safe_load(saas_file_yaml.decode())
+            saas_file = yaml.safe_load(saas_file_yaml)
         except Exception as e:
             LOG.info(f"failed to decode saas file {saastarget.path} with error: {e}")
             return (None, None)

--- a/reconcile/test/utils/test_github_api.py
+++ b/reconcile/test/utils/test_github_api.py
@@ -135,12 +135,12 @@ def test_get_raw_file(github: Mock) -> None:
 
 
 def test_get_raw_file_with_multiple_contents(github: Mock) -> None:
-    repo = create_autospec(Repository)
+    repo = create_autospec(Repository, full_name="my/repo")
     mocked_file = create_autospec(spec=ContentFile, size=10)
     repo.get_contents.return_value = [mocked_file]
 
     with pytest.raises(
         UnsupportedDirectoryError,
-        match=r"Path some/path of ref some-ref is a directory!",
+        match=r"Path some/path of ref some-ref in repo my/repo is a directory!",
     ):
         GithubRepositoryApi.get_raw_file(path="some/path", ref="some-ref", repo=repo)

--- a/reconcile/test/utils/test_github_api.py
+++ b/reconcile/test/utils/test_github_api.py
@@ -1,73 +1,146 @@
+import base64
 from unittest.mock import (
-    MagicMock,
+    Mock,
     create_autospec,
 )
 
+import pytest
 from github import Github
 from github.ContentFile import ContentFile
+from github.GitBlob import GitBlob
 from github.Repository import Repository
 
-from reconcile.utils.github_api import GithubRepositoryApi
+from reconcile.utils.github_api import GithubRepositoryApi, UnsupportedDirectoryError
 
 
-def github(multiple_contents: bool = False):
+@pytest.fixture
+def github() -> Mock:
     github_mock = create_autospec(spec=Github)
     repo_mock = create_autospec(spec=Repository)
-    get_content_mock = MagicMock()
-    repo_mock.get_contents = get_content_mock
-    content_file = create_autospec(spec=ContentFile)
-    content_file.decoded_content = b"test"
-    get_content_mock.side_effect = [content_file]
-    if multiple_contents:
-        get_content_mock.side_effect = [[content_file, content_file]]
-    github_mock.get_repo = MagicMock()
-    github_mock.get_repo.side_effect = [repo_mock]
+    github_mock.get_repo.return_value = repo_mock
     return github_mock
 
 
-def test_create():
-    gh = github()
+def test_create(github: Mock) -> None:
     GithubRepositoryApi(
         repo_url="https://github.com/my/repo",
         token="some-token",
-        github=gh,
+        github=github,
     )
-    gh.get_repo.assert_called_once_with("my/repo")
+    github.get_repo.assert_called_once_with("my/repo")
 
 
-def test_get_file_default():
+def test_get_file_default(github: Mock) -> None:
     api = GithubRepositoryApi(
-        repo_url="https://github.com/my/repo", token="some-token", github=github()
+        repo_url="https://github.com/my/repo",
+        token="some-token",
+        github=github,
     )
+    repo = github.get_repo.return_value
+    expected_content = b"test"
+    mocked_file = create_autospec(spec=ContentFile, size=len(expected_content))
+    repo.get_contents.return_value = mocked_file
+    mocked_file.decoded_content = expected_content
+
     content = api.get_file(path="some/path")
-    assert content == b"test"
-    api._repo.get_contents.assert_called_once_with(
+
+    assert content == expected_content
+    repo.get_contents.assert_called_once_with(
         path="some/path",
         ref="master",
     )
 
 
-def test_get_file_with_ref():
+def test_get_file_with_ref(github: Mock) -> None:
     api = GithubRepositoryApi(
-        repo_url="https://github.com/my/repo", token="some-token", github=github()
+        repo_url="https://github.com/my/repo",
+        token="some-token",
+        github=github,
     )
+    repo = github.get_repo.return_value
+    expected_content = b"test"
+    mocked_file = create_autospec(spec=ContentFile, size=len(expected_content))
+    repo.get_contents.return_value = mocked_file
+    mocked_file.decoded_content = expected_content
+
     content = api.get_file(path="some/path", ref="some-ref")
-    assert content == b"test"
-    api._repo.get_contents.assert_called_once_with(
+
+    assert content == expected_content
+    repo.get_contents.assert_called_once_with(
         path="some/path",
         ref="some-ref",
     )
 
 
-def test_get_file_list_returned():
+def test_get_file_list_returned(github: Mock) -> None:
     api = GithubRepositoryApi(
         repo_url="https://github.com/my/repo",
         token="some-token",
-        github=github(multiple_contents=True),
+        github=github,
     )
+    repo = github.get_repo.return_value
+    mocked_file = create_autospec(spec=ContentFile)
+    repo.get_contents.return_value = [mocked_file]
+
     content = api.get_file(path="some/path")
+
     assert content is None
-    api._repo.get_contents.assert_called_once_with(
+    repo.get_contents.assert_called_once_with(
         path="some/path",
         ref="master",
     )
+
+
+def test_get_file_with_large_file(github: Mock) -> None:
+    api = GithubRepositoryApi(
+        repo_url="https://github.com/my/repo",
+        token="some-token",
+        github=github,
+    )
+    repo = github.get_repo.return_value
+    sha = "3a0f86fb8db8eea7ccbb9a95f325ddbedfb25e15"
+    mocked_file = create_autospec(spec=ContentFile, size=1024 * 1024, sha=sha)  # 1MB
+    repo.get_contents.return_value = mocked_file
+    mocked_blob = create_autospec(spec=GitBlob)
+    expected_content = b"large content"
+    mocked_blob.content = base64.b64encode(expected_content)
+    repo.get_git_blob.return_value = mocked_blob
+
+    content = api.get_file(path="some/path")
+
+    assert content == expected_content
+    repo.get_contents.assert_called_once_with(
+        path="some/path",
+        ref="master",
+    )
+    repo.get_git_blob.assert_called_once_with(sha)
+
+
+def test_get_raw_file(github: Mock) -> None:
+    repo = create_autospec(Repository)
+    expected_content = b"test"
+    mocked_file = create_autospec(spec=ContentFile, size=len(expected_content))
+    repo.get_contents.return_value = mocked_file
+    mocked_file.decoded_content = expected_content
+
+    content = GithubRepositoryApi.get_raw_file(
+        path="some/path", ref="some-ref", repo=repo
+    )
+
+    assert content == expected_content
+    repo.get_contents.assert_called_once_with(
+        path="some/path",
+        ref="some-ref",
+    )
+
+
+def test_get_raw_file_with_multiple_contents(github: Mock) -> None:
+    repo = create_autospec(Repository)
+    mocked_file = create_autospec(spec=ContentFile, size=10)
+    repo.get_contents.return_value = [mocked_file]
+
+    with pytest.raises(
+        UnsupportedDirectoryError,
+        match=r"Path some/path of ref some-ref is a directory!",
+    ):
+        GithubRepositoryApi.get_raw_file(path="some/path", ref="some-ref", repo=repo)

--- a/reconcile/test/utils/test_gitlab_api.py
+++ b/reconcile/test/utils/test_gitlab_api.py
@@ -644,41 +644,6 @@ def test_get_repository_tree_as_git_cli_interface(
         pagination="keyset",
         per_page=100,
         get_all=True,
-        path="",
-    )
-
-
-def test_get_repository_tree_with_project(
-    mocked_gitlab_api: GitLabApi,
-    mocked_gl: Mock,
-) -> None:
-    project = create_autospec(Project)
-    expected_result = [
-        {
-            "id": "a1e8f8d745cc87e3a9248358d9352bb7f9a0aeba",
-            "name": "html",
-            "type": "tree",
-            "path": "files/html",
-            "mode": "040000",
-        }
-    ]
-    project.repository_tree.return_value = expected_result
-
-    result = mocked_gitlab_api.get_repository_tree(
-        ref="main",
-        recursive=False,
-        project=project,
-        path="some/path",
-    )
-
-    assert result == expected_result
-    project.repository_tree.assert_called_once_with(
-        ref="main",
-        recursive=False,
-        pagination="keyset",
-        per_page=100,
-        get_all=True,
-        path="some/path",
     )
 
 

--- a/reconcile/test/utils/test_gitlab_api.py
+++ b/reconcile/test/utils/test_gitlab_api.py
@@ -785,17 +785,14 @@ def test_get_file_when_not_found(
     )
 
 
-def test_get_file_with_project(
-    mocked_gitlab_api: GitLabApi,
-    mocked_gl: Mock,
-) -> None:
+def test_get_raw_file() -> None:
     expected_file = b"# README\nThis is a test file."
     project = create_autospec(Project)
     project_file_manager = create_autospec(ProjectFileManager)
     project.files = project_file_manager
     project_file_manager.raw.return_value = expected_file
 
-    file = mocked_gitlab_api.get_file(path="/README.md", ref="main", project=project)
+    file = GitLabApi.get_raw_file(project=project, path="/README.md", ref="main")
 
     assert file == expected_file
     project_file_manager.raw.assert_called_once_with(

--- a/reconcile/test/utils/test_mr_clusters_updates.py
+++ b/reconcile/test/utils/test_mr_clusters_updates.py
@@ -5,6 +5,8 @@ from unittest.mock import (
     patch,
 )
 
+from gitlab.v4.objects import Project
+
 import reconcile.utils.mr.clusters_updates as sut
 from reconcile.test.fixtures import Fixtures
 from reconcile.utils.gitlab_api import GitLabApi
@@ -25,11 +27,12 @@ class TestProcess(TestCase):
         c.process(cli)
         cancel.assert_called_once()
 
-        cli.get_file.assert_not_called()
+        cli.get_raw_file.assert_not_called()
 
     def test_changes_to_spec(self, cancel):
         cli = create_autospec(GitLabApi)
-        cli.get_file.return_value = self.raw_clusters.encode()
+        cli.project = create_autospec(Project)
+        cli.get_raw_file.return_value = self.raw_clusters.encode()
         c = sut.CreateClustersUpdates({
             "cluster1": {"spec": {"id": "42"}, "root": {}, "path": "/a/path"}
         })
@@ -47,7 +50,8 @@ class TestProcess(TestCase):
             commit_message="update cluster cluster1 spec fields",
             content=content,
         )
-        cli.get_file.assert_called_once_with(
+        cli.get_raw_file.assert_called_once_with(
+            project=cli.project,
             path="/a/path",
             ref=cli.main_branch,
         )
@@ -55,7 +59,8 @@ class TestProcess(TestCase):
 
     def test_changes_to_root(self, cancel):
         cli = create_autospec(GitLabApi)
-        cli.get_file.return_value = self.raw_clusters.encode()
+        cli.project = create_autospec(Project)
+        cli.get_raw_file.return_value = self.raw_clusters.encode()
         c = sut.CreateClustersUpdates({
             "cluster1": {
                 "spec": {},
@@ -76,7 +81,8 @@ class TestProcess(TestCase):
             commit_message="update cluster cluster1 spec fields",
             content=content,
         )
-        cli.get_file.assert_called_once_with(
+        cli.get_raw_file.assert_called_once_with(
+            project=cli.project,
             path="/a/path",
             ref=cli.main_branch,
         )

--- a/reconcile/test/utils/vcs/test_vcs.py
+++ b/reconcile/test/utils/vcs/test_vcs.py
@@ -117,8 +117,8 @@ def test_get_file_content_from_app_interface_ref_defaults(
     vcs = vcs_builder({})
     vcs.get_file_content_from_app_interface_ref(file_path="/file.yaml")
 
-    vcs._app_interface_api.project.files.get.assert_called_once_with(  # type: ignore[attr-defined]
-        file_path="data/file.yaml",
+    vcs._app_interface_api.get_file.assert_called_once_with(  # type: ignore[attr-defined]
+        path="data/file.yaml",
         ref="master",
     )
 
@@ -131,8 +131,8 @@ def test_get_file_content_from_app_interface_ref_overrides(
         file_path="/file.yaml", is_data=False, ref="ref"
     )
 
-    vcs._app_interface_api.project.files.get.assert_called_once_with(  # type: ignore[attr-defined]
-        file_path="/file.yaml",
+    vcs._app_interface_api.get_file.assert_called_once_with(  # type: ignore[attr-defined]
+        path="/file.yaml",
         ref="ref",
     )
 

--- a/reconcile/test/utils/vcs/test_vcs.py
+++ b/reconcile/test/utils/vcs/test_vcs.py
@@ -117,7 +117,8 @@ def test_get_file_content_from_app_interface_ref_defaults(
     vcs = vcs_builder({})
     vcs.get_file_content_from_app_interface_ref(file_path="/file.yaml")
 
-    vcs._app_interface_api.get_file.assert_called_once_with(  # type: ignore[attr-defined]
+    vcs._app_interface_api.get_raw_file.assert_called_once_with(  # type: ignore[attr-defined]
+        project=vcs._app_interface_api.project,
         path="data/file.yaml",
         ref="master",
     )
@@ -131,7 +132,8 @@ def test_get_file_content_from_app_interface_ref_overrides(
         file_path="/file.yaml", is_data=False, ref="ref"
     )
 
-    vcs._app_interface_api.get_file.assert_called_once_with(  # type: ignore[attr-defined]
+    vcs._app_interface_api.get_raw_file.assert_called_once_with(  # type: ignore[attr-defined]
+        project=vcs._app_interface_api.project,
         path="/file.yaml",
         ref="ref",
     )

--- a/reconcile/utils/github_api.py
+++ b/reconcile/utils/github_api.py
@@ -1,12 +1,20 @@
+import base64
 import os
 from pathlib import Path
 from types import TracebackType
 from urllib.parse import urlparse
 
 from github import Commit, Github, GithubException, UnknownObjectException
+from github.Repository import Repository
 from sretoolbox.utils import retry
 
 GH_BASE_URL = os.environ.get("GITHUB_API", "https://api.github.com")
+
+MAX_FILE_CONTENT_SIZE = 1024**2  # 1MB
+
+
+class UnsupportedDirectoryError(Exception):
+    pass
 
 
 class GithubRepositoryApi:
@@ -66,16 +74,34 @@ class GithubRepositoryApi:
             tree_items.append(tree_item)
         return tree_items
 
-    @retry()
-    def get_file(self, path: str, ref: str = "master") -> bytes | None:
-        try:
-            content = self._repo.get_contents(path=path, ref=ref)
-            if isinstance(content, list):
-                # TODO: we should probably raise an exception here
-                # or handle this properly
-                # -> for now staying backwards compatible
-                return None
+    @staticmethod
+    def get_raw_file(
+        repo: Repository,
+        path: str,
+        ref: str,
+    ) -> bytes:
+        content = repo.get_contents(path=path, ref=ref)
+        if isinstance(content, list):
+            raise UnsupportedDirectoryError(f"Path {path} of ref {ref} is a directory!")
+        if content.size < MAX_FILE_CONTENT_SIZE:
             return content.decoded_content
+        blob = repo.get_git_blob(content.sha)
+        return base64.b64decode(blob.content)
+
+    @retry()
+    def get_file(
+        self,
+        path: str,
+        ref: str = "master",
+    ) -> bytes | None:
+        try:
+            return self.get_raw_file(
+                repo=self._repo,
+                path=path,
+                ref=ref,
+            )
+        except UnsupportedDirectoryError:
+            return None
         except GithubException as e:
             # handling a bug in the upstream GH library
             # https://github.com/PyGithub/PyGithub/issues/3179

--- a/reconcile/utils/github_api.py
+++ b/reconcile/utils/github_api.py
@@ -82,7 +82,9 @@ class GithubRepositoryApi:
     ) -> bytes:
         content = repo.get_contents(path=path, ref=ref)
         if isinstance(content, list):
-            raise UnsupportedDirectoryError(f"Path {path} of ref {ref} is a directory!")
+            raise UnsupportedDirectoryError(
+                f"Path {path} of ref {ref} in repo {repo.full_name} is a directory!"
+            )
         if content.size < MAX_FILE_CONTENT_SIZE:
             return content.decoded_content
         blob = repo.get_git_blob(content.sha)

--- a/reconcile/utils/gitlab_api.py
+++ b/reconcile/utils/gitlab_api.py
@@ -41,7 +41,6 @@ from gitlab.v4.objects import (
     GroupMember,
     PersonalAccessToken,
     Project,
-    ProjectFile,
     ProjectHook,
     ProjectIssue,
     ProjectIssueManager,
@@ -692,13 +691,27 @@ class GitLabApi:
             ),
         )
 
-    def get_file(self, path: str, ref: str = "master") -> ProjectFile | None:
+    def get_file(
+        self,
+        path: str,
+        ref: str = "master",
+        project: Project | None = None,
+    ) -> bytes | None:
         """
-        Wrapper around Gitlab.files.get() with exception handling.
+        Get the raw content of a file in a project.
+
+        :param path: The path to the file in the repository.
+        :param ref: The name of branch, tag or commit.
+        :param project: The project to get the file from, if None, use the current project.
+        :return: The content of the file as bytes, or None if the file does not exist.
         """
+        target_project = self.project if project is None else project
+        file_path = path.lstrip("/")
         try:
-            path = path.lstrip("/")
-            return self.project.files.get(file_path=path, ref=ref)
+            return target_project.files.raw(
+                file_path=file_path,
+                ref=ref,
+            )
         except GitlabGetError:
             return None
 

--- a/reconcile/utils/gitlab_api.py
+++ b/reconcile/utils/gitlab_api.py
@@ -691,25 +691,34 @@ class GitLabApi:
             ),
         )
 
+    @staticmethod
+    def get_raw_file(
+        project: Project,
+        path: str,
+        ref: str,
+    ) -> bytes:
+        file_path = path.lstrip("/")
+        return project.files.raw(
+            file_path=file_path,
+            ref=ref,
+        )
+
     def get_file(
         self,
         path: str,
         ref: str = "master",
-        project: Project | None = None,
     ) -> bytes | None:
         """
         Get the raw content of a file in a project.
 
         :param path: The path to the file in the repository.
         :param ref: The name of branch, tag or commit.
-        :param project: The project to get the file from, if None, use the current project.
         :return: The content of the file as bytes, or None if the file does not exist.
         """
-        target_project = self.project if project is None else project
-        file_path = path.lstrip("/")
         try:
-            return target_project.files.raw(
-                file_path=file_path,
+            return self.get_raw_file(
+                project=self.project,
+                path=path,
                 ref=ref,
             )
         except GitlabGetError:

--- a/reconcile/utils/gitlab_api.py
+++ b/reconcile/utils/gitlab_api.py
@@ -665,25 +665,19 @@ class GitLabApi:
         *,
         ref: str = "master",
         recursive: bool = False,
-        project: Project | None = None,
-        path: str = "",
     ) -> list[dict]:
         """
         Get a list of repository files and directories in a project.
 
         :param ref: The name of a repository branch or tag or, if not given, the default branch.
         :param recursive: Boolean value used to get a recursive tree. Default is false.
-        :param project: The project to get the tree from, if None, use the current project
-        :param path: The path inside the repository. Used to get content of subdirectories.
 
         :return: list of tree objects
         """
-        target_project = self.project if project is None else project
         return cast(
             list[dict],
-            target_project.repository_tree(
+            self.project.repository_tree(
                 ref=ref,
-                path=path,
                 recursive=recursive,
                 pagination="keyset",
                 per_page=MAX_PER_PAGE,

--- a/reconcile/utils/jinja2/utils.py
+++ b/reconcile/utils/jinja2/utils.py
@@ -12,6 +12,7 @@ from reconcile.checkpoint import url_makes_sense
 from reconcile.github_users import init_github
 from reconcile.utils import gql
 from reconcile.utils.aws_api import AWSApi
+from reconcile.utils.github_api import GithubRepositoryApi
 from reconcile.utils.helpers import flatten
 from reconcile.utils.jinja2.extensions import B64EncodeExtension, RaiseErrorExtension
 from reconcile.utils.jinja2.filters import (
@@ -116,10 +117,12 @@ def lookup_github_file_content(
         )
 
     gh = init_github()
-    content = gh.get_repo(repo).get_contents(path, ref)
-    if isinstance(content, list):
-        raise Exception(f"multiple files found for {repo}/{path}/{ref}")
-    return content.decoded_content.decode("utf-8")
+    content = GithubRepositoryApi.get_raw_file(
+        repo=gh.get_repo(repo),
+        path=path,
+        ref=ref,
+    )
+    return content.decode("utf-8")
 
 
 def lookup_graphql_query_results(query: str, **kwargs: dict[str, Any]) -> list[Any]:

--- a/reconcile/utils/mr/aws_access.py
+++ b/reconcile/utils/mr/aws_access.py
@@ -37,7 +37,11 @@ class CreateDeleteAwsAccessKey(MergeRequestBase):
 
     def process(self, gitlab_cli: GitLabApi) -> None:
         # add key to deleteKeys list to be picked up by aws-iam-keys
-        raw_file = gitlab_cli.get_file(path=self.path, ref=gitlab_cli.main_branch)
+        raw_file = gitlab_cli.get_raw_file(
+            project=gitlab_cli.project,
+            path=self.path,
+            ref=gitlab_cli.main_branch,
+        )
         content = yaml.load(raw_file, Loader=yaml.RoundTripLoader)
 
         content.setdefault("deleteKeys", [])

--- a/reconcile/utils/mr/aws_access.py
+++ b/reconcile/utils/mr/aws_access.py
@@ -37,10 +37,8 @@ class CreateDeleteAwsAccessKey(MergeRequestBase):
 
     def process(self, gitlab_cli: GitLabApi) -> None:
         # add key to deleteKeys list to be picked up by aws-iam-keys
-        raw_file = gitlab_cli.project.files.get(
-            file_path=self.path, ref=gitlab_cli.main_branch
-        )
-        content = yaml.load(raw_file.decode(), Loader=yaml.RoundTripLoader)
+        raw_file = gitlab_cli.get_file(path=self.path, ref=gitlab_cli.main_branch)
+        content = yaml.load(raw_file, Loader=yaml.RoundTripLoader)
 
         content.setdefault("deleteKeys", [])
         content["deleteKeys"].append(self.key)

--- a/reconcile/utils/mr/clusters_updates.py
+++ b/reconcile/utils/mr/clusters_updates.py
@@ -37,7 +37,8 @@ class CreateClustersUpdates(MergeRequestBase):
                 continue
 
             cluster_path = cluster_updates.pop("path")
-            raw_file = gitlab_cli.get_file(
+            raw_file = gitlab_cli.get_raw_file(
+                project=gitlab_cli.project,
                 path=cluster_path,
                 ref=gitlab_cli.main_branch,
             )

--- a/reconcile/utils/mr/clusters_updates.py
+++ b/reconcile/utils/mr/clusters_updates.py
@@ -37,10 +37,11 @@ class CreateClustersUpdates(MergeRequestBase):
                 continue
 
             cluster_path = cluster_updates.pop("path")
-            raw_file = gitlab_cli.project.files.get(
-                file_path=cluster_path, ref=gitlab_cli.main_branch
+            raw_file = gitlab_cli.get_file(
+                path=cluster_path,
+                ref=gitlab_cli.main_branch,
             )
-            content = yaml.load(raw_file.decode())
+            content = yaml.load(raw_file)
             if "spec" not in content:
                 self.cancel("Spec missing. Nothing to do.")
 

--- a/reconcile/utils/mr/ocm_update_recommended_version.py
+++ b/reconcile/utils/mr/ocm_update_recommended_version.py
@@ -28,10 +28,8 @@ class CreateOCMUpdateRecommendedVersion(MergeRequestBase):
         return f"ocm update recommended version for {self.ocm_name}"
 
     def process(self, gitlab_cli: GitLabApi) -> None:
-        raw_file = gitlab_cli.project.files.get(
-            file_path=self.path, ref=gitlab_cli.main_branch
-        )
-        content = yaml.load(raw_file.decode(), Loader=yaml.RoundTripLoader)
+        raw_file = gitlab_cli.get_file(path=self.path, ref=gitlab_cli.main_branch)
+        content = yaml.load(raw_file, Loader=yaml.RoundTripLoader)
 
         content["recommendedVersions"] = self.recommended_versions
 

--- a/reconcile/utils/mr/ocm_update_recommended_version.py
+++ b/reconcile/utils/mr/ocm_update_recommended_version.py
@@ -28,7 +28,11 @@ class CreateOCMUpdateRecommendedVersion(MergeRequestBase):
         return f"ocm update recommended version for {self.ocm_name}"
 
     def process(self, gitlab_cli: GitLabApi) -> None:
-        raw_file = gitlab_cli.get_file(path=self.path, ref=gitlab_cli.main_branch)
+        raw_file = gitlab_cli.get_raw_file(
+            project=gitlab_cli.project,
+            path=self.path,
+            ref=gitlab_cli.main_branch,
+        )
         content = yaml.load(raw_file, Loader=yaml.RoundTripLoader)
 
         content["recommendedVersions"] = self.recommended_versions

--- a/reconcile/utils/mr/ocm_upgrade_scheduler_org_updates.py
+++ b/reconcile/utils/mr/ocm_upgrade_scheduler_org_updates.py
@@ -28,7 +28,11 @@ class CreateOCMUpgradeSchedulerOrgUpdates(MergeRequestBase):
         ocm_path = self.updates_info["path"]
         ocm_name = self.updates_info["name"]
 
-        raw_file = gitlab_cli.get_file(path=ocm_path, ref=gitlab_cli.main_branch)
+        raw_file = gitlab_cli.get_raw_file(
+            project=gitlab_cli.project,
+            path=ocm_path,
+            ref=gitlab_cli.main_branch,
+        )
         content = yaml.load(raw_file, Loader=yaml.RoundTripLoader)
         upgrade_policy_clusters = content["upgradePolicyClusters"]
 

--- a/reconcile/utils/mr/ocm_upgrade_scheduler_org_updates.py
+++ b/reconcile/utils/mr/ocm_upgrade_scheduler_org_updates.py
@@ -28,10 +28,8 @@ class CreateOCMUpgradeSchedulerOrgUpdates(MergeRequestBase):
         ocm_path = self.updates_info["path"]
         ocm_name = self.updates_info["name"]
 
-        raw_file = gitlab_cli.project.files.get(
-            file_path=ocm_path, ref=gitlab_cli.main_branch
-        )
-        content = yaml.load(raw_file.decode(), Loader=yaml.RoundTripLoader)
+        raw_file = gitlab_cli.get_file(path=ocm_path, ref=gitlab_cli.main_branch)
+        content = yaml.load(raw_file, Loader=yaml.RoundTripLoader)
         upgrade_policy_clusters = content["upgradePolicyClusters"]
 
         for update in self.updates_info["updates"]:

--- a/reconcile/utils/mr/promote_qontract.py
+++ b/reconcile/utils/mr/promote_qontract.py
@@ -37,10 +37,10 @@ class PromoteQontractSchemas(MergeRequestBase):
         return f"promote qontract-schemas to version {self.version}"
 
     def process(self, gitlab_cli: GitLabApi) -> None:
-        raw_file = gitlab_cli.project.files.get(
-            file_path=self.path, ref=gitlab_cli.main_branch
-        )
-        content = raw_file.decode().decode("utf-8")
+        raw_file = gitlab_cli.get_file(path=self.path, ref=gitlab_cli.main_branch)
+        if raw_file is None:
+            raise ValueError(f"File {self.path} not found in {gitlab_cli.main_branch}.")
+        content = raw_file.decode("utf-8")
         lines = content.splitlines()
         for index, text in enumerate(lines):
             if text.startswith("export SCHEMAS_IMAGE_TAG="):
@@ -121,9 +121,9 @@ class PromoteQontractReconcileCommercial(MergeRequestBase):
         search_text: str,
         replace_text: str,
     ) -> None:
-        raw_file = gitlab_cli.project.files.get(
-            file_path=path, ref=gitlab_cli.main_branch
-        ).decode()
+        raw_file = gitlab_cli.get_file(path=path, ref=gitlab_cli.main_branch)
+        if raw_file is None:
+            raise ValueError(f"File {path} not found in {gitlab_cli.main_branch}.")
         match method:
             case "line_search":
                 new_content = self._process_by_line_search(

--- a/reconcile/utils/mr/promote_qontract.py
+++ b/reconcile/utils/mr/promote_qontract.py
@@ -37,9 +37,11 @@ class PromoteQontractSchemas(MergeRequestBase):
         return f"promote qontract-schemas to version {self.version}"
 
     def process(self, gitlab_cli: GitLabApi) -> None:
-        raw_file = gitlab_cli.get_file(path=self.path, ref=gitlab_cli.main_branch)
-        if raw_file is None:
-            raise ValueError(f"File {self.path} not found in {gitlab_cli.main_branch}.")
+        raw_file = gitlab_cli.get_raw_file(
+            project=gitlab_cli.project,
+            path=self.path,
+            ref=gitlab_cli.main_branch,
+        )
         content = raw_file.decode("utf-8")
         lines = content.splitlines()
         for index, text in enumerate(lines):
@@ -121,9 +123,11 @@ class PromoteQontractReconcileCommercial(MergeRequestBase):
         search_text: str,
         replace_text: str,
     ) -> None:
-        raw_file = gitlab_cli.get_file(path=path, ref=gitlab_cli.main_branch)
-        if raw_file is None:
-            raise ValueError(f"File {path} not found in {gitlab_cli.main_branch}.")
+        raw_file = gitlab_cli.get_raw_file(
+            project=gitlab_cli.project,
+            path=path,
+            ref=gitlab_cli.main_branch,
+        )
         match method:
             case "line_search":
                 new_content = self._process_by_line_search(

--- a/reconcile/utils/mr/update_access_report_base.py
+++ b/reconcile/utils/mr/update_access_report_base.py
@@ -100,14 +100,11 @@ class UpdateAccessReportBase(MergeRequestBase):
         return new_workbook_md
 
     def process(self, gitlab_cli: GitLabApi) -> None:
-        workbook_file = gitlab_cli.get_file(
+        workbook_file = gitlab_cli.get_raw_file(
+            project=gitlab_cli.project,
             path=self._workbook_file_name,
             ref=self.branch,
         )
-        if workbook_file is None:
-            raise ValueError(
-                f"Workbook file {self._workbook_file_name} not found in {self.branch}."
-            )
         workbook_md = self._update_workbook(workbook_file.decode("utf-8"))
 
         if not self._dry_run:

--- a/reconcile/utils/mr/update_access_report_base.py
+++ b/reconcile/utils/mr/update_access_report_base.py
@@ -100,10 +100,15 @@ class UpdateAccessReportBase(MergeRequestBase):
         return new_workbook_md
 
     def process(self, gitlab_cli: GitLabApi) -> None:
-        workbook_file = gitlab_cli.project.files.get(
-            file_path=self._workbook_file_name, ref=self.branch
+        workbook_file = gitlab_cli.get_file(
+            path=self._workbook_file_name,
+            ref=self.branch,
         )
-        workbook_md = self._update_workbook(workbook_file.decode().decode("utf-8"))
+        if workbook_file is None:
+            raise ValueError(
+                f"Workbook file {self._workbook_file_name} not found in {self.branch}."
+            )
+        workbook_md = self._update_workbook(workbook_file.decode("utf-8"))
 
         if not self._dry_run:
             logging.info(

--- a/reconcile/utils/mr/user_maintenance.py
+++ b/reconcile/utils/mr/user_maintenance.py
@@ -56,7 +56,11 @@ class CreateDeleteUserAppInterface(MergeRequestBase):
                     branch_name=self.branch, file_path=path, commit_message=self.title
                 )
             elif path_type == PathTypes.GABI:
-                raw_file = gitlab_cli.get_file(path=path, ref=self.branch)
+                raw_file = gitlab_cli.get_raw_file(
+                    project=gitlab_cli.project,
+                    path=path,
+                    ref=self.branch,
+                )
                 content = yaml.load(raw_file, Loader=yaml.RoundTripLoader)
                 for gabi_user in content["users"][:]:
                     if self.username in gabi_user["$ref"]:
@@ -70,7 +74,11 @@ class CreateDeleteUserAppInterface(MergeRequestBase):
                     content=new_content,
                 )
             elif path_type == PathTypes.AWS_ACCOUNTS:
-                raw_file = gitlab_cli.get_file(path=path, ref=self.branch)
+                raw_file = gitlab_cli.get_raw_file(
+                    project=gitlab_cli.project,
+                    path=path,
+                    ref=self.branch,
+                )
                 content = yaml.load(raw_file, Loader=yaml.RoundTripLoader)
                 for reset_record in content["resetPasswords"]:
                     if self.username in reset_record["user"]["$ref"]:
@@ -84,7 +92,11 @@ class CreateDeleteUserAppInterface(MergeRequestBase):
                             content=new_content,
                         )
             elif path_type == PathTypes.SCHEDULE:
-                raw_file = gitlab_cli.get_file(path=path, ref=self.branch)
+                raw_file = gitlab_cli.get_raw_file(
+                    project=gitlab_cli.project,
+                    path=path,
+                    ref=self.branch,
+                )
                 content = yaml.load(raw_file, Loader=yaml.RoundTripLoader)
                 delete_indexes: list[tuple[int, int]] = []
                 for schedule_index, schedule_record in enumerate(content["schedule"]):
@@ -124,7 +136,11 @@ class CreateDeleteUserInfra(MergeRequestBase):
         return "delete user(s)"
 
     def process(self, gitlab_cli):
-        raw_file = gitlab_cli.get_file(path=self.PLAYBOOK, ref=self.branch)
+        raw_file = gitlab_cli.get_raw_file(
+            project=gitlab_cli.project,
+            path=self.PLAYBOOK,
+            ref=self.branch,
+        )
         content = yaml.load(raw_file, Loader=yaml.RoundTripLoader)
 
         new_list = []

--- a/reconcile/utils/mr/user_maintenance.py
+++ b/reconcile/utils/mr/user_maintenance.py
@@ -56,8 +56,8 @@ class CreateDeleteUserAppInterface(MergeRequestBase):
                     branch_name=self.branch, file_path=path, commit_message=self.title
                 )
             elif path_type == PathTypes.GABI:
-                raw_file = gitlab_cli.project.files.get(file_path=path, ref=self.branch)
-                content = yaml.load(raw_file.decode(), Loader=yaml.RoundTripLoader)
+                raw_file = gitlab_cli.get_file(path=path, ref=self.branch)
+                content = yaml.load(raw_file, Loader=yaml.RoundTripLoader)
                 for gabi_user in content["users"][:]:
                     if self.username in gabi_user["$ref"]:
                         content["users"].remove(gabi_user)
@@ -70,8 +70,8 @@ class CreateDeleteUserAppInterface(MergeRequestBase):
                     content=new_content,
                 )
             elif path_type == PathTypes.AWS_ACCOUNTS:
-                raw_file = gitlab_cli.project.files.get(file_path=path, ref=self.branch)
-                content = yaml.load(raw_file.decode(), Loader=yaml.RoundTripLoader)
+                raw_file = gitlab_cli.get_file(path=path, ref=self.branch)
+                content = yaml.load(raw_file, Loader=yaml.RoundTripLoader)
                 for reset_record in content["resetPasswords"]:
                     if self.username in reset_record["user"]["$ref"]:
                         content["resetPasswords"].remove(reset_record)
@@ -84,8 +84,8 @@ class CreateDeleteUserAppInterface(MergeRequestBase):
                             content=new_content,
                         )
             elif path_type == PathTypes.SCHEDULE:
-                raw_file = gitlab_cli.project.files.get(file_path=path, ref=self.branch)
-                content = yaml.load(raw_file.decode(), Loader=yaml.RoundTripLoader)
+                raw_file = gitlab_cli.get_file(path=path, ref=self.branch)
+                content = yaml.load(raw_file, Loader=yaml.RoundTripLoader)
                 delete_indexes: list[tuple[int, int]] = []
                 for schedule_index, schedule_record in enumerate(content["schedule"]):
                     for user_index, user in enumerate(schedule_record["users"]):
@@ -124,10 +124,8 @@ class CreateDeleteUserInfra(MergeRequestBase):
         return "delete user(s)"
 
     def process(self, gitlab_cli):
-        raw_file = gitlab_cli.project.files.get(
-            file_path=self.PLAYBOOK, ref=self.branch
-        )
-        content = yaml.load(raw_file.decode(), Loader=yaml.RoundTripLoader)
+        raw_file = gitlab_cli.get_file(path=self.PLAYBOOK, ref=self.branch)
+        content = yaml.load(raw_file, Loader=yaml.RoundTripLoader)
 
         new_list = []
         for user in content[0]["vars"]["users"]:

--- a/reconcile/utils/repo_owners.py
+++ b/reconcile/utils/repo_owners.py
@@ -131,7 +131,7 @@ class RepoOwners:
                 _LOG.warning(f"{self._git_cli!s}:{owner_file['path']} not found")
                 continue
             try:
-                owners = yaml.safe_load(raw_owners.decode())
+                owners = yaml.safe_load(raw_owners)
             except yaml.parser.ParserError:
                 owners = None
             if owners is None:
@@ -184,7 +184,7 @@ class RepoOwners:
         if raw_aliases is None:
             return {}
 
-        aliases = yaml.safe_load(raw_aliases.decode())
+        aliases = yaml.safe_load(raw_aliases)
         if aliases is None:
             return {}
 

--- a/reconcile/utils/saasherder/saasherder.py
+++ b/reconcile/utils/saasherder/saasherder.py
@@ -773,7 +773,7 @@ class SaasHerder:  # pylint: disable=too-many-public-methods
                 if not self.gitlab:
                     raise Exception("gitlab is not initialized")
                 project = self.gitlab.get_project(url)
-                f = project.files.get(file_path=path.lstrip("/"), ref=commit_sha)
+                f = self.gitlab.get_file(path=path, ref=commit_sha, project=project)
                 content = f.decode()
             case _:
                 raise Exception(f"Only GitHub and GitLab are supported: {url}")

--- a/reconcile/utils/saasherder/saasherder.py
+++ b/reconcile/utils/saasherder/saasherder.py
@@ -759,18 +759,14 @@ class SaasHerder:  # pylint: disable=too-many-public-methods
                 if not self.gitlab:
                     raise Exception("gitlab is not initialized")
                 project = self.gitlab.get_project(url)
-                content = self.gitlab.get_file(
+                content = self.gitlab.get_raw_file(
+                    project=project,
                     path=path,
                     ref=commit_sha,
-                    project=project,
                 )
             case _:
                 raise Exception(f"Only GitHub and GitLab are supported: {url}")
 
-        if content is None:
-            raise Exception(
-                f"File {path} not found in {url} at ref {ref} (sha: {commit_sha})"
-            )
         return yaml.safe_load(content), commit_sha
 
     @retry()

--- a/reconcile/utils/vcs.py
+++ b/reconcile/utils/vcs.py
@@ -266,11 +266,12 @@ class VCS:
                 if not file_path.startswith("data")
                 else file_path
             )
-        return (
-            self._app_interface_api.project.files.get(file_path=file_path, ref=ref)
-            .decode()
-            .decode("utf-8")
-        )
+        file = self._app_interface_api.get_file(path=file_path, ref=ref)
+        if file is None:
+            raise ValueError(
+                f"File {file_path} not found in {ref} branch of app-interface."
+            )
+        return file.decode("utf-8")
 
     def get_open_app_interface_merge_requests(self) -> list[ProjectMergeRequest]:
         return self._app_interface_api.get_merge_requests(state=MRState.OPENED)

--- a/reconcile/utils/vcs.py
+++ b/reconcile/utils/vcs.py
@@ -266,11 +266,11 @@ class VCS:
                 if not file_path.startswith("data")
                 else file_path
             )
-        file = self._app_interface_api.get_file(path=file_path, ref=ref)
-        if file is None:
-            raise ValueError(
-                f"File {file_path} not found in {ref} branch of app-interface."
-            )
+        file = self._app_interface_api.get_raw_file(
+            project=self._app_interface_api.project,
+            path=file_path,
+            ref=ref,
+        )
         return file.decode("utf-8")
 
     def get_open_app_interface_merge_requests(self) -> list[ProjectMergeRequest]:


### PR DESCRIPTION
Use [raw file api](https://docs.gitlab.com/api/repository_files/#get-raw-file-from-repository) download single file. No major performance differences, only reduced response size and no need to do another base64 decode anymore. Also refactored GitHub api to use the same method to get file.

[APPSRE-12038](https://issues.redhat.com/browse/APPSRE-12038)

### Enhancements to GitHub and GitLab APIs:
* Added a `get_raw_file` method in `GithubRepositoryApi` to handle file retrieval, including support for large files and directory checks. This method replaces direct calls to `get_contents` and improves error handling. (`reconcile/utils/github_api.py`) [[1]](diffhunk://#diff-ab174d601846566383961ef80e2598ffcddfd0b0d081b6408afee089dc13535dR1-R18) [[2]](diffhunk://#diff-ab174d601846566383961ef80e2598ffcddfd0b0d081b6408afee089dc13535dR77-L78)
* Introduced a `get_raw_file` static method in `GitLabApi` for retrieving raw file content, replacing the previous `project.files.get` calls. Simplified the `get_file` method to use `get_raw_file`. (`reconcile/utils/gitlab_api.py`)

### Updates to Test Cases:
* Refactored GitHub-related tests to use the new `get_raw_file` method, enhancing clarity and consistency. Added new test cases for handling large files and directories. (`reconcile/test/utils/test_github_api.py`)
* Updated GitLab-related tests to use the new `get_raw_file` method. Added test cases for scenarios like file not found and retrieving raw file content. (`reconcile/test/utils/test_gitlab_api.py`) [[1]](diffhunk://#diff-0b89eef785c5d5eafddc4849caf0ebfd6e028bbe73d43cd6abe234f4cd95f1eeR9) [[2]](diffhunk://#diff-0b89eef785c5d5eafddc4849caf0ebfd6e028bbe73d43cd6abe234f4cd95f1eeR714-R766)
* Modified tests in `test_mr_clusters_updates.py` and `test_vcs.py` to align with the new `get_raw_file` method, ensuring compatibility with the updated APIs. (`reconcile/test/utils/test_mr_clusters_updates.py`, `reconcile/test/utils/vcs/test_vcs.py`) [[1]](diffhunk://#diff-c5134aafc67f4bfe1f88530f3f52a9ca0fd58030b174290ac2e70b20a1af17b0L4-R12) [[2]](diffhunk://#diff-aff8cbf2a40d93f2467801d32d8a74defed67d3f28e1215f72930bc2b5562649L120-R122)

### Code Cleanup:
* Removed the unused `ProjectFile` import from `gitlab_api.py` and deprecated parameters like `path` and `project` in the `get_repository_tree` method. (`reconcile/utils/gitlab_api.py`) [[1]](diffhunk://#diff-1d5ab1abb6ecb1d8c243a9e8c04d4cf6505e6be2c8932df654ea9a11c6c1b64bL44) [[2]](diffhunk://#diff-1d5ab1abb6ecb1d8c243a9e8c04d4cf6505e6be2c8932df654ea9a11c6c1b64bL669-R717)
* Updated `lookup_github_file_content` in `jinja2/utils.py` to use the new `get_raw_file` method, replacing the older `get_contents` logic. (`reconcile/utils/jinja2/utils.py`)
