### PR TITLE
feat(change-log-tracking): support squash merge request

### DIFF
--- a/reconcile/test/change_owners/test_change_log_tracking.py
+++ b/reconcile/test/change_owners/test_change_log_tracking.py
@@ -19,7 +19,6 @@ from reconcile.gql_definitions.change_owners.queries.change_types import (
     ChangeTypesQueryData,
 )
 from reconcile.gql_definitions.common.apps import AppV1
-from reconcile.utils.gitlab_api import MRState
 from reconcile.utils.gql import GqlApi
 
 APP_PATH = "/services/a/app.yml"
@@ -69,15 +68,11 @@ def setup_mocks(
     project = create_autospec(Project)
     project.default_branch = "master"
     project.commits = create_autospec(ProjectCommitManager)
-    commit = create_autospec(ProjectCommit)
-    commit.merge_requests.return_value = [
-        {
-            "merged_at": MERGED_AT,
-            "state": MRState.MERGED,
-            "target_branch": "master",
-        }
-    ]
-    commit.message = f"a\nb\n{DESCRIPTION}"
+    commit = create_autospec(
+        ProjectCommit,
+        committed_date=MERGED_AT,
+        message=f"Merge branch 'dev' into 'master'\n\n{DESCRIPTION}\n",
+    )
     project.commits.get.return_value = commit
     mocked_gl.project = project
 

--- a/reconcile/test/change_owners/test_change_log_tracking.py
+++ b/reconcile/test/change_owners/test_change_log_tracking.py
@@ -2,6 +2,7 @@ from collections.abc import Callable
 from typing import Any
 from unittest.mock import create_autospec
 
+import pytest
 from gitlab.v4.objects import (
     Project,
     ProjectCommit,
@@ -23,7 +24,6 @@ from reconcile.utils.gql import GqlApi
 
 APP_PATH = "/services/a/app.yml"
 MERGED_AT = "2024-01-01T00:00:00Z"
-DESCRIPTION = "c"
 COMMIT_SHA = "commit_sha"
 
 
@@ -33,6 +33,7 @@ def setup_mocks(
     gql_class_factory: Callable[..., ChangeTypesQueryData],
     apps: list[AppV1],
     datafiles: dict[str, Any],
+    commit_message: str,
 ) -> dict[str, Any]:
     data = gql_class_factory(ChangeTypesQueryData, {})
     mocked_gql_api = gql_api_builder(data.dict(by_alias=True))
@@ -71,7 +72,7 @@ def setup_mocks(
     commit = create_autospec(
         ProjectCommit,
         committed_date=MERGED_AT,
-        message=f"Merge branch 'dev' into 'master'\n\n{DESCRIPTION}\n",
+        message=commit_message,
     )
     project.commits.get.return_value = commit
     mocked_gl.project = project
@@ -82,10 +83,20 @@ def setup_mocks(
     }
 
 
+@pytest.mark.parametrize(
+    ["commit_message", "expected_description"],
+    [
+        ("Merge branch 'dev' into 'master'\n\nmy title", "my title"),
+        ("my title (!123)\n\nother messages", "my title (!123)"),
+        ("my title", "my title"),
+    ],
+)
 def test_change_log_tracking_with_deleted_app(
     mocker: MockerFixture,
     gql_api_builder: Callable[..., GqlApi],
     gql_class_factory: Callable[..., ChangeTypesQueryData],
+    commit_message: str,
+    expected_description: str,
 ) -> None:
     mocks = setup_mocks(
         mocker,
@@ -104,6 +115,7 @@ def test_change_log_tracking_with_deleted_app(
                 },
             }
         },
+        commit_message=commit_message,
     )
     expected_change_log = ChangeLog(
         items=[
@@ -111,7 +123,7 @@ def test_change_log_tracking_with_deleted_app(
                 apps=[APP_PATH],
                 change_types=[],
                 commit=COMMIT_SHA,
-                description=DESCRIPTION,
+                description=expected_description,
                 error=False,
                 merged_at=MERGED_AT,
             ),


### PR DESCRIPTION
Support extract description from squashed merge request commit, use the same way to skip [default template for merge commits](https://gitlab.cee.redhat.com/help/user/project/merge_requests/commit_templates#default-template-for-merge-commits), pick the first meaningful line.

Also use commit's `committed_date` as merge/squash commit is created when merge request merge, so can be used as merged timestamp, save one request to gitlab per merge.

[APPSRE-12074](https://issues.redhat.com/browse/APPSRE-12074)