### PR TITLE
RHCLOUD-39268 status-board-exporter add saas-files to metadata

### DIFF
--- a/reconcile/gql_definitions/introspection.json
+++ b/reconcile/gql_definitions/introspection.json
@@ -4362,18 +4362,6 @@
                             },
                             "isDeprecated": false,
                             "deprecationReason": null
-                        },
-                        {
-                            "name": "rhcsProvider",
-                            "description": null,
-                            "args": [],
-                            "type": {
-                                "kind": "OBJECT",
-                                "name": "RhcsProviderSettings_v1",
-                                "ofType": null
-                            },
-                            "isDeprecated": false,
-                            "deprecationReason": null
                         }
                     ],
                     "inputFields": null,
@@ -5735,16 +5723,6 @@
                         {
                             "kind": "OBJECT",
                             "name": "AutomatedActionCreateToken_v1",
-                            "ofType": null
-                        },
-                        {
-                            "kind": "OBJECT",
-                            "name": "AutomatedActionExternalResourceFlushElastiCache_v1",
-                            "ofType": null
-                        },
-                        {
-                            "kind": "OBJECT",
-                            "name": "AutomatedActionExternalResourceRdsReboot_v1",
                             "ofType": null
                         },
                         {
@@ -10464,18 +10442,6 @@
                             "type": {
                                 "kind": "SCALAR",
                                 "name": "JSON",
-                                "ofType": null
-                            },
-                            "isDeprecated": false,
-                            "deprecationReason": null
-                        },
-                        {
-                            "name": "externalResources",
-                            "description": null,
-                            "args": [],
-                            "type": {
-                                "kind": "OBJECT",
-                                "name": "ExternalResourcesAccountSettings_v1",
                                 "ofType": null
                             },
                             "isDeprecated": false,
@@ -15448,29 +15414,6 @@
                 },
                 {
                     "kind": "OBJECT",
-                    "name": "ExternalResourcesAccountSettings_v1",
-                    "description": null,
-                    "fields": [
-                        {
-                            "name": "channel",
-                            "description": null,
-                            "args": [],
-                            "type": {
-                                "kind": "SCALAR",
-                                "name": "String",
-                                "ofType": null
-                            },
-                            "isDeprecated": false,
-                            "deprecationReason": null
-                        }
-                    ],
-                    "inputFields": null,
-                    "interfaces": [],
-                    "enumValues": null,
-                    "possibleTypes": null
-                },
-                {
-                    "kind": "OBJECT",
                     "name": "AWSAccountRequest_v1",
                     "description": null,
                     "fields": [
@@ -18370,21 +18313,13 @@
                             "deprecationReason": null
                         },
                         {
-                            "name": "jiraComponents",
+                            "name": "jiraComponent",
                             "description": null,
                             "args": [],
                             "type": {
-                                "kind": "LIST",
-                                "name": null,
-                                "ofType": {
-                                    "kind": "NON_NULL",
-                                    "name": null,
-                                    "ofType": {
-                                        "kind": "SCALAR",
-                                        "name": "String",
-                                        "ofType": null
-                                    }
-                                }
+                                "kind": "SCALAR",
+                                "name": "String",
+                                "ofType": null
                             },
                             "isDeprecated": false,
                             "deprecationReason": null
@@ -24838,11 +24773,6 @@
                         },
                         {
                             "kind": "OBJECT",
-                            "name": "NamespaceOpenshiftResourceRhcsCert_v1",
-                            "ofType": null
-                        },
-                        {
-                            "kind": "OBJECT",
                             "name": "NamespaceOpenshiftResourceRoute_v1",
                             "ofType": null
                         },
@@ -26595,65 +26525,6 @@
                 },
                 {
                     "kind": "OBJECT",
-                    "name": "RhcsProviderSettings_v1",
-                    "description": null,
-                    "fields": [
-                        {
-                            "name": "issuerUrl",
-                            "description": null,
-                            "args": [],
-                            "type": {
-                                "kind": "NON_NULL",
-                                "name": null,
-                                "ofType": {
-                                    "kind": "SCALAR",
-                                    "name": "String",
-                                    "ofType": null
-                                }
-                            },
-                            "isDeprecated": false,
-                            "deprecationReason": null
-                        },
-                        {
-                            "name": "vaultBasePath",
-                            "description": null,
-                            "args": [],
-                            "type": {
-                                "kind": "NON_NULL",
-                                "name": null,
-                                "ofType": {
-                                    "kind": "SCALAR",
-                                    "name": "String",
-                                    "ofType": null
-                                }
-                            },
-                            "isDeprecated": false,
-                            "deprecationReason": null
-                        },
-                        {
-                            "name": "caCertUrl",
-                            "description": null,
-                            "args": [],
-                            "type": {
-                                "kind": "NON_NULL",
-                                "name": null,
-                                "ofType": {
-                                    "kind": "SCALAR",
-                                    "name": "String",
-                                    "ofType": null
-                                }
-                            },
-                            "isDeprecated": false,
-                            "deprecationReason": null
-                        }
-                    ],
-                    "inputFields": null,
-                    "interfaces": [],
-                    "enumValues": null,
-                    "possibleTypes": null
-                },
-                {
-                    "kind": "OBJECT",
                     "name": "AppInterfaceEmail_v1",
                     "description": null,
                     "fields": [
@@ -27347,16 +27218,6 @@
                         {
                             "kind": "OBJECT",
                             "name": "AutomatedActionCreateToken_v1",
-                            "ofType": null
-                        },
-                        {
-                            "kind": "OBJECT",
-                            "name": "AutomatedActionExternalResourceFlushElastiCache_v1",
-                            "ofType": null
-                        },
-                        {
-                            "kind": "OBJECT",
-                            "name": "AutomatedActionExternalResourceRdsReboot_v1",
                             "ofType": null
                         },
                         {
@@ -34956,6 +34817,38 @@
                             "deprecationReason": null
                         },
                         {
+                            "name": "image",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "NON_NULL",
+                                "name": null,
+                                "ofType": {
+                                    "kind": "SCALAR",
+                                    "name": "String",
+                                    "ofType": null
+                                }
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "version",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "NON_NULL",
+                                "name": null,
+                                "ofType": {
+                                    "kind": "SCALAR",
+                                    "name": "String",
+                                    "ofType": null
+                                }
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
                             "name": "reconcile_drift_interval_minutes",
                             "description": null,
                             "args": [],
@@ -35038,46 +34931,6 @@
                             },
                             "isDeprecated": false,
                             "deprecationReason": null
-                        },
-                        {
-                            "name": "default_channel",
-                            "description": null,
-                            "args": [],
-                            "type": {
-                                "kind": "NON_NULL",
-                                "name": null,
-                                "ofType": {
-                                    "kind": "SCALAR",
-                                    "name": "String",
-                                    "ofType": null
-                                }
-                            },
-                            "isDeprecated": false,
-                            "deprecationReason": null
-                        },
-                        {
-                            "name": "channels",
-                            "description": null,
-                            "args": [],
-                            "type": {
-                                "kind": "NON_NULL",
-                                "name": null,
-                                "ofType": {
-                                    "kind": "LIST",
-                                    "name": null,
-                                    "ofType": {
-                                        "kind": "NON_NULL",
-                                        "name": null,
-                                        "ofType": {
-                                            "kind": "OBJECT",
-                                            "name": "ExternalResourcesChannel_v1",
-                                            "ofType": null
-                                        }
-                                    }
-                                }
-                            },
-                            "isDeprecated": false,
-                            "deprecationReason": null
                         }
                     ],
                     "inputFields": null,
