### PR TITLE
feat: Add target_ref to saas deploy trigger

### DIFF
--- a/reconcile/openshift_saas_deploy_trigger_base.py
+++ b/reconcile/openshift_saas_deploy_trigger_base.py
@@ -38,7 +38,7 @@ from reconcile.utils.saasherder import (
     TriggerSpecUnion,
 )
 from reconcile.utils.saasherder.interfaces import SaasPipelinesProviderTekton
-from reconcile.utils.saasherder.models import TriggerTypes
+from reconcile.utils.saasherder.models import TriggerSpecConfig, TriggerTypes
 from reconcile.utils.secret_reader import create_secret_reader
 from reconcile.utils.sharding import is_in_shard
 from reconcile.utils.state import init_state
@@ -267,6 +267,10 @@ def _trigger_tekton(
         )
         return False
 
+    target_ref = None
+    if isinstance(spec, TriggerSpecConfig):
+        target_ref = spec.target_ref
+
     tkn_trigger_resource, tkn_name = _construct_tekton_trigger_resource(
         spec.saas_file_name,
         spec.env_name,
@@ -278,7 +282,7 @@ def _trigger_tekton(
         integration_version,
         saasherder.include_trigger_trace,
         spec.reason,
-        spec.target_ref,
+        target_ref,
     )
 
     error = False
@@ -335,7 +339,7 @@ def _construct_tekton_trigger_resource(
     integration_version: str,
     include_trigger_trace: bool,
     reason: str | None,
-    target_ref: str | Any,
+    target_ref: str | None,
 ) -> tuple[OR, str]:
     """Construct a resource (PipelineRun) to trigger a deployment via Tekton.
 

--- a/reconcile/openshift_saas_deploy_trigger_base.py
+++ b/reconcile/openshift_saas_deploy_trigger_base.py
@@ -335,7 +335,7 @@ def _construct_tekton_trigger_resource(
     integration_version: str,
     include_trigger_trace: bool,
     reason: str | None,
-    target_ref: str | any,
+    target_ref: str | Any,
 ) -> tuple[OR, str]:
     """Construct a resource (PipelineRun) to trigger a deployment via Tekton.
 

--- a/reconcile/openshift_saas_deploy_trigger_base.py
+++ b/reconcile/openshift_saas_deploy_trigger_base.py
@@ -278,6 +278,7 @@ def _trigger_tekton(
         integration_version,
         saasherder.include_trigger_trace,
         spec.reason,
+        spec.target_ref,
     )
 
     error = False
@@ -334,6 +335,7 @@ def _construct_tekton_trigger_resource(
     integration_version: str,
     include_trigger_trace: bool,
     reason: str | None,
+    target_ref: str | any,
 ) -> tuple[OR, str]:
     """Construct a resource (PipelineRun) to trigger a deployment via Tekton.
 
@@ -348,6 +350,7 @@ def _construct_tekton_trigger_resource(
         integration_version (string): Version of calling integration
         include_trigger_trace (bool): Should include traces of the triggering integration and reason
         reason (string): The reason this trigger was created
+        target_ref (string): the SHA ref of the target
 
     Returns:
         OpenshiftResource: OpenShift resource to be applied
@@ -385,6 +388,7 @@ def _construct_tekton_trigger_resource(
             "labels": {
                 "qontract.saas_file_name": saas_file_name,
                 "qontract.env_name": env_name,
+                "qontract.target_ref": target_ref or "",
             },
         },
         "spec": {


### PR DESCRIPTION
The `target_ref` is the SHA ref of the target and is added as a label to the PipelineRun resource.
We're using pod labels & annotations to build a dashboard for saas deploy logs and a tenant requested the abillity to query by targetted refs, see https://redhat-internal.slack.com/archives/CCRND57FW/p1750433539235259

