### PR TITLE
Revert "increase terraform plan max_attempts"

### DIFF
--- a/reconcile/utils/terraform_client.py
+++ b/reconcile/utils/terraform_client.py
@@ -222,7 +222,7 @@ class TerraformClient:  # pylint: disable=too-many-public-methods
         if disable_deletions_detected:
             raise RuntimeError("Terraform plan has disabled deletions detected")
 
-    @retry(max_attempts=10, no_retry_exceptions=RdsUpgradeValidationError)
+    @retry(no_retry_exceptions=RdsUpgradeValidationError)
     def terraform_plan(
         self, spec: TerraformSpec, enable_deletion: bool
     ) -> tuple[bool, list[AccountUser], bool]:


### PR DESCRIPTION
Reverts app-sre/qontract-reconcile#5009

rate limit is not during terraform plan step, it's during setup.

Track in [APPSRE-12114](https://issues.redhat.com/browse/APPSRE-12114)