### PR TITLE
[saasherder] add types to all TriggerSpec

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -290,7 +290,6 @@ module = [
     "reconcile.utils.gpg",
     "reconcile.utils.gql",
     "reconcile.utils.imap_client",
-    "reconcile.utils.jenkins_api",
     "reconcile.utils.jjb_client",
     "reconcile.utils.ldap_client",
     "reconcile.utils.lean_terraform_client",

--- a/reconcile/test/test_jenkins_api.py
+++ b/reconcile/test/test_jenkins_api.py
@@ -1,0 +1,52 @@
+from unittest.mock import create_autospec
+
+import pytest
+from pytest_mock import MockerFixture
+from requests import Response
+
+from reconcile.utils.jenkins_api import JenkinsApi
+
+
+@pytest.fixture
+def jenkins_api() -> JenkinsApi:
+    return JenkinsApi("http://example.com", "user", "password", ssl_verify=False)
+
+
+def test_get_jobs_state(
+    jenkins_api: JenkinsApi,
+    mocker: MockerFixture,
+) -> None:
+    mocked_requests = mocker.patch("reconcile.utils.jenkins_api.requests")
+    mocked_response = create_autospec(Response)
+    mocked_requests.get.return_value = mocked_response
+    build = {
+        "_class": "hudson.model.FreeStyleBuild",
+        "actions": [
+            {"_class": "hudson.model.CauseAction"},
+            {},
+            {
+                "_class": "hudson.plugins.git.util.BuildData",
+                "lastBuiltRevision": {
+                    "SHA1": "1283f348a8364d925385388ae2943903c0bdd86a"
+                },
+            },
+        ],
+        "number": 1,
+        "result": "SUCCESS",
+    }
+    mocked_response.json.return_value = {
+        "_class": "hudson.model.Hudson",
+        "jobs": [
+            {
+                "_class": "hudson.model.FreeStyleProject",
+                "name": "job1",
+                "builds": [build],
+            },
+        ],
+    }
+    expected_build = build | {"commit_sha": "1283f348a8364d925385388ae2943903c0bdd86a"}
+    expected_job_state = {"job1": [expected_build]}
+
+    job_state = jenkins_api.get_jobs_state()
+
+    assert job_state == expected_job_state

--- a/reconcile/test/test_saasherder.py
+++ b/reconcile/test/test_saasherder.py
@@ -32,6 +32,7 @@ from reconcile.typed_queries.saas_files import (
     SaasFile,
     SaasResourceTemplate,
 )
+from reconcile.utils.jenkins_api import JobBuildState
 from reconcile.utils.jjb_client import JJB
 from reconcile.utils.openshift_resource import ResourceInventory
 from reconcile.utils.promotion_state import PromotionData
@@ -575,7 +576,11 @@ class TestGetUpstreamJobsDiffSaasFile(TestCase):
         self.maxDiff = None
 
     def test_get_upstream_jobs_diff_saas_file_all_fine(self) -> None:
-        state_content = {"number": 2, "result": "SUCCESS", "commit_sha": "abcd4242"}
+        state_content = JobBuildState(
+            number=2,
+            result="SUCCESS",
+            commit_sha="abcd4242",
+        )
         current_state = {"ci": {"job": [state_content]}}
         saasherder = SaasHerder(
             [self.saas_file],
@@ -619,7 +624,11 @@ class TestGetUpstreamJobsDiffSaasFile(TestCase):
     def test_get_upstream_jobs_diff_saas_file_all_fine_include_trigger_trace(
         self,
     ) -> None:
-        state_content = {"number": 2, "result": "SUCCESS", "commit_sha": "abcd4242"}
+        state_content = JobBuildState(
+            number=2,
+            result="SUCCESS",
+            commit_sha="abcd4242",
+        )
         current_state = {"ci": {"job": [state_content]}}
         saasherder = SaasHerder(
             [self.saas_file],

--- a/reconcile/utils/jenkins_api.py
+++ b/reconcile/utils/jenkins_api.py
@@ -1,5 +1,6 @@
 import logging
-from typing import Any
+from collections.abc import Mapping
+from typing import Any, NotRequired, Self, TypedDict
 
 import requests
 import toml
@@ -9,23 +10,40 @@ from sretoolbox.utils import retry
 from reconcile.utils.secret_reader import SecretReaderBase
 
 
+class JobBuildState(TypedDict):
+    _class: NotRequired[str]
+    number: int
+    result: NotRequired[str | None]
+    actions: NotRequired[list]
+    commit_sha: NotRequired[str]
+
+
 class JenkinsApi:
     """Wrapper around Jenkins API calls"""
 
-    @staticmethod
+    @classmethod
     def init_jenkins_from_secret(
-        secret_reader: SecretReaderBase, secret, ssl_verify=True
-    ) -> "JenkinsApi":
+        cls,
+        secret_reader: SecretReaderBase,
+        secret: Mapping[str, Any],
+        ssl_verify: bool = True,
+    ) -> Self:
         token_config = secret_reader.read(secret)
         config = toml.loads(token_config)
-        return JenkinsApi(
+        return cls(
             config["jenkins"]["url"],
             config["jenkins"]["user"],
             config["jenkins"]["password"],
             ssl_verify=ssl_verify,
         )
 
-    def __init__(self, url: str, user: str, password: str, ssl_verify=True):
+    def __init__(
+        self,
+        url: str,
+        user: str,
+        password: str,
+        ssl_verify: bool = True,
+    ):
         self.url = url
         self.user = user
         self.password = password
@@ -43,7 +61,7 @@ class JenkinsApi:
         res.raise_for_status()
         return yaml.safe_load(res.text)
 
-    def apply_jcasc_config(self, config: dict[str, Any]):
+    def apply_jcasc_config(self, config: dict[str, Any]) -> None:
         url = f"{self.url}/manage/configuration-as-code/apply"
         res = requests.post(
             url,
@@ -54,7 +72,7 @@ class JenkinsApi:
         )
         res.raise_for_status()
 
-    def get_job_names(self):
+    def get_job_names(self) -> list[str]:
         url = f"{self.url}/api/json?tree=jobs[name]"
         res = requests.get(
             url, verify=self.ssl_verify, auth=(self.user, self.password), timeout=60
@@ -64,36 +82,54 @@ class JenkinsApi:
         job_names = [r["name"] for r in res.json()["jobs"]]
         return job_names
 
+    @staticmethod
+    def _build_job_build_state(build: Mapping) -> JobBuildState:
+        job_build_state = JobBuildState(number=build["number"])
+        if "_class" in build:
+            job_build_state["_class"] = build["_class"]
+        if "actions" in build:
+            job_build_state["actions"] = build["actions"]
+        if "result" in build:
+            job_build_state["result"] = build["result"]
+        commit_sha = next(
+            (
+                revision["SHA1"]
+                for a in reversed(build.get("actions", []))
+                if (revision := a.get("lastBuiltRevision"))
+            ),
+            None,
+        )
+        if commit_sha:
+            job_build_state["commit_sha"] = commit_sha
+        return job_build_state
+
     @retry()
-    def get_jobs_state(self):
+    def get_jobs_state(self) -> dict[str, list[JobBuildState]]:
         url = f"{self.url}/api/json?tree=jobs[name,builds[number,result,actions[lastBuiltRevision[SHA1]]]]"
         res = requests.get(
             url, verify=self.ssl_verify, auth=(self.user, self.password), timeout=60
         )
 
         res.raise_for_status()
-        jobs_state = {}
-        for r in res.json()["jobs"]:
-            job_name = r["name"]
-            builds = r.get("builds", [])
-            for b in builds:
-                actions = b.get("actions", [])
-                for a in actions:
-                    revision = a.get("lastBuiltRevision")
-                    if revision:
-                        b["commit_sha"] = revision["SHA1"]
-            jobs_state[job_name] = builds
+        jobs = res.json().get("jobs") or []
+        return {
+            job["name"]: list(
+                map(
+                    self._build_job_build_state,
+                    job.get("builds", []),
+                )
+            )
+            for job in jobs
+        }
 
-        return jobs_state
-
-    def delete_build(self, job_name, build_id):
+    def delete_build(self, job_name: str, build_id: str) -> None:
         url = f"{self.url}/job/{job_name}/{build_id}/doDelete"
         res = requests.post(
             url, verify=self.ssl_verify, auth=(self.user, self.password), timeout=60
         )
         res.raise_for_status()
 
-    def get_all_roles(self):
+    def get_all_roles(self) -> dict[str, Any]:
         url = f"{self.url}/role-strategy/strategy/getAllRoles"
         res = requests.get(
             url, verify=self.ssl_verify, auth=(self.user, self.password), timeout=60
@@ -102,7 +138,7 @@ class JenkinsApi:
         res.raise_for_status()
         return res.json()
 
-    def assign_role_to_user(self, role, user):
+    def assign_role_to_user(self, role: str, user: str) -> None:
         url = f"{self.url}/role-strategy/strategy/assignRole"
         data = {"type": "globalRoles", "roleName": role, "sid": user}
         res = requests.post(
@@ -115,7 +151,7 @@ class JenkinsApi:
 
         res.raise_for_status()
 
-    def unassign_role_from_user(self, role, user):
+    def unassign_role_from_user(self, role: str, user: str) -> None:
         url = f"{self.url}/role-strategy/strategy/unassignRole"
         data = {"type": "globalRoles", "roleName": role, "sid": user}
         res = requests.post(
@@ -128,7 +164,7 @@ class JenkinsApi:
 
         res.raise_for_status()
 
-    def safe_restart(self, force_restart=False):
+    def safe_restart(self, force_restart: bool = False) -> None:
         url = f"{self.url}/safeRestart"
         if self.should_restart or force_restart:
             logging.debug(
@@ -142,7 +178,7 @@ class JenkinsApi:
 
             res.raise_for_status()
 
-    def get_builds(self, job_name):
+    def get_builds(self, job_name: str) -> list[dict[str, Any]]:
         url = (
             f"{self.url}/job/{job_name}/api/json"
             + "?tree=allBuilds[timestamp,result,id]"
@@ -157,14 +193,14 @@ class JenkinsApi:
         except KeyError:
             return []
 
-    def get_build_history(self, job_name, time_limit):
+    def get_build_history(self, job_name: str, time_limit: int) -> list[str]:
         return [
             b["result"]
             for b in self.get_builds(job_name)
             if time_limit < self.timestamp_seconds(b["timestamp"])
         ]
 
-    def is_job_running(self, job_name):
+    def is_job_running(self, job_name: str) -> bool:
         url = f"{self.url}/job/{job_name}/lastBuild/api/json"
         res = requests.get(
             url, verify=self.ssl_verify, auth=(self.user, self.password), timeout=60
@@ -178,7 +214,7 @@ class JenkinsApi:
         res.raise_for_status()
         return res.json()["building"] is True
 
-    def get_crumb_kwargs(self):
+    def get_crumb_kwargs(self) -> dict[str, Any]:
         try:
             crumb_url = f"{self.url}/crumbIssuer/api/json"
             res = requests.get(
@@ -197,7 +233,7 @@ class JenkinsApi:
 
         return kwargs
 
-    def trigger_job(self, job_name):
+    def trigger_job(self, job_name: str) -> None:
         kwargs = self.get_crumb_kwargs()
 
         url = f"{self.url}/job/{job_name}/build"
@@ -212,5 +248,5 @@ class JenkinsApi:
         res.raise_for_status()
 
     @staticmethod
-    def timestamp_seconds(timestamp):
+    def timestamp_seconds(timestamp: float) -> int:
         return int(timestamp / 1000)

--- a/reconcile/utils/jenkins_api.py
+++ b/reconcile/utils/jenkins_api.py
@@ -89,8 +89,7 @@ class JenkinsApi:
                 return revision["SHA1"]
         return None
 
-    @staticmethod
-    def _build_job_build_state(build: Mapping) -> JobBuildState:
+    def _build_job_build_state(self, build: Mapping) -> JobBuildState:
         job_build_state = JobBuildState(number=build["number"])
         if "_class" in build:
             job_build_state["_class"] = build["_class"]
@@ -98,7 +97,7 @@ class JenkinsApi:
             job_build_state["actions"] = build["actions"]
         if "result" in build:
             job_build_state["result"] = build["result"]
-        if commit_sha := JenkinsApi._get_commit_sha_from_build(build):
+        if commit_sha := self._get_commit_sha_from_build(build):
             job_build_state["commit_sha"] = commit_sha
         return job_build_state
 

--- a/reconcile/utils/saasherder/interfaces.py
+++ b/reconcile/utils/saasherder/interfaces.py
@@ -245,6 +245,8 @@ class SaasResourceTemplateTargetPromotion(Protocol):
     @property
     def promotion_data(self) -> Sequence[SaasPromotionData] | None: ...
 
+    def dict(self, *, by_alias: bool = False) -> dict[str, Any]: ...
+
 
 class Channel(Protocol):
     name: str
@@ -289,6 +291,8 @@ class SaasResourceTemplateTargetUpstream(Protocol):
     @property
     def instance(self) -> SaasJenkinsInstance: ...
 
+    def dict(self, *, by_alias: bool = False) -> dict[str, Any]: ...
+
 
 class SaasQuayInstance(Protocol):
     url: str
@@ -306,6 +310,8 @@ class SaasResourceTemplateTargetImage(Protocol):
 
     @property
     def org(self) -> SaasQuayOrg: ...
+
+    def dict(self, *, by_alias: bool = False) -> dict[str, Any]: ...
 
 
 class SaasResourceTemplateTarget(HasParameters, HasSecretParameters, Protocol):

--- a/reconcile/utils/saasherder/models.py
+++ b/reconcile/utils/saasherder/models.py
@@ -4,7 +4,7 @@ import logging
 from collections.abc import Iterable, Sequence
 from dataclasses import dataclass
 from enum import Enum
-from typing import Any
+from typing import Any, NotRequired, TypedDict
 
 from github import Github
 from pydantic import (
@@ -78,8 +78,53 @@ class SLOKey:
     cluster_name: str
 
 
+class TriggerSpecConfigStateContentNamespaceApp(TypedDict):
+    name: str
+
+
+class TriggerSpecConfigStateContentNamespaceCluster(TypedDict):
+    name: str
+    serverUrl: str
+
+
+class TriggerSpecConfigStateContentNamespace(TypedDict):
+    name: str
+    cluster: TriggerSpecConfigStateContentNamespaceCluster
+    app: TriggerSpecConfigStateContentNamespaceApp
+
+
+class TriggerSpecConfigStateContent(TypedDict):
+    """
+    dict representation of reconcile.typed_queries.saas_files.SaasResourceTemplateTarget
+    with some additional fields.
+    """
+
+    path: str | None
+    name: str | None
+    namespace: TriggerSpecConfigStateContentNamespace
+    ref: str | None
+    promotion: dict | None
+    parameters: str | None
+    secretParameters: list[dict] | None
+    slos: list[Any] | None
+    upstream: Any | None
+    images: list[Any] | None
+    disable: bool | None
+    delete: bool | None
+
+    # additional fields
+    saas_file_parameters: str | None
+    saas_file_managed_resource_types: list[str]
+    saas_file_managed_resource_names: NotRequired[list[Any]]
+    url: str
+    rt_parameters: str | None
+    rt_secretparameters: NotRequired[list[dict]]
+    saas_file_secretparameters: NotRequired[list[dict]]
+
+
 @dataclass(frozen=True)
 class TriggerSpecConfig(TriggerSpecBase):
+    state_content: TriggerSpecConfigStateContent | None
     resource_template_url: str
     slos: list[SLODocument] | None = None
     target_name: str | None = None

--- a/reconcile/utils/saasherder/models.py
+++ b/reconcile/utils/saasherder/models.py
@@ -15,6 +15,7 @@ from pydantic import (
 from reconcile.gql_definitions.fragments.saas_slo_document import (
     SLODocument,
 )
+from reconcile.utils.jenkins_api import JobBuildState
 from reconcile.utils.oc_connection_parameters import Cluster
 from reconcile.utils.saasherder.interfaces import (
     HasParameters,
@@ -169,6 +170,7 @@ class TriggerSpecMovingCommit(TriggerSpecBase):
 
 @dataclass(frozen=True)
 class TriggerSpecUpstreamJob(TriggerSpecBase):
+    state_content: JobBuildState
     instance_name: str
     job_name: str
 

--- a/reconcile/utils/saasherder/models.py
+++ b/reconcile/utils/saasherder/models.py
@@ -155,6 +155,7 @@ class TriggerSpecConfig(TriggerSpecBase):
 
 @dataclass(frozen=True)
 class TriggerSpecMovingCommit(TriggerSpecBase):
+    state_content: str
     ref: str
 
     @property

--- a/reconcile/utils/saasherder/models.py
+++ b/reconcile/utils/saasherder/models.py
@@ -182,6 +182,7 @@ class TriggerSpecUpstreamJob(TriggerSpecBase):
 
 @dataclass(frozen=True)
 class TriggerSpecContainerImage(TriggerSpecBase):
+    state_content: str
     images: Sequence[str]
 
     @property


### PR DESCRIPTION
Add types and explicit list of fields stored as state, avoid unexpected null pointer like https://github.com/app-sre/qontract-reconcile/pull/5057.

### Jenkins API Enhancements
* Added a new `JobBuildState` `TypedDict` to represent the state of Jenkins builds, improving type safety and readability (`reconcile/utils/jenkins_api.py`).
* Refactored the `get_jobs_state` method to use helper methods `_get_commit_sha_from_build` and `_build_job_build_state`, simplifying the logic and improving maintainability (`reconcile/utils/jenkins_api.py`).
* Added type annotations to all methods in `JenkinsApi`, ensuring stricter type checking and better documentation (`reconcile/utils/jenkins_api.py`). [[1]](diffhunk://#diff-ef3e0025228a0d9395553d563aae4769227f0ec0e38ace08ca42334c643ac280L46-R64) [[2]](diffhunk://#diff-ef3e0025228a0d9395553d563aae4769227f0ec0e38ace08ca42334c643ac280L57-R75) [[3]](diffhunk://#diff-ef3e0025228a0d9395553d563aae4769227f0ec0e38ace08ca42334c643ac280L110-R145) [[4]](diffhunk://#diff-ef3e0025228a0d9395553d563aae4769227f0ec0e38ace08ca42334c643ac280L119-R154) [[5]](diffhunk://#diff-ef3e0025228a0d9395553d563aae4769227f0ec0e38ace08ca42334c643ac280L132-R167) [[6]](diffhunk://#diff-ef3e0025228a0d9395553d563aae4769227f0ec0e38ace08ca42334c643ac280L145-R180) [[7]](diffhunk://#diff-ef3e0025228a0d9395553d563aae4769227f0ec0e38ace08ca42334c643ac280L159-R194) [[8]](diffhunk://#diff-ef3e0025228a0d9395553d563aae4769227f0ec0e38ace08ca42334c643ac280L174-R216) [[9]](diffhunk://#diff-ef3e0025228a0d9395553d563aae4769227f0ec0e38ace08ca42334c643ac280L195-R230) [[10]](diffhunk://#diff-ef3e0025228a0d9395553d563aae4769227f0ec0e38ace08ca42334c643ac280L214-R249) [[11]](diffhunk://#diff-ef3e0025228a0d9395553d563aae4769227f0ec0e38ace08ca42334c643ac280L229-R264)
* Updated the `init_jenkins_from_secret` method to use the `@classmethod` decorator for better extensibility (`reconcile/utils/jenkins_api.py`).

### Test Coverage
* Added a new test file `test_jenkins_api.py` with a test for the `get_jobs_state` method, providing coverage for the refactored logic in `JenkinsApi` (`reconcile/test/test_jenkins_api.py`).

### SaasHerder Models and Interfaces
* Introduced `TriggerSpecConfigStateContent` and related `TypedDict` classes to represent the state content of SaasHerder triggers, improving type safety (`reconcile/utils/saasherder/models.py`). [[1]](diffhunk://#diff-e47584de2456bc976d3db764f3a75366cecb1df4db50a7490f29a4dc071a1b7eR82-R128) [[2]](diffhunk://#diff-e47584de2456bc976d3db764f3a75366cecb1df4db50a7490f29a4dc071a1b7eR159)
* Updated `TriggerSpecUpstreamJob` and other `TriggerSpec` classes to include `state_content` as a strongly-typed field (`reconcile/utils/saasherder/models.py`). [[1]](diffhunk://#diff-e47584de2456bc976d3db764f3a75366cecb1df4db50a7490f29a4dc071a1b7eR173) [[2]](diffhunk://#diff-e47584de2456bc976d3db764f3a75366cecb1df4db50a7490f29a4dc071a1b7eR188)
* Added a `dict` method to several `Protocol` interfaces in `saasherder/interfaces.py`, allowing easier serialization of objects (`reconcile/utils/saasherder/interfaces.py`). [[1]](diffhunk://#diff-5726fd925e2cd692fe9b381bd1fb930e2bdaad5673c2fd7e2cad55898d44a524R248-R249) [[2]](diffhunk://#diff-5726fd925e2cd692fe9b381bd1fb930e2bdaad5673c2fd7e2cad55898d44a524R294-R295) [[3]](diffhunk://#diff-5726fd925e2cd692fe9b381bd1fb930e2bdaad5673c2fd7e2cad55898d44a524R314-R315)

### Miscellaneous Changes
* Removed the unused `ChainMap` import from `saasherder.py` for cleanup (`reconcile/utils/saasherder/saasherder.py`).
* Removed the `jenkins_api` entry from the `pyproject.toml` module list, indicating potential deprecation or restructuring (`pyproject.toml`).

[APPSRE-12177](https://issues.redhat.com/browse/APPSRE-12177)