### PR TITLE
[AUS] include current cluster version in metrics when node pool upgrade pending

### DIFF
--- a/reconcile/aus/base.py
+++ b/reconcile/aus/base.py
@@ -606,21 +606,27 @@ def fetch_current_state(
                 ocm_api, spec.cluster.id
             )
             for upgrade_policy in upgrade_policies:
-                upgrade_policy["cluster"] = spec.cluster
-                current_state.append(ControlPlaneUpgradePolicy(**upgrade_policy))
+                policy = upgrade_policy | {
+                    "cluster": spec.cluster,
+                }
+                current_state.append(ControlPlaneUpgradePolicy(**policy))
             for node_pool in spec.node_pools:
                 node_upgrade_policies = get_node_pool_upgrade_policies(
                     ocm_api, spec.cluster.id, node_pool.id
                 )
                 for upgrade_policy in node_upgrade_policies:
-                    upgrade_policy["cluster"] = spec.cluster
-                    upgrade_policy["node_pool"] = node_pool.id
-                    current_state.append(NodePoolUpgradePolicy(**upgrade_policy))
+                    policy = upgrade_policy | {
+                        "cluster": spec.cluster,
+                        "node_pool": node_pool.id,
+                    }
+                    current_state.append(NodePoolUpgradePolicy(**policy))
         else:
             upgrade_policies = get_upgrade_policies(ocm_api, spec.cluster.id)
             for upgrade_policy in upgrade_policies:
-                upgrade_policy["cluster"] = spec.cluster
-                current_state.append(ClusterUpgradePolicy(**upgrade_policy))
+                policy = upgrade_policy | {
+                    "cluster": spec.cluster,
+                }
+                current_state.append(ClusterUpgradePolicy(**policy))
 
     return current_state
 

--- a/reconcile/aus/models.py
+++ b/reconcile/aus/models.py
@@ -68,7 +68,13 @@ class ClusterUpgradeSpec(BaseModel):
         return any(re.search(b, version) for b in self.blocked_versions)
 
     def get_available_upgrades(self) -> list[str]:
-        return self.cluster.available_upgrades()
+        cluster_available_upgrades = self.cluster.available_upgrades()
+        if (
+            self.oldest_current_version != self.current_version
+            and self.current_version not in cluster_available_upgrades
+        ):
+            return [self.current_version, *cluster_available_upgrades]
+        return cluster_available_upgrades
 
     @property
     def effective_mutexes(self) -> set[str]:

--- a/reconcile/test/ocm/aus/fixtures.py
+++ b/reconcile/test/ocm/aus/fixtures.py
@@ -1,6 +1,6 @@
-from datetime import datetime
+from datetime import UTC, datetime
 
