### PR TITLE
Revert "Set Cloudflare user status to 'accepted' to skip accepting invites"

### DIFF
--- a/reconcile/terraform_cloudflare_users.py
+++ b/reconcile/terraform_cloudflare_users.py
@@ -342,11 +342,6 @@ def build_external_resource_spec_from_cloudflare_users(
                 "provider": "account_member",
                 "identifier": safe_resource_id(cf_user.org_username),
                 "email_address": cf_user.email_address,
-                # Setting status to 'accepted' skips the need for the user to accept
-                # all the invites for the accounts that they're added to. This only
-                # works if the Cloudflare user account already exists, which seems to be
-                # acceptable for now.
-                "status": "accepted",
                 "account_id": "${var.account_id}",
                 "role_ids": [
                     # I know this is ugly :(

--- a/reconcile/test/test_terraform_cloudflare_users.py
+++ b/reconcile/test/test_terraform_cloudflare_users.py
@@ -708,7 +708,6 @@ def test_build_external_resource_spec_from_cloudflare_users(
             "provider": "account_member",
             "identifier": "user1",
             "email_address": "user1@redhat.com",
-            "status": "accepted",
             "account_id": "${var.account_id}",
             "role_ids": [
                 '%{ for role in data.cloudflare_account_roles.cloudflare-account.roles ~}  %{if role.name == "Administrator" ~}${role.id}%{ endif ~}  %{ endfor ~}',


### PR DESCRIPTION
Reverts app-sre/qontract-reconcile#3462

New members can't be invited anymore, error

```
Error: error creating Cloudflare account member: Invalid request: automatic verification of new members is not allowed (1001)
```

Can be locally reproduced by sending api request to https://developers.cloudflare.com/api/resources/accounts/subresources/members/methods/create/, with `"status": "accepted"`, the response is

```json
{"result":[],"success":false,"errors":[{"code":1001,"message":"Invalid request: automatic verification of new members is not allowed"}],"messages":[]}
```