### PR TITLE
APPSRE-11020 konflux build

### DIFF
--- a/.tekton/qontract-reconcile-master-pull-request.yaml
+++ b/.tekton/qontract-reconcile-master-pull-request.yaml
@@ -1,0 +1,61 @@
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+metadata:
+  annotations:
+    build.appstudio.openshift.io/repo: https://github.com/app-sre/qontract-reconcile?rev={{revision}}
+    build.appstudio.redhat.com/commit_sha: '{{revision}}'
+    build.appstudio.redhat.com/pull_request_number: '{{pull_request_number}}'
+    build.appstudio.redhat.com/target_branch: '{{target_branch}}'
+    pipelinesascode.tekton.dev/max-keep-runs: "3"
+    pipelinesascode.tekton.dev/on-cel-expression: (event == "pull_request" && target_branch
+      == "master") || (event == "push" && target_branch.startsWith("gh-readonly-queue/master/"))
+  creationTimestamp: null
+  labels:
+    appstudio.openshift.io/application: qontract-reconcile-master
+    appstudio.openshift.io/component: qontract-reconcile-master
+    pipelines.appstudio.openshift.io/type: build
+  name: qontract-reconcile-master-on-pull-request
+  namespace: app-sre-tenant
+spec:
+  params:
+  - name: git-url
+    value: '{{source_url}}'
+  - name: revision
+    value: '{{revision}}'
+  - name: output-image
+    value: quay.io/redhat-user-workloads/app-sre-tenant/qontract-reconcile-master/qontract-reconcile-master:on-pr-{{revision}}
+  - name: image-expires-after
+    value: 5d
+  - name: dockerfile
+    value: dockerfiles/Dockerfile
+  - name: path-context
+    value: .
+  - name: target-stage
+    value: prod-image
+  pipelineRef:
+    params:
+    - name: url
+      value: https://github.com/app-sre/shared-pipelines
+    - name: revision
+      value: main
+    - name: pathInRepo
+      value: pipelines/multi-arch-build-pipeline.yaml
+    resolver: git
+  taskRunTemplate:
+    serviceAccountName: build-pipeline-qontract-reconcile-master
+  workspaces:
+  - name: workspace
+    volumeClaimTemplate:
+      metadata:
+        creationTimestamp: null
+      spec:
+        accessModes:
+        - ReadWriteOnce
+        resources:
+          requests:
+            storage: 1Gi
+      status: {}
+  - name: git-auth
+    secret:
+      secretName: '{{ git_auth_secret }}'
+status: {}

--- a/.tekton/qontract-reconcile-master-push.yaml
+++ b/.tekton/qontract-reconcile-master-push.yaml
@@ -1,0 +1,58 @@
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+metadata:
+  annotations:
+    build.appstudio.openshift.io/repo: https://github.com/app-sre/qontract-reconcile?rev={{revision}}
+    build.appstudio.redhat.com/commit_sha: '{{revision}}'
+    build.appstudio.redhat.com/target_branch: '{{target_branch}}'
+    pipelinesascode.tekton.dev/max-keep-runs: "3"
+    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
+      == "master"
+  creationTimestamp: null
+  labels:
+    appstudio.openshift.io/application: qontract-reconcile-master
+    appstudio.openshift.io/component: qontract-reconcile-master
+    pipelines.appstudio.openshift.io/type: build
+  name: qontract-reconcile-master-on-push
+  namespace: app-sre-tenant
+spec:
+  params:
+  - name: git-url
+    value: '{{source_url}}'
+  - name: revision
+    value: '{{revision}}'
+  - name: output-image
+    value: quay.io/redhat-user-workloads/app-sre-tenant/qontract-reconcile-master/qontract-reconcile-master:{{revision}}
+  - name: dockerfile
+    value: dockerfiles/Dockerfile
+  - name: path-context
+    value: .
+  - name: target-stage
+    value: prod-image
+  pipelineRef:
+    params:
+    - name: url
+      value: https://github.com/app-sre/shared-pipelines
+    - name: revision
+      value: main
+    - name: pathInRepo
+      value: pipelines/multi-arch-build-pipeline.yaml
+    resolver: git
+  taskRunTemplate:
+    serviceAccountName: build-pipeline-qontract-reconcile-master
+  workspaces:
+  - name: workspace
+    volumeClaimTemplate:
+      metadata:
+        creationTimestamp: null
+      spec:
+        accessModes:
+        - ReadWriteOnce
+        resources:
+          requests:
+            storage: 1Gi
+      status: {}
+  - name: git-auth
+    secret:
+      secretName: '{{ git_auth_secret }}'
+status: {}


### PR DESCRIPTION
Note, that this is just the initial stage. We do not run the structure test - this will be tackled in a follow-up.

For now, we just want to build qr prod image besides our ci.ext pipeline.