-from reconcile.aus.base import ClusterUpgradePolicy
+from reconcile.aus.base import ClusterUpgradePolicy, NodePoolUpgradePolicy
 from reconcile.aus.healthchecks import AUSClusterHealth, AUSHealthError
 from reconcile.aus.models import (
     ClusterAddonUpgradeSpec,
@@ -206,11 +206,15 @@ def build_cluster_upgrade_spec(
     blocked_versions: list[str] | None = None,
     cluster_health: bool = True,
     node_pools: list[NodePoolSpec] | None = None,
+    hypershift: bool = False,
 ) -> ClusterUpgradeSpec:
     return ClusterUpgradeSpec(
         org=org or build_organization(),
         cluster=build_ocm_cluster(
-            name=name, version=current_version, available_upgrades=available_upgrades
+            name=name,
+            version=current_version,
+            available_upgrades=available_upgrades,
+            hypershift=hypershift,
         ),
         upgradePolicy=build_upgrade_policy(
             workloads=workloads,
@@ -273,7 +277,7 @@ def build_addon_upgrade_spec(
 def build_cluster_upgrade_policy(
     cluster: OCMCluster, version: str, state: str, next_run: datetime | None = None
 ) -> ClusterUpgradePolicy:
-    next_run_str = (next_run or datetime.utcnow()).strftime("%Y-%m-%dT%H:%M:%SZ")
+    next_run_str = (next_run or datetime.now(tz=UTC)).strftime("%Y-%m-%dT%H:%M:%SZ")
     return ClusterUpgradePolicy(
         cluster=cluster,
         id="1",
@@ -282,6 +286,26 @@ def build_cluster_upgrade_policy(
         next_run=next_run_str,
         schedule_type="manual",
         schedule=None,
+    )
+
+
+def build_node_pool_upgrade_policy(
+    cluster: OCMCluster,
+    node_pool_id: str,
+    version: str,
+    state: str,
+    next_run: datetime | None = None,
+) -> NodePoolUpgradePolicy:
+    next_run_str = (next_run or datetime.now(tz=UTC)).strftime("%Y-%m-%dT%H:%M:%SZ")
+    return NodePoolUpgradePolicy(
+        cluster=cluster,
+        id="1",
+        version=version,
+        state=state,
+        next_run=next_run_str,
+        schedule_type="manual",
+        schedule=None,
+        node_pool=node_pool_id,
     )
 
 

--- a/reconcile/test/ocm/aus/test_expose_metrics.py
+++ b/reconcile/test/ocm/aus/test_expose_metrics.py
@@ -22,6 +22,7 @@ from reconcile.test.ocm.aus.fixtures import (
     build_cluster_health,
     build_cluster_upgrade_policy,
     build_cluster_upgrade_spec,
+    build_node_pool_upgrade_policy,
     build_organization,
     build_organization_upgrade_spec,
     build_upgrade_policy,
@@ -287,6 +288,30 @@ def test_remaining_soak_day_metric_values_for_cluster_not_filtering() -> None:
         "4.13.11": 0.0,
         "4.13.12": 2.0,
         "4.14.1": UPGRADE_BLOCKED_METRIC_VALUE,
+    }
+
+
+def test_remaining_soak_day_metric_values_for_hypershift_node_pool() -> None:
+    spec = build_cluster_upgrade_spec(
+        name="cluster1",
+        current_version="4.13.0",
+        available_upgrades=[],
+        soak_days=0,
+        hypershift=True,
+        node_pools=[NodePoolSpec(id="np1", version="4.12.0")],
+    )
+    node_pool_upgrade = build_node_pool_upgrade_policy(
+        cluster=spec.cluster,
+        node_pool_id="np1",
+        version="4.13.0",
+        state="scheduled",
+    )
+    assert remaining_soak_day_metric_values_for_cluster(
+        spec=spec,
+        soaked_versions={"4.13.0": 0},
+        current_upgrade=node_pool_upgrade,
+    ) == {
+        "4.13.0": UPGRADE_SCHEDULED_METRIC_VALUE,
     }
 
 


### PR DESCRIPTION
Ensure metrics `aus_cluster_version_remaining_soak_days` still include current cluster version before all node pools upgraded to match cluster version, so we can view the schedule and progress in grafana, and long running upgrade alerts can trigger.


### Refactoring and Code Simplification:
* Replaced manual dictionary manipulation with the `|` operator to merge dictionaries when constructing `ControlPlaneUpgradePolicy`, `NodePoolUpgradePolicy`, and `ClusterUpgradePolicy` objects in `reconcile/aus/base.py`. This improves readability and reduces repetitive code.
* Introduced a `TypedDict` class `UpgradePolicy` to define the structure of upgrade policies and refactored utility methods (`get_upgrade_policies`, `get_control_plane_upgrade_policies`, and `get_node_pool_upgrade_policies`) to use this type, simplifying the logic and improving type safety. [[1]](diffhunk://#diff-d362fdc7fdade1a503a5e3ddc6eaa51a9d36749988d01901e2118d27eb62e8d4L1-R27) [[2]](diffhunk://#diff-d362fdc7fdade1a503a5e3ddc6eaa51a9d36749988d01901e2118d27eb62e8d4L19-R58) [[3]](diffhunk://#diff-d362fdc7fdade1a503a5e3ddc6eaa51a9d36749988d01901e2118d27eb62e8d4L79-R109) [[4]](diffhunk://#diff-d362fdc7fdade1a503a5e3ddc6eaa51a9d36749988d01901e2118d27eb62e8d4L127-R153)

### New Features:
* Added support for Hypershift clusters in the `build_cluster_upgrade_spec` function by introducing a new `hypershift` parameter. This allows tests to simulate Hypershift-specific scenarios.
* Implemented a new utility function, `build_node_pool_upgrade_policy`, to create node pool upgrade policies for testing. This complements the existing `build_cluster_upgrade_policy` function.

### Test Enhancements:
* Updated test fixtures and imports to include `NodePoolUpgradePolicy` and support Hypershift scenarios. [[1]](diffhunk://#diff-9dc9d7ac134aab5cb10fdc810309cdd6c58f46bafef056cebb6826eea041e712L1-R3) [[2]](diffhunk://#diff-1f661a13a2971ae8735076343a1c6e6804bcdebef090163609342bf77b088eb2R25)
* Added a new test case, `test_remaining_soak_day_metric_values_for_hypershift_node_pool`, to verify the behavior of soak day metrics for Hypershift node pools.

### Bug Fixes and Improvements:
* Adjusted the handling of available upgrades in `get_available_upgrades` to include the current version if it is not already in the list of available upgrades, ensuring more accurate results.
* Updated datetime handling to use `datetime.now(tz=UTC)` instead of `datetime.utcnow()` for better timezone consistency. [[1]](diffhunk://#diff-9dc9d7ac134aab5cb10fdc810309cdd6c58f46bafef056cebb6826eea041e712L276-R280) [[2]](diffhunk://#diff-9dc9d7ac134aab5cb10fdc810309cdd6c58f46bafef056cebb6826eea041e712R292-R311)

[APPSRE-12165](https://issues.redhat.com/browse/APPSRE-12165)