@@ -35088,65 +34941,6 @@
                             "ofType": null
                         }
                     ],
-                    "enumValues": null,
-                    "possibleTypes": null
-                },
-                {
-                    "kind": "OBJECT",
-                    "name": "ExternalResourcesChannel_v1",
-                    "description": null,
-                    "fields": [
-                        {
-                            "name": "name",
-                            "description": null,
-                            "args": [],
-                            "type": {
-                                "kind": "NON_NULL",
-                                "name": null,
-                                "ofType": {
-                                    "kind": "SCALAR",
-                                    "name": "String",
-                                    "ofType": null
-                                }
-                            },
-                            "isDeprecated": false,
-                            "deprecationReason": null
-                        },
-                        {
-                            "name": "image",
-                            "description": null,
-                            "args": [],
-                            "type": {
-                                "kind": "NON_NULL",
-                                "name": null,
-                                "ofType": {
-                                    "kind": "SCALAR",
-                                    "name": "String",
-                                    "ofType": null
-                                }
-                            },
-                            "isDeprecated": false,
-                            "deprecationReason": null
-                        },
-                        {
-                            "name": "version",
-                            "description": null,
-                            "args": [],
-                            "type": {
-                                "kind": "NON_NULL",
-                                "name": null,
-                                "ofType": {
-                                    "kind": "SCALAR",
-                                    "name": "String",
-                                    "ofType": null
-                                }
-                            },
-                            "isDeprecated": false,
-                            "deprecationReason": null
-                        }
-                    ],
-                    "inputFields": null,
-                    "interfaces": [],
                     "enumValues": null,
                     "possibleTypes": null
                 },
