### PR TITLE
[aws-account-manager] support IT managed accounts

### DIFF
--- a/reconcile/aws_account_manager/integration.py
+++ b/reconcile/aws_account_manager/integration.py
@@ -53,7 +53,7 @@ class AwsAccountMgmtIntegrationParams(PydanticRunParams):
     )
     # To avoid the accidental deletion of the resource file, explicitly set the
     # qontract.cli option in the integration extraArgs!
-    account_tmpl_resource: str = "/aws-account-manager/account-tmpl.yml"
+    account_tmpl_resource: str = "/aws-account-manager/account-tmpl.yml.j2"
     template_collection_root_path: str = "data/templating/collections/aws-account"
 
 

--- a/reconcile/cli.py
+++ b/reconcile/cli.py
@@ -969,7 +969,7 @@ def aws_saml_roles(
     "--account-tmpl-resource",
     help="Resource name of the account template-collection template in the app-interface.",
     required=True,
-    default="/aws-account-manager/account-tmpl.yml",
+    default="/aws-account-manager/account-tmpl.yml.j2",
 )
 @click.option(
     "--template-collection-root-path",

--- a/reconcile/test/utils/aws_api_typed/test_aws_api_typed_account.py
+++ b/reconcile/test/utils/aws_api_typed/test_aws_api_typed_account.py
@@ -1,20 +1,16 @@
-from typing import TYPE_CHECKING
 from unittest.mock import MagicMock
 
+import botocore
 import pytest
+from mypy_boto3_account import AccountClient
 from pytest_mock import MockerFixture
 
 from reconcile.utils.aws_api_typed.account import AWSApiAccount, OptStatus, Region
 
-if TYPE_CHECKING:
-    from mypy_boto3_account import AccountClient
-else:
-    AccountClient = object
-
 
 @pytest.fixture
 def account_client(mocker: MockerFixture) -> AccountClient:
-    return mocker.Mock()
+    return mocker.MagicMock(spec=AccountClient)
 
 
 @pytest.fixture
@@ -31,6 +27,107 @@ def test_aws_api_typed_account_set_security_contact(
         title="title",
         email="email",
         phone_number="phone_number",
+    )
+
+
+def test_aws_api_typed_account_set_security_contact_permission_denied_by_already_set(
+    aws_api_account: AWSApiAccount, account_client: MagicMock
+) -> None:
+    account_client.put_alternate_contact.side_effect = botocore.exceptions.ClientError(
+        error_response={
+            "Error": {
+                "Code": "AccessDenied",
+                "Message": "User: arn:aws:iam::xxxx:user/terraform is not authorized to perform: account:PutAlternateContact on resource: arn:aws:account::787755075174:account with an explicit deny",
+            }
+        },
+        operation_name="PutAlternateContact",
+    )
+    account_client.get_alternate_contact.return_value = {
+        "AlternateContact": {
+            "EmailAddress": "email",
+            "Name": "name",
+            "Title": "title",
+            "PhoneNumber": "phone_number",
+        }
+    }
+    aws_api_account.set_security_contact(
+        name="name",
+        title="title",
+        email="email",
+        phone_number="phone_number",
+    )
+
+
+def test_aws_api_typed_account_set_security_contact_permission_denied_and_not_set(
+    aws_api_account: AWSApiAccount, account_client: MagicMock
+) -> None:
+    account_client.put_alternate_contact.side_effect = botocore.exceptions.ClientError(
+        error_response={
+            "Error": {
+                "Code": "AccessDenied",
+                "Message": "User: arn:aws:iam::xxxx:user/terraform is not authorized to perform: account:PutAlternateContact on resource: arn:aws:account::787755075174:account with an explicit deny",
+            }
+        },
+        operation_name="PutAlternateContact",
+    )
+    account_client.get_alternate_contact.return_value = {"AlternateContact": None}
+    with pytest.raises(botocore.exceptions.ClientError):
+        aws_api_account.set_security_contact(
+            name="name",
+            title="title",
+            email="email",
+            phone_number="phone_number",
+        )
+
+
+def test_aws_api_typed_account_set_security_contact_permission_denied_and_different(
+    aws_api_account: AWSApiAccount, account_client: MagicMock
+) -> None:
+    account_client.put_alternate_contact.side_effect = botocore.exceptions.ClientError(
+        error_response={
+            "Error": {
+                "Code": "AccessDenied",
+                "Message": "User: arn:aws:iam::xxxx:user/terraform is not authorized to perform: account:PutAlternateContact on resource: arn:aws:account::787755075174:account with an explicit deny",
+            }
+        },
+        operation_name="PutAlternateContact",
+    )
+    account_client.get_alternate_contact.return_value = {
+        "AlternateContact": {
+            "EmailAddress": "different_email",
+            "Name": "name",
+            "Title": "title",
+            "PhoneNumber": "phone_number",
+        }
+    }
+    with pytest.raises(botocore.exceptions.ClientError):
+        aws_api_account.set_security_contact(
+            name="name",
+            title="title",
+            email="email",
+            phone_number="phone_number",
+        )
+
+
+def test_aws_api_typed_account_get_security_contact(
+    aws_api_account: AWSApiAccount, account_client: MagicMock
+) -> None:
+    account_client.get_alternate_contact.return_value = {
+        "AlternateContact": {
+            "EmailAddress": "email",
+            "Name": "name",
+            "Title": "title",
+            "PhoneNumber": "phone_number",
+        }
+    }
+    contact = aws_api_account.get_security_contact()
+    assert contact is not None
+    assert contact["EmailAddress"] == "email"
+    assert contact["Name"] == "name"
+    assert contact["Title"] == "title"
+    assert contact["PhoneNumber"] == "phone_number"
+    account_client.get_alternate_contact.assert_called_once_with(
+        AlternateContactType="SECURITY"
     )
 
 

--- a/reconcile/test/utils/aws_api_typed/test_aws_api_typed_iam.py
+++ b/reconcile/test/utils/aws_api_typed/test_aws_api_typed_iam.py
@@ -1,20 +1,17 @@
-from typing import TYPE_CHECKING
 from unittest.mock import MagicMock
 
+import botocore
 import pytest
+from mypy_boto3_iam import IAMClient
+from mypy_boto3_iam.type_defs import ListAccountAliasesResponseTypeDef
 from pytest_mock import MockerFixture
 
 from reconcile.utils.aws_api_typed.iam import AWSApiIam
 
-if TYPE_CHECKING:
-    from mypy_boto3_iam import IAMClient
-else:
-    IAMClient = object
-
 
 @pytest.fixture
 def iam_client(mocker: MockerFixture) -> IAMClient:
-    return mocker.Mock()
+    return mocker.MagicMock(spec=IAMClient)
 
 
 @pytest.fixture
@@ -71,6 +68,85 @@ def test_aws_api_typed_iam_set_account_alias(
     iam_client.create_account_alias.assert_called_once_with(
         AccountAlias="account_alias",
     )
+
+
+def test_aws_api_typed_iam_set_account_alias_already_set(
+    aws_api_iam: AWSApiIam, iam_client: MagicMock
+) -> None:
+    iam_client.create_account_alias.side_effect = botocore.exceptions.ClientError(
+        error_response={
+            "Error": {
+                "Code": "EntityAlreadyExists",
+                "Message": "An account alias already exists for this account.",
+            }
+        },
+        operation_name="CreateAccountAlias",
+    )
+    iam_client.list_account_aliases.return_value = ListAccountAliasesResponseTypeDef(
+        AccountAliases=["account_alias"],
+        IsTruncated=False,
+        Marker="",
+        ResponseMetadata={
+            "RequestId": "request_id",
+            "HTTPStatusCode": 200,
+            "HTTPHeaders": {},
+            "RetryAttempts": 0,
+        },
+    )
+    aws_api_iam.set_account_alias("account_alias")
+
+
+def test_aws_api_typed_iam_set_account_alias_permission_denied_by_already_set(
+    aws_api_iam: AWSApiIam, iam_client: MagicMock
+) -> None:
+    iam_client.create_account_alias.side_effect = botocore.exceptions.ClientError(
+        error_response={
+            "Error": {
+                "Code": "AccessDenied",
+                "Message": "User: arn:aws:iam::xxxxx:user/terraform is not authorized to perform: iam:CreateAccountAlias on resource: * with an explicit deny in a service control policy",
+            }
+        },
+        operation_name="CreateAccountAlias",
+    )
+    iam_client.list_account_aliases.return_value = ListAccountAliasesResponseTypeDef(
+        AccountAliases=["account_alias"],
+        IsTruncated=False,
+        Marker="",
+        ResponseMetadata={
+            "RequestId": "request_id",
+            "HTTPStatusCode": 200,
+            "HTTPHeaders": {},
+            "RetryAttempts": 0,
+        },
+    )
+    aws_api_iam.set_account_alias("account_alias")
+
+
+def test_aws_api_typed_iam_set_account_alias_permission_denied_and_not_set(
+    aws_api_iam: AWSApiIam, iam_client: MagicMock
+) -> None:
+    iam_client.create_account_alias.side_effect = botocore.exceptions.ClientError(
+        error_response={
+            "Error": {
+                "Code": "AccessDenied",
+                "Message": "User: arn:aws:iam::xxxxx:user/terraform is not authorized to perform: iam:CreateAccountAlias on resource: * with an explicit deny in a service control policy",
+            }
+        },
+        operation_name="CreateAccountAlias",
+    )
+    iam_client.list_account_aliases.return_value = ListAccountAliasesResponseTypeDef(
+        AccountAliases=["some_other_alias"],
+        IsTruncated=False,
+        Marker="",
+        ResponseMetadata={
+            "RequestId": "request_id",
+            "HTTPStatusCode": 200,
+            "HTTPHeaders": {},
+            "RetryAttempts": 0,
+        },
+    )
+    with pytest.raises(botocore.exceptions.ClientError):
+        aws_api_iam.set_account_alias("account_alias")
 
 
 def test_aws_api_typed_iam_get_account_alias(


### PR DESCRIPTION
We want to onboard and manage AWS accounts created by IT. These accounts have restrictions on changing the alias and the security contact information. The plan is to ignore all AWS API errors as long as the app-interface settings match those in the account; otherwise, throw an exception as usual.


Ticket: [APPSRE-12236](https://issues.redhat.com/browse/APPSRE-12236)