### PR TITLE
:recycle: migrate jiraComponent -> jiraComponents

### DIFF
--- a/reconcile/glitchtip_project_alerts/integration.py
+++ b/reconcile/glitchtip_project_alerts/integration.py
@@ -160,9 +160,7 @@ class GlitchtipProjectAlertsIntegration(
                             continue
                         params = {
                             "labels": alert_labels + (channels.jira_labels or []),
-                            "components": [channels.jira_component]
-                            if channels.jira_component
-                            else [],
+                            "components": channels.jira_components or [],
                         } | token_params
                         if board.issue_type:
                             params["issue_type"] = board.issue_type

--- a/reconcile/gql_definitions/glitchtip_project_alerts/glitchtip_project.gql
+++ b/reconcile/gql_definitions/glitchtip_project_alerts/glitchtip_project.gql
@@ -40,7 +40,7 @@ query GlitchtipProjectsWithAlerts {
               integrations
             }
           }
-          jiraComponent
+          jiraComponents
           jiraLabels
         }
       }

--- a/reconcile/gql_definitions/glitchtip_project_alerts/glitchtip_project.py
+++ b/reconcile/gql_definitions/glitchtip_project_alerts/glitchtip_project.py
@@ -68,7 +68,7 @@ query GlitchtipProjectsWithAlerts {
               integrations
             }
           }
-          jiraComponent
+          jiraComponents
           jiraLabels
         }
       }
@@ -127,7 +127,7 @@ class JiraBoardV1(ConfiguredBaseModel):
 
 class AppEscalationPolicyChannelsV1(ConfiguredBaseModel):
     jira_board: list[JiraBoardV1] = Field(..., alias="jiraBoard")
-    jira_component: Optional[str] = Field(..., alias="jiraComponent")
+    jira_components: Optional[list[str]] = Field(..., alias="jiraComponents")
     jira_labels: Optional[list[str]] = Field(..., alias="jiraLabels")
 
 