@@ -41077,111 +40871,6 @@
                 },
                 {
                     "kind": "OBJECT",
-                    "name": "NamespaceOpenshiftResourceRhcsCert_v1",
-                    "description": null,
-                    "fields": [
-                        {
-                            "name": "provider",
-                            "description": null,
-                            "args": [],
-                            "type": {
-                                "kind": "NON_NULL",
-                                "name": null,
-                                "ofType": {
-                                    "kind": "SCALAR",
-                                    "name": "String",
-                                    "ofType": null
-                                }
-                            },
-                            "isDeprecated": false,
-                            "deprecationReason": null
-                        },
-                        {
-                            "name": "secret_name",
-                            "description": null,
-                            "args": [],
-                            "type": {
-                                "kind": "NON_NULL",
-                                "name": null,
-                                "ofType": {
-                                    "kind": "SCALAR",
-                                    "name": "String",
-                                    "ofType": null
-                                }
-                            },
-                            "isDeprecated": false,
-                            "deprecationReason": null
-                        },
-                        {
-                            "name": "service_account_name",
-                            "description": null,
-                            "args": [],
-                            "type": {
-                                "kind": "NON_NULL",
-                                "name": null,
-                                "ofType": {
-                                    "kind": "SCALAR",
-                                    "name": "String",
-                                    "ofType": null
-                                }
-                            },
-                            "isDeprecated": false,
-                            "deprecationReason": null
-                        },
-                        {
-                            "name": "service_account_password",
-                            "description": null,
-                            "args": [],
-                            "type": {
-                                "kind": "NON_NULL",
-                                "name": null,
-                                "ofType": {
-                                    "kind": "OBJECT",
-                                    "name": "VaultSecret_v1",
-                                    "ofType": null
-                                }
-                            },
-                            "isDeprecated": false,
-                            "deprecationReason": null
-                        },
-                        {
-                            "name": "auto_renew_threshold_days",
-                            "description": null,
-                            "args": [],
-                            "type": {
-                                "kind": "SCALAR",
-                                "name": "Int",
-                                "ofType": null
-                            },
-                            "isDeprecated": false,
-                            "deprecationReason": null
-                        },
-                        {
-                            "name": "annotations",
-                            "description": null,
-                            "args": [],
-                            "type": {
-                                "kind": "SCALAR",
-                                "name": "JSON",
-                                "ofType": null
-                            },
-                            "isDeprecated": false,
-                            "deprecationReason": null
-                        }
-                    ],
-                    "inputFields": null,
-                    "interfaces": [
-                        {
-                            "kind": "INTERFACE",
-                            "name": "NamespaceOpenshiftResource_v1",
-                            "ofType": null
-                        }
-                    ],
-                    "enumValues": null,
-                    "possibleTypes": null
-                },
-                {
-                    "kind": "OBJECT",
                     "name": "NamespaceOpenshiftResourceRoute_v1",
                     "description": null,
                     "fields": [
@@ -44462,18 +44151,6 @@
                         },
                         {
                             "name": "module_type",
-                            "description": null,
-                            "args": [],
-                            "type": {
-                                "kind": "SCALAR",
-                                "name": "String",
-                                "ofType": null
-                            },
-                            "isDeprecated": false,
-                            "deprecationReason": null
-                        },
-                        {
-                            "name": "channel",
                             "description": null,
                             "args": [],
                             "type": {
@@ -53497,381 +53174,6 @@
                                         "kind": "OBJECT",
                                         "name": "PermissionAutomatedActions_v1",
                                         "ofType": null
-                                    }
-                                }
-                            },
-                            "isDeprecated": false,
-                            "deprecationReason": null
-                        }
-                    ],
-                    "inputFields": null,
-                    "interfaces": [
-                        {
-                            "kind": "INTERFACE",
-                            "name": "AutomatedAction_v1",
-                            "ofType": null
-                        },
-                        {
-                            "kind": "INTERFACE",
-                            "name": "DatafileObject_v1",
-                            "ofType": null
-                        }
-                    ],
-                    "enumValues": null,
-                    "possibleTypes": null
-                },
-                {
-                    "kind": "OBJECT",
-                    "name": "AutomatedActionExternalResourceFlushElastiCache_v1",
-                    "description": null,
-                    "fields": [
-                        {
-                            "name": "schema",
-                            "description": null,
-                            "args": [],
-                            "type": {
-                                "kind": "NON_NULL",
-                                "name": null,
-                                "ofType": {
-                                    "kind": "SCALAR",
-                                    "name": "String",
-                                    "ofType": null
-                                }
-                            },
-                            "isDeprecated": false,
-                            "deprecationReason": null
-                        },
-                        {
-                            "name": "path",
-                            "description": null,
-                            "args": [],
-                            "type": {
-                                "kind": "NON_NULL",
-                                "name": null,
-                                "ofType": {
-                                    "kind": "SCALAR",
-                                    "name": "String",
-                                    "ofType": null
-                                }
-                            },
-                            "isDeprecated": false,
-                            "deprecationReason": null
-                        },
-                        {
-                            "name": "type",
-                            "description": null,
-                            "args": [],
-                            "type": {
-                                "kind": "NON_NULL",
-                                "name": null,
-                                "ofType": {
-                                    "kind": "SCALAR",
-                                    "name": "String",
-                                    "ofType": null
-                                }
-                            },
-                            "isDeprecated": false,
-                            "deprecationReason": null
-                        },
-                        {
-                            "name": "description",
-                            "description": null,
-                            "args": [],
-                            "type": {
-                                "kind": "SCALAR",
-                                "name": "String",
-                                "ofType": null
-                            },
-                            "isDeprecated": false,
-                            "deprecationReason": null
-                        },
-                        {
-                            "name": "maxOps",
-                            "description": null,
-                            "args": [],
-                            "type": {
-                                "kind": "NON_NULL",
-                                "name": null,
-                                "ofType": {
-                                    "kind": "SCALAR",
-                                    "name": "Int",
-                                    "ofType": null
-                                }
-                            },
-                            "isDeprecated": false,
-                            "deprecationReason": null
-                        },
-                        {
-                            "name": "instances",
-                            "description": null,
-                            "args": [],
-                            "type": {
-                                "kind": "NON_NULL",
-                                "name": null,
-                                "ofType": {
-                                    "kind": "LIST",
-                                    "name": null,
-                                    "ofType": {
-                                        "kind": "NON_NULL",
-                                        "name": null,
-                                        "ofType": {
-                                            "kind": "OBJECT",
-                                            "name": "AutomatedActionsInstance_v1",
-                                            "ofType": null
-                                        }
-                                    }
-                                }
-                            },
-                            "isDeprecated": false,
-                            "deprecationReason": null
-                        },
-                        {
-                            "name": "permissions",
-                            "description": null,
-                            "args": [],
-                            "type": {
-                                "kind": "LIST",
-                                "name": null,
-                                "ofType": {
-                                    "kind": "NON_NULL",
-                                    "name": null,
-                                    "ofType": {
-                                        "kind": "OBJECT",
-                                        "name": "PermissionAutomatedActions_v1",
-                                        "ofType": null
-                                    }
-                                }
-                            },
-                            "isDeprecated": false,
-                            "deprecationReason": null
-                        },
-                        {
-                            "name": "arguments",
-                            "description": null,
-                            "args": [],
-                            "type": {
-                                "kind": "NON_NULL",
-                                "name": null,
-                                "ofType": {
-                                    "kind": "LIST",
-                                    "name": null,
-                                    "ofType": {
-                                        "kind": "NON_NULL",
-                                        "name": null,
-                                        "ofType": {
-                                            "kind": "OBJECT",
-                                            "name": "AutomatedActionExternalResourceArgument_v1",
-                                            "ofType": null
-                                        }
-                                    }
-                                }
-                            },
-                            "isDeprecated": false,
-                            "deprecationReason": null
-                        }
-                    ],
-                    "inputFields": null,
-                    "interfaces": [
-                        {
-                            "kind": "INTERFACE",
-                            "name": "AutomatedAction_v1",
-                            "ofType": null
-                        },
-                        {
-                            "kind": "INTERFACE",
-                            "name": "DatafileObject_v1",
-                            "ofType": null
-                        }
-                    ],
-                    "enumValues": null,
-                    "possibleTypes": null
-                },
-                {
-                    "kind": "OBJECT",
-                    "name": "AutomatedActionExternalResourceArgument_v1",
-                    "description": null,
-                    "fields": [
-                        {
-                            "name": "namespace",
-                            "description": null,
-                            "args": [],
-                            "type": {
-                                "kind": "NON_NULL",
-                                "name": null,
-                                "ofType": {
-                                    "kind": "OBJECT",
-                                    "name": "Namespace_v1",
-                                    "ofType": null
-                                }
-                            },
-                            "isDeprecated": false,
-                            "deprecationReason": null
-                        },
-                        {
-                            "name": "identifier",
-                            "description": null,
-                            "args": [],
-                            "type": {
-                                "kind": "NON_NULL",
-                                "name": null,
-                                "ofType": {
-                                    "kind": "SCALAR",
-                                    "name": "String",
-                                    "ofType": null
-                                }
-                            },
-                            "isDeprecated": false,
-                            "deprecationReason": null
-                        }
-                    ],
-                    "inputFields": null,
-                    "interfaces": [],
-                    "enumValues": null,
-                    "possibleTypes": null
-                },
-                {
-                    "kind": "OBJECT",
-                    "name": "AutomatedActionExternalResourceRdsReboot_v1",
-                    "description": null,
-                    "fields": [
-                        {
-                            "name": "schema",
-                            "description": null,
-                            "args": [],
-                            "type": {
-                                "kind": "NON_NULL",
-                                "name": null,
-                                "ofType": {
-                                    "kind": "SCALAR",
-                                    "name": "String",
-                                    "ofType": null
-                                }
-                            },
-                            "isDeprecated": false,
-                            "deprecationReason": null
-                        },
-                        {
-                            "name": "path",
-                            "description": null,
-                            "args": [],
-                            "type": {
-                                "kind": "NON_NULL",
-                                "name": null,
-                                "ofType": {
-                                    "kind": "SCALAR",
-                                    "name": "String",
-                                    "ofType": null
-                                }
-                            },
-                            "isDeprecated": false,
-                            "deprecationReason": null
-                        },
-                        {
-                            "name": "type",
-                            "description": null,
-                            "args": [],
-                            "type": {
-                                "kind": "NON_NULL",
-                                "name": null,
-                                "ofType": {
-                                    "kind": "SCALAR",
-                                    "name": "String",
-                                    "ofType": null
-                                }
-                            },
-                            "isDeprecated": false,
-                            "deprecationReason": null
-                        },
-                        {
-                            "name": "description",
-                            "description": null,
-                            "args": [],
-                            "type": {
-                                "kind": "SCALAR",
-                                "name": "String",
-                                "ofType": null
-                            },
-                            "isDeprecated": false,
-                            "deprecationReason": null
-                        },
-                        {
-                            "name": "maxOps",
-                            "description": null,
-                            "args": [],
-                            "type": {
-                                "kind": "NON_NULL",
-                                "name": null,
-                                "ofType": {
-                                    "kind": "SCALAR",
-                                    "name": "Int",
-                                    "ofType": null
-                                }
-                            },
-                            "isDeprecated": false,
-                            "deprecationReason": null
-                        },
-                        {
-                            "name": "instances",
-                            "description": null,
-                            "args": [],
-                            "type": {
-                                "kind": "NON_NULL",
-                                "name": null,
-                                "ofType": {
-                                    "kind": "LIST",
-                                    "name": null,
-                                    "ofType": {
-                                        "kind": "NON_NULL",
-                                        "name": null,
-                                        "ofType": {
-                                            "kind": "OBJECT",
-                                            "name": "AutomatedActionsInstance_v1",
-                                            "ofType": null
-                                        }
-                                    }
-                                }
-                            },
-                            "isDeprecated": false,
-                            "deprecationReason": null
-                        },
-                        {
-                            "name": "permissions",
-                            "description": null,
-                            "args": [],
-                            "type": {
-                                "kind": "LIST",
-                                "name": null,
-                                "ofType": {
-                                    "kind": "NON_NULL",
-                                    "name": null,
-                                    "ofType": {
-                                        "kind": "OBJECT",
-                                        "name": "PermissionAutomatedActions_v1",
-                                        "ofType": null
-                                    }
-                                }
-                            },
-                            "isDeprecated": false,
-                            "deprecationReason": null
-                        },
-                        {
-                            "name": "arguments",
-                            "description": null,
-                            "args": [],
-                            "type": {
-                                "kind": "NON_NULL",
-                                "name": null,
-                                "ofType": {
-                                    "kind": "LIST",
-                                    "name": null,
-                                    "ofType": {
-                                        "kind": "NON_NULL",
-                                        "name": null,
-                                        "ofType": {
-                                            "kind": "OBJECT",
-                                            "name": "AutomatedActionExternalResourceArgument_v1",
-                                            "ofType": null
-                                        }
                                     }
                                 }
                             },

--- a/reconcile/gql_definitions/status_board/status_board.gql
+++ b/reconcile/gql_definitions/status_board/status_board.gql
@@ -37,6 +37,10 @@ query StatusBoard {
               name
               onboardingStatus
             }
+            saasFiles {
+              name
+              managedResourceTypes
+            }
           }
         }
       }

