### PR TITLE
APPSRE-11020 konflux pipeline tests

### DIFF
--- a/.tekton/qontract-reconcile-master-pull-request.yaml
+++ b/.tekton/qontract-reconcile-master-pull-request.yaml
@@ -27,11 +27,17 @@ spec:
   - name: image-expires-after
     value: 5d
   - name: dockerfile
-    value: dockerfiles/Dockerfile
+    value: dockerfiles/Dockerfile.konflux
   - name: path-context
     value: .
   - name: target-stage
     value: prod-image
+  - name: fetchTags
+    value: 'true'
+  # Note, that we have to specify some depth here. Lets go with something we wont reach in a long time
+  # We need the depth to properly have uv infer version
+  - name: cloneDepth
+    value: '100000'
   pipelineRef:
     params:
     - name: url

--- a/.tekton/qontract-reconcile-master-push.yaml
+++ b/.tekton/qontract-reconcile-master-push.yaml
@@ -24,11 +24,17 @@ spec:
   - name: output-image
     value: quay.io/redhat-user-workloads/app-sre-tenant/qontract-reconcile-master/qontract-reconcile-master:{{revision}}
   - name: dockerfile
-    value: dockerfiles/Dockerfile
+    value: dockerfiles/Dockerfile.konflux
   - name: path-context
     value: .
   - name: target-stage
-    value: prod-image
+    value: prod-image-post-pypi-push
+  - name: fetchTags
+    value: 'true'
+  # Note, that we have to specify some depth here. Lets go with something we wont reach in a long time
+  # We need the depth to properly have uv infer version
+  - name: cloneDepth
+    value: '100000'
   pipelineRef:
     params:
     - name: url

