### PR TITLE
:bug: ocm-upgrade-scheduler-org-updater: fix keyerror

### DIFF
--- a/reconcile/ocm_upgrade_scheduler_org_updater.py
+++ b/reconcile/ocm_upgrade_scheduler_org_updater.py
@@ -56,7 +56,7 @@ def run(dry_run: bool, gitlab_project_id: str | None) -> None:
         )
         ocm_name = ocm_info["name"]
         ocm_path = ocm_info["path"]
-        ocm = ocm_map.get(ocm_name)
+        ocm = ocm_map[ocm_name]
 
         for ocm_cluster_name, ocm_cluster_spec in ocm.clusters.items():
             found = [


### PR DESCRIPTION
Fix

```
Traceback (most recent call last):
  File "/work/reconcile/cli.py", line 584, in run_class_integration
    run_integration_cfg(
  File "/work/reconcile/utils/runtime/runner.py", line 158, in run_integration_cfg
    _integration_wet_run(run_cfg.integration)
  File "/work/reconcile/utils/runtime/runner.py", line 167, in _integration_wet_run
    integration.run(False)
  File "/work/reconcile/utils/runtime/integration.py", line 315, in run
    self.params.module.run(dry_run, *self.params.args, **self.params.kwargs)
  File "/work/reconcile/ocm_upgrade_scheduler_org_updater.py", line 59, in run
    ocm = ocm_map.get(ocm_name)
          ^^^^^^^^^^^^^^^^^^^^^
  File "/work/reconcile/utils/ocm/ocm.py", line 929, in get
    ocm = self.clusters_map[cluster]
          ~~~~~~~~~~~~~~~~~^^^^^^^^^
KeyError: 'osd-fleet-manager-ocm-integration'
```