### PR TITLE
increase terraform plan max_attempts

### DIFF
--- a/reconcile/utils/terraform_client.py
+++ b/reconcile/utils/terraform_client.py
@@ -222,7 +222,7 @@ class TerraformClient:  # pylint: disable=too-many-public-methods
         if disable_deletions_detected:
             raise RuntimeError("Terraform plan has disabled deletions detected")
 
-    @retry(no_retry_exceptions=RdsUpgradeValidationError)
+    @retry(max_attempts=10, no_retry_exceptions=RdsUpgradeValidationError)
     def terraform_plan(
         self, spec: TerraformSpec, enable_deletion: bool
     ) -> tuple[bool, list[AccountUser], bool]:


### PR DESCRIPTION
try to fix `Failed to run integration shard quayio-prod: An error occurred (Throttling) when calling the DescribeLoadBalancers operation (reached max retries: 4): Rate exceeded`
