### PR TITLE
[openshift-rhcs-certs] - utilize VaultClient singleton to address memory leak

### DIFF
--- a/reconcile/test/test_openshift_rhcs_certs.py
+++ b/reconcile/test/test_openshift_rhcs_certs.py
@@ -123,7 +123,7 @@ def test_openshift_rhcs_certs__fetch_desired_state_new_certs(
     ri: ResourceInventory,
     query_func: Callable,
 ) -> None:
-    mock_vault = mocker.patch("reconcile.openshift_rhcs_certs._VaultClient")
+    mock_vault = mocker.patch("reconcile.openshift_rhcs_certs.VaultClient")
     vault_instance = mock_vault.return_value
     vault_instance.read_all.side_effect = SecretNotFound("not found")
     vault_instance.read.return_value = "FAKE_SA_PASSWORD"
@@ -170,7 +170,7 @@ def test_openshift_rhcs_certs__fetch_desired_state_new_certs_dry_run(
     ri: ResourceInventory,
     query_func: Callable,
 ) -> None:
-    mock_vault = mocker.patch("reconcile.openshift_rhcs_certs._VaultClient")
+    mock_vault = mocker.patch("reconcile.openshift_rhcs_certs.VaultClient")
     vault_instance = mock_vault.return_value
     vault_instance.read_all.side_effect = SecretNotFound("not found")
     vault_instance.read.return_value = "FAKE_SA_PASSWORD"
@@ -201,7 +201,7 @@ def test_openshift_rhcs_certs__fetch_desired_state_existing_certs(
     ri: ResourceInventory,
     query_func: Callable,
 ) -> None:
-    mock_vault = mocker.patch("reconcile.openshift_rhcs_certs._VaultClient")
+    mock_vault = mocker.patch("reconcile.openshift_rhcs_certs.VaultClient")
     vault_instance = mock_vault.return_value
     vault_instance.read.return_value = "FAKE_SA_PASSWORD"
     vault_instance.write.return_value = None
@@ -261,7 +261,7 @@ def test_openshift_rhcs_certs__fetch_desired_state_expired_cert(
         "expiration_timestamp": str(int(time.time()) + 86400 * 120),  # 120 days
     }
 
-    mock_vault = mocker.patch("reconcile.openshift_rhcs_certs._VaultClient")
+    mock_vault = mocker.patch("reconcile.openshift_rhcs_certs.VaultClient")
     vault_instance = mock_vault.return_value
 
     # Simulate returning [expiring_cert, valid_cert] for cert-1 and cert-2 respectively


### PR DESCRIPTION
Utilize `VaultClient`, which is a singleton. This addresses memory leak caused by continuously growing open sessions