### PR TITLE
:rotating_light: remove obsolete pylint exceptions

### DIFF
--- a/reconcile/aus/metrics.py
+++ b/reconcile/aus/metrics.py
@@ -100,7 +100,7 @@ class AUSClusterUpgradePolicyInfoMetric(AUSBaseMetric, InfoMetric):
         return "aus_cluster_upgrade_policy_info"
 
 
-class AUSAddonUpgradePolicyInfoMetric(AUSClusterUpgradePolicyInfoMetric):  # pylint: disable=R0901
+class AUSAddonUpgradePolicyInfoMetric(AUSClusterUpgradePolicyInfoMetric):
     "Info metric for cluster addons under AUS upgrade control"
 
     addon: str

--- a/reconcile/test/ocm/test_utils_ocm_clusters.py
+++ b/reconcile/test/ocm/test_utils_ocm_clusters.py
@@ -183,9 +183,7 @@ def test_discover_clusters_by_labels(
     get_clusters_for_subscriptions_mock.assert_called_once_with(
         ocm_api=ocm_api,
         subscription_filter=(
-            Filter().is_in(  # pylint: disable=unsupported-binary-operation
-                "id", ["sub_id", "sub_id_2"]
-            )
+            Filter().is_in("id", ["sub_id", "sub_id_2"])
             | Filter().is_in("organization_id", ["org_id"])
         ),
     )

--- a/reconcile/test/test_aws_ami_cleanup.py
+++ b/reconcile/test/test_aws_ami_cleanup.py
@@ -1,7 +1,3 @@
-# pylint does not consider frozen BaseModels as hashable and then complains that they cannot
-# be members of a set.
-# pylint: disable=unhashable-member
-
 from collections.abc import Generator
 from datetime import (
     datetime,

--- a/reconcile/test/test_quay_mirror.py
+++ b/reconcile/test/test_quay_mirror.py
@@ -50,9 +50,7 @@ class TestControlFile:
 @patch("time.time", return_value=NOW)
 class TestIsCompareTags:
     def setup_method(self):
-        self.tmp_dir = (
-            tempfile.TemporaryDirectory()  # pylint: disable=consider-using-with
-        )
+        self.tmp_dir = tempfile.TemporaryDirectory()
         with open(
             os.path.join(self.tmp_dir.name, CONTROL_FILE_NAME), "w", encoding="locale"
         ) as fh:

--- a/reconcile/test/test_quay_mirror_org.py
+++ b/reconcile/test/test_quay_mirror_org.py
@@ -30,9 +30,7 @@ class TestControlFile:
 @patch("time.time", return_value=NOW)
 class TestIsCompareTags:
     def setup_method(self):
-        self.tmp_dir = (
-            tempfile.TemporaryDirectory()  # pylint: disable=consider-using-with
-        )
+        self.tmp_dir = tempfile.TemporaryDirectory()
         with open(
             os.path.join(self.tmp_dir.name, CONTROL_FILE_NAME), "w", encoding="locale"
         ) as fh:

--- a/reconcile/test/test_vault_utils.py
+++ b/reconcile/test/test_vault_utils.py
@@ -15,8 +15,8 @@ class SleepCalledError(Exception):
     pass
 
 
-class TestVaultClient(vault._VaultClient):  # pylint: disable=W0223
-    def __init__(self):  # pylint: disable=W0231
+class TestVaultClient(vault._VaultClient):
+    def __init__(self):
         pass
 
 

--- a/reconcile/test/utils/test_oc.py
+++ b/reconcile/test/utils/test_oc.py
@@ -946,7 +946,6 @@ def test_get_replicaset_fail(
     oc__get_owned_replicasets.return_value = []
 
     with pytest.raises(ResourceNotFoundError):
-        # pylint: disable-next=expression-not-assigned
         oc_cli.get_replicaset("namespace", deployment)["metadata"]["name"]
     assert oc__get_owned_replicasets.call_count == GET_REPLICASET_MAX_ATTEMPTS
 

--- a/reconcile/utils/jjb_client.py
+++ b/reconcile/utils/jjb_client.py
@@ -30,7 +30,7 @@ from reconcile.utils.vcs import GITHUB_BASE_URL
 JJB_INI = "[jenkins]\nurl = https://JENKINS_URL"
 
 
-class JJB:  # pylint: disable=too-many-public-methods
+class JJB:
     """Wrapper around Jenkins Jobs"""
 
     def __init__(self, configs, ssl_verify=True, secret_reader=None, print_only=False):

--- a/reconcile/utils/oc.py
+++ b/reconcile/utils/oc.py
@@ -258,7 +258,7 @@ class OCCliApiResource:
         return self.api_version
 
 
-class OCCli:  # pylint: disable=too-many-public-methods
+class OCCli:
     def __init__(
         self,
         cluster_name: str | None,
@@ -1836,9 +1836,7 @@ class OpenshiftLazyDiscoverer(LazyDiscoverer):
                 if result.group_version == kwargs["api_version"]
             ]
         # If there are multiple matches, prefer non-List kinds
-        if len(results) > 1 and not all(  # pylint: disable=R1729
-            isinstance(x, ResourceList) for x in results
-        ):
+        if len(results) > 1 and not all(isinstance(x, ResourceList) for x in results):
             results = [
                 result for result in results if not isinstance(result, ResourceList)
             ]

--- a/reconcile/utils/ocm/clusters.py
+++ b/reconcile/utils/ocm/clusters.py
@@ -62,10 +62,7 @@ def discover_clusters_by_labels(
 
     sub_id_filter = Filter().is_in("id", subscription_labels.keys())
     org_id_filter = Filter().is_in("organization_id", organization_labels.keys())
-    subscription_filter = (
-        sub_id_filter | org_id_filter  # pylint: disable=unsupported-binary-operation
-    )
-    # the pylint ignore above is because of a bug in pylint - https://github.com/PyCQA/pylint/issues/7381
+    subscription_filter = sub_id_filter | org_id_filter
 
     clusters = list(
         get_cluster_details_for_subscriptions(

--- a/reconcile/utils/ocm/ocm.py
+++ b/reconcile/utils/ocm/ocm.py
@@ -64,7 +64,7 @@ CLUSTER_ADMIN_LABEL_KEY = "capability.cluster.manage_cluster_admin"
 REQUEST_TIMEOUT_SEC = 60
 
 
-class OCM:  # pylint: disable=too-many-public-methods
+class OCM:
     """
     OCM is an instance of OpenShift Cluster Manager.
 
@@ -249,7 +249,6 @@ class OCM:  # pylint: disable=too-many-public-methods
         switch_role_link = role_grants[0][-1]
         return awsh.get_account_uid_from_role_link(switch_role_link)
 
-    # pylint: disable=method-hidden
     def get_aws_infrastructure_access_role_grants(self, cluster):
         """Returns a list of AWS users (ARN, access level)
         who have AWS infrastructure access in a cluster.
@@ -734,7 +733,7 @@ class OCM:  # pylint: disable=too-many-public-methods
         )
 
 
-class OCMMap:  # pylint: disable=too-many-public-methods
+class OCMMap:
     """
     OCMMap gets a GraphQL query results list as input
     and initiates a dictionary of OCM clients per OCM.

--- a/reconcile/utils/openshift_resource.py
+++ b/reconcile/utils/openshift_resource.py
@@ -70,7 +70,6 @@ QONTRACT_ANNOTATIONS = {
 }
 
 
-# pylint: disable=R0904
 class OpenshiftResource:
     def __init__(
         self,

--- a/reconcile/utils/runtime/integration.py
+++ b/reconcile/utils/runtime/integration.py
@@ -212,9 +212,7 @@ class QontractReconcileIntegration(ABC, Generic[RunParamsTypeVar]):
         """
         Returns `True` if the params already contain sharding information.
         """
-        sharding_config = (  # pylint: disable=assignment-from-none
-            self.get_desired_state_shard_config()
-        )
+        sharding_config = self.get_desired_state_shard_config()
         if sharding_config:
             shard_arg_value = self.params.get(sharding_config.shard_arg_name)
             return bool(shard_arg_value)
@@ -227,9 +225,7 @@ class QontractReconcileIntegration(ABC, Generic[RunParamsTypeVar]):
         Create an instegration instance for a specific shard, by patching the run parameters.
         If the integration does not support sharded runs, it raises an exception.
         """
-        sharding_config = (  # pylint: disable=assignment-from-none
-            self.get_desired_state_shard_config()
-        )
+        sharding_config = self.get_desired_state_shard_config()
         if sharding_config:
             sharded_params = self.params.copy_and_update({
                 sharding_config.shard_arg_name: [shard]

--- a/reconcile/utils/runtime/runner.py
+++ b/reconcile/utils/runtime/runner.py
@@ -71,9 +71,7 @@ class IntegrationRunConfiguration:
 
     def comparison_bundle_desired_state(self) -> dict[str, Any] | None:
         self.switch_to_comparison_bundle()
-        data = (  # pylint: disable=assignment-from-none
-            self.integration.get_early_exit_desired_state()
-        )
+        data = self.integration.get_early_exit_desired_state()
         self.switch_to_main_bundle()
         return data
 

--- a/reconcile/utils/saasherder/saasherder.py
+++ b/reconcile/utils/saasherder/saasherder.py
@@ -111,7 +111,7 @@ class TriggerSpecContainerImageError(Exception):
     pass
 
 
-class SaasHerder:  # pylint: disable=too-many-public-methods
+class SaasHerder:
     """Wrapper around SaaS deployment actions."""
 
     def __init__(

--- a/reconcile/utils/terraform_client.py
+++ b/reconcile/utils/terraform_client.py
@@ -76,7 +76,7 @@ class DeletionApprovalExpirationValueError(Exception):
     pass
 
 
-class TerraformClient:  # pylint: disable=too-many-public-methods
+class TerraformClient:
     def __init__(
         self,
         integration: str,

--- a/reconcile/utils/terrascript_aws_client.py
+++ b/reconcile/utils/terrascript_aws_client.py
@@ -432,7 +432,7 @@ class ProviderExcludedError(Exception):
         )
 
 
-class TerrascriptClient:  # pylint: disable=too-many-public-methods
+class TerrascriptClient:
     """
     At a high-level, this class is responsible for generating Terraform configuration in
     JSON format from app-interface schemas/openshift/terraform-resource-1.yml objects.

--- a/tools/app_interface_metrics_exporter.py
+++ b/tools/app_interface_metrics_exporter.py
@@ -90,4 +90,4 @@ def main(
 
 
 if __name__ == "__main__":
-    main()  # pylint: disable=no-value-for-parameter
+    main()

--- a/tools/app_interface_reporter.py
+++ b/tools/app_interface_reporter.py
@@ -327,14 +327,14 @@ def get_apps_data(
                             slo_mx[cluster] = {}
                         if namespace not in slo_mx[cluster]:
                             slo_mx[cluster][namespace] = {}
-                        if slo_doc_name not in slo_mx[cluster][namespace]:  # pylint: disable=line-too-long
+                        if slo_doc_name not in slo_mx[cluster][namespace]:
                             slo_mx[cluster][namespace][slo_doc_name] = {}
                         if slo_name not in slo_mx[cluster][namespace][slo_doc_name]:
                             slo_mx[cluster][namespace][slo_doc_name][slo_name] = {
                                 sample.labels["type"]: sample.value
                             }
                         else:
-                            slo_mx[cluster][namespace][slo_doc_name][slo_name].update({  # pylint: disable=line-too-long
+                            slo_mx[cluster][namespace][slo_doc_name][slo_name].update({
                                 sample.labels["type"]: sample.value
                             })
         app["container_vulnerabilities"] = vuln_mx

--- a/tools/app_sre_tekton_access_reporter.py
+++ b/tools/app_sre_tekton_access_reporter.py
@@ -96,4 +96,4 @@ def main(
 
 
 if __name__ == "__main__":
-    main()  # pylint: disable=no-value-for-parameter
+    main()

--- a/tools/app_sre_tekton_access_revalidation.py
+++ b/tools/app_sre_tekton_access_revalidation.py
@@ -87,4 +87,4 @@ def main(
 
 
 if __name__ == "__main__":
-    main()  # pylint: disable=no-value-for-parameter
+    main()

--- a/tools/glitchtip_access_reporter.py
+++ b/tools/glitchtip_access_reporter.py
@@ -89,4 +89,4 @@ def main(
 
 
 if __name__ == "__main__":
-    main()  # pylint: disable=no-value-for-parameter
+    main()

--- a/tools/glitchtip_access_revalidation.py
+++ b/tools/glitchtip_access_revalidation.py
@@ -89,4 +89,4 @@ def main(
 
 
 if __name__ == "__main__":
-    main()  # pylint: disable=no-value-for-parameter
+    main()

--- a/tools/qontract_cli.py
+++ b/tools/qontract_cli.py
@@ -4848,4 +4848,4 @@ def top_talkers(ctx: click.Context, top: int) -> None:
 
 
 if __name__ == "__main__":
-    root()  # pylint: disable=no-value-for-parameter
+    root()

--- a/tools/saas_metrics_exporter/main.py
+++ b/tools/saas_metrics_exporter/main.py
@@ -96,4 +96,4 @@ def main(
 
 
 if __name__ == "__main__":
-    main()  # pylint: disable=no-value-for-parameter
+    main()

--- a/tools/template_validation.py
+++ b/tools/template_validation.py
@@ -104,4 +104,4 @@ def main(templates: tuple[str]) -> None:
 
 
 if __name__ == "__main__":
-    main()  # pylint: disable=no-value-for-parameter
+    main()


### PR DESCRIPTION
`pylint` isn't in used anymore; therefore we don't need those exception comments anymore.