### PR TITLE
APPSRE-11020 pypi push

### DIFF
--- a/.tekton/qontract-reconcile-master-push.yaml
+++ b/.tekton/qontract-reconcile-master-push.yaml
@@ -29,6 +29,8 @@ spec:
     value: .
   - name: target-stage
     value: prod-image-post-pypi-push
+  - name: additional_secret
+    value: app-sre-pypi-credentials
   - name: fetchTags
     value: 'true'
   # Note, that we have to specify some depth here. Lets go with something we wont reach in a long time

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,6 @@ BUILD_TARGET := prod-image
 
 .EXPORT_ALL_VARIABLES:
 # TWINE_USERNAME & TWINE_PASSWORD are available in jenkins job
-UV_PUBLISH_TOKEN = $(TWINE_PASSWORD)
 
 
 ifneq (,$(wildcard $(CURDIR)/.docker))
@@ -90,6 +89,10 @@ pypi-release:
 	@$(CONTAINER_ENGINE) build --progress=plain --build-arg TWINE_USERNAME --build-arg TWINE_PASSWORD --target pypi -f dockerfiles/Dockerfile .
 
 pypi:
+	uv build --sdist --wheel
+	UV_PUBLISH_TOKEN=$(TWINE_PASSWORD) uv publish
+
+pypi-konflux:
 	uv build --sdist --wheel
 	uv publish
 

--- a/dockerfiles/Dockerfile.konflux
+++ b/dockerfiles/Dockerfile.konflux
@@ -117,17 +117,15 @@ COPY --from=test-image /is_tested /is_tested
 # STAGE 7 - PyPI publish package
 ###############################################################################
 FROM test-image AS pypi
-ARG TWINE_USERNAME
-ARG TWINE_PASSWORD
 
 # Lets make sure we ran previous prod stage before uploading to pypi
 COPY --from=prod-image /is_tested /is_tested
 RUN echo "true" > /is_pypi_pushed
 
 # qontract-reconcile version depends on git tags!
-# The .git dir should already be part of the test image.
-# TODO
-# RUN make pypi
+# The .git dir should already be part of the test image
+# TODO: re-enable to take over from ci.ext
+#RUN --mount=type=secret,id=app-sre-pypi-credentials/token export UV_PUBLISH_TOKEN=$(cat /run/secrets/app-sre-pypi-credentials/token); make pypi-konflux
 
 ###############################################################################
 # STAGE 8 - tested and pypi pushed prod image


### PR DESCRIPTION
Konflux should also push our package to pypi. Note, for now the push is still commented out, as ci.ext is still doing that job. When we move away from ci.ext, we just have to uncomment that line and it will take over.