### PR TITLE
more type hints

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -262,7 +262,6 @@ disallow_incomplete_defs = true
 [[tool.mypy.overrides]]
 # Untyped modules
 module = [
-    "reconcile.ocm_groups",
     "reconcile.ocm_machine_pools",
     "reconcile.ocm_upgrade_scheduler_org_updater",
     "reconcile.openshift_base",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -365,7 +365,6 @@ module = [
     "reconcile.test.test_jenkins_worker_fleets",
     "reconcile.test.test_jump_host",
     "reconcile.test.test_make",
-    "reconcile.test.test_ocm_clusters_manifest_updates",
     "reconcile.test.test_ocm_machine_pools",
     "reconcile.test.test_ocm_update_recommended_version",
     "reconcile.test.test_ocm_upgrade_scheduler_org_updater",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -262,7 +262,6 @@ disallow_incomplete_defs = true
 [[tool.mypy.overrides]]
 # Untyped modules
 module = [
-    "reconcile.ocm_addons",
     "reconcile.ocm_aws_infrastructure_access",
     "reconcile.ocm_clusters",
     "reconcile.ocm_external_configuration_labels",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -262,7 +262,6 @@ disallow_incomplete_defs = true
 [[tool.mypy.overrides]]
 # Untyped modules
 module = [
-    "reconcile.ocm_clusters",
     "reconcile.ocm_external_configuration_labels",
     "reconcile.ocm_groups",
     "reconcile.ocm_machine_pools",
@@ -368,7 +367,6 @@ module = [
     "reconcile.test.test_jump_host",
     "reconcile.test.test_make",
     "reconcile.test.test_ocm_clusters_manifest_updates",
-    "reconcile.test.test_ocm_clusters",
     "reconcile.test.test_ocm_machine_pools",
     "reconcile.test.test_ocm_update_recommended_version",
     "reconcile.test.test_ocm_upgrade_scheduler_org_updater",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -262,7 +262,6 @@ disallow_incomplete_defs = true
 [[tool.mypy.overrides]]
 # Untyped modules
 module = [
-    "reconcile.ocm_machine_pools",
     "reconcile.ocm_upgrade_scheduler_org_updater",
     "reconcile.openshift_base",
     "reconcile.openshift_clusterrolebindings",
@@ -364,7 +363,6 @@ module = [
     "reconcile.test.test_jenkins_worker_fleets",
     "reconcile.test.test_jump_host",
     "reconcile.test.test_make",
-    "reconcile.test.test_ocm_machine_pools",
     "reconcile.test.test_ocm_update_recommended_version",
     "reconcile.test.test_ocm_upgrade_scheduler_org_updater",
     "reconcile.test.test_openshift_base",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -262,7 +262,6 @@ disallow_incomplete_defs = true
 [[tool.mypy.overrides]]
 # Untyped modules
 module = [
-    "reconcile.ocm_aws_infrastructure_access",
     "reconcile.ocm_clusters",
     "reconcile.ocm_external_configuration_labels",
     "reconcile.ocm_groups",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -262,7 +262,6 @@ disallow_incomplete_defs = true
 [[tool.mypy.overrides]]
 # Untyped modules
 module = [
-    "reconcile.ocm_additional_routers",
     "reconcile.ocm_addons",
     "reconcile.ocm_aws_infrastructure_access",
     "reconcile.ocm_clusters",
@@ -370,7 +369,6 @@ module = [
     "reconcile.test.test_jenkins_worker_fleets",
     "reconcile.test.test_jump_host",
     "reconcile.test.test_make",
-    "reconcile.test.test_ocm_additional_routers",
     "reconcile.test.test_ocm_clusters_manifest_updates",
     "reconcile.test.test_ocm_clusters",
     "reconcile.test.test_ocm_machine_pools",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -262,7 +262,6 @@ disallow_incomplete_defs = true
 [[tool.mypy.overrides]]
 # Untyped modules
 module = [
-    "reconcile.mr_client_gateway",
     "reconcile.ocm_additional_routers",
     "reconcile.ocm_addons",
     "reconcile.ocm_aws_infrastructure_access",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -262,7 +262,6 @@ disallow_incomplete_defs = true
 [[tool.mypy.overrides]]
 # Untyped modules
 module = [
-    "reconcile.ocm_external_configuration_labels",
     "reconcile.ocm_groups",
     "reconcile.ocm_machine_pools",
     "reconcile.ocm_upgrade_scheduler_org_updater",

--- a/reconcile/cli.py
+++ b/reconcile/cli.py
@@ -2944,12 +2944,11 @@ def ocm_update_recommended_version(
 
 
 @integration.command(short_help="Manages cluster Addons in OCM.")
-@threaded()
 @click.pass_context
-def ocm_addons(ctx: click.Context, thread_pool_size: int) -> None:
+def ocm_addons(ctx: click.Context) -> None:
     import reconcile.ocm_addons
 
-    run_integration(reconcile.ocm_addons, ctx, thread_pool_size)
+    run_integration(reconcile.ocm_addons, ctx)
 
 
 @integration.command(

--- a/reconcile/mr_client_gateway.py
+++ b/reconcile/mr_client_gateway.py
@@ -27,14 +27,19 @@ MR_GW_QUERY = """
 def get_mr_gateway_settings() -> Mapping[str, Any]:
     """Returns SecretReader settings"""
     gqlapi = gql.get_api()
-    settings = gqlapi.query(MR_GW_QUERY)["settings"]
+    data = gqlapi.query(MR_GW_QUERY)
+    if not data:
+        raise ValueError("no app-interface-settings found from gql query")
+    settings = data.get("settings")
     if settings:
         # assuming a single settings file for now
         return settings[0]
     raise ValueError("no app-interface-settings found")
 
 
-def init(gitlab_project_id=None, sqs_or_gitlab=None):
+def init(
+    gitlab_project_id: str | int | None = None, sqs_or_gitlab: str | None = None
+) -> GitLabApi | SQSGateway:
     """
     Creates the Merge Request client to of a given type.
 

--- a/reconcile/ocm_additional_routers.py
+++ b/reconcile/ocm_additional_routers.py
@@ -1,7 +1,7 @@
 import json
 import logging
 import sys
-from collections.abc import Mapping
+from collections.abc import Iterable, Mapping
 from typing import Any
 
 from reconcile import queries
@@ -37,7 +37,7 @@ def fetch_current_state(
     return ocm_map, current_state
 
 
-def fetch_desired_state(clusters: list[dict[str, Any]]) -> list[dict[str, Any]]:
+def fetch_desired_state(clusters: Iterable[dict[str, Any]]) -> list[dict[str, Any]]:
     desired_state = []
     for cluster in clusters:
         cluster_name = cluster["name"]
@@ -53,7 +53,7 @@ def fetch_desired_state(clusters: list[dict[str, Any]]) -> list[dict[str, Any]]:
 
 
 def calculate_diff(
-    current_state: list[dict[str, Any]], desired_state: list[dict[str, Any]]
+    current_state: Iterable[dict[str, Any]], desired_state: Iterable[dict[str, Any]]
 ) -> list[dict[str, Any]]:
     diffs = []
     for d_item in desired_state:

--- a/reconcile/ocm_additional_routers.py
+++ b/reconcile/ocm_additional_routers.py
@@ -17,7 +17,9 @@ QONTRACT_INTEGRATION = "ocm-additional-routers"
 SUPPORTED_OCM_PRODUCTS = [OCM_PRODUCT_OSD]
 
 
-def fetch_current_state(clusters):
+def fetch_current_state(
+    clusters: list[dict[str, Any]],
+) -> tuple[OCMMap, list[dict[str, Any]]]:
     settings = queries.get_app_interface_settings()
     ocm_map = OCMMap(
         clusters=clusters, integration=QONTRACT_INTEGRATION, settings=settings
@@ -35,13 +37,13 @@ def fetch_current_state(clusters):
     return ocm_map, current_state
 
 
-def fetch_desired_state(clusters):
+def fetch_desired_state(clusters: list[dict[str, Any]]) -> list[dict[str, Any]]:
     desired_state = []
     for cluster in clusters:
         cluster_name = cluster["name"]
         for router in cluster["additionalRouters"]:
             listening = "internal" if router["private"] else "external"
-            item = {"listening": listening, "cluster": cluster_name}
+            item: dict[str, Any] = {"listening": listening, "cluster": cluster_name}
             selectors = router.get("route_selectors", None)
             if selectors:
                 item["route_selectors"] = json.loads(selectors)
@@ -50,31 +52,33 @@ def fetch_desired_state(clusters):
     return desired_state
 
 
-def calculate_diff(current_state, desired_state):
+def calculate_diff(
+    current_state: list[dict[str, Any]], desired_state: list[dict[str, Any]]
+) -> list[dict[str, Any]]:
     diffs = []
-    for d in desired_state:
-        c = [c for c in current_state if d.items() <= c.items()]
-        if not c:
-            d["action"] = "create"
-            diffs.append(d)
+    for d_item in desired_state:
+        c_items = [c for c in current_state if d_item.items() <= c.items()]
+        if not c_items:
+            d_item["action"] = "create"
+            diffs.append(d_item)
 
-    for c in current_state:
-        d = [d for d in desired_state if d.items() <= c.items()]
-        if not d:
-            c["action"] = "delete"
-            diffs.append(c)
+    for c_item in current_state:
+        d_items = [d for d in desired_state if d.items() <= c_item.items()]
+        if not d_items:
+            c_item["action"] = "delete"
+            diffs.append(c_item)
 
     return diffs
 
 
-def sort_diffs(diff):
+def sort_diffs(diff: dict[str, Any]) -> int:
     """Sort diffs so we delete first and create later"""
     if diff["action"] == "delete":
         return 1
     return 2
 
 
-def act(dry_run, diffs, ocm_map):
+def act(dry_run: bool, diffs: list[dict[str, Any]], ocm_map: OCMMap) -> None:
     diffs.sort(key=sort_diffs)
     for diff in diffs:
         action = diff.pop("action")
@@ -82,6 +86,9 @@ def act(dry_run, diffs, ocm_map):
         logging.info([action, cluster])
         if not dry_run:
             ocm = ocm_map.get(cluster)
+            if ocm is None:
+                logging.error(f"OCM client for cluster {cluster} not found.")
+                continue
             if action == "create":
                 ocm.create_additional_router(cluster, diff)
             elif action == "delete":
@@ -96,11 +103,10 @@ def _cluster_is_compatible(cluster: Mapping[str, Any]) -> bool:
     )
 
 
-def run(dry_run):
-    clusters = queries.get_clusters()
+def run(dry_run: bool) -> None:
     clusters = [
         c
-        for c in clusters
+        for c in queries.get_clusters()
         if integration_is_enabled(QONTRACT_INTEGRATION, c) and _cluster_is_compatible(c)
     ]
     if not clusters:

--- a/reconcile/ocm_additional_routers.py
+++ b/reconcile/ocm_additional_routers.py
@@ -1,7 +1,7 @@
 import json
 import logging
 import sys
-from collections.abc import Iterable, Mapping
+from collections.abc import Iterable, Mapping, MutableMapping
 from typing import Any
 
 from reconcile import queries
@@ -18,7 +18,7 @@ SUPPORTED_OCM_PRODUCTS = [OCM_PRODUCT_OSD]
 
 
 def fetch_current_state(
-    clusters: list[dict[str, Any]],
+    clusters: list[Mapping[str, Any]],
 ) -> tuple[OCMMap, list[dict[str, Any]]]:
     settings = queries.get_app_interface_settings()
     ocm_map = OCMMap(
@@ -37,7 +37,7 @@ def fetch_current_state(
     return ocm_map, current_state
 
 
-def fetch_desired_state(clusters: Iterable[dict[str, Any]]) -> list[dict[str, Any]]:
+def fetch_desired_state(clusters: Iterable[Mapping[str, Any]]) -> list[dict[str, Any]]:
     desired_state = []
     for cluster in clusters:
         cluster_name = cluster["name"]
@@ -53,8 +53,9 @@ def fetch_desired_state(clusters: Iterable[dict[str, Any]]) -> list[dict[str, An
 
 
 def calculate_diff(
-    current_state: Iterable[dict[str, Any]], desired_state: Iterable[dict[str, Any]]
-) -> list[dict[str, Any]]:
+    current_state: Iterable[MutableMapping[str, Any]],
+    desired_state: Iterable[MutableMapping[str, Any]],
+) -> list[MutableMapping[str, Any]]:
     diffs = []
     for d_item in desired_state:
         c_items = [c for c in current_state if d_item.items() <= c.items()]
@@ -71,14 +72,14 @@ def calculate_diff(
     return diffs
 
 
-def sort_diffs(diff: dict[str, Any]) -> int:
+def sort_diffs(diff: Mapping[str, Any]) -> int:
     """Sort diffs so we delete first and create later"""
     if diff["action"] == "delete":
         return 1
     return 2
 
 
-def act(dry_run: bool, diffs: list[dict[str, Any]], ocm_map: OCMMap) -> None:
+def act(dry_run: bool, diffs: list[MutableMapping[str, Any]], ocm_map: OCMMap) -> None:
     diffs.sort(key=sort_diffs)
     for diff in diffs:
         action = diff.pop("action")

--- a/reconcile/ocm_addons.py
+++ b/reconcile/ocm_addons.py
@@ -1,6 +1,6 @@
 import logging
 import sys
-from collections.abc import Iterable, Mapping
+from collections.abc import Iterable, Mapping, MutableMapping
 from operator import itemgetter
 from typing import Any
 
@@ -13,7 +13,7 @@ QONTRACT_INTEGRATION = "ocm-addons"
 
 
 def fetch_current_state(
-    clusters: list[dict[str, Any]],
+    clusters: Iterable[Mapping[str, Any]],
 ) -> tuple[OCMMap, list[dict[str, Any]]]:
     settings = queries.get_app_interface_settings()
     ocm_map = OCMMap(
@@ -37,7 +37,7 @@ def fetch_current_state(
     return ocm_map, current_state
 
 
-def fetch_desired_state(clusters: Iterable[dict[str, Any]]) -> list[dict[str, Any]]:
+def fetch_desired_state(clusters: Iterable[Mapping[str, Any]]) -> list[dict[str, Any]]:
     desired_state = []
     for cluster in clusters:
         cluster_name = cluster["name"]
@@ -51,15 +51,16 @@ def fetch_desired_state(clusters: Iterable[dict[str, Any]]) -> list[dict[str, An
     return desired_state
 
 
-def sort_parameters(addon: dict[str, Any]) -> None:
+def sort_parameters(addon: MutableMapping[str, Any]) -> None:
     addon_parameters = addon.get("parameters")
     if addon_parameters:
         addon["parameters"] = sorted(addon_parameters, key=itemgetter("id"))
 
 
 def calculate_diff(
-    current_state: Iterable[dict[str, Any]], desired_state: Iterable[dict[str, Any]]
-) -> list[dict[str, Any]]:
+    current_state: Iterable[Mapping[str, Any]],
+    desired_state: Iterable[MutableMapping[str, Any]],
+) -> list[MutableMapping[str, Any]]:
     diffs = []
     for d in desired_state:
         c = [c for c in current_state if d.items() <= c.items()]
@@ -70,7 +71,9 @@ def calculate_diff(
     return diffs
 
 
-def act(dry_run: bool, diffs: Iterable[dict[str, Any]], ocm_map: OCMMap) -> bool:
+def act(
+    dry_run: bool, diffs: Iterable[MutableMapping[str, Any]], ocm_map: OCMMap
+) -> bool:
     err = False
     for diff in diffs:
         action = diff.pop("action")

--- a/reconcile/ocm_addons.py
+++ b/reconcile/ocm_addons.py
@@ -12,7 +12,9 @@ from reconcile.utils.ocm import OCMMap
 QONTRACT_INTEGRATION = "ocm-addons"
 
 
-def fetch_current_state(clusters):
+def fetch_current_state(
+    clusters: list[dict[str, Any]],
+) -> tuple[OCMMap, list[dict[str, Any]]]:
     settings = queries.get_app_interface_settings()
     ocm_map = OCMMap(
         clusters=clusters,
@@ -35,7 +37,7 @@ def fetch_current_state(clusters):
     return ocm_map, current_state
 
 
-def fetch_desired_state(clusters):
+def fetch_desired_state(clusters: list[dict[str, Any]]) -> list[dict[str, Any]]:
     desired_state = []
     for cluster in clusters:
         cluster_name = cluster["name"]
@@ -49,13 +51,15 @@ def fetch_desired_state(clusters):
     return desired_state
 
 
-def sort_parameters(addon):
+def sort_parameters(addon: dict[str, Any]) -> None:
     addon_parameters = addon.get("parameters")
     if addon_parameters:
         addon["parameters"] = sorted(addon_parameters, key=itemgetter("id"))
 
 
-def calculate_diff(current_state, desired_state):
+def calculate_diff(
+    current_state: list[dict[str, Any]], desired_state: list[dict[str, Any]]
+) -> list[dict[str, Any]]:
     diffs = []
     for d in desired_state:
         c = [c for c in current_state if d.items() <= c.items()]
@@ -66,7 +70,7 @@ def calculate_diff(current_state, desired_state):
     return diffs
 
 
-def act(dry_run, diffs, ocm_map):
+def act(dry_run: bool, diffs: list[dict[str, Any]], ocm_map: OCMMap) -> bool:
     err = False
     for diff in diffs:
         action = diff.pop("action")
@@ -95,7 +99,7 @@ def _cluster_is_compatible(cluster: Mapping[str, Any]) -> bool:
     return cluster.get("ocm") is not None and cluster.get("addons") is not None
 
 
-def run(dry_run, gitlab_project_id=None, thread_pool_size=10):
+def run(dry_run: bool) -> None:
     clusters = queries.get_clusters()
     clusters = [
         c

--- a/reconcile/ocm_addons.py
+++ b/reconcile/ocm_addons.py
@@ -1,6 +1,6 @@
 import logging
 import sys
-from collections.abc import Mapping
+from collections.abc import Iterable, Mapping
 from operator import itemgetter
 from typing import Any
 
@@ -37,7 +37,7 @@ def fetch_current_state(
     return ocm_map, current_state
 
 
-def fetch_desired_state(clusters: list[dict[str, Any]]) -> list[dict[str, Any]]:
+def fetch_desired_state(clusters: Iterable[dict[str, Any]]) -> list[dict[str, Any]]:
     desired_state = []
     for cluster in clusters:
         cluster_name = cluster["name"]
@@ -58,7 +58,7 @@ def sort_parameters(addon: dict[str, Any]) -> None:
 
 
 def calculate_diff(
-    current_state: list[dict[str, Any]], desired_state: list[dict[str, Any]]
+    current_state: Iterable[dict[str, Any]], desired_state: Iterable[dict[str, Any]]
 ) -> list[dict[str, Any]]:
     diffs = []
     for d in desired_state:
@@ -70,7 +70,7 @@ def calculate_diff(
     return diffs
 
 
-def act(dry_run: bool, diffs: list[dict[str, Any]], ocm_map: OCMMap) -> bool:
+def act(dry_run: bool, diffs: Iterable[dict[str, Any]], ocm_map: OCMMap) -> bool:
     err = False
     for diff in diffs:
         action = diff.pop("action")

--- a/reconcile/ocm_aws_infrastructure_access.py
+++ b/reconcile/ocm_aws_infrastructure_access.py
@@ -1,6 +1,6 @@
 import logging
 import sys
-from collections.abc import Mapping
+from collections.abc import Iterable, Mapping
 from typing import Any
 
 from reconcile import queries
@@ -23,7 +23,7 @@ SUPPORTED_OCM_PRODUCTS = [OCM_PRODUCT_OSD]
 
 
 def fetch_current_state(
-    clusters: list[dict[str, Any]],
+    clusters: Iterable[dict[str, Any]],
 ) -> tuple[OCMMap, list[dict[str, Any]], list[dict[str, Any]], list[dict[str, Any]]]:
     current_state = []
     current_failed = []
@@ -54,7 +54,7 @@ def fetch_current_state(
     return ocm_map, current_state, current_failed, current_deleting
 
 
-def fetch_desired_state(clusters: list[dict[str, Any]]) -> list[dict[str, Any]]:
+def fetch_desired_state(clusters: Iterable[dict[str, Any]]) -> list[dict[str, Any]]:
     desired_state = []
 
     for cluster_info in clusters:
@@ -134,8 +134,8 @@ def act(
     dry_run: bool,
     ocm_map: OCMMap,
     current_state: list[dict[str, Any]],
-    current_failed: list[dict[str, Any]],
-    desired_state: list[dict[str, Any]],
+    current_failed: Iterable[dict[str, Any]],
+    desired_state: Iterable[dict[str, Any]],
     current_deleting: list[dict[str, Any]],
 ) -> None:
     to_delete = [c for c in current_state if c not in desired_state]

--- a/reconcile/ocm_aws_infrastructure_access.py
+++ b/reconcile/ocm_aws_infrastructure_access.py
@@ -23,7 +23,7 @@ SUPPORTED_OCM_PRODUCTS = [OCM_PRODUCT_OSD]
 
 
 def fetch_current_state(
-    clusters: Iterable[dict[str, Any]],
+    clusters: Iterable[Mapping[str, Any]],
 ) -> tuple[OCMMap, list[dict[str, Any]], list[dict[str, Any]], list[dict[str, Any]]]:
     current_state = []
     current_failed = []
@@ -54,7 +54,7 @@ def fetch_current_state(
     return ocm_map, current_state, current_failed, current_deleting
 
 
-def fetch_desired_state(clusters: Iterable[dict[str, Any]]) -> list[dict[str, Any]]:
+def fetch_desired_state(clusters: Iterable[Mapping[str, Any]]) -> list[dict[str, Any]]:
     desired_state = []
 
     for cluster_info in clusters:

--- a/reconcile/ocm_aws_infrastructure_access.py
+++ b/reconcile/ocm_aws_infrastructure_access.py
@@ -22,7 +22,9 @@ QONTRACT_INTEGRATION = "ocm-aws-infrastructure-access"
 SUPPORTED_OCM_PRODUCTS = [OCM_PRODUCT_OSD]
 
 
-def fetch_current_state(clusters):
+def fetch_current_state(
+    clusters: list[dict[str, Any]],
+) -> tuple[OCMMap, list[dict[str, Any]], list[dict[str, Any]], list[dict[str, Any]]]:
     current_state = []
     current_failed = []
     current_deleting = []
@@ -52,7 +54,7 @@ def fetch_current_state(clusters):
     return ocm_map, current_state, current_failed, current_deleting
 
 
-def fetch_desired_state(clusters):
+def fetch_desired_state(clusters: list[dict[str, Any]]) -> list[dict[str, Any]]:
     desired_state = []
 
     for cluster_info in clusters:
@@ -129,8 +131,13 @@ def fetch_desired_state(clusters):
 
 
 def act(
-    dry_run, ocm_map, current_state, current_failed, desired_state, current_deleting
-):
+    dry_run: bool,
+    ocm_map: OCMMap,
+    current_state: list[dict[str, Any]],
+    current_failed: list[dict[str, Any]],
+    desired_state: list[dict[str, Any]],
+    current_deleting: list[dict[str, Any]],
+) -> None:
     to_delete = [c for c in current_state if c not in desired_state]
     to_delete += current_failed
     for item in to_delete:
@@ -173,7 +180,7 @@ def _cluster_is_compatible(cluster: Mapping[str, Any]) -> bool:
     )
 
 
-def get_clusters():
+def get_clusters() -> list[dict[str, Any]]:
     return [
         c
         for c in queries.get_clusters(aws_infrastructure_access=True)
@@ -181,7 +188,7 @@ def get_clusters():
     ]
 
 
-def run(dry_run):
+def run(dry_run: bool) -> None:
     clusters = get_clusters()
     if not clusters:
         logging.debug(

--- a/reconcile/ocm_clusters.py
+++ b/reconcile/ocm_clusters.py
@@ -40,7 +40,7 @@ QONTRACT_INTEGRATION = "ocm-clusters"
 QONTRACT_INTEGRATION_VERSION = make_semver(0, 1, 0)
 
 
-def _set_rosa_ocm_attrs(cluster: Mapping[str, Any]):
+def _set_rosa_ocm_attrs(cluster: Mapping[str, Any]) -> None:
     """Cluster account (aws) attribute from app-interface differs from the OCMSpec.
     app-interface's account includes the details for all the OCM environments
     but the cluster only needs the target OCM environment where it belongs.
@@ -78,8 +78,7 @@ def _set_rosa_ocm_attrs(cluster: Mapping[str, Any]):
 
     # doing this allows to exclude account fields which can be queried in graphql
     rosa_cluster_aws_account = ROSAClusterAWSAccount(
-        uid=uid,
-        rosa=rosa,
+        uid=uid, rosa=rosa, billing_account_id=None
     )
     if billing_account := account.get("billingAccount"):
         rosa_cluster_aws_account.billing_account_id = billing_account["uid"]
@@ -293,7 +292,7 @@ def get_cluster_ocm_update_spec(
 
 def _app_interface_updates_mr(
     clusters_updates: Mapping[str, Any], gitlab_project_id: str | None, dry_run: bool
-):
+) -> None:
     """Creates an MR to app-interface with the necessary cluster manifest updates
 
     :param clusters_updates: Updates to perform. Format required by the MR utils code

--- a/reconcile/ocm_external_configuration_labels.py
+++ b/reconcile/ocm_external_configuration_labels.py
@@ -12,7 +12,7 @@ from reconcile.utils.ocm import OCMMap
 QONTRACT_INTEGRATION = "ocm-external-configuration-labels"
 
 
-def get_allowed_labels_for_cluster(cluster: dict[str, Any]) -> set[str]:
+def get_allowed_labels_for_cluster(cluster: Mapping[str, Any]) -> set[str]:
     allowed_labels = cluster.get("ocm", {}).get(
         "allowedClusterExternalConfigLabels", []
     )
@@ -20,7 +20,7 @@ def get_allowed_labels_for_cluster(cluster: dict[str, Any]) -> set[str]:
 
 
 def fetch_current_state(
-    clusters: Iterable[dict[str, Any]],
+    clusters: Iterable[Mapping[str, Any]],
 ) -> tuple[OCMMap, list[dict[str, Any]]]:
     settings = queries.get_app_interface_settings()
     ocm_map = OCMMap(
@@ -45,7 +45,7 @@ def fetch_current_state(
     return ocm_map, current_state
 
 
-def fetch_desired_state(clusters: list[dict[str, Any]]) -> list[dict[str, Any]]:
+def fetch_desired_state(clusters: Iterable[Mapping[str, Any]]) -> list[dict[str, Any]]:
     desired_state = []
     for cluster in clusters:
         cluster_name = cluster["name"]
@@ -63,7 +63,8 @@ def fetch_desired_state(clusters: list[dict[str, Any]]) -> list[dict[str, Any]]:
 
 
 def calculate_diff(
-    current_state: Iterable[dict[str, Any]], desired_state: Iterable[dict[str, Any]]
+    current_state: Iterable[dict[str, Any]],
+    desired_state: Iterable[dict[str, Any]],
 ) -> tuple[list[dict[str, Any]], bool]:
     diffs = []
     err = False
@@ -82,7 +83,7 @@ def calculate_diff(
     return diffs, err
 
 
-def sort_diffs(diff: dict[str, Any]) -> int:
+def sort_diffs(diff: Mapping[str, Any]) -> int:
     """Sort diffs so we delete first and create later"""
     if diff["action"] == "delete":
         return 1

--- a/reconcile/ocm_external_configuration_labels.py
+++ b/reconcile/ocm_external_configuration_labels.py
@@ -1,7 +1,7 @@
 import json
 import logging
 import sys
-from collections.abc import Mapping
+from collections.abc import Iterable, Mapping
 from typing import Any
 
 from reconcile import queries
@@ -20,7 +20,7 @@ def get_allowed_labels_for_cluster(cluster: dict[str, Any]) -> set[str]:
 
 
 def fetch_current_state(
-    clusters: list[dict[str, Any]],
+    clusters: Iterable[dict[str, Any]],
 ) -> tuple[OCMMap, list[dict[str, Any]]]:
     settings = queries.get_app_interface_settings()
     ocm_map = OCMMap(
@@ -63,7 +63,7 @@ def fetch_desired_state(clusters: list[dict[str, Any]]) -> list[dict[str, Any]]:
 
 
 def calculate_diff(
-    current_state: list[dict[str, Any]], desired_state: list[dict[str, Any]]
+    current_state: Iterable[dict[str, Any]], desired_state: Iterable[dict[str, Any]]
 ) -> tuple[list[dict[str, Any]], bool]:
     diffs = []
     err = False

--- a/reconcile/ocm_groups.py
+++ b/reconcile/ocm_groups.py
@@ -48,7 +48,7 @@ def get_cluster_state(
 
 
 def fetch_current_state(
-    clusters: list[Mapping[str, Any]], thread_pool_size: int
+    clusters: Iterable[Mapping[str, Any]], thread_pool_size: int
 ) -> tuple[OCMMap, list[dict[str, str]]]:
     settings = queries.get_app_interface_settings()
     ocm_map = OCMMap(

--- a/reconcile/ocm_groups.py
+++ b/reconcile/ocm_groups.py
@@ -1,7 +1,10 @@
 import itertools
 import logging
 import sys
-from collections.abc import Mapping
+from collections.abc import (
+    Iterable,
+    Mapping,
+)
 from typing import Any
 
 from sretoolbox.utils import threaded
@@ -18,7 +21,20 @@ from reconcile.utils.ocm.base import OCMClusterGroupId
 QONTRACT_INTEGRATION = "ocm-groups"
 
 
-def get_cluster_state(group_items, ocm_map):
+def create_groups_list(clusters: Iterable[Mapping[str, Any]]) -> list[dict[str, str]]:
+    groups_list: list[dict[str, str]] = []
+    for cluster_info in clusters:
+        cluster = cluster_info["name"]
+        groups = cluster_info["managedGroups"] or []
+        groups_list.extend(
+            {"cluster": cluster, "group_name": group_name} for group_name in groups
+        )
+    return groups_list
+
+
+def get_cluster_state(
+    group_items: Mapping[str, str], ocm_map: OCMMap
+) -> list[dict[str, str]]:
     cluster = group_items["cluster"]
     ocm = ocm_map.get(cluster)
     group_name = group_items["group_name"]
@@ -27,17 +43,18 @@ def get_cluster_state(group_items, ocm_map):
         return []
     return [
         {"cluster": cluster, "group": group_name, "user": user}
-        for user in group["users"] or []
+        for user in group.get("users") or []
     ]
 
 
-def fetch_current_state(clusters, thread_pool_size):
-    current_state = []
+def fetch_current_state(
+    clusters: list[Mapping[str, Any]], thread_pool_size: int
+) -> tuple[OCMMap, list[dict[str, str]]]:
     settings = queries.get_app_interface_settings()
     ocm_map = OCMMap(
         clusters=clusters, integration=QONTRACT_INTEGRATION, settings=settings
     )
-    groups_list = openshift_groups.create_groups_list(clusters, oc_map=ocm_map)
+    groups_list = create_groups_list(clusters)
     results = threaded.run(
         get_cluster_state, groups_list, thread_pool_size, ocm_map=ocm_map
     )
@@ -46,7 +63,7 @@ def fetch_current_state(clusters, thread_pool_size):
     return ocm_map, current_state
 
 
-def act(diff, ocm_map):
+def act(diff: Mapping[str, Any], ocm_map: OCMMap) -> None:
     cluster = diff["cluster"]
     group = diff["group"]
     user = diff["user"]
@@ -63,8 +80,12 @@ def _cluster_is_compatible(cluster: Mapping[str, Any]) -> bool:
     return cluster.get("ocm") is not None
 
 
-def run(dry_run, thread_pool_size=10):
+def run(dry_run: bool, thread_pool_size: int = 10) -> None:
     clusters = queries.get_clusters()
+    if not clusters:
+        logging.debug("No clusters found in app-interface")
+        sys.exit(ExitCodes.SUCCESS)
+
     clusters = [
         c
         for c in clusters
@@ -97,10 +118,10 @@ def run(dry_run, thread_pool_size=10):
             act(diff, ocm_map)
 
 
-def early_exit_desired_state(*args, **kwargs) -> dict[str, Any]:
+def early_exit_desired_state(*args: Any, **kwargs: Any) -> dict[str, Any]:
     clusters = [
         c["name"]
-        for c in queries.get_clusters()
+        for c in queries.get_clusters() or []
         if integration_is_enabled(QONTRACT_INTEGRATION, c) and _cluster_is_compatible(c)
     ]
     desired_state = openshift_groups.fetch_desired_state(clusters=clusters)

--- a/reconcile/ocm_machine_pools.py
+++ b/reconcile/ocm_machine_pools.py
@@ -62,7 +62,7 @@ class MachinePoolAutoscaling(AbstractAutoscaling):
     max_replicas: int
 
     @root_validator()
-    def max_greater_min(cls, field_values: dict[str, Any]) -> dict[str, Any]:
+    def max_greater_min(cls, field_values: Mapping[str, Any]) -> Mapping[str, Any]:
         min_replicas = field_values.get("min_replicas")
         max_replicas = field_values.get("max_replicas")
         if min_replicas is None or max_replicas is None:
@@ -83,7 +83,7 @@ class NodePoolAutoscaling(AbstractAutoscaling):
     max_replica: int
 
     @root_validator()
-    def max_greater_min(cls, field_values: dict[str, Any]) -> dict[str, Any]:
+    def max_greater_min(cls, field_values: Mapping[str, Any]) -> Mapping[str, Any]:
         min_replica = field_values.get("min_replica")
         max_replica = field_values.get("max_replica")
         if min_replica is None or max_replica is None:
@@ -111,7 +111,7 @@ class AbstractPool(ABC, BaseModel):
     autoscaling: AbstractAutoscaling | None
 
     @root_validator()
-    def validate_scaling(cls, field_values: dict[str, Any]) -> dict[str, Any]:
+    def validate_scaling(cls, field_values: Mapping[str, Any]) -> Mapping[str, Any]:
         if field_values.get("autoscaling") and field_values.get("replicas"):
             raise ValueError("autoscaling and replicas are mutually exclusive")
         return field_values

--- a/reconcile/ocm_machine_pools.py
+++ b/reconcile/ocm_machine_pools.py
@@ -5,7 +5,7 @@ from abc import (
 )
 from collections.abc import Iterable, Mapping
 from enum import Enum
-from typing import Any
+from typing import Any, Self
 
 from pydantic import (
     BaseModel,
@@ -202,7 +202,7 @@ class MachinePool(AbstractPool):
         pool: ClusterMachinePoolV1,
         cluster: str,
         cluster_type: ClusterType,
-    ) -> "MachinePool":
+    ) -> Self:
         autoscaling: MachinePoolAutoscaling | None = None
         if pool.autoscale:
             autoscaling = MachinePoolAutoscaling(
@@ -282,7 +282,7 @@ class NodePool(AbstractPool):
         pool: ClusterMachinePoolV1,
         cluster: str,
         cluster_type: ClusterType,
-    ) -> "NodePool":
+    ) -> Self:
         autoscaling: NodePoolAutoscaling | None = None
         if pool.autoscale:
             autoscaling = NodePoolAutoscaling(

--- a/reconcile/ocm_machine_pools.py
+++ b/reconcile/ocm_machine_pools.py
@@ -5,6 +5,7 @@ from abc import (
 )
 from collections.abc import Iterable, Mapping
 from enum import Enum
+from typing import Any
 
 from pydantic import (
     BaseModel,
@@ -48,11 +49,11 @@ class AbstractAutoscaling(BaseModel):
         )
 
     @abstractmethod
-    def get_min(self):
+    def get_min(self) -> int:
         pass
 
     @abstractmethod
-    def get_max(self):
+    def get_max(self) -> int:
         pass
 
 
@@ -61,9 +62,12 @@ class MachinePoolAutoscaling(AbstractAutoscaling):
     max_replicas: int
 
     @root_validator()
-    @classmethod
-    def max_greater_min(cls, field_values):
-        if field_values.get("min_replicas") > field_values.get("max_replicas"):
+    def max_greater_min(cls, field_values: dict[str, Any]) -> dict[str, Any]:
+        min_replicas = field_values.get("min_replicas")
+        max_replicas = field_values.get("max_replicas")
+        if min_replicas is None or max_replicas is None:
+            raise ValueError("min_replicas and max_replicas must be set")
+        if min_replicas > max_replicas:
             raise ValueError("max_replicas must be greater than min_replicas")
         return field_values
 
@@ -79,10 +83,13 @@ class NodePoolAutoscaling(AbstractAutoscaling):
     max_replica: int
 
     @root_validator()
-    @classmethod
-    def max_greater_min(cls, field_values):
-        if field_values.get("min_replica") > field_values.get("max_replica"):
-            raise ValueError("max_replicas must be greater than min_replicas")
+    def max_greater_min(cls, field_values: dict[str, Any]) -> dict[str, Any]:
+        min_replica = field_values.get("min_replica")
+        max_replica = field_values.get("max_replica")
+        if min_replica is None or max_replica is None:
+            raise ValueError("min_replica and max_replica must be set")
+        if min_replica > max_replica:
+            raise ValueError("max_replica must be greater than min_replica")
         return field_values
 
     def get_min(self) -> int:
@@ -104,8 +111,7 @@ class AbstractPool(ABC, BaseModel):
     autoscaling: AbstractAutoscaling | None
 
     @root_validator()
-    @classmethod
-    def validate_scaling(cls, field_values):
+    def validate_scaling(cls, field_values: dict[str, Any]) -> dict[str, Any]:
         if field_values.get("autoscaling") and field_values.get("replicas"):
             raise ValueError("autoscaling and replicas are mutually exclusive")
         return field_values
@@ -134,14 +140,12 @@ class AbstractPool(ABC, BaseModel):
     def deletable(self) -> bool:
         pass
 
-    def _has_diff_autoscale(self, pool):
-        match (self.autoscaling, pool.autoscale):
-            case (None, None):
-                return False
-            case (None, _) | (_, None):
-                return True
-            case _:
-                return self.autoscaling.has_diff(pool.autoscale)
+    def _has_diff_autoscale(self, pool: ClusterMachinePoolV1) -> bool:
+        if self.autoscaling is None and pool.autoscale is None:
+            return False
+        if self.autoscaling is None or pool.autoscale is None:
+            return True
+        return self.autoscaling.has_diff(pool.autoscale)
 
 
 class MachinePool(AbstractPool):
@@ -198,7 +202,7 @@ class MachinePool(AbstractPool):
         pool: ClusterMachinePoolV1,
         cluster: str,
         cluster_type: ClusterType,
-    ):
+    ) -> "MachinePool":
         autoscaling: MachinePoolAutoscaling | None = None
         if pool.autoscale:
             autoscaling = MachinePoolAutoscaling(
@@ -278,7 +282,7 @@ class NodePool(AbstractPool):
         pool: ClusterMachinePoolV1,
         cluster: str,
         cluster_type: ClusterType,
-    ):
+    ) -> "NodePool":
         autoscaling: NodePoolAutoscaling | None = None
         if pool.autoscale:
             autoscaling = NodePoolAutoscaling(
@@ -369,7 +373,7 @@ def _classify_cluster_type(cluster: ClusterV1) -> ClusterType:
             raise ValueError(f"unknown cluster type for cluster {cluster.name}")
 
 
-def fetch_current_state_for_cluster(cluster, ocm):
+def fetch_current_state_for_cluster(cluster: ClusterV1, ocm: OCM) -> list[AbstractPool]:
     cluster_type = _classify_cluster_type(cluster)
     if cluster_type == ClusterType.ROSA_HCP:
         return [
@@ -505,14 +509,15 @@ def act(dry_run: bool, diffs: Iterable[PoolHandler], ocm_map: OCMMap) -> None:
         logging.info([diff.action, diff.pool.cluster, diff.pool.id])
         if not dry_run:
             ocm = ocm_map.get(diff.pool.cluster)
-            diff.act(dry_run, ocm)
+            if ocm is not None:
+                diff.act(dry_run, ocm)
 
 
 def _cluster_is_compatible(cluster: ClusterV1) -> bool:
     return cluster.ocm is not None and cluster.machine_pools is not None
 
 
-def run(dry_run: bool):
+def run(dry_run: bool) -> None:
     clusters = get_clusters()
 
     filtered_clusters = [

--- a/reconcile/openshift_groups.py
+++ b/reconcile/openshift_groups.py
@@ -5,11 +5,11 @@ from collections.abc import (
     Iterable,
     Mapping,
 )
-from typing import Any
 
 from sretoolbox.utils import threaded
 
 import reconcile.openshift_base as ob
+from reconcile.gql_definitions.common.clusters import ClusterV1
 from reconcile.gql_definitions.openshift_groups.managed_groups import (
     query as query_managed_groups,
 )
@@ -62,20 +62,16 @@ def get_cluster_state(
 
 
 def create_groups_list(
-    clusters: Iterable[Mapping[str, Any]], oc_map: ClusterMap
+    clusters: Iterable[ClusterV1], oc_map: ClusterMap
 ) -> list[dict[str, str]]:
-    """
-    Also used by ocm-groups integration and thus requires to work with dict for now
-    """
     groups_list: list[dict[str, str]] = []
-    for cluster_info in clusters:
-        cluster = cluster_info["name"]
-        oc = oc_map.get(cluster)
+    for cluster in clusters:
+        oc = oc_map.get(cluster.name)
         if isinstance(oc, OCLogMsg):
             logging.log(level=oc.log_level, msg=oc.message)
-        groups = cluster_info["managedGroups"] or []
+        groups = cluster.managed_groups or []
         groups_list.extend(
-            {"cluster": cluster, "group_name": group_name} for group_name in groups
+            {"cluster": cluster.name, "group_name": group_name} for group_name in groups
         )
     return groups_list
 
@@ -97,7 +93,7 @@ def fetch_current_state(
         thread_pool_size=thread_pool_size,
     )
 
-    groups_list = create_groups_list([c.dict(by_alias=True) for c in clusters], oc_map)
+    groups_list = create_groups_list(clusters, oc_map)
     results = threaded.run(
         get_cluster_state, groups_list, thread_pool_size, oc_map=oc_map
     )

--- a/reconcile/test/test_ocm_additional_routers.py
+++ b/reconcile/test/test_ocm_additional_routers.py
@@ -1,3 +1,5 @@
+from collections.abc import Mapping
+from typing import Any
 from unittest import TestCase
 from unittest.mock import (
     Mock,
@@ -74,7 +76,7 @@ class TestOCMAdditionalRouters(TestCase):
         fixture = fxt.get_anymarkup("state.yml")
 
         ocm_api = fixture["ocm_api"]
-        clusters = [{"name": c} for c in ocm_api]
+        clusters: list[Mapping[str, Any]] = [{"name": c} for c in ocm_api]
         ocm = get.return_value
         ocm.get_additional_routers.side_effect = lambda x: fixture["ocm_api"][x]
 

--- a/reconcile/test/test_ocm_additional_routers.py
+++ b/reconcile/test/test_ocm_additional_routers.py
@@ -1,5 +1,6 @@
 from unittest import TestCase
 from unittest.mock import (
+    Mock,
     call,
     patch,
 )
@@ -16,7 +17,7 @@ fxt = Fixtures("ocm_additional_routers")
 class TestOCMAdditionalRouters(TestCase):
     # integration test
     @patch.object(queries, "get_clusters")
-    def test_integ_fail(self, get_clusters):
+    def test_integ_fail(self, get_clusters: Mock) -> None:
         fixture = fxt.get_anymarkup("state.yml")
 
         clusters = fixture["gql_response"]
@@ -33,11 +34,11 @@ class TestOCMAdditionalRouters(TestCase):
     @patch.object(OCMMap, "get")
     def test_integ(
         self,
-        get,
-        init_ocm_client_from_cluster,
-        get_clusters,
-        get_app_interface_settings,
-    ):
+        get: Mock,
+        init_ocm_client_from_cluster: Mock,
+        get_clusters: Mock,
+        get_app_interface_settings: Mock,
+    ) -> None:
         fixture = fxt.get_anymarkup("state.yml")
 
         get_clusters.return_value = fixture["gql_response"]
@@ -65,8 +66,11 @@ class TestOCMAdditionalRouters(TestCase):
     @patch.object(OCMMap, "init_ocm_client_from_cluster")
     @patch.object(OCMMap, "get")
     def test_current_state(
-        self, get, init_ocm_client_from_cluster, get_app_interface_settings
-    ):
+        self,
+        get: Mock,
+        init_ocm_client_from_cluster: Mock,
+        get_app_interface_settings: Mock,
+    ) -> None:
         fixture = fxt.get_anymarkup("state.yml")
 
         ocm_api = fixture["ocm_api"]
@@ -78,7 +82,7 @@ class TestOCMAdditionalRouters(TestCase):
         expected = fixture["current_state"]
         self.assertEqual(current_state, expected)
 
-    def test_desired_state(self):
+    def test_desired_state(self) -> None:
         fixture = fxt.get_anymarkup("state.yml")
 
         gql_response = fixture["gql_response"]
@@ -87,7 +91,7 @@ class TestOCMAdditionalRouters(TestCase):
         expected = fixture["desired_state"]
         self.assertEqual(desired_state, expected)
 
-    def test_diffs(self):
+    def test_diffs(self) -> None:
         fixture = fxt.get_anymarkup("state.yml")
 
         current_state = fixture["current_state"]
@@ -99,11 +103,11 @@ class TestOCMAdditionalRouters(TestCase):
 
     @patch.object(OCMMap, "init_ocm_client_from_cluster")
     @patch.object(OCMMap, "get")
-    def test_act(self, get, init_ocm_client_from_cluster):
+    def test_act(self, get: Mock, init_ocm_client_from_cluster: Mock) -> None:
         fixture = fxt.get_anymarkup("state.yml")
         ocm = get.return_value
 
-        ocm_map = OCMMap(fixture["gql_response"])
+        ocm_map = OCMMap(clusters=fixture["gql_response"])
         diffs = fixture["diffs"]
         integ.act(False, diffs, ocm_map)
 

--- a/reconcile/test/test_ocm_clusters.py
+++ b/reconcile/test/test_ocm_clusters.py
@@ -1,6 +1,10 @@
 # ruff: noqa: SIM117
-import typing
-from unittest.mock import patch
+from collections.abc import Generator
+from typing import Any
+from unittest.mock import (
+    Mock,
+    patch,
+)
 
 import pytest
 from pydantic import ValidationError
@@ -42,37 +46,37 @@ fxt = Fixtures("clusters")
 
 
 @pytest.fixture
-def ocm_osd_cluster_raw_spec():
+def ocm_osd_cluster_raw_spec() -> dict[str, Any]:
     return fxt.get_anymarkup("osd_spec.json")
 
 
 @pytest.fixture
-def ocm_osd_cluster_ai_spec():
+def ocm_osd_cluster_ai_spec() -> dict[str, Any]:
     return fxt.get_anymarkup("osd_spec_ai.yml")
 
 
 @pytest.fixture
-def ocm_osd_cluster_post_spec():
+def ocm_osd_cluster_post_spec() -> dict[str, Any]:
     return fxt.get_anymarkup("osd_spec_post.json")
 
 
 @pytest.fixture
-def ocm_rosa_cluster_raw_spec():
+def ocm_rosa_cluster_raw_spec() -> dict[str, Any]:
     return fxt.get_anymarkup("rosa_spec.json")
 
 
 @pytest.fixture
-def ocm_rosa_cluster_ai_spec():
+def ocm_rosa_cluster_ai_spec() -> dict[str, Any]:
     return fxt.get_anymarkup("rosa_spec_ai.yml")
 
 
 @pytest.fixture
-def ocm_rosa_cluster_post_spec():
+def ocm_rosa_cluster_post_spec() -> dict[str, Any]:
     return fxt.get_anymarkup("rosa_spec_post.json")
 
 
 @pytest.fixture
-def ocm_osd_cluster_spec():
+def ocm_osd_cluster_spec() -> Generator[OCMSpec, None, None]:
     n = OCMClusterNetwork(
         type="OpenShiftSDN",
         vpc="10.112.0.0/16",
@@ -93,27 +97,35 @@ def ocm_osd_cluster_spec():
         load_balancers=5,
         storage=1100,
         provider="aws",
+        autoscale=None,
+        instance_type=None,
+        nodes=None,
+        initial_version=None,
+        hypershift=None,
     )
     machine_pools = [
         ClusterMachinePool(
             id="worker",
             instance_type="m5.xlarge",
             replicas=5,
+            autoscale=None,
         )
     ]
     obj = OCMSpec(
         spec=spec,
-        machine_pools=machine_pools,
+        machinePools=machine_pools,
         network=n,
         domain="devshift.net",
-        server_url="https://api.test-cluster.0000.p1.openshiftapps.com:6443",
-        console_url="https://console-openshift-console.test-cluster.0000.p1.openshiftapps.com",
+        serverUrl="https://api.test-cluster.0000.p1.openshiftapps.com:6443",
+        consoleUrl="https://console-openshift-console.test-cluster.0000.p1.openshiftapps.com",
+        path=None,
+        elbFQDN="",
     )
     yield obj
 
 
 @pytest.fixture
-def osd_cluster_fxt():
+def osd_cluster_fxt() -> dict[str, Any]:
     return {
         "spec": {
             "product": "osd",
@@ -181,7 +193,7 @@ def osd_cluster_fxt():
 
 
 @pytest.fixture
-def rosa_cluster_fxt():
+def rosa_cluster_fxt() -> dict[str, Any]:
     return {
         "spec": {
             "product": "rosa",
@@ -259,7 +271,7 @@ def rosa_cluster_fxt():
 
 
 @pytest.fixture
-def rosa_hosted_cp_cluster_fxt():
+def rosa_hosted_cp_cluster_fxt() -> dict[str, Any]:
     return {
         "spec": {
             "product": "rosa",
@@ -324,7 +336,9 @@ def rosa_hosted_cp_cluster_fxt():
 
 
 @pytest.fixture
-def queries_mock(osd_cluster_fxt):
+def queries_mock(
+    osd_cluster_fxt: dict[str, Any],
+) -> Generator[tuple[Mock, Mock], None, None]:
     with patch.object(queries, "get_app_interface_settings", autospec=True) as s:
         with patch.object(queries, "get_clusters", autospec=True) as gc:
             s.return_value = {}
@@ -333,7 +347,9 @@ def queries_mock(osd_cluster_fxt):
 
 
 @pytest.fixture
-def ocmmap_mock(ocm_osd_cluster_spec, ocm_mock):
+def ocmmap_mock(
+    ocm_osd_cluster_spec: OCMSpec, ocm_mock: tuple[Mock, Mock]
+) -> Generator[tuple[Mock, Mock], None, None]:
     with patch.object(OCMMap, "get", autospec=True) as get:
         with patch.object(OCMMap, "init_ocm_client_from_cluster", autospec=True):
             with patch.object(OCMMap, "cluster_specs", autospec=True) as cs:
@@ -343,7 +359,7 @@ def ocmmap_mock(ocm_osd_cluster_spec, ocm_mock):
 
 
 @pytest.fixture
-def ocm_mock(mocker: MockerFixture):
+def ocm_mock(mocker: MockerFixture) -> Generator[tuple[Mock, Mock], None, None]:
     with patch.object(ocm, "init_ocm_base_client") as ioc:
         ocm_api_mock = mocker.Mock(OCMBaseClient)
         ioc.return_value = ocm_api_mock
@@ -355,27 +371,27 @@ def ocm_mock(mocker: MockerFixture):
 
 
 @pytest.fixture
-def cluster_updates_mr_mock():
+def cluster_updates_mr_mock() -> Generator[Mock, None, None]:
     with patch.object(mr_client_gateway, "init", autospec=True):
         with patch.object(CreateClustersUpdates, "submit", autospec=True) as ccu:
             yield ccu
 
 
 @pytest.fixture
-def get_json_mock():
+def get_json_mock() -> Generator[Mock, None, None]:
     with patch.object(OCM, "_get_json", autospec=True) as get_json:
         yield get_json
 
 
 @pytest.fixture
-def osd_product() -> typing.Generator[OCMProductOsd, None, None]:
+def osd_product() -> Generator[OCMProductOsd, None, None]:
     with patch.object(products, "get_provisioning_shard_id") as g:
         g.return_value = "provision_shard_id"
         yield OCMProductOsd()
 
 
 @pytest.fixture
-def rosa_product() -> typing.Generator[OCMProductRosa, None, None]:
+def rosa_product() -> Generator[OCMProductRosa, None, None]:
     with patch.object(products, "get_provisioning_shard_id") as g:
         g.return_value = "provision_shard_id"
         yield OCMProductRosa(None)
@@ -396,7 +412,7 @@ def product_portfolio(
 @pytest.fixture
 def integration(
     product_portfolio: OCMProductPortfolio,
-) -> typing.Generator[occ.OcmClusters, None, None]:
+) -> Generator[occ.OcmClusters, None, None]:
     integration = occ.OcmClusters(
         params=occ.OcmClustersParams(
             job_controller_cluster="cluster",
@@ -414,24 +430,28 @@ def integration(
         yield integration
 
 
-def test_ocm_spec_population_rosa(rosa_cluster_fxt):
+def test_ocm_spec_population_rosa(rosa_cluster_fxt: dict[str, Any]) -> None:
     n = OCMSpec(**rosa_cluster_fxt)
     assert isinstance(n.spec, ROSAClusterSpec)
 
 
-def test_ocm_spec_population_hcp(rosa_hosted_cp_cluster_fxt):
+def test_ocm_spec_population_hcp(
+    rosa_hosted_cp_cluster_fxt: dict[str, Any],
+) -> None:
     n = OCMSpec(**rosa_hosted_cp_cluster_fxt)
     assert isinstance(n.spec, ROSAClusterSpec)
 
 
-def test_ocm_spec_population_osd(osd_cluster_fxt):
+def test_ocm_spec_population_osd(osd_cluster_fxt: dict[str, Any]) -> None:
     n = OCMSpec(**osd_cluster_fxt)
     assert isinstance(n.spec, OSDClusterSpec)
     assert n.server_url == osd_cluster_fxt[SPEC_ATTR_SERVER_URL]
     assert n.console_url == osd_cluster_fxt[SPEC_ATTR_CONSOLE_URL]
 
 
-def test_ocm_spec_population_osd_with_extra(osd_cluster_fxt):
+def test_ocm_spec_population_osd_with_extra(
+    osd_cluster_fxt: dict[str, Any],
+) -> None:
     osd_cluster_fxt["spec"]["extra_attribute"] = True
     with pytest.raises(ValidationError):
         OCMSpec(**osd_cluster_fxt)
@@ -439,7 +459,7 @@ def test_ocm_spec_population_osd_with_extra(osd_cluster_fxt):
 
 def test_get_ocm_cluster_update_spec_no_changes(
     osd_product: OCMProductOsd, ocm_osd_cluster_spec: OCMSpec
-):
+) -> None:
     current_spec = ocm_osd_cluster_spec
     desired_spec = ocm_osd_cluster_spec
     upd, err = occ.get_cluster_ocm_update_spec(
@@ -450,7 +470,7 @@ def test_get_ocm_cluster_update_spec_no_changes(
 
 def test_get_ocm_cluster_update_spec_network_banned(
     osd_product: OCMProductOsd, ocm_osd_cluster_spec: OCMSpec
-):
+) -> None:
     current_spec = ocm_osd_cluster_spec
     desired_spec = current_spec.copy(deep=True)
     desired_spec.network.vpc = "0.0.0.0/0"
@@ -462,7 +482,7 @@ def test_get_ocm_cluster_update_spec_network_banned(
 
 def test_get_ocm_cluster_update_spec_network_type_ignored(
     osd_product: OCMProductOsd, ocm_osd_cluster_spec: OCMSpec
-):
+) -> None:
     current_spec = ocm_osd_cluster_spec
     desired_spec = current_spec.copy(deep=True)
     desired_spec.network.type = "OVNKubernetes"
@@ -472,13 +492,12 @@ def test_get_ocm_cluster_update_spec_network_type_ignored(
     assert (upd, err) == ({}, False)
 
 
-@typing.no_type_check
 def test_get_ocm_cluster_update_spec_allowed_change(
     osd_product: OCMProductOsd, ocm_osd_cluster_spec: OCMSpec
-):
+) -> None:
     current_spec = ocm_osd_cluster_spec
     desired_spec = current_spec.copy(deep=True)
-    desired_spec.spec.storage = 2000
+    desired_spec.spec.storage = 2000  # type: ignore
     upd, err = occ.get_cluster_ocm_update_spec(
         osd_product, "cluster1", current_spec, desired_spec
     )
@@ -487,7 +506,7 @@ def test_get_ocm_cluster_update_spec_allowed_change(
 
 def test_get_ocm_cluster_update_spec_not_allowed_change(
     osd_product: OCMProductOsd, ocm_osd_cluster_spec: OCMSpec
-):
+) -> None:
     current_spec = ocm_osd_cluster_spec
     desired_spec = current_spec.copy(deep=True)
     desired_spec.spec.multi_az = not desired_spec.spec.multi_az
@@ -502,7 +521,7 @@ def test_get_ocm_cluster_update_spec_not_allowed_change(
 
 def test_get_ocm_cluster_update_spec_disable_uwm(
     osd_product: OCMProductOsd, ocm_osd_cluster_spec: OCMSpec
-):
+) -> None:
     current_spec = ocm_osd_cluster_spec
     desired_spec = current_spec.copy(deep=True)
     desired_spec.spec.disable_user_workload_monitoring = (
@@ -521,10 +540,10 @@ def test_get_ocm_cluster_update_spec_disable_uwm(
 
 def test_noop_dry_run(
     integration: occ.OcmClusters,
-    queries_mock,
-    ocmmap_mock,
-    ocm_mock,
-    cluster_updates_mr_mock,
+    queries_mock: tuple[Mock, Mock],
+    ocmmap_mock: tuple[Mock, Mock],
+    ocm_mock: tuple[Mock, Mock],
+    cluster_updates_mr_mock: Mock,
 ) -> None:
     with pytest.raises(SystemExit):
         integration.run(False)
@@ -537,12 +556,12 @@ def test_noop_dry_run(
 
 def test_changed_id(
     integration: occ.OcmClusters,
-    get_json_mock,
-    queries_mock,
-    ocm_mock,
-    ocm_osd_cluster_raw_spec,
-    ocm_osd_cluster_ai_spec,
-    cluster_updates_mr_mock,
+    get_json_mock: Mock,
+    queries_mock: tuple[Mock, Mock],
+    ocm_mock: tuple[Mock, Mock],
+    ocm_osd_cluster_raw_spec: dict[str, Any],
+    ocm_osd_cluster_ai_spec: dict[str, Any],
+    cluster_updates_mr_mock: Mock,
 ) -> None:
     # App Interface attributes are only considered if are null or blank
     # Won't be better to update them if have changed?
@@ -560,13 +579,13 @@ def test_changed_id(
 
 def test_ocm_osd_create_cluster(
     integration: occ.OcmClusters,
-    get_json_mock,
-    queries_mock,
-    ocm_mock,
-    cluster_updates_mr_mock,
-    ocm_osd_cluster_ai_spec,
-    ocm_osd_cluster_post_spec,
-):
+    get_json_mock: Mock,
+    queries_mock: tuple[Mock, Mock],
+    ocm_mock: tuple[Mock, Mock],
+    cluster_updates_mr_mock: Mock,
+    ocm_osd_cluster_ai_spec: dict[str, Any],
+    ocm_osd_cluster_post_spec: dict[str, Any],
+) -> None:
     get_json_mock.return_value = {"items": []}
     queries_mock[1].return_value = [ocm_osd_cluster_ai_spec]
 
@@ -586,13 +605,13 @@ def test_ocm_osd_create_cluster(
 
 def test_ocm_osd_create_cluster_without_machine_pools(
     integration: occ.OcmClusters,
-    get_json_mock,
-    queries_mock,
-    ocm_mock,
-    cluster_updates_mr_mock,
-    ocm_osd_cluster_ai_spec,
-    ocm_osd_cluster_post_spec,
-):
+    get_json_mock: Mock,
+    queries_mock: tuple[Mock, Mock],
+    ocm_mock: tuple[Mock, Mock],
+    cluster_updates_mr_mock: Mock,
+    ocm_osd_cluster_ai_spec: dict[str, Any],
+    ocm_osd_cluster_post_spec: dict[str, Any],
+) -> None:
     get_json_mock.return_value = {"items": []}
     bad_spec = ocm_osd_cluster_ai_spec | {"machinePools": []}
     queries_mock[1].return_value = [bad_spec]
@@ -609,13 +628,13 @@ def test_ocm_osd_create_cluster_without_machine_pools(
 
 def test_ocm_rosa_update_cluster(
     integration: occ.OcmClusters,
-    get_json_mock,
-    queries_mock,
-    ocm_mock,
-    cluster_updates_mr_mock,
-    ocm_rosa_cluster_raw_spec,
-    ocm_rosa_cluster_ai_spec,
-):
+    get_json_mock: Mock,
+    queries_mock: tuple[Mock, Mock],
+    ocm_mock: tuple[Mock, Mock],
+    cluster_updates_mr_mock: Mock,
+    ocm_rosa_cluster_raw_spec: dict[str, Any],
+    ocm_rosa_cluster_ai_spec: dict[str, Any],
+) -> None:
     ocm_rosa_cluster_ai_spec["spec"]["channel"] = "rapid"
     get_json_mock.return_value = {"items": [ocm_rosa_cluster_raw_spec]}
     queries_mock[1].return_value = [ocm_rosa_cluster_ai_spec]
@@ -629,13 +648,13 @@ def test_ocm_rosa_update_cluster(
 
 def test_ocm_rosa_update_cluster_dont_update_ocm_on_oidc_drift(
     integration: occ.OcmClusters,
-    get_json_mock,
-    queries_mock,
-    ocm_mock,
-    cluster_updates_mr_mock,
-    ocm_rosa_cluster_raw_spec,
-    ocm_rosa_cluster_ai_spec,
-):
+    get_json_mock: Mock,
+    queries_mock: tuple[Mock, Mock],
+    ocm_mock: tuple[Mock, Mock],
+    cluster_updates_mr_mock: Mock,
+    ocm_rosa_cluster_raw_spec: dict[str, Any],
+    ocm_rosa_cluster_ai_spec: dict[str, Any],
+) -> None:
     ocm_rosa_cluster_ai_spec["spec"]["oidc_endpoint_url"] = "some-other-oidc-url"
     get_json_mock.return_value = {"items": [ocm_rosa_cluster_raw_spec]}
     queries_mock[1].return_value = [ocm_rosa_cluster_ai_spec]
@@ -649,13 +668,13 @@ def test_ocm_rosa_update_cluster_dont_update_ocm_on_oidc_drift(
 
 def test_ocm_rosa_update_cluster_with_machine_pools_change(
     integration: occ.OcmClusters,
-    get_json_mock,
-    queries_mock,
-    ocm_mock,
-    cluster_updates_mr_mock,
-    ocm_rosa_cluster_raw_spec,
-    ocm_rosa_cluster_ai_spec,
-):
+    get_json_mock: Mock,
+    queries_mock: tuple[Mock, Mock],
+    ocm_mock: tuple[Mock, Mock],
+    cluster_updates_mr_mock: Mock,
+    ocm_rosa_cluster_raw_spec: dict[str, Any],
+    ocm_rosa_cluster_ai_spec: dict[str, Any],
+) -> None:
     new_spec = ocm_rosa_cluster_ai_spec | {
         "machinePools": [
             {
@@ -679,13 +698,13 @@ def test_ocm_rosa_update_cluster_with_machine_pools_change(
 
 def test_ocm_osd_update_cluster(
     integration: occ.OcmClusters,
-    get_json_mock,
-    queries_mock,
-    ocm_mock,
-    cluster_updates_mr_mock,
-    ocm_osd_cluster_raw_spec,
-    ocm_osd_cluster_ai_spec,
-):
+    get_json_mock: Mock,
+    queries_mock: tuple[Mock, Mock],
+    ocm_mock: tuple[Mock, Mock],
+    cluster_updates_mr_mock: Mock,
+    ocm_osd_cluster_raw_spec: dict[str, Any],
+    ocm_osd_cluster_ai_spec: dict[str, Any],
+) -> None:
     ocm_osd_cluster_ai_spec["spec"]["storage"] = 40000
     get_json_mock.return_value = {"items": [ocm_osd_cluster_raw_spec]}
     queries_mock[1].return_value = [ocm_osd_cluster_ai_spec]
@@ -699,13 +718,13 @@ def test_ocm_osd_update_cluster(
 
 def test_ocm_osd_update_cluster_with_machine_pools_change(
     integration: occ.OcmClusters,
-    get_json_mock,
-    queries_mock,
-    ocm_mock,
-    cluster_updates_mr_mock,
-    ocm_osd_cluster_raw_spec,
-    ocm_osd_cluster_ai_spec,
-):
+    get_json_mock: Mock,
+    queries_mock: tuple[Mock, Mock],
+    ocm_mock: tuple[Mock, Mock],
+    cluster_updates_mr_mock: Mock,
+    ocm_osd_cluster_raw_spec: dict[str, Any],
+    ocm_osd_cluster_ai_spec: dict[str, Any],
+) -> None:
     new_spec = ocm_osd_cluster_ai_spec | {
         "machinePools": [
             {
@@ -729,14 +748,14 @@ def test_ocm_osd_update_cluster_with_machine_pools_change(
 
 def test_ocm_returns_a_rosa_cluster(
     integration: occ.OcmClusters,
-    get_json_mock,
-    queries_mock,
-    ocm_mock,
-    cluster_updates_mr_mock,
-    ocm_osd_cluster_raw_spec,
-    ocm_rosa_cluster_raw_spec,
-    ocm_osd_cluster_ai_spec,
-):
+    get_json_mock: Mock,
+    queries_mock: tuple[Mock, Mock],
+    ocm_mock: tuple[Mock, Mock],
+    cluster_updates_mr_mock: Mock,
+    ocm_osd_cluster_raw_spec: dict[str, Any],
+    ocm_rosa_cluster_raw_spec: dict[str, Any],
+    ocm_osd_cluster_ai_spec: dict[str, Any],
+) -> None:
     get_json_mock.return_value = {
         "items": [ocm_osd_cluster_raw_spec, ocm_rosa_cluster_raw_spec]
     }
@@ -751,13 +770,13 @@ def test_ocm_returns_a_rosa_cluster(
 
 def test_changed_ocm_spec_disable_uwm(
     integration: occ.OcmClusters,
-    get_json_mock,
-    queries_mock,
-    ocm_mock,
-    ocm_osd_cluster_raw_spec,
-    ocm_osd_cluster_ai_spec,
-    cluster_updates_mr_mock,
-):
+    get_json_mock: Mock,
+    queries_mock: tuple[Mock, Mock],
+    ocm_mock: tuple[Mock, Mock],
+    ocm_osd_cluster_raw_spec: dict[str, Any],
+    ocm_osd_cluster_ai_spec: dict[str, Any],
+    cluster_updates_mr_mock: Mock,
+) -> None:
     ocm_osd_cluster_ai_spec["spec"][
         "disable_user_workload_monitoring"
     ] = not ocm_osd_cluster_ai_spec["spec"]["disable_user_workload_monitoring"]
@@ -776,13 +795,13 @@ def test_changed_ocm_spec_disable_uwm(
 
 def test_console_url_changes_ai(
     integration: occ.OcmClusters,
-    get_json_mock,
-    queries_mock,
-    ocm_mock,
-    ocm_osd_cluster_raw_spec,
-    ocm_osd_cluster_ai_spec,
-    cluster_updates_mr_mock,
-):
+    get_json_mock: Mock,
+    queries_mock: tuple[Mock, Mock],
+    ocm_mock: tuple[Mock, Mock],
+    ocm_osd_cluster_raw_spec: dict[str, Any],
+    ocm_osd_cluster_ai_spec: dict[str, Any],
+    cluster_updates_mr_mock: Mock,
+) -> None:
     ocm_osd_cluster_ai_spec["consoleUrl"] = "old-console-url"
 
     get_json_mock.return_value = {"items": [ocm_osd_cluster_raw_spec]}

--- a/reconcile/test/test_ocm_clusters_manifest_updates.py
+++ b/reconcile/test/test_ocm_clusters_manifest_updates.py
@@ -1,3 +1,5 @@
+from collections.abc import Iterator
+
 import pytest
 
 from reconcile.ocm.types import (
@@ -9,7 +11,7 @@ from reconcile.ocm_clusters import get_app_interface_spec_updates
 
 
 @pytest.fixture
-def cluster_ocm_spec():
+def cluster_ocm_spec() -> Iterator[OCMSpec]:
     n = OCMClusterNetwork(
         type="OpenShiftSDN",
         vpc="10.112.0.0/16",
@@ -31,19 +33,25 @@ def cluster_ocm_spec():
         load_balancers=5,
         storage=1100,
         provider="aws",
+        # OSDClusterSpec requires these fields
+        instance_type="m5.xlarge",
+        nodes=2,
+        initial_version="4.10.0",
+        hypershift=False,
     )
     obj = OCMSpec(
         spec=spec,
         network=n,
         domain="0000.p1.openshiftapps.com",
-        server_url="https://api.cluster.0000.p1.openshiftapps.com:6443",
-        console_url="https://console-openshift-console.apps.cluster.0000.p1.openshiftapps.com",
-        elb_fqdn="elb.apps.cluster.0000.p1.openshiftapps.com",
+        serverUrl="https://api.cluster.0000.p1.openshiftapps.com:6443",
+        consoleUrl="https://console-openshift-console.apps.cluster.0000.p1.openshiftapps.com",
+        elbFQDN="elb.apps.cluster.0000.p1.openshiftapps.com",
+        path=None,
     )
     yield obj
 
 
-def test_all_attributes_missing(cluster_ocm_spec: OCMSpec):
+def test_all_attributes_missing(cluster_ocm_spec: OCMSpec) -> None:
     current_spec = cluster_ocm_spec
     desired_spec = cluster_ocm_spec.copy(deep=True)
     desired_spec.spec.id = None
@@ -54,13 +62,12 @@ def test_all_attributes_missing(cluster_ocm_spec: OCMSpec):
     updates, _ = get_app_interface_spec_updates("cluster", current_spec, desired_spec)
     assert updates["root"]["consoleUrl"] == current_spec.console_url
     assert updates["root"]["serverUrl"] == current_spec.server_url
-    assert updates["root"]["consoleUrl"] == current_spec.console_url
     assert updates["root"]["elbFQDN"] == current_spec.elb_fqdn
     assert updates["spec"]["external_id"] == current_spec.spec.external_id
     assert updates["spec"]["id"] == current_spec.spec.id
 
 
-def test_all_attributes_changed(cluster_ocm_spec: OCMSpec):
+def test_all_attributes_changed(cluster_ocm_spec: OCMSpec) -> None:
     current_spec = cluster_ocm_spec
     desired_spec = cluster_ocm_spec.copy(deep=True)
     desired_spec.spec.id = "previous-id"
@@ -71,13 +78,12 @@ def test_all_attributes_changed(cluster_ocm_spec: OCMSpec):
     updates, _ = get_app_interface_spec_updates("cluster", current_spec, desired_spec)
     assert updates["root"]["consoleUrl"] == current_spec.console_url
     assert updates["root"]["serverUrl"] == current_spec.server_url
-    assert updates["root"]["consoleUrl"] == current_spec.console_url
     assert updates["root"]["elbFQDN"] == current_spec.elb_fqdn
     assert updates["spec"]["external_id"] == current_spec.spec.external_id
     assert updates["spec"]["id"] == current_spec.spec.id
 
 
-def test_elb_fqdn(cluster_ocm_spec: OCMSpec):
+def test_elb_fqdn(cluster_ocm_spec: OCMSpec) -> None:
     current_spec = cluster_ocm_spec
     desired_spec = cluster_ocm_spec.copy(deep=True)
     desired_spec.elb_fqdn = "non-valid"


### PR DESCRIPTION
- **:label: mr_client_gateway: type hints**
- **:label: ocm_additional_routers: type hints**
- **:label: ocm_addons: type hints**
- **:label: ocm_aws_infrastructure_access: type hints**
- **:label: ocm_clusters: type hints**
- **:label: ocm_external_configuration_labels: type hints**
- **:label: test_ocm_clusters_manifest_updates: type hints**
- **:label: ocm_groups: type hints and refactor openshift_groups**
- **:label: ocm_machine_pools: type hints**


Depends on: https://github.com/app-sre/qontract-reconcile/pull/5094