### PR TITLE
fix(saas): proper auto-promotion check for config trigger

### DIFF
--- a/reconcile/utils/saasherder/saasherder.py
+++ b/reconcile/utils/saasherder/saasherder.py
@@ -1869,7 +1869,7 @@ class SaasHerder:  # pylint: disable=too-many-public-methods
         # to reduce false-positives.
         auto_promotion_suffix = (
             " [auto-promotion]"
-            if state_content.get("promotion", {}).get("auto", False)
+            if (state_content.get("promotion") or {}).get("auto", False)
             else ""
         )
         return f"{self.repo_url}/commit/{RunningState().commit}{auto_promotion_suffix}"


### PR DESCRIPTION
Fix auto promotion check changed in https://github.com/app-sre/qontract-reconcile/pull/5054

```
qontract-reconcile-openshift-saas-deploy-trigger-configs-24jsq8 int   File "/work/reconcile/utils/saasherder/saasherder.py", line 1872, in _build_trigger_spec_config_reason
qontract-reconcile-openshift-saas-deploy-trigger-configs-24jsq8 int     if state_content.get("promotion", {}).get("auto", False)
qontract-reconcile-openshift-saas-deploy-trigger-configs-24jsq8 int        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
qontract-reconcile-openshift-saas-deploy-trigger-configs-24jsq8 int AttributeError: 'NoneType' object has no attribute 'get'
```