--- a/reconcile/gql_definitions/status_board/status_board.py
+++ b/reconcile/gql_definitions/status_board/status_board.py
@@ -56,6 +56,10 @@ query StatusBoard {
               name
               onboardingStatus
             }
+            saasFiles {
+              name
+              managedResourceTypes
+            }
           }
         }
       }
@@ -106,11 +110,17 @@ class NamespaceV1_AppV1_AppV1(ConfiguredBaseModel):
     onboarding_status: str = Field(..., alias="onboardingStatus")
 
 
+class SaasFileV2(ConfiguredBaseModel):
+    name: str = Field(..., alias="name")
+    managed_resource_types: list[str] = Field(..., alias="managedResourceTypes")
+
+
 class AppV1(ConfiguredBaseModel):
     name: str = Field(..., alias="name")
     onboarding_status: str = Field(..., alias="onboardingStatus")
     children_apps: Optional[list[AppV1_AppV1]] = Field(..., alias="childrenApps")
     parent_app: Optional[NamespaceV1_AppV1_AppV1] = Field(..., alias="parentApp")
+    saas_files: Optional[list[SaasFileV2]] = Field(..., alias="saasFiles")
 
 
 class NamespaceV1(ConfiguredBaseModel):

--- a/reconcile/status_board.py
+++ b/reconcile/status_board.py
@@ -13,7 +13,7 @@ from pydantic import BaseModel
 
 from reconcile.gql_definitions.status_board.status_board import StatusBoardV1
 from reconcile.typed_queries.status_board import (
-    get_selected_app_names,
+    get_selected_app_data,
     get_status_board,
 )
 from reconcile.utils.differ import diff_mappings