--- a/reconcile/gql_definitions/introspection.json
+++ b/reconcile/gql_definitions/introspection.json
@@ -18360,13 +18360,21 @@
                             "deprecationReason": null
                         },
                         {
-                            "name": "jiraComponent",
+                            "name": "jiraComponents",
                             "description": null,
                             "args": [],
                             "type": {
-                                "kind": "SCALAR",
-                                "name": "String",
-                                "ofType": null
+                                "kind": "LIST",
+                                "name": null,
+                                "ofType": {
+                                    "kind": "NON_NULL",
+                                    "name": null,
+                                    "ofType": {
+                                        "kind": "SCALAR",
+                                        "name": "String",
+                                        "ofType": null
+                                    }
+                                }
                             },
                             "isDeprecated": false,
                             "deprecationReason": null

--- a/reconcile/gql_definitions/jira_permissions_validator/jira_boards_for_permissions_validator.gql
+++ b/reconcile/gql_definitions/jira_permissions_validator/jira_boards_for_permissions_validator.gql
@@ -26,7 +26,7 @@ query JiraBoardsForPermissionValidation {
     escalationPolicies {
       name
       channels {
-        jiraComponent
+        jiraComponents
       }
     }
     disable {

--- a/reconcile/gql_definitions/jira_permissions_validator/jira_boards_for_permissions_validator.py
+++ b/reconcile/gql_definitions/jira_permissions_validator/jira_boards_for_permissions_validator.py
@@ -54,7 +54,7 @@ query JiraBoardsForPermissionValidation {
     escalationPolicies {
       name
       channels {
-        jiraComponent
+        jiraComponents
       }
     }
     disable {
@@ -91,7 +91,7 @@ class JiraSeverityPriorityMappingsV1(ConfiguredBaseModel):
 
 
 class AppEscalationPolicyChannelsV1(ConfiguredBaseModel):
-    jira_component: Optional[str] = Field(..., alias="jiraComponent")
+    jira_components: Optional[list[str]] = Field(..., alias="jiraComponents")
 
 
 class AppEscalationPolicyV1(ConfiguredBaseModel):

--- a/reconcile/jira_permissions_validator.py
+++ b/reconcile/jira_permissions_validator.py
@@ -105,13 +105,13 @@ def board_is_valid(
 
         components = jira.components()
         for escalation_policy in board.escalation_policies or []:
-            jira_component = escalation_policy.channels.jira_component
-            if jira_component and jira_component not in components:
-                logging.error(
-                    f"[{board.name}] escalation policy '{escalation_policy.name}' references a non existing Jira component "
-                    f"'{jira_component}'. Valid components: {components}"
-                )
-                error |= ValidationError.INVALID_COMPONENT
+            for jira_component in escalation_policy.channels.jira_components or []:
+                if jira_component not in components:
+                    logging.error(
+                        f"[{board.name}] escalation policy '{escalation_policy.name}' references a non existing Jira component "
+                        f"'{jira_component}'. Valid components: {components}"
+                    )
+                    error |= ValidationError.INVALID_COMPONENT
 
         issue_type = board.issue_type or default_issue_type
         project_issue_type = jira.get_issue_type(issue_type)

--- a/reconcile/test/fixtures/glitchtip/project_alerts.yml
+++ b/reconcile/test/fixtures/glitchtip/project_alerts.yml
@@ -54,7 +54,8 @@ glitchtip_projects:
         - name: JIRA-VIA-BOARD
           disable: null
           issueType: CustomIssueType
-        jiraComponent: jira-component
+        jiraComponents:
+        - jira-component
         jiraLabels:
         - escalation-label-1
         - escalation-label-2
@@ -103,7 +104,7 @@ glitchtip_projects:
             integrations:
             - glitchtip-project-alerts
           issueType: null
-        jiraComponent: null
+        jiraComponents: null
         jiraLabels: null
     labels: null
   alerts: null
@@ -125,7 +126,7 @@ glitchtip_projects:
             integrations:
             - jira-permissions-validator
           issueType: null
-        jiraComponent: null
+        jiraComponents: null
         jiraLabels: null
     labels: null
   alerts: null

--- a/reconcile/test/fixtures/jira_permissions_validator/boards.yml
+++ b/reconcile/test/fixtures/jira_permissions_validator/boards.yml
@@ -17,6 +17,14 @@ jira_boards:
     - priority: Minor
     - priority: Major
     - priority: Critical
+  escalationPolicies:
+  - name: escalation-1
+    channels:
+      jiraComponents: null
+  - name: escalation-2
+    channels:
+      jiraComponents: null
+
 - name: jira-board-custom
   server:
     serverUrl: 'https://jira-server.com'
@@ -36,6 +44,16 @@ jira_boards:
     - priority: Major
     - priority: Major
     - priority: Critical
+  escalationPolicies:
+  - name: escalation-1
+    channels:
+      jiraComponents:
+      - component-1
+      - component-2
+  - name: escalation-2
+    channels:
+      jiraComponents: null
+
 - name: disabled
   server:
     serverUrl: 'https://jira-server.com'

--- a/reconcile/test/glitchtip/test_glitchtip_project_alerts.py
+++ b/reconcile/test/glitchtip/test_glitchtip_project_alerts.py
@@ -205,7 +205,7 @@ def test_glitchtip_project_alerts_get_projects(
                                 disable=None,
                             )
                         ],
-                        jiraComponent="jira-component",
+                        jiraComponents=["jira-component"],
                         jiraLabels=["escalation-label-1", "escalation-label-2"],
                     )
                 ),
@@ -247,7 +247,7 @@ def test_glitchtip_project_alerts_get_projects(
                                 ),
                             )
                         ],
-                        jiraComponent=None,
+                        jiraComponents=None,
                         jiraLabels=None,
                     )
                 ),
@@ -275,7 +275,7 @@ def test_glitchtip_project_alerts_get_projects(
                                 ),
                             )
                         ],
-                        jiraComponent=None,
+                        jiraComponents=None,
                         jiraLabels=None,
                     )
                 ),


### PR DESCRIPTION
Convert `jiraComponent` to a list of Jira components `jiraComponents`

Depends on https://github.com/app-sre/qontract-schemas/pull/835
Ticket: [APPSRE-12116](https://issues.redhat.com/browse/APPSRE-12116)