### PR TITLE
add a label check in fetch_current_state to not add argocd managed resources to the inventory

### DIFF
--- a/reconcile/openshift_resources_base.py
+++ b/reconcile/openshift_resources_base.py
@@ -667,6 +667,15 @@ def fetch_current_state(
         openshift_resource = OR(
             item, QONTRACT_INTEGRATION, QONTRACT_INTEGRATION_VERSION
         )
+        labels = openshift_resource.body.get("metadata", {}).get("labels", {})
+        # Skip resources managed by ArgoCD
+        # This uses the Kubernetes recommended label 'app.kubernetes.io/part-of=argocd'
+        # https://argo-cd.readthedocs.io/en/stable/user-guide/resource_tracking/
+        if labels.get("app.kubernetes.io/part-of") == "argocd":
+            _locked_info_log(
+                f"Skipping {openshift_resource.kind} {openshift_resource.name} in current state because it is managed by ArgoCD"
+            )
+            continue
         ri.add_current(
             cluster,
             namespace,

--- a/reconcile/openshift_resources_base.py
+++ b/reconcile/openshift_resources_base.py
@@ -707,12 +707,6 @@ def fetch_desired_state(
         msg = f"[{cluster}/{namespace}] {e!s}"
         _locked_error_log(msg)
         return
-
-    labels = openshift_resource.body.get("metadata", {}).get("labels", {})
-    if labels.get("app.kubernetes.io/part-of") == "argocd":
-        _locked_info_log(f"Skipping {openshift_resource.kind} {openshift_resource.name} because it is managed by ArgoCD")
-        return
-
     # add to inventory
     try:
         ri.add_desired_resource(

--- a/reconcile/openshift_resources_base.py
+++ b/reconcile/openshift_resources_base.py
@@ -699,6 +699,11 @@ def fetch_desired_state(
         _locked_error_log(msg)
         return
 
+    labels = openshift_resource.body.get("metadata", {}).get("labels", {})
+    if labels.get("app.kubernetes.io/part-of") == "argocd":
+        _locked_info_log(f"Skipping {openshift_resource.kind} {openshift_resource.name} because it is managed by ArgoCD")
+        return
+
     # add to inventory
     try:
         ri.add_desired_resource(


### PR DESCRIPTION
https://issues.redhat.com/browse/APPSRE-12138

Add a change to the `fetch_current_state` function in `reconcile/openshift_resources_base.py` to skip processing resources managed by ArgoCD. This ensures that such resources are not modified unintentionally.

Key change:
Added a check for the `app.kubernetes.io/part-of` label in the resource's metadata. If the label's value is "argocd", the resource is skipped with an informational log message.