@@ -24,6 +24,8 @@ from reconcile.utils.ocm.status_board import (
     delete_product,
     get_managed_products,
     get_product_applications,
+    update_application,
+    update_product,
 )
 from reconcile.utils.ocm_base_client import (
     OCMBaseClient,
@@ -52,6 +54,10 @@ class AbstractStatusBoard(ABC, BaseModel):
         pass
 
     @abstractmethod
+    def update(self, ocm: OCMBaseClient) -> None:
+        pass
+
+    @abstractmethod
     def summarize(self) -> str:
         pass
 
@@ -76,6 +82,15 @@ class Product(AbstractStatusBoard):
             return
         delete_product(ocm, self.id)
 
+    def update(self, ocm: OCMBaseClient) -> None:
+        if not self.id:
+            logging.error(f'Trying to update Product "{self.name}" without id')
+            return
+        spec = self.dict(by_alias=True)
+        spec.pop("applications")
+        spec.pop("id")
+        update_product(ocm, self.id, spec)
+
     def summarize(self) -> str:
         return f'Product: "{self.name}"'
 
@@ -86,10 +101,12 @@ class Product(AbstractStatusBoard):
 
 class Application(AbstractStatusBoard):
     product: Optional["Product"]
+    old_metadata: Optional[dict[str, Any]] = None  # For tracking changes during updates
 
     def create(self, ocm: OCMBaseClient) -> None:
         spec = self.dict(by_alias=True)
         spec.pop("id")
+        spec.pop("old_metadata", None)  # Don't send old_metadata to API
         product = spec.pop("product")
         product_id = product.get("id")
         if product_id:
@@ -104,8 +121,55 @@ class Application(AbstractStatusBoard):
             return
         delete_application(ocm, self.id)
 
+    def update(self, ocm: OCMBaseClient) -> None:
+        if not self.id:
+            logging.error(f'Trying to update Application "{self.name}" without id')
+            return
+        spec = self.dict(by_alias=True)
+        spec.pop("id")
+        spec.pop("old_metadata", None)  # Don't send old_metadata to API
+        product = spec.pop("product")
+        product_id = product.get("id") if product else None
+        if product_id:
+            spec["product"] = {"id": product_id}
+        update_application(ocm, self.id, spec)
+
+    def get_metadata_diff(self) -> str:
+        """Generate git-style diff for metadata changes"""
+        if not self.old_metadata:
+            return ""
+        
+        old_meta = self.old_metadata or {}
+        new_meta = self.metadata or {}
+        
+        # Get all unique keys from both metadata dicts
+        all_keys = set(old_meta.keys()) | set(new_meta.keys())
+        diff_lines = []
+        
+        for key in sorted(all_keys):
+            old_value = old_meta.get(key)
+            new_value = new_meta.get(key)
+            
+            if old_value != new_value:
+                if old_value is not None and new_value is None:
+                    # Key was removed
+                    diff_lines.append(f"    -{key}: {old_value}")
+                elif old_value is None and new_value is not None:
+                    # Key was added
+                    diff_lines.append(f"    +{key}: {new_value}")
+                else:
+                    # Key was changed
+                    diff_lines.append(f"    -{key}: {old_value}")
+                    diff_lines.append(f"    +{key}: {new_value}")
+        
+        return "\n".join(diff_lines) if diff_lines else ""
+
     def summarize(self) -> str:
-        return f'Application: "{self.name}" "{self.fullname}"'
+        base_summary = f'Application: "{self.name}" "{self.fullname}"'
+        diff = self.get_metadata_diff()
+        if diff:
+            return f'{base_summary}\n{diff}'
+        return base_summary
 
     @staticmethod
     def get_priority() -> int:
@@ -126,6 +190,8 @@ class StatusBoardHandler(BaseModel):
                 self.status_board_object.delete(ocm)
             case "create":
                 self.status_board_object.create(ocm)
+            case "update":
+                self.status_board_object.update(ocm)
 
 
 class StatusBoardExporterIntegration(QontractReconcileIntegration):
@@ -134,12 +200,16 @@ class StatusBoardExporterIntegration(QontractReconcileIntegration):
         return QONTRACT_INTEGRATION
 
     @staticmethod
-    def get_product_apps(sb: StatusBoardV1) -> dict[str, set[str]]:
+    def get_product_apps(sb: StatusBoardV1) -> dict[str, dict[str, dict[str, Any]]]:
+        """
+        Get product apps with their metadata including saasFiles.
+        Returns a mapping of product_name -> {app_name -> app_data_with_metadata}
+        """
         global_selectors = (
             sb.global_app_selectors.exclude or [] if sb.global_app_selectors else []
         )
         return {
-            p.product_environment.product.name: get_selected_app_names(
+            p.product_environment.product.name: get_selected_app_data(
                 global_selectors, p
             )
             for p in sb.products
@@ -162,15 +232,63 @@ class StatusBoardExporterIntegration(QontractReconcileIntegration):
 
     @staticmethod
     def get_diff(
-        desired_product_apps: Mapping[str, set[str]],
+        desired_product_apps: Mapping[str, dict[str, dict[str, Any]]],
         current_products_applications: Iterable[Product],
     ) -> list[StatusBoardHandler]:
-        def create_app(app_name: str, product: Product) -> Application:
+        def create_app(
+            app_name: str, app_data: dict[str, Any], product: Product
+        ) -> Application:
             return Application(
+                id=None,
                 name=app_name,
                 fullname=f"{product.name}/{app_name}",
+                metadata=app_data.get("metadata", {}),
                 product=product,
             )
+
+        def update_app(current_app: Application, app_data: dict[str, Any]) -> Application:
+            # Generate fresh metadata with deploymentSaasFiles and managedBy
+            new_metadata = app_data.get("metadata", {}).copy()
+            new_metadata["managedBy"] = "qontract-reconcile"
+            
+            return Application(
+                id=current_app.id,
+                name=current_app.name,
+                fullname=current_app.fullname,
+                metadata=new_metadata,
+                old_metadata=current_app.metadata,  # Store old metadata for diff
+                product=current_app.product,
+            )
+
+        def metadata_differs(
+            current_metadata: dict[str, Any] | None, desired_metadata: dict[str, Any]
+        ) -> bool:
+            # Compare metadata, focusing on deploymentSaasFiles
+            current_saas_files = set(
+                current_metadata.get("deploymentSaasFiles", [])
+                if current_metadata
+                else []
+            )
+            desired_saas_files = set(desired_metadata.get("deploymentSaasFiles", []))
+            return current_saas_files != desired_saas_files
+
+        def add_metadata_updates(
+            product: Product,
+            apps_data: dict[str, dict[str, Any]],
+            return_list: list[StatusBoardHandler],
+        ) -> None:
+            """Helper function to add metadata update actions for a product's applications"""
+            for application in product.applications or []:
+                if application.name in apps_data:
+                    app_data = apps_data[application.name]
+                    desired_metadata = app_data.get("metadata", {})
+                    if metadata_differs(application.metadata, desired_metadata):
+                        return_list.append(
+                            StatusBoardHandler(
+                                action="update",
+                                status_board_object=update_app(application, app_data),
+                            )
+                        )
 
         return_list: list[StatusBoardHandler] = []
         current_products = {p.name: p for p in current_products_applications}
@@ -180,13 +298,25 @@ class StatusBoardExporterIntegration(QontractReconcileIntegration):
             for c in current_products_applications
         }
 
+        # Convert desired apps to the format expected by diff_mappings
+        desired_as_mapping: Mapping[str, set[str]] = {
+            product_name: set(apps_data.keys())
+            for product_name, apps_data in desired_product_apps.items()
+        }
+
         diff_result = diff_mappings(
             current_as_mapping,
-            desired_product_apps,
+            desired_as_mapping,
         )
 
         for product_name in diff_result.add:
-            product = Product(name=product_name, fullname=product_name, applications=[])
+            product = Product(
+                id=None,
+                name=product_name,
+                fullname=product_name,
+                metadata=None,
+                applications=[],
+            )
             return_list.append(
                 StatusBoardHandler(
                     action="create",
@@ -194,24 +324,32 @@ class StatusBoardExporterIntegration(QontractReconcileIntegration):
                 )
             )
             # new product, so it misses also the applications
+            apps_data = desired_product_apps[product_name]
             return_list.extend(
                 StatusBoardHandler(
                     action="create",
-                    status_board_object=create_app(app_name, product),
+                    status_board_object=create_app(app_name, app_data, product),
                 )
-                for app_name in desired_product_apps[product_name]
+                for app_name, app_data in apps_data.items()
             )
 
-        # existing product, only add/remove applications
+        # existing product, only add/remove/update applications
         for product_name, apps in diff_result.change.items():
             product = current_products[product_name]
+            apps_data = desired_product_apps[product_name]
+
+            # Create new applications
             return_list.extend(
                 StatusBoardHandler(
                     action="create",
-                    status_board_object=create_app(app_name, product),
+                    status_board_object=create_app(
+                        app_name, apps_data[app_name], product
+                    ),
                 )
                 for app_name in apps.desired - apps.current
             )
+
+            # Delete removed applications
             to_delete = apps.current - apps.desired
             return_list.extend(
                 StatusBoardHandler(
@@ -221,6 +359,21 @@ class StatusBoardExporterIntegration(QontractReconcileIntegration):
                 for application in product.applications or []
                 if application.name in to_delete
             )
+
+            # Update existing applications that have metadata changes
+            add_metadata_updates(product, apps_data, return_list)
+
+        # Handle products where app names stay the same but metadata might have changed
+        for product_name in diff_result.identical:
+            if (
+                product_name in current_products
+                and product_name in desired_product_apps
+            ):
+                product = current_products[product_name]
+                apps_data = desired_product_apps[product_name]
+
+                # Check if any existing applications need metadata updates
+                add_metadata_updates(product, apps_data, return_list)
 
         # product is deleted entirely
         for product_name in diff_result.delete:
@@ -240,12 +393,15 @@ class StatusBoardExporterIntegration(QontractReconcileIntegration):
         dry_run: bool, ocm_api: OCMBaseClient, diff: list[StatusBoardHandler]
     ) -> None:
         creations: list[StatusBoardHandler] = []
+        updates: list[StatusBoardHandler] = []
         deletions: list[StatusBoardHandler] = []
 
         for o in diff:
             match o.action:
                 case "create":
                     creations.append(o)
+                case "update":
+                    updates.append(o)
                 case "delete":
                     deletions.append(o)
 
@@ -255,7 +411,10 @@ class StatusBoardExporterIntegration(QontractReconcileIntegration):
         # Applications need to be deleted before Products
         deletions.sort(key=lambda x: x.status_board_object.get_priority(), reverse=True)
 
-        for d in creations + deletions:
+        # Updates can happen in any order but let's do products first for consistency
+        updates.sort(key=lambda x: x.status_board_object.get_priority())
+
+        for d in creations + updates + deletions:
             d.act(dry_run, ocm_api)
 
     def run(self, dry_run: bool) -> None:
@@ -264,7 +423,9 @@ class StatusBoardExporterIntegration(QontractReconcileIntegration):
 
         for sb in get_status_board():
             ocm_api = init_ocm_base_client(sb.ocm, self.secret_reader)
-            desired_product_apps: dict[str, set[str]] = self.get_product_apps(sb)
+            desired_product_apps: dict[str, dict[str, dict[str, Any]]] = (
+                self.get_product_apps(sb)
+            )
 
             current_products_applications = self.get_current_products_applications(
                 ocm_api

--- a/reconcile/status_board.py
+++ b/reconcile/status_board.py
@@ -25,7 +25,6 @@ from reconcile.utils.ocm.status_board import (
     get_managed_products,
     get_product_applications,
     update_application,
-    update_product,
 )
 from reconcile.utils.ocm_base_client import (
     OCMBaseClient,
@@ -82,14 +81,6 @@ class Product(AbstractStatusBoard):
             return
         delete_product(ocm, self.id)
 
-    def update(self, ocm: OCMBaseClient) -> None:
-        if not self.id:
-            logging.error(f'Trying to update Product "{self.name}" without id')
-            return
-        spec = self.dict(by_alias=True)
-        spec.pop("applications")
-        spec.pop("id")
-        update_product(ocm, self.id, spec)
 
     def summarize(self) -> str:
         return f'Product: "{self.name}"'

--- a/reconcile/test/ocm/test_utils_ocm_status_board.py
+++ b/reconcile/test/ocm/test_utils_ocm_status_board.py
@@ -13,7 +13,6 @@ from reconcile.utils.ocm.status_board import (
     get_managed_products,
     get_product_applications,
     update_application,
-    update_product,
 )
 
 
@@ -138,22 +137,6 @@ def test_delete_application(mocker: MockFixture) -> None:
 
     ocm.delete.assert_called_once_with(
         f"/api/status-board/v1/applications/{application_id}"
-    )
-
-
-def test_update_product(mocker: MockFixture) -> None:
-    ocm = mocker.patch("reconcile.utils.ocm_base_client.OCMBaseClient", autospec=True)
-    product_id = "foo"
-
-    update_product(ocm, product_id, {"name": "foo", "fullname": "foo"})
-
-    ocm.patch.assert_called_once_with(
-        f"/api/status-board/v1/products/{product_id}",
-        data={
-            "metadata": {METADATA_MANAGED_BY_KEY: METADATA_MANAGED_BY_VALUE},
-            "name": "foo",
-            "fullname": "foo",
-        },
     )
 
 

--- a/reconcile/test/ocm/test_utils_ocm_status_board.py
+++ b/reconcile/test/ocm/test_utils_ocm_status_board.py
@@ -12,6 +12,8 @@ from reconcile.utils.ocm.status_board import (
     delete_product,
     get_managed_products,
     get_product_applications,
+    update_application,
+    update_product,
 )
 
 
@@ -136,4 +138,36 @@ def test_delete_application(mocker: MockFixture) -> None:
 
     ocm.delete.assert_called_once_with(
         f"/api/status-board/v1/applications/{application_id}"
+    )
+
+
+def test_update_product(mocker: MockFixture) -> None:
+    ocm = mocker.patch("reconcile.utils.ocm_base_client.OCMBaseClient", autospec=True)
+    product_id = "foo"
+
+    update_product(ocm, product_id, {"name": "foo", "fullname": "foo"})
+
+    ocm.patch.assert_called_once_with(
+        f"/api/status-board/v1/products/{product_id}",
+        data={
+            "metadata": {METADATA_MANAGED_BY_KEY: METADATA_MANAGED_BY_VALUE},
+            "name": "foo",
+            "fullname": "foo",
+        },
+    )
+
+
+def test_update_application(mocker: MockFixture) -> None:
+    ocm = mocker.patch("reconcile.utils.ocm_base_client.OCMBaseClient", autospec=True)
+    application_id = "foo"
+
+    update_application(ocm, application_id, {"name": "foo", "fullname": "foo"})
+
+    ocm.patch.assert_called_once_with(
+        f"/api/status-board/v1/applications/{application_id}",
+        data={
+            "metadata": {METADATA_MANAGED_BY_KEY: METADATA_MANAGED_BY_VALUE},
+            "name": "foo",
+            "fullname": "foo",
+        },
     )

--- a/reconcile/test/test_status_board.py
+++ b/reconcile/test/test_status_board.py
@@ -18,6 +18,7 @@ from reconcile.utils.ocm_base_client import OCMBaseClient
 class StatusBoardStub(AbstractStatusBoard):
     created: bool | None = False
     deleted: bool | None = False
+    updated: bool | None = False
     summarized: bool | None = False
 
     def create(self, ocm: OCMBaseClient) -> None:
@@ -25,6 +26,9 @@ class StatusBoardStub(AbstractStatusBoard):
 
     def delete(self, ocm: OCMBaseClient) -> None:
         self.deleted = True
+
+    def update(self, ocm: OCMBaseClient) -> None:
+        self.updated = True
 
     def summarize(self) -> str:
         self.summarized = True
@@ -78,6 +82,19 @@ def status_board(gql_class_factory: Callable[..., StatusBoardV1]) -> StatusBoard
                                             "onboardingStatus": "OnBoarded",
                                         },
                                     ],
+                                    "saasFiles": [
+                                        {
+                                            "name": "foo-deployment",
+                                            "managedResourceTypes": [
+                                                "Deployment",
+                                                "Service",
+                                            ],
+                                        },
+                                        {
+                                            "name": "foo-config",
+                                            "managedResourceTypes": ["ConfigMap"],
+                                        },
+                                    ],
                                 }
                             },
                             {"app": {"name": "oof", "onboardingStatus": "BestEffort"}},
