### PR TITLE
feat(gitlab): respect squash option on merge

### DIFF
--- a/reconcile/gitlab_housekeeping.py
+++ b/reconcile/gitlab_housekeeping.py
@@ -72,6 +72,7 @@ HOLD_LABELS = [
 QONTRACT_INTEGRATION = "gitlab-housekeeping"
 DATE_FORMAT = "%Y-%m-%dT%H:%M:%S.%fZ"
 EXPIRATION_DATE_FORMAT = "%Y-%m-%d"
+SQUASH_OPTION_ALWAYS = "always"
 
 merged_merge_requests = Counter(
     name="qontract_reconcile_merged_merge_requests",
@@ -613,7 +614,8 @@ def merge_merge_requests(
         logging.info(["merge", gl.project.name, mr.iid])
         if not dry_run and merges < merge_limit:
             try:
-                mr.merge()
+                squash = (gl.project.squash_option == SQUASH_OPTION_ALWAYS) or mr.squash
+                mr.merge(squash=squash)
                 labels = mr.labels
                 merged_merge_requests.labels(
                     project_id=mr.target_project_id,


### PR DESCRIPTION
When merge gitlab merge request, if project `squash_option` is `always` (Required) [doc](https://docs.gitlab.com/api/projects/#get-a-single-project), then merge will fail if not include `squash` in request. [doc](https://docs.gitlab.com/api/merge_requests/#merge-a-merge-request).

This change set `squash` based on project's `squash_option` and merge request's `squash`.

[APPSRE-12074](https://issues.redhat.com/browse/APPSRE-12074)