### PR TITLE
Update `openshift-rhcs-certs` output secrets 

### DIFF
--- a/reconcile/gql_definitions/common/rhcs_provider_settings.gql
+++ b/reconcile/gql_definitions/common/rhcs_provider_settings.gql
@@ -3,8 +3,9 @@
 query RhcsProviderSettings {
   settings: app_interface_settings_v1 {
     rhcsProvider {
-      url
+      issuerUrl
       vaultBasePath
+      caCertUrl
     }
   }
 }

--- a/reconcile/gql_definitions/common/rhcs_provider_settings.py
+++ b/reconcile/gql_definitions/common/rhcs_provider_settings.py
@@ -22,8 +22,9 @@ DEFINITION = """
 query RhcsProviderSettings {
   settings: app_interface_settings_v1 {
     rhcsProvider {
-      url
+      issuerUrl
       vaultBasePath
+      caCertUrl
     }
   }
 }
@@ -37,8 +38,9 @@ class ConfiguredBaseModel(BaseModel):
 
 
 class RhcsProviderSettingsV1(ConfiguredBaseModel):
-    url: str = Field(..., alias="url")
+    issuer_url: str = Field(..., alias="issuerUrl")
     vault_base_path: str = Field(..., alias="vaultBasePath")
+    ca_cert_url: str = Field(..., alias="caCertUrl")
 
 
 class AppInterfaceSettingsV1(ConfiguredBaseModel):

--- a/reconcile/gql_definitions/introspection.json
+++ b/reconcile/gql_definitions/introspection.json
@@ -26581,7 +26581,7 @@
                     "description": null,
                     "fields": [
                         {
-                            "name": "url",
+                            "name": "issuerUrl",
                             "description": null,
                             "args": [],
                             "type": {
@@ -26598,6 +26598,22 @@
                         },
                         {
                             "name": "vaultBasePath",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "NON_NULL",
+                                "name": null,
+                                "ofType": {
+                                    "kind": "SCALAR",
+                                    "name": "String",
+                                    "ofType": null
+                                }
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "caCertUrl",
                             "description": null,
                             "args": [],
                             "type": {


### PR DESCRIPTION
## Summary

Update to create `kubernetes.io/tls`-compliant secrets and include `ca.crt` attribute. 

## Dependencies
https://github.com/app-sre/qontract-schemas/pull/837