@@ -96,7 +113,7 @@ def test_status_board_handler(mocker: MockerFixture) -> None:
     ocm = mocker.patch("reconcile.status_board.OCMBaseClient")
     h = StatusBoardHandler(
         action="create",
-        status_board_object=StatusBoardStub(name="foo", fullname="foo"),
+        status_board_object=StatusBoardStub(id=None, name="foo", fullname="foo", metadata=None),
     )
 
     h.act(dry_run=False, ocm=ocm)
@@ -106,7 +123,7 @@ def test_status_board_handler(mocker: MockerFixture) -> None:
 
     h = StatusBoardHandler(
         action="delete",
-        status_board_object=StatusBoardStub(name="foo", fullname="foo"),
+        status_board_object=StatusBoardStub(id=None, name="foo", fullname="foo", metadata=None),
     )
 
     h.act(dry_run=False, ocm=ocm)
@@ -117,15 +134,25 @@ def test_status_board_handler(mocker: MockerFixture) -> None:
 
 def test_get_product_apps(status_board: StatusBoardV1) -> None:
     p = StatusBoardExporterIntegration.get_product_apps(status_board)
-    assert p == {"foo": {"foo", "foo-bar"}}
+    assert "foo" in p
+    assert "foo" in p["foo"]
+    assert "foo-bar" in p["foo"]
+
+    assert p["foo"]["foo"]["metadata"]["deploymentSaasFiles"] == ["foo-deployment"]
+    assert p["foo"]["foo-bar"]["metadata"]["deploymentSaasFiles"] == ["foo-deployment"]
 
 
 def test_get_diff_create_app() -> None:
     Product.update_forward_refs()
 
     h = StatusBoardExporterIntegration.get_diff(
-        {"foo": {"foo", "bar"}},
-        [Product(name="foo", fullname="foo", applications=[])],
+        {
+            "foo": {
+                "foo": {"name": "foo", "metadata": {}},
+                "bar": {"name": "bar", "metadata": {}},
+            }
+        },
+        [Product(id=None, name="foo", fullname="foo", metadata=None, applications=[])],
     )
 
     assert len(h) == 2