--- a/dockerfiles/Dockerfile.konflux
+++ b/dockerfiles/Dockerfile.konflux
@@ -1,0 +1,141 @@
+###############################################################################
+# STAGE 1 - build-image
+###############################################################################
+FROM quay.io/redhat-services-prod/app-sre-tenant/container-images-master/qontract-reconcile-builder-master:1.0.0-1 AS build-image
+COPY --from=ghcr.io/astral-sh/uv:0.7.14@sha256:cda0fdc9b6066975ba4c791597870d18bc3a441dfc18ab24c5e888c16e15780c /uv /bin/uv
+
+WORKDIR /work
+
+COPY pyproject.toml uv.lock README.md ./
+COPY helm helm
+COPY tools tools
+COPY reconcile reconcile
+
+ENV \
+    # compile bytecode for faster startup
+    UV_COMPILE_BYTECODE="true" \
+    # disable uv cache. it doesn't make sense in a container
+    UV_NO_CACHE=true
+
+# Install dependencies and qontract-reconcile
+RUN UV_DYNAMIC_VERSIONING_BYPASS="0.0.0" uv sync --frozen --no-group dev --python /usr/bin/python3
+
+
+###############################################################################
+# STAGE 2 - dev-image
+###############################################################################
+FROM quay.io/redhat-services-prod/app-sre-tenant/container-images-master/qontract-reconcile-base-master:1.0.0-1 AS dev-image
+COPY --from=ghcr.io/astral-sh/uv:0.7.14@sha256:cda0fdc9b6066975ba4c791597870d18bc3a441dfc18ab24c5e888c16e15780c /uv /bin/uv
+
+ARG CONTAINER_UID=1000
+RUN useradd --uid ${CONTAINER_UID} reconcile && \
+    chown -R reconcile /.terraform.d
+
+# Use a different workdir so venv can't be overwritten by volume mount
+WORKDIR /opt/app-root/src
+
+COPY --from=build-image --chown=reconcile:root /work/ ./
+RUN UV_DYNAMIC_VERSIONING_BYPASS="0.0.0" uv sync --frozen --no-cache --group debugger --no-group dev
+
+WORKDIR /work
+USER reconcile
+VOLUME ["/work", "/config"]
+# Set the PATH to include the virtualenv
+ENV PATH="/opt/app-root/src/.venv/bin:${PATH}"
+ENTRYPOINT ["/work/dev/run.sh"]
+
+
+###############################################################################
+# STAGE 3 - prod-image-pre-test
+###############################################################################
+FROM quay.io/redhat-services-prod/app-sre-tenant/container-images-master/qontract-reconcile-base-master:1.0.0-1 AS prod-image-pre-test
+
+ARG quay_expiration=never
+LABEL quay.expires-after=${quay_expiration}
+
+# Tini
+ENV TINI_VERSION=v0.19.0
+ADD https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini /tini
+RUN chmod +x /tini
+
+# Keep the image up to date
+RUN microdnf upgrade -y && microdnf clean all
+
+
+WORKDIR /work
+# the integration-manager needs the helm charts
+RUN ln -s /work/helm /helm
+COPY --from=build-image /work ./
+
+# Set the PATH to include the virtualenv
+ENV PATH="/work/.venv/bin:${PATH}"
+
+ENTRYPOINT ["/tini", "--"]
+CMD ["run-integration"]
+
+###############################################################################
+# STAGE 4 - unittest image
+###############################################################################
+FROM prod-image-pre-test AS test-image
+COPY --from=ghcr.io/astral-sh/uv:0.7.14@sha256:cda0fdc9b6066975ba4c791597870d18bc3a441dfc18ab24c5e888c16e15780c /uv /bin/uv
+
+RUN microdnf install -y make
+
+# Tests need the .git directory to run and infer version
+COPY .git .git
+
+# Install test dependencies
+RUN uv sync --frozen --no-cache --group dev
+
+# Run tests
+COPY Makefile .
+RUN make all-tests
+RUN echo "true" > /is_tested
+
+###############################################################################
+# STAGE 5 - tested prod image
+###############################################################################
+FROM prod-image-pre-test AS prod-image
+
+# Lets make sure we run tests when targeting prod-image
+# However, we dont want any installed deps from test image
+COPY --from=test-image /is_tested /is_tested
+
+###############################################################################
+# STAGE 6 - tested fips-prod-image
+###############################################################################
+FROM prod-image-pre-test AS fips-prod-image
+ENV OC_VERSION=4.16.2
+
+# oc versions sometimes have issues with FIPS enabled systems requiring us to use specific
+# versions in these environments so in this case we extract an older version of oc and kubectl
+COPY --chown=0:0 --from=quay.io/app-sre/qontract-reconcile-oc:0.3.1 \
+    /work/${OC_VERSION}/ /usr/local/bin/
+
+# Lets make sure we run tests when targeting fips-prod-image
+# However, we dont want any installed deps from test image
+COPY --from=test-image /is_tested /is_tested
+
+###############################################################################
+# STAGE 7 - PyPI publish package
+###############################################################################
+FROM test-image AS pypi
+ARG TWINE_USERNAME
+ARG TWINE_PASSWORD
+
+# Lets make sure we ran previous prod stage before uploading to pypi
+COPY --from=prod-image /is_tested /is_tested
+RUN echo "true" > /is_pypi_pushed
+
+# qontract-reconcile version depends on git tags!
+# The .git dir should already be part of the test image.
+# TODO
+# RUN make pypi
+
+###############################################################################
+# STAGE 8 - tested and pypi pushed prod image
+###############################################################################
+FROM prod-image AS prod-image-post-pypi-push
+
+# Lets make sure we pypi push
+COPY --from=pypi /is_pypi_pushed /is_pypi_pushed


### PR DESCRIPTION
We introduce qr unittests for konflux build pipeline.
We introduce a new dockerfile, as we make changes to the targets and their deps. For now we dont want to affect ci.ext builds with those changes. Long-term, we will move completely to the new Dockerfile.

**dockerfile target chain**

on master push

```
builder -> prod-pre-test-image -> test-image -> prod-image -> pypi -> prod-image-post-pypi-push
```

on PR

```
builder -> prod-pre-test-image -> test-image -> prod-image
```

Note, that the pypi push is still in TODO. We are implementing it in a follow up PR (when we obsolete ci.ext builds). This PR introduces the general pipeline stucture