### PR TITLE
fix target ref in trigger reason

### DIFF
--- a/reconcile/openshift_saas_deploy_trigger_base.py
+++ b/reconcile/openshift_saas_deploy_trigger_base.py
@@ -38,7 +38,7 @@ from reconcile.utils.saasherder import (
     TriggerSpecUnion,
 )
 from reconcile.utils.saasherder.interfaces import SaasPipelinesProviderTekton
-from reconcile.utils.saasherder.models import TriggerSpecConfig, TriggerTypes
+from reconcile.utils.saasherder.models import TriggerTypes
 from reconcile.utils.secret_reader import create_secret_reader
 from reconcile.utils.sharding import is_in_shard
 from reconcile.utils.state import init_state
@@ -267,10 +267,6 @@ def _trigger_tekton(
         )
         return False
 
-    target_ref = None
-    if isinstance(spec, TriggerSpecConfig):
-        target_ref = spec.target_ref
-
     tkn_trigger_resource, tkn_name = _construct_tekton_trigger_resource(
         spec.saas_file_name,
         spec.env_name,
@@ -282,7 +278,7 @@ def _trigger_tekton(
         integration_version,
         saasherder.include_trigger_trace,
         spec.reason,
-        target_ref,
+        spec.state_content,
     )
 
     error = False


### PR DESCRIPTION
target_ref is showing as empty for job built from image updates. 

eg
```
 labels:
    qontract.env_name: osd-integration-hivei01ue1
    qontract.saas_file_name: saas-oeo
    qontract.target_ref: ''
    tekton.dev/pipeline: o-saas-deploy-saas-oeo
```

It might be fixed by using a flexible desired state param available , i.e. state_content