@@ -140,12 +167,14 @@ def test_get_diff_create_one_app() -> None:
     Product.update_forward_refs()
 
     h = StatusBoardExporterIntegration.get_diff(
-        {"foo": {"foo", "bar"}},
+        {"foo": {"foo": {"name": "foo", "metadata": {}}, "bar": {"name": "bar", "metadata": {}}}},
         [
             Product(
+                id=None,
                 name="foo",
                 fullname="foo",
-                applications=[Application(name="bar", fullname="foo/bar")],
+                metadata=None,
+                applications=[Application(id=None, name="bar", fullname="foo/bar", metadata=None, old_metadata=None, product=None)],
             )
         ],
     )
@@ -161,7 +190,12 @@ def test_get_diff_create_product_and_apps() -> None:
     Product.update_forward_refs()
 
     h = StatusBoardExporterIntegration.get_diff(
-        {"foo": {"foo", "bar"}},
+        {
+            "foo": {
+                "foo": {"name": "foo", "metadata": {}},
+                "bar": {"name": "bar", "metadata": {}},
+            }
+        },
         [],
     )
 
@@ -176,12 +210,14 @@ def test_get_diff_noop() -> None:
     Product.update_forward_refs()
 
     h = StatusBoardExporterIntegration.get_diff(
-        {"foo": {"bar"}},
+        {"foo": {"bar": {"name": "bar", "metadata": {}}}},
         [
             Product(
+                id=None,
                 name="foo",
                 fullname="foo",
-                applications=[Application(name="bar", fullname="foo/bar")],
+                metadata=None,
+                applications=[Application(id=None, name="bar", fullname="foo/bar", metadata=None, old_metadata=None, product=None)],
             )
         ],
     )
@@ -193,12 +229,14 @@ def test_get_diff_delete_app() -> None:
     Product.update_forward_refs()
 
     h = StatusBoardExporterIntegration.get_diff(
-        {"foo": set()},
+        {"foo": {}},
         [
             Product(
+                id=None,
                 name="foo",
                 fullname="foo",
-                applications=[Application(name="bar", fullname="foo/bar")],
+                metadata=None,
+                applications=[Application(id=None, name="bar", fullname="foo/bar", metadata=None, old_metadata=None, product=None)],
             )
         ],
     )
@@ -216,9 +254,11 @@ def test_get_diff_delete_apps_and_product() -> None:
         {},
         [
             Product(
+                id=None,
                 name="foo",
                 fullname="foo",
-                applications=[Application(name="bar", fullname="foo/bar")],
+                metadata=None,
+                applications=[Application(id=None, name="bar", fullname="foo/bar", metadata=None, old_metadata=None, product=None)],
             )
         ],
     )
@@ -229,17 +269,117 @@ def test_get_diff_delete_apps_and_product() -> None:
     assert isinstance(h[1].status_board_object, Product)
 
 
+def test_get_diff_update_app_metadata() -> None:
+    Product.update_forward_refs()
+
+    # Existing application with old metadata (no deploymentSaasFiles)
+    existing_app = Application(
+        id="app-123",
+        name="foo",
+        fullname="product/foo",
+        metadata={"someOtherField": "value"},  # No deploymentSaasFiles
+        old_metadata=None,
+        product=None
+    )
+    existing_product = Product(
+        id="prod-123",
+        name="product",
+        fullname="product",
+        metadata=None,
+        applications=[existing_app]
+    )
+
+    # Desired state with deploymentSaasFiles
+    desired_apps = {
+        "product": {
+            "foo": {
+                "name": "foo",
+                "metadata": {
+                    "deploymentSaasFiles": ["foo-deployment"]
+                }
+            }
+        }
+    }
+
+    h = StatusBoardExporterIntegration.get_diff(
+        desired_apps,
+        [existing_product],
+    )
+
+    # Should generate an update action
+    assert len(h) == 1
+    assert h[0].action == "update"
+    assert isinstance(h[0].status_board_object, Application)
+    assert h[0].status_board_object.name == "foo"
+    assert h[0].status_board_object.id == "app-123"  # Should preserve the ID
+    if h[0].status_board_object.metadata:
+        assert h[0].status_board_object.metadata["deploymentSaasFiles"] == ["foo-deployment"]
+
+
+def test_get_diff_update_app_metadata_preserves_managed_by() -> None:
+    Product.update_forward_refs()
+
+    # Existing application with old metadata that should be replaced
+    existing_app = Application(
+        id="app-123",
+        name="foo",
+        fullname="product/foo",
+        metadata={
+            "managedBy": "qontract-reconcile",
+            "someOtherField": "value"  # This should be discarded in fresh metadata
+        },
+        old_metadata=None,
+        product=None
+    )
+    existing_product = Product(
+        id="prod-123",
+        name="product",
+        fullname="product",
+        metadata=None,
+        applications=[existing_app]
+    )
+
+    # Desired state with deploymentSaasFiles
+    desired_apps = {
+        "product": {
+            "foo": {
+                "name": "foo",
+                "metadata": {
+                    "deploymentSaasFiles": ["foo-deployment"]
+                }
+            }
+        }
+    }
+
+    h = StatusBoardExporterIntegration.get_diff(
+        desired_apps,
+        [existing_product],
+    )
+
+    # Should generate an update action with fresh metadata
+    assert len(h) == 1
+    assert h[0].action == "update"
+    assert isinstance(h[0].status_board_object, Application)
+    
+    updated_metadata = h[0].status_board_object.metadata
+    if updated_metadata:
+        assert updated_metadata["managedBy"] == "qontract-reconcile"  # Always present
+        assert updated_metadata["deploymentSaasFiles"] == ["foo-deployment"]  # From desired state
+        assert "someOtherField" not in updated_metadata  # Old metadata discarded
+        assert len(updated_metadata) == 2  # Only managedBy and deploymentSaasFiles
+
+
 def test_apply_sorted(mocker: MockerFixture) -> None:
     Product.update_forward_refs()
     ocm = mocker.patch("reconcile.status_board.OCMBaseClient", autospec=True)
     logging = mocker.patch("reconcile.status_board.logging", autospec=True)
 
-    product = Product(name="foo", fullname="foo", applications=[])
+    product = Product(id=None, name="foo", fullname="foo", metadata=None, applications=[])
     h = [
         StatusBoardHandler(
             action="create",
             status_board_object=Application(
-                name="bar", fullname="foo/bar", product=product
+                id=None, name="bar", fullname="foo/bar", metadata=None, old_metadata=None, product=product
             ),
         ),
         StatusBoardHandler(
@@ -256,3 +396,16 @@ def test_apply_sorted(mocker: MockerFixture) -> None:
         ],
         any_order=False,
     )
