### PR TITLE
feat(saas): Include target ref in triggered PipelineRun labels

### DIFF
--- a/reconcile/openshift_saas_deploy_trigger_base.py
+++ b/reconcile/openshift_saas_deploy_trigger_base.py
@@ -278,6 +278,7 @@ def _trigger_tekton(
         integration_version,
         saasherder.include_trigger_trace,
         spec.reason,
+        spec.target_ref,
     )
 
     error = False
@@ -334,6 +335,7 @@ def _construct_tekton_trigger_resource(
     integration_version: str,
     include_trigger_trace: bool,
     reason: str | None,
+    target_ref: str,
 ) -> tuple[OR, str]:
     """Construct a resource (PipelineRun) to trigger a deployment via Tekton.
 
@@ -348,6 +350,7 @@ def _construct_tekton_trigger_resource(
         integration_version (string): Version of calling integration
         include_trigger_trace (bool): Should include traces of the triggering integration and reason
         reason (string): The reason this trigger was created
+        target_ref (string): the ref of the target, can be a branch or a commit hash.
 
     Returns:
         OpenshiftResource: OpenShift resource to be applied
@@ -385,6 +388,7 @@ def _construct_tekton_trigger_resource(
             "labels": {
                 "qontract.saas_file_name": saas_file_name,
                 "qontract.env_name": env_name,
+                "qontract.target_ref": target_ref,
             },
         },
         "spec": {

--- a/reconcile/test/test_saasherder.py
+++ b/reconcile/test/test_saasherder.py
@@ -40,6 +40,7 @@ from reconcile.utils.saasherder.interfaces import SaasFile as SaasFileInterface
 from reconcile.utils.saasherder.models import (
     Channel,
     Promotion,
+    TriggerSpecConfig,
     TriggerSpecContainerImage,
     TriggerSpecMovingCommit,
     TriggerSpecUpstreamJob,
@@ -496,6 +497,7 @@ class TestGetMovingCommitsDiffSaasFile(TestCase):
                 state_content="abcd4242",
                 ref="main",
                 reason=None,
+                target_ref="abcd4242",
             )
         ]
 
@@ -533,6 +535,7 @@ class TestGetMovingCommitsDiffSaasFile(TestCase):
                 state_content="abcd4242",
                 ref="main",
                 reason="https://github.com/app-sre/test-saas-deployments/commit/abcd4242",
+                target_ref="abcd4242",
             ),
         ]
         actual = saasherder.get_moving_commits_diff_saas_file(self.saas_file, True)
@@ -602,6 +605,7 @@ class TestGetUpstreamJobsDiffSaasFile(TestCase):
                 job_name="job",
                 state_content=state_content,
                 reason=None,
+                target_ref="abcd4242",
             )
         ]
 
@@ -646,6 +650,7 @@ class TestGetUpstreamJobsDiffSaasFile(TestCase):
                 job_name="job",
                 state_content=state_content,
                 reason="https://github.com/app-sre/test-saas-deployments/commit/abcd4242 via https://jenkins.com/job/job/2",
+                target_ref="abcd4242",
             )
         ]
 
@@ -719,6 +724,7 @@ class TestGetContainerImagesDiffSaasFile(TestCase):
                 images=["quay.io/centos/centos"],
                 state_content="abcd424",
                 reason="https://github.com/app-sre/test-saas-deployments/commit/abcd4242 build quay.io/centos/centos:abcd424",
+                target_ref="abcd4242",
             ),
             TriggerSpecContainerImage(
                 saas_file_name=self.saas_file.name,
@@ -731,6 +737,7 @@ class TestGetContainerImagesDiffSaasFile(TestCase):
                 images=["quay.io/centos/centos", "quay.io/fedora/fedora"],
                 state_content="abcd424",
                 reason="https://github.com/app-sre/test-saas-deployments/commit/abcd4242 build quay.io/centos/centos:abcd424, quay.io/fedora/fedora:abcd424",
+                target_ref="abcd4242",
             ),
         ])
 
@@ -761,6 +768,7 @@ class TestGetContainerImagesDiffSaasFile(TestCase):
             images=images,
             state_content="abcd424",
             reason=None,
+            target_ref="abcd4242",
         )
         b = TriggerSpecContainerImage(
             saas_file_name=self.saas_file.name,
@@ -773,6 +781,7 @@ class TestGetContainerImagesDiffSaasFile(TestCase):
             images=images[::-1],
             state_content="abcd424",
             reason=None,
+            target_ref="abcd4242",
         )
         expected_key = "test-saas-deployments-deploy/test-saas-deployments/appsres03ue1/test-image-trigger-v2/App-SRE-stage/quay.io/centos/centos/quay.io/fedora/fedora"
 
@@ -814,6 +823,7 @@ class TestGetContainerImagesDiffSaasFile(TestCase):
                 images=["quay.io/centos/centos"],
                 state_content="abcd424",
                 reason="https://github.com/app-sre/test-saas-deployments/commit/abcd4242 build quay.io/centos/centos:abcd424",
+                target_ref="abcd4242",
             ),
             TriggerSpecContainerImage(
                 saas_file_name=self.saas_file.name,
@@ -826,6 +836,7 @@ class TestGetContainerImagesDiffSaasFile(TestCase):
                 images=["quay.io/centos/centos", "quay.io/fedora/fedora"],
                 state_content="abcd424",
                 reason="https://github.com/app-sre/test-saas-deployments/commit/abcd4242 build quay.io/centos/centos:abcd424, quay.io/fedora/fedora:abcd424",
+                target_ref="abcd4242",
             ),
         ])
 
@@ -1503,7 +1514,67 @@ class TestConfigHashTrigger(TestCase):
             1
         ].promotion.promotion_data[0].data[0].target_config_hash = "Changed"
         trigger_specs = self.saasherder.get_configs_diff_saas_file(self.saas_file)
-        self.assertEqual(len(trigger_specs), 1)
+        expected_trigger_specs = [
+            TriggerSpecConfig(
+                saas_file_name=self.saas_file.name,
+                env_name="App-SRE",
+                timeout=None,
+                pipelines_provider=self.saas_file.pipelines_provider,
+                resource_template_name="test-saas-deployments",
+                cluster_name="appsres03ue1",
+                namespace_name="test-ns-subscriber",
+                state_content={
+                    "delete": None,
+                    "disable": None,
+                    "images": None,
+                    "name": None,
+                    "namespace": {
+                        "app": {"name": "test-saas-deployments"},
+                        "cluster": {
+                            "name": "appsres03ue1",
+                            "serverUrl": "https://api.appsres03ue1.5nvu.p1.openshiftapps.com:6443",
+                        },
+                        "name": "test-ns-subscriber",
+                    },
+                    "parameters": None,
+                    "path": "/openshift/deploy-template.yml",
+                    "promotion": {
+                        "auto": True,
+                        "promotion_data": [
+                            {
+                                "channel": "test-saas-deployments-deploy",
+                                "data": [
+                                    {
+                                        "parent_saas": "test-saas-deployments-deploy",
+                                        "target_config_hash": "Changed",
+                                        "type": "parent_saas_config",
+                                    }
+                                ],
+                            }
+                        ],
+                        "publish": None,
+                        "redeployOnPublisherConfigChange": None,
+                        "schedule": None,
+                        "soakDays": None,
+                        "subscribe": ["test-saas-deployments-deploy"],
+                    },
+                    "ref": "1234567890123456789012345678901234567890",
+                    "rt_parameters": '{"PARAM":"test"}',
+                    "saas_file_managed_resource_types": ["Job"],
+                    "saas_file_parameters": None,
+                    "secretParameters": None,
+                    "slos": None,
+                    "upstream": None,
+                    "url": "https://github.com/app-sre/test-saas-deployments",
+                },
+                reason=None,
+                target_ref="1234567890123456789012345678901234567890",
+                resource_template_url="https://github.com/app-sre/test-saas-deployments",
+                slos=None,
+                target_name=None,
+            )
+        ]
+        self.assertEqual(trigger_specs, expected_trigger_specs)
 
     def test_non_existent_config_triggers(self) -> None:
         self.state_mock.get.side_effect = [self.deploy_current_state_fxt, None]

--- a/reconcile/utils/saasherder/models.py
+++ b/reconcile/utils/saasherder/models.py
@@ -64,6 +64,7 @@ class TriggerSpecBase:
     namespace_name: str
     state_content: Any
     reason: str | None
+    target_ref: str
 
     @property
     def state_key(self) -> str:
@@ -80,7 +81,6 @@ class SLOKey:
 @dataclass(frozen=True)
 class TriggerSpecConfig(TriggerSpecBase):
     resource_template_url: str
-    target_ref: str
     slos: list[SLODocument] | None = None
     target_name: str | None = None
 

--- a/reconcile/utils/saasherder/saasherder.py
+++ b/reconcile/utils/saasherder/saasherder.py
@@ -1475,6 +1475,7 @@ class SaasHerder:  # pylint: disable=too-many-public-methods
                             url=rt.url,
                             desired_commit_sha=desired_commit_sha,
                         ),
+                        target_ref=desired_commit_sha,
                     )
 
                     if not self.state:
@@ -1582,6 +1583,7 @@ class SaasHerder:  # pylint: disable=too-many-public-methods
                         job_name=job_name,
                         url=rt.url,
                     ),
+                    target_ref=last_build_result.get("commit_sha") or target.ref,
                 )
                 if not self.state:
                     raise Exception("state is not initialized")
@@ -1705,6 +1707,7 @@ class SaasHerder:  # pylint: disable=too-many-public-methods
                             url=rt.url,
                             commit_sha=commit_sha,
                         ),
+                        target_ref=commit_sha,
                     )
                     if not self.state:
                         raise Exception("state is not initialized")


### PR DESCRIPTION
Include `target_ref` in triggered PipelineRun, covers all 4 different triggers:

* `CONFIGS`: `ref` from `saas` file
* `MOVING_COMMITS`: commit sha
* `UPSTREAM_JOBS`: `commit_sha` from jenkins build result, use `ref` from `saas` file if not found in build result
* `CONTAINER_IMAGES`: commit sha

Redo https://github.com/app-sre/qontract-reconcile/pull/5041

Also refactored models to be frozen, easier to read and test.


### Enhancements to Tekton Trigger Logic:
* Added `target_ref` as a new parameter in `_trigger_tekton` and `_construct_tekton_trigger_resource` functions to represent the target reference (branch or commit hash). (`reconcile/openshift_saas_deploy_trigger_base.py`) [[1]](diffhunk://#diff-4135c05c1738ae40c0a45092f3748e2d3768f6777db8a2399f7e6afc50f2ccebR281) [[2]](diffhunk://#diff-4135c05c1738ae40c0a45092f3748e2d3768f6777db8a2399f7e6afc50f2ccebR338) [[3]](diffhunk://#diff-4135c05c1738ae40c0a45092f3748e2d3768f6777db8a2399f7e6afc50f2ccebR353) [[4]](diffhunk://#diff-4135c05c1738ae40c0a45092f3748e2d3768f6777db8a2399f7e6afc50f2ccebR391)

### Updates to Data Models:
* Made `TriggerSpecBase` and its derived classes immutable by marking them as `@dataclass(frozen=True)`.
* Added `reason` and `target_ref` attributes to `TriggerSpecBase` for consistency across all trigger spec types. (`reconcile/utils/saasherder/models.py`) [[1]](diffhunk://#diff-e47584de2456bc976d3db764f3a75366cecb1df4db50a7490f29a4dc071a1b7eL56-R56) [[2]](diffhunk://#diff-e47584de2456bc976d3db764f3a75366cecb1df4db50a7490f29a4dc071a1b7eR66-R67) [[3]](diffhunk://#diff-e47584de2456bc976d3db764f3a75366cecb1df4db50a7490f29a4dc071a1b7eL79-L85) [[4]](diffhunk://#diff-e47584de2456bc976d3db764f3a75366cecb1df4db50a7490f29a4dc071a1b7eL111-L114) [[5]](diffhunk://#diff-e47584de2456bc976d3db764f3a75366cecb1df4db50a7490f29a4dc071a1b7eL125-L129) [[6]](diffhunk://#diff-e47584de2456bc976d3db764f3a75366cecb1df4db50a7490f29a4dc071a1b7eL140-L143)

### Improvements to Trigger Reason Handling:
* Refactored the logic for constructing the `reason` attribute for moving commits, upstream jobs, and container images, encapsulating it into dedicated helper methods for better readability and maintainability. (`reconcile/utils/saasherder/saasherder.py`) [[1]](diffhunk://#diff-52a815feb4bcd8276212403b5f0ae22e3a3d9508acb5b7a75a5134dcf2657bbcR1436-R1444) [[2]](diffhunk://#diff-52a815feb4bcd8276212403b5f0ae22e3a3d9508acb5b7a75a5134dcf2657bbcR1535-R1552) [[3]](diffhunk://#diff-52a815feb4bcd8276212403b5f0ae22e3a3d9508acb5b7a75a5134dcf2657bbcR1642-R1655)

### Test Suite Updates:
* Updated test cases to include `target_ref` in various scenarios, ensuring comprehensive coverage for the new attribute. (`reconcile/test/test_saasherder.py`) [[1]](diffhunk://#diff-030da5841d7f3803513d0f23617a415c29c66a449c1244650f586de678efe50fR43) [[2]](diffhunk://#diff-030da5841d7f3803513d0f23617a415c29c66a449c1244650f586de678efe50fR500) [[3]](diffhunk://#diff-030da5841d7f3803513d0f23617a415c29c66a449c1244650f586de678efe50fR538) [[4]](diffhunk://#diff-030da5841d7f3803513d0f23617a415c29c66a449c1244650f586de678efe50fR608) [[5]](diffhunk://#diff-030da5841d7f3803513d0f23617a415c29c66a449c1244650f586de678efe50fR727) [[6]](diffhunk://#diff-030da5841d7f3803513d0f23617a415c29c66a449c1244650f586de678efe50fR740) [[7]](diffhunk://#diff-030da5841d7f3803513d0f23617a415c29c66a449c1244650f586de678efe50fR771) [[8]](diffhunk://#diff-030da5841d7f3803513d0f23617a415c29c66a449c1244650f586de678efe50fR784) [[9]](diffhunk://#diff-030da5841d7f3803513d0f23617a415c29c66a449c1244650f586de678efe50fR826) [[10]](diffhunk://#diff-030da5841d7f3803513d0f23617a415c29c66a449c1244650f586de678efe50fR839) [[11]](diffhunk://#diff-030da5841d7f3803513d0f23617a415c29c66a449c1244650f586de678efe50fL1506-R1577)

[APPSRE-12177](https://issues.redhat.com/browse/APPSRE-12177)