### PR TITLE
Revert "feat(saas): Include target ref in triggered PipelineRun labels"

### DIFF
--- a/reconcile/openshift_saas_deploy_trigger_base.py
+++ b/reconcile/openshift_saas_deploy_trigger_base.py
@@ -278,7 +278,6 @@ def _trigger_tekton(
         integration_version,
         saasherder.include_trigger_trace,
         spec.reason,
-        spec.target_ref,
     )
 
     error = False
@@ -335,7 +334,6 @@ def _construct_tekton_trigger_resource(
     integration_version: str,
     include_trigger_trace: bool,
     reason: str | None,
-    target_ref: str,
 ) -> tuple[OR, str]:
     """Construct a resource (PipelineRun) to trigger a deployment via Tekton.
 
@@ -350,7 +348,6 @@ def _construct_tekton_trigger_resource(
         integration_version (string): Version of calling integration
         include_trigger_trace (bool): Should include traces of the triggering integration and reason
         reason (string): The reason this trigger was created
-        target_ref (string): the ref of the target, can be a branch or a commit hash.
 
     Returns:
         OpenshiftResource: OpenShift resource to be applied
@@ -388,7 +385,6 @@ def _construct_tekton_trigger_resource(
             "labels": {
                 "qontract.saas_file_name": saas_file_name,
                 "qontract.env_name": env_name,
-                "qontract.target_ref": target_ref,
             },
         },
         "spec": {

--- a/reconcile/test/test_saasherder.py
+++ b/reconcile/test/test_saasherder.py
@@ -40,7 +40,6 @@ from reconcile.utils.saasherder.interfaces import SaasFile as SaasFileInterface
 from reconcile.utils.saasherder.models import (
     Channel,
     Promotion,
-    TriggerSpecConfig,
     TriggerSpecContainerImage,
     TriggerSpecMovingCommit,
     TriggerSpecUpstreamJob,
@@ -497,7 +496,6 @@ class TestGetMovingCommitsDiffSaasFile(TestCase):
                 state_content="abcd4242",
                 ref="main",
                 reason=None,
-                target_ref="abcd4242",
             )
         ]
 
@@ -535,7 +533,6 @@ class TestGetMovingCommitsDiffSaasFile(TestCase):
                 state_content="abcd4242",
                 ref="main",
                 reason="https://github.com/app-sre/test-saas-deployments/commit/abcd4242",
-                target_ref="abcd4242",
             ),
         ]
         actual = saasherder.get_moving_commits_diff_saas_file(self.saas_file, True)
@@ -605,7 +602,6 @@ class TestGetUpstreamJobsDiffSaasFile(TestCase):
                 job_name="job",
                 state_content=state_content,
                 reason=None,
-                target_ref="abcd4242",
             )
         ]
 
@@ -650,7 +646,6 @@ class TestGetUpstreamJobsDiffSaasFile(TestCase):
                 job_name="job",
                 state_content=state_content,
                 reason="https://github.com/app-sre/test-saas-deployments/commit/abcd4242 via https://jenkins.com/job/job/2",
-                target_ref="abcd4242",
             )
         ]
 
@@ -724,7 +719,6 @@ class TestGetContainerImagesDiffSaasFile(TestCase):
                 images=["quay.io/centos/centos"],
                 state_content="abcd424",
                 reason="https://github.com/app-sre/test-saas-deployments/commit/abcd4242 build quay.io/centos/centos:abcd424",
-                target_ref="abcd4242",
             ),
             TriggerSpecContainerImage(
                 saas_file_name=self.saas_file.name,
@@ -737,7 +731,6 @@ class TestGetContainerImagesDiffSaasFile(TestCase):
                 images=["quay.io/centos/centos", "quay.io/fedora/fedora"],
                 state_content="abcd424",
                 reason="https://github.com/app-sre/test-saas-deployments/commit/abcd4242 build quay.io/centos/centos:abcd424, quay.io/fedora/fedora:abcd424",
-                target_ref="abcd4242",
             ),
         ])
 
@@ -768,7 +761,6 @@ class TestGetContainerImagesDiffSaasFile(TestCase):
             images=images,
             state_content="abcd424",
             reason=None,
-            target_ref="abcd4242",
         )
         b = TriggerSpecContainerImage(
             saas_file_name=self.saas_file.name,
@@ -781,7 +773,6 @@ class TestGetContainerImagesDiffSaasFile(TestCase):
             images=images[::-1],
             state_content="abcd424",
             reason=None,
-            target_ref="abcd4242",
         )
         expected_key = "test-saas-deployments-deploy/test-saas-deployments/appsres03ue1/test-image-trigger-v2/App-SRE-stage/quay.io/centos/centos/quay.io/fedora/fedora"
 
@@ -823,7 +814,6 @@ class TestGetContainerImagesDiffSaasFile(TestCase):
                 images=["quay.io/centos/centos"],
                 state_content="abcd424",
                 reason="https://github.com/app-sre/test-saas-deployments/commit/abcd4242 build quay.io/centos/centos:abcd424",
-                target_ref="abcd4242",
             ),
             TriggerSpecContainerImage(
                 saas_file_name=self.saas_file.name,
@@ -836,7 +826,6 @@ class TestGetContainerImagesDiffSaasFile(TestCase):
                 images=["quay.io/centos/centos", "quay.io/fedora/fedora"],
                 state_content="abcd424",
                 reason="https://github.com/app-sre/test-saas-deployments/commit/abcd4242 build quay.io/centos/centos:abcd424, quay.io/fedora/fedora:abcd424",
-                target_ref="abcd4242",
             ),
         ])
 
@@ -1514,67 +1503,7 @@ class TestConfigHashTrigger(TestCase):
             1
         ].promotion.promotion_data[0].data[0].target_config_hash = "Changed"
         trigger_specs = self.saasherder.get_configs_diff_saas_file(self.saas_file)
-        expected_trigger_specs = [
-            TriggerSpecConfig(
-                saas_file_name=self.saas_file.name,
-                env_name="App-SRE",
-                timeout=None,
-                pipelines_provider=self.saas_file.pipelines_provider,
-                resource_template_name="test-saas-deployments",
-                cluster_name="appsres03ue1",
-                namespace_name="test-ns-subscriber",
-                state_content={
-                    "delete": None,
-                    "disable": None,
-                    "images": None,
-                    "name": None,
-                    "namespace": {
-                        "app": {"name": "test-saas-deployments"},
-                        "cluster": {
-                            "name": "appsres03ue1",
-                            "serverUrl": "https://api.appsres03ue1.5nvu.p1.openshiftapps.com:6443",
-                        },
-                        "name": "test-ns-subscriber",
-                    },
-                    "parameters": None,
-                    "path": "/openshift/deploy-template.yml",
-                    "promotion": {
-                        "auto": True,
-                        "promotion_data": [
-                            {
-                                "channel": "test-saas-deployments-deploy",
-                                "data": [
-                                    {
-                                        "parent_saas": "test-saas-deployments-deploy",
-                                        "target_config_hash": "Changed",
-                                        "type": "parent_saas_config",
-                                    }
-                                ],
-                            }
-                        ],
-                        "publish": None,
-                        "redeployOnPublisherConfigChange": None,
-                        "schedule": None,
-                        "soakDays": None,
-                        "subscribe": ["test-saas-deployments-deploy"],
-                    },
-                    "ref": "1234567890123456789012345678901234567890",
-                    "rt_parameters": '{"PARAM":"test"}',
-                    "saas_file_managed_resource_types": ["Job"],
-                    "saas_file_parameters": None,
-                    "secretParameters": None,
-                    "slos": None,
-                    "upstream": None,
-                    "url": "https://github.com/app-sre/test-saas-deployments",
-                },
-                reason=None,
-                target_ref="1234567890123456789012345678901234567890",
-                resource_template_url="https://github.com/app-sre/test-saas-deployments",
-                slos=None,
-                target_name=None,
-            )
-        ]
-        self.assertEqual(trigger_specs, expected_trigger_specs)
+        self.assertEqual(len(trigger_specs), 1)
 
     def test_non_existent_config_triggers(self) -> None:
         self.state_mock.get.side_effect = [self.deploy_current_state_fxt, None]

--- a/reconcile/utils/saasherder/models.py
+++ b/reconcile/utils/saasherder/models.py
@@ -53,7 +53,7 @@ class UpstreamJob:
         return self.__str__()
 
 
-@dataclass(frozen=True)
+@dataclass
 class TriggerSpecBase:
     saas_file_name: str
     env_name: str
@@ -63,8 +63,6 @@ class TriggerSpecBase:
     cluster_name: str
     namespace_name: str
     state_content: Any
-    reason: str | None
-    target_ref: str
 
     @property
     def state_key(self) -> str:
@@ -78,11 +76,13 @@ class SLOKey:
     cluster_name: str
 
 
-@dataclass(frozen=True)
+@dataclass
 class TriggerSpecConfig(TriggerSpecBase):
     resource_template_url: str
+    target_ref: str
     slos: list[SLODocument] | None = None
     target_name: str | None = None
+    reason: str | None = None
 
     @property
     def state_key(self) -> str:
@@ -108,9 +108,10 @@ class TriggerSpecConfig(TriggerSpecBase):
         ]
 
 
-@dataclass(frozen=True)
+@dataclass
 class TriggerSpecMovingCommit(TriggerSpecBase):
     ref: str
+    reason: str | None = None
 
     @property
     def state_key(self) -> str:
@@ -121,10 +122,11 @@ class TriggerSpecMovingCommit(TriggerSpecBase):
         return key
 
 
-@dataclass(frozen=True)
+@dataclass
 class TriggerSpecUpstreamJob(TriggerSpecBase):
     instance_name: str
     job_name: str
+    reason: str | None = None
 
     @property
     def state_key(self) -> str:
@@ -135,9 +137,10 @@ class TriggerSpecUpstreamJob(TriggerSpecBase):
         return key
 
 
-@dataclass(frozen=True)
+@dataclass
 class TriggerSpecContainerImage(TriggerSpecBase):
     images: Sequence[str]
+    reason: str | None = None
 
     @property
     def state_key(self) -> str:

--- a/reconcile/utils/saasherder/saasherder.py
+++ b/reconcile/utils/saasherder/saasherder.py
@@ -1278,7 +1278,6 @@ class SaasHerder:  # pylint: disable=too-many-public-methods
                     resource_template_url=rt.url,
                     target_ref=target.ref,
                     state_content=None,
-                    reason=None,
                 ).state_key
                 digest = SaasHerder.get_target_config_hash(
                     all_trigger_specs[state_key].state_content
@@ -1433,15 +1432,6 @@ class SaasHerder:  # pylint: disable=too-many-public-methods
         )
         return list(itertools.chain.from_iterable(results))
 
-    def _build_trigger_spec_moving_commit_reason(
-        self,
-        url: str,
-        desired_commit_sha: str,
-    ) -> str | None:
-        if not self.include_trigger_trace:
-            return None
-        return f"{url}/commit/{desired_commit_sha}"
-
     def get_moving_commits_diff_saas_file(
         self, saas_file: SaasFile, dry_run: bool
     ) -> list[TriggerSpecMovingCommit]:
@@ -1471,12 +1461,9 @@ class SaasHerder:  # pylint: disable=too-many-public-methods
                         namespace_name=target.namespace.name,
                         ref=target.ref,
                         state_content=desired_commit_sha,
-                        reason=self._build_trigger_spec_moving_commit_reason(
-                            url=rt.url,
-                            desired_commit_sha=desired_commit_sha,
-                        ),
-                        target_ref=desired_commit_sha,
                     )
+                    if self.include_trigger_trace:
+                        trigger_spec.reason = f"{rt.url}/commit/{desired_commit_sha}"
 
                     if not self.state:
                         raise Exception("state is not initialized")
@@ -1532,24 +1519,6 @@ class SaasHerder:  # pylint: disable=too-many-public-methods
 
         return current_state, error
 
-    def _build_trigger_spec_upstream_job_reason(
-        self,
-        last_build_result: Any,
-        server_url: str,
-        job_name: str,
-        url: str,
-    ) -> str | None:
-        if not self.include_trigger_trace:
-            return None
-        last_build_result_number = last_build_result["number"]
-        last_build_result_commit_sha = last_build_result.get("commit_sha")
-        prefix = (
-            f"{url}/commit/{last_build_result_commit_sha} via "
-            if last_build_result_commit_sha
-            else ""
-        )
-        return f"{prefix}{server_url}/job/{job_name}/{last_build_result_number}"
-
     def get_upstream_jobs_diff_saas_file(
         self, saas_file: SaasFile, dry_run: bool, current_state: dict[str, Any]
     ) -> list[TriggerSpecUpstreamJob]:
@@ -1577,14 +1546,16 @@ class SaasHerder:  # pylint: disable=too-many-public-methods
                     instance_name=target.upstream.instance.name,
                     job_name=job_name,
                     state_content=last_build_result,
-                    reason=self._build_trigger_spec_upstream_job_reason(
-                        last_build_result=last_build_result,
-                        server_url=target.upstream.instance.server_url,
-                        job_name=job_name,
-                        url=rt.url,
-                    ),
-                    target_ref=last_build_result.get("commit_sha") or target.ref,
                 )
+                last_build_result_number = last_build_result["number"]
+                if self.include_trigger_trace:
+                    trigger_spec.reason = f"{target.upstream.instance.server_url}/job/{job_name}/{last_build_result_number}"
+                    last_build_result_commit_sha = last_build_result.get("commit_sha")
+                    if last_build_result_commit_sha:
+                        trigger_spec.reason = (
+                            f"{rt.url}/commit/{last_build_result_commit_sha} via "
+                            + trigger_spec.reason
+                        )
                 if not self.state:
                     raise Exception("state is not initialized")
                 state_build_result = self.state.get(trigger_spec.state_key, None)
@@ -1605,7 +1576,6 @@ class SaasHerder:  # pylint: disable=too-many-public-methods
                         self.update_state(trigger_spec)
                     continue
 
-                last_build_result_number = last_build_result["number"]
                 state_build_result_number = state_build_result["number"]
                 # this is the most important condition
                 # if there is a successful newer build -
@@ -1638,20 +1608,6 @@ class SaasHerder:  # pylint: disable=too-many-public-methods
             dry_run=dry_run,
         )
         return list(itertools.chain.from_iterable(results))
-
-    def _build_trigger_spec_container_image_reason(
-        self,
-        desired_image_tag: str,
-        image_registries: list[str],
-        url: str,
-        commit_sha: str,
-    ) -> str | None:
-        if not self.include_trigger_trace:
-            return None
-        image_uris = ", ".join(
-            f"{image}:{desired_image_tag}" for image in sorted(image_registries)
-        )
-        return f"{url}/commit/{commit_sha} build {image_uris}"
 
     def get_container_images_diff_saas_file(
         self, saas_file: SaasFile, dry_run: bool
@@ -1701,14 +1657,15 @@ class SaasHerder:  # pylint: disable=too-many-public-methods
                         namespace_name=target.namespace.name,
                         images=image_registries,
                         state_content=desired_image_tag,
-                        reason=self._build_trigger_spec_container_image_reason(
-                            desired_image_tag=desired_image_tag,
-                            image_registries=image_registries,
-                            url=rt.url,
-                            commit_sha=commit_sha,
-                        ),
-                        target_ref=commit_sha,
                     )
+                    if self.include_trigger_trace:
+                        image_uris = ", ".join(
+                            f"{image}:{desired_image_tag}"
+                            for image in sorted(image_registries)
+                        )
+                        trigger_spec.reason = (
+                            f"{rt.url}/commit/{commit_sha} build {image_uris}"
+                        )
                     if not self.state:
                         raise Exception("state is not initialized")
                     current_image_tag = self.state.get(trigger_spec.state_key, None)
@@ -1847,6 +1804,15 @@ class SaasHerder:  # pylint: disable=too-many-public-methods
             dtc = SaasHerder.remove_none_values(trigger_spec.state_content)
             if ctc == dtc:
                 continue
+            if self.include_trigger_trace:
+                trigger_spec.reason = f"{self.repo_url}/commit/{RunningState().commit}"
+                # For now we count every saas config change as an auto-promotion
+                # if the auto promotion field is enabled in the saas target.
+                # Ideally, we check if there was an actual ref change in order
+                # to reduce false-positives.
+                promotion = trigger_spec.state_content.get("promotion")
+                if promotion and promotion.get("auto", False):
+                    trigger_spec.reason += " [auto-promotion]"
             trigger_specs.append(trigger_spec)
         return trigger_specs
 
@@ -1856,23 +1822,6 @@ class SaasHerder:  # pylint: disable=too-many-public-methods
         m.update(json.dumps(target_config, sort_keys=True).encode("utf-8"))
         digest = m.hexdigest()[:16]
         return digest
-
-    def _build_trigger_spec_config_reason(
-        self,
-        state_content: dict,
-    ) -> str | None:
-        if not self.include_trigger_trace:
-            return None
-        # For now we count every saas config change as an auto-promotion
-        # if the auto promotion field is enabled in the saas target.
-        # Ideally, we check if there was an actual ref change in order
-        # to reduce false-positives.
-        auto_promotion_suffix = (
-            " [auto-promotion]"
-            if state_content.get("promotion", {}).get("auto", False)
-            else ""
-        )
-        return f"{self.repo_url}/commit/{RunningState().commit}{auto_promotion_suffix}"
 
     def get_saas_targets_config_trigger_specs(
         self, saas_file: SaasFile
@@ -1952,9 +1901,6 @@ class SaasHerder:  # pylint: disable=too-many-public-methods
                     resource_template_url=rt.url,
                     target_ref=target.ref,
                     slos=target.slos or None,
-                    reason=self._build_trigger_spec_config_reason(
-                        state_content=serializable_target_config
-                    ),
                 )
                 configs[trigger_spec.state_key] = trigger_spec
 


### PR DESCRIPTION
Reverts app-sre/qontract-reconcile#5054

`openshift-saas-deploy-trigger-configs` is failing with

```
qontract-reconcile-openshift-saas-deploy-trigger-configs-24jsq8 int   File "/work/reconcile/cli.py", line 583, in run_class_integration
qontract-reconcile-openshift-saas-deploy-trigger-configs-24jsq8 int     run_integration_cfg(
qontract-reconcile-openshift-saas-deploy-trigger-configs-24jsq8 int   File "/work/reconcile/utils/runtime/runner.py", line 158, in run_integration_cfg
qontract-reconcile-openshift-saas-deploy-trigger-configs-24jsq8 int     _integration_wet_run(run_cfg.integration)
qontract-reconcile-openshift-saas-deploy-trigger-configs-24jsq8 int   File "/work/reconcile/utils/runtime/runner.py", line 167, in _integration_wet_run
qontract-reconcile-openshift-saas-deploy-trigger-configs-24jsq8 int     integration.run(False)
qontract-reconcile-openshift-saas-deploy-trigger-configs-24jsq8 int   File "/work/reconcile/utils/runtime/integration.py", line 315, in run
qontract-reconcile-openshift-saas-deploy-trigger-configs-24jsq8 int     self.params.module.run(dry_run, *self.params.args, **self.params.kwargs)
qontract-reconcile-openshift-saas-deploy-trigger-configs-24jsq8 int   File "/work/reconcile/openshift_saas_deploy_trigger_configs.py", line 19, in run
qontract-reconcile-openshift-saas-deploy-trigger-configs-24jsq8 int     error = osdt_base.run(
qontract-reconcile-openshift-saas-deploy-trigger-configs-24jsq8 int             ^^^^^^^^^^^^^^
qontract-reconcile-openshift-saas-deploy-trigger-configs-24jsq8 int   File "/work/reconcile/utils/defer.py", line 15, in func_wrapper
qontract-reconcile-openshift-saas-deploy-trigger-configs-24jsq8 int     return func(*args, defer=stack.callback, **kwargs)
qontract-reconcile-openshift-saas-deploy-trigger-configs-24jsq8 int            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
qontract-reconcile-openshift-saas-deploy-trigger-configs-24jsq8 int   File "/work/reconcile/openshift_saas_deploy_trigger_base.py", line 93, in run
qontract-reconcile-openshift-saas-deploy-trigger-configs-24jsq8 int     trigger_specs, diff_err = saasherder.get_diff(trigger_type, dry_run)
qontract-reconcile-openshift-saas-deploy-trigger-configs-24jsq8 int                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
qontract-reconcile-openshift-saas-deploy-trigger-configs-24jsq8 int   File "/work/reconcile/utils/saasherder/saasherder.py", line 1410, in get_diff
qontract-reconcile-openshift-saas-deploy-trigger-configs-24jsq8 int     return self.get_configs_diff(), error
qontract-reconcile-openshift-saas-deploy-trigger-configs-24jsq8 int            ^^^^^^^^^^^^^^^^^^^^^^^
qontract-reconcile-openshift-saas-deploy-trigger-configs-24jsq8 int   File "/work/reconcile/utils/saasherder/saasherder.py", line 1738, in get_configs_diff
qontract-reconcile-openshift-saas-deploy-trigger-configs-24jsq8 int     results = threaded.run(
qontract-reconcile-openshift-saas-deploy-trigger-configs-24jsq8 int               ^^^^^^^^^^^^^
qontract-reconcile-openshift-saas-deploy-trigger-configs-24jsq8 int   File "/work/.venv/lib64/python3.11/site-packages/sretoolbox/utils/threaded.py", line 71, in run
qontract-reconcile-openshift-saas-deploy-trigger-configs-24jsq8 int     return pmap(
qontract-reconcile-openshift-saas-deploy-trigger-configs-24jsq8 int            ^^^^^
qontract-reconcile-openshift-saas-deploy-trigger-configs-24jsq8 int   File "/work/.venv/lib64/python3.11/site-packages/sretoolbox/utils/concurrent.py", line 86, in pmap
qontract-reconcile-openshift-saas-deploy-trigger-configs-24jsq8 int     return list(pool.map(func_partial, iterable))
qontract-reconcile-openshift-saas-deploy-trigger-configs-24jsq8 int            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
qontract-reconcile-openshift-saas-deploy-trigger-configs-24jsq8 int   File "/usr/lib64/python3.11/concurrent/futures/_base.py", line 619, in result_iterator
qontract-reconcile-openshift-saas-deploy-trigger-configs-24jsq8 int     yield _result_or_cancel(fs.pop())
qontract-reconcile-openshift-saas-deploy-trigger-configs-24jsq8 int           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
qontract-reconcile-openshift-saas-deploy-trigger-configs-24jsq8 int   File "/usr/lib64/python3.11/concurrent/futures/_base.py", line 317, in _result_or_cancel
qontract-reconcile-openshift-saas-deploy-trigger-configs-24jsq8 int     return fut.result(timeout)
qontract-reconcile-openshift-saas-deploy-trigger-configs-24jsq8 int            ^^^^^^^^^^^^^^^^^^^
qontract-reconcile-openshift-saas-deploy-trigger-configs-24jsq8 int   File "/usr/lib64/python3.11/concurrent/futures/_base.py", line 449, in result
qontract-reconcile-openshift-saas-deploy-trigger-configs-24jsq8 int     return self.__get_result()
qontract-reconcile-openshift-saas-deploy-trigger-configs-24jsq8 int            ^^^^^^^^^^^^^^^^^^^
qontract-reconcile-openshift-saas-deploy-trigger-configs-24jsq8 int   File "/usr/lib64/python3.11/concurrent/futures/_base.py", line 401, in __get_result
qontract-reconcile-openshift-saas-deploy-trigger-configs-24jsq8 int     raise self._exception
qontract-reconcile-openshift-saas-deploy-trigger-configs-24jsq8 int   File "/usr/lib64/python3.11/concurrent/futures/thread.py", line 58, in run
qontract-reconcile-openshift-saas-deploy-trigger-configs-24jsq8 int     result = self.fn(*self.args, **self.kwargs)
qontract-reconcile-openshift-saas-deploy-trigger-configs-24jsq8 int              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
qontract-reconcile-openshift-saas-deploy-trigger-configs-24jsq8 int   File "/work/.venv/lib64/python3.11/site-packages/sretoolbox/utils/concurrent.py", line 111, in _full_traceback
qontract-reconcile-openshift-saas-deploy-trigger-configs-24jsq8 int     return func(*args, **kwargs)
qontract-reconcile-openshift-saas-deploy-trigger-configs-24jsq8 int            ^^^^^^^^^^^^^^^^^^^^^
qontract-reconcile-openshift-saas-deploy-trigger-configs-24jsq8 int   File "/work/reconcile/utils/saasherder/saasherder.py", line 1833, in get_configs_diff_saas_file
qontract-reconcile-openshift-saas-deploy-trigger-configs-24jsq8 int     all_trigger_specs = self.get_saas_targets_config_trigger_specs(saas_file)
qontract-reconcile-openshift-saas-deploy-trigger-configs-24jsq8 int                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
qontract-reconcile-openshift-saas-deploy-trigger-configs-24jsq8 int   File "/work/reconcile/utils/saasherder/saasherder.py", line 1955, in get_saas_targets_config_trigger_specs
qontract-reconcile-openshift-saas-deploy-trigger-configs-24jsq8 int     reason=self._build_trigger_spec_config_reason(
qontract-reconcile-openshift-saas-deploy-trigger-configs-24jsq8 int            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
qontract-reconcile-openshift-saas-deploy-trigger-configs-24jsq8 int   File "/work/reconcile/utils/saasherder/saasherder.py", line 1872, in _build_trigger_spec_config_reason
qontract-reconcile-openshift-saas-deploy-trigger-configs-24jsq8 int     if state_content.get("promotion", {}).get("auto", False)
qontract-reconcile-openshift-saas-deploy-trigger-configs-24jsq8 int        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
qontract-reconcile-openshift-saas-deploy-trigger-configs-24jsq8 int AttributeError: 'NoneType' object has no attribute 'get'
```