+
+
+def test_status_board_handler_update(mocker: MockerFixture) -> None:
+    ocm = mocker.patch("reconcile.status_board.OCMBaseClient")
+    h = StatusBoardHandler(
+        action="update",
+        status_board_object=StatusBoardStub(id="123", name="foo", fullname="foo", metadata=None),
+    )
+
+    h.act(dry_run=False, ocm=ocm)
+    assert isinstance(h.status_board_object, StatusBoardStub)
+    assert h.status_board_object.updated
+    assert h.status_board_object.summarized

--- a/reconcile/typed_queries/status_board.py
+++ b/reconcile/typed_queries/status_board.py
@@ -19,11 +19,15 @@ def get_status_board(
     return query(query_func).status_board_v1 or []
 
 
-def get_selected_app_names(
+def get_selected_app_data(
     global_selectors: Iterable[str],
     product: StatusBoardProductV1,
-) -> set[str]:
-    selected_app_names: set[str] = set()
+) -> dict[str, dict[str, Any]]:
+    """
+    Get selected app data including saasFiles metadata.
+    Returns a mapping of app_name -> app_data_with_metadata
+    """
+    selected_app_data: dict[str, dict[str, Any]] = {}
 
     apps: dict[str, Any] = {"apps": []}
     for namespace in product.product_environment.namespaces or []:
@@ -31,17 +35,38 @@ def get_selected_app_names(
         if namespace.app.parent_app:
             prefix = f"{namespace.app.parent_app.name}-"
         name = f"{prefix}{namespace.app.name}"
-        selected_app_names.add(name)
+
+        # Get deployment saasFiles for this app
+        deployment_saas_files = []
+        if namespace.app.saas_files:
+            deployment_saas_files = [
+                saas_file.name
+                for saas_file in namespace.app.saas_files
+                if "Deployment" in saas_file.managed_resource_types
+            ]
+
+        app_data = {
+            "name": name,
+            "metadata": {"deploymentSaasFiles": deployment_saas_files},
+        }
+        selected_app_data[name] = app_data
+
         app = namespace.app.dict(by_alias=True)
         app["name"] = name
         apps["apps"].append(app)
 
         for child in namespace.app.children_apps or []:
-            name = f"{namespace.app.name}-{child.name}"
-            if name not in selected_app_names:
-                selected_app_names.add(f"{namespace.app.name}-{child.name}")
+            child_name = f"{namespace.app.name}-{child.name}"
+            if child_name not in selected_app_data:
+                # Children don't have their own saasFiles, they inherit from parent
+                child_data = {
+                    "name": child_name,
+                    "metadata": {"deploymentSaasFiles": deployment_saas_files},
+                }
+                selected_app_data[child_name] = child_data
+
                 child_dict = child.dict(by_alias=True)
-                child_dict["name"] = name
+                child_dict["name"] = child_name
                 apps["apps"].append(child_dict)
 
     selectors = set(global_selectors)
@@ -52,6 +77,15 @@ def get_selected_app_names(
         apps_to_remove: set[str] = set()
         results = parser.parse(selector).find(apps)
         apps_to_remove.update(match.value["name"] for match in results)
-        selected_app_names -= apps_to_remove
+        for app_name in apps_to_remove:
+            selected_app_data.pop(app_name, None)
 
-    return selected_app_names
+    return selected_app_data
+
+
+def get_selected_app_names(
+    global_selectors: Iterable[str],
+    product: StatusBoardProductV1,
+) -> set[str]:
+    app_data = get_selected_app_data(global_selectors, product)
+    return set(app_data.keys())

--- a/reconcile/utils/ocm/status_board.py
+++ b/reconcile/utils/ocm/status_board.py
@@ -58,15 +58,6 @@ def create_application(ocm_api: OCMBaseClient, spec: dict[str, Any]) -> str:
     return resp["id"]
 
 
-def update_product(
-    ocm_api: OCMBaseClient, product_id: str, spec: dict[str, Any]
-) -> None:
-    if "metadata" not in spec or spec["metadata"] is None:
-        spec["metadata"] = {}
-    spec["metadata"][METADATA_MANAGED_BY_KEY] = METADATA_MANAGED_BY_VALUE
-    ocm_api.patch(f"/api/status-board/v1/products/{product_id}", data=spec)
-
-
 def update_application(
     ocm_api: OCMBaseClient, application_id: str, spec: dict[str, Any]
 ) -> None:

--- a/reconcile/utils/ocm/status_board.py
+++ b/reconcile/utils/ocm/status_board.py
@@ -58,6 +58,24 @@ def create_application(ocm_api: OCMBaseClient, spec: dict[str, Any]) -> str:
     return resp["id"]
 
 
+def update_product(
+    ocm_api: OCMBaseClient, product_id: str, spec: dict[str, Any]
+) -> None:
+    if "metadata" not in spec or spec["metadata"] is None:
+        spec["metadata"] = {}
+    spec["metadata"][METADATA_MANAGED_BY_KEY] = METADATA_MANAGED_BY_VALUE
+    ocm_api.patch(f"/api/status-board/v1/products/{product_id}", data=spec)
+
+
+def update_application(
+    ocm_api: OCMBaseClient, application_id: str, spec: dict[str, Any]
+) -> None:
+    if "metadata" not in spec or spec["metadata"] is None:
+        spec["metadata"] = {}
+    spec["metadata"][METADATA_MANAGED_BY_KEY] = METADATA_MANAGED_BY_VALUE
+    ocm_api.patch(f"/api/status-board/v1/applications/{application_id}", data=spec)
+
+
 def delete_product(ocm_api: OCMBaseClient, product_id: str) -> None:
     ocm_api.delete(f"/api/status-board/v1/products/{product_id}")
 

--- a/tools/qontract_cli.py
+++ b/tools/qontract_cli.py
@@ -2754,9 +2754,12 @@ def slo_document_services(ctx: click.Context, status_board_instance: str) -> Non
         print(f"Status-board instance '{status_board_instance}' not found.")
         sys.exit(1)
 
-    desired_product_apps: dict[str, set[str]] = (
-        StatusBoardExporterIntegration.get_product_apps(sb)
-    )
+    desired_product_apps: dict[str, set[str]] = {
+        product_name: set(apps_data.keys())
+        for product_name, apps_data in StatusBoardExporterIntegration.get_product_apps(
+            sb
+        ).items()
+    }
 
     slodocs = []
     for slodoc in get_slo_documents():


### PR DESCRIPTION
This PR is intended to add the names of saas-file objects to the metadata of application in status-board.
The format of this will look like:
`"metadata": 
{
    "managedBy": "qontract-reconcile",
    "deploymentSaasFiles": ["foo-deployment"]
}`

This PR is blocked by this [MR](https://gitlab.cee.redhat.com/service/app-interface/-/merge_requests/147200) which adds the saas-file-v2 schema to the list of allowed schemas for the integration.

The two main changes with this are hitting new endpoints in status-board and refactoring the code to handle the additional layer of nesting in product_apps.