### PR TITLE
template rendering - support multiline yaml static variables

### DIFF
--- a/reconcile/templating/renderer.py
+++ b/reconcile/templating/renderer.py
@@ -216,16 +216,13 @@ def unpack_static_variables(
     rendered_vars = {}
     for k, v in (collection_variables.static or {}).items():
         template_val = process_jinja2_template(body=json.dumps(v), vars={"each": each})
-        try:
-            rendered_vars[k] = json.loads(template_val)
-        except json.JSONDecodeError as e:
-            # attempt to resolve json decoding issues related to string formatting
-            if not isinstance(template_val, str):
-                raise e
+        # treat as string literal and remove potential newlines
+        if template_val.startswith('"') and template_val.endswith('"'):
+            template_val = template_val[1:-1]
             template_val = template_val.replace("\n", "")
-            if template_val.startswith('"') and template_val.endswith('"'):
-                template_val = template_val[1:-1]
-            rendered_vars[k] = str(template_val)
+            rendered_vars[k] = template_val
+        else:
+            rendered_vars[k] = json.loads(template_val)
     return rendered_vars
 
 

--- a/reconcile/utils/jinja2/utils.py
+++ b/reconcile/utils/jinja2/utils.py
@@ -1,6 +1,5 @@
 import datetime
 import os
-import re
 from collections.abc import Mapping
 from functools import cache
 from typing import Any, Self

--- a/reconcile/utils/jinja2/utils.py
+++ b/reconcile/utils/jinja2/utils.py
@@ -189,32 +189,6 @@ def list_s3_objects(
         )
 
 
-def extract_timeseries(expression: str) -> dict[str, str]:
-    """
-    Extracts labeled time series from a Prometheus expression and categorizes them for test generation.
-
-    Example expression:
-        sum(rate(qontract_reconcile_function_elapsed_seconds_since_bundle_commit_bucket{le="1200.0",integration!~"foo",namespace="production"}[{{window}}]))
-        /
-        sum(rate(qontract_reconcile_function_elapsed_seconds_since_bundle_commit_count{integration!~"foo",namespace="production"}[{{window}}]))
-
-    Output:
-        {
-            "success": "qontract_reconcile_function_elapsed_seconds_since_bundle_commit_bucket{le=\"1200.0\",integration!~\"foo\",namespace=\"production\"}",
-            "total": "qontract_reconcile_function_elapsed_seconds_since_bundle_commit_count{integration!~\"foo\",namespace=\"production\"}"
-        }
-    """
-    timeseries_pattern = r"\b[a-zA-Z_:][a-zA-Z0-9_:]*\{[^{}]*\}"
-    result = {}
-    parsed = re.findall(timeseries_pattern, expression)
-    if len(parsed) > 1:
-        result["success"] = parsed[0]
-        result["total"] = parsed[1]
-    else:
-        result["expr"] = parsed[0]
-    return result
-
-
 @retry()
 def lookup_secret(
     path: str,
@@ -285,7 +259,6 @@ def process_jinja2_template(
         "s3": lookup_s3_object,
         "s3_ls": list_s3_objects,
         "flatten_dict": flatten,
-        "extract_timeseries": extract_timeseries,
         "yesterday": lambda: (datetime.datetime.now() - datetime.timedelta(1)).strftime(
             "%Y-%m-%d"
         ),


### PR DESCRIPTION
SDE-4648

This allows `template-renderer` to handle multi-line static variables.  
Example:
```yaml
forEach:
  items:
  - app_name: app-interface
    slo_expr: |
      sum(rate(qontract_reconcile_function_elapsed_seconds_since_bundle_commit_bucket{le="1200.0",name=~"reconcile\\.utils\\.oc\\.OC[^.]*\\.(apply|replace|delete|create)",integration!~"terraform-resources|sql-query",namespace="app-interface-production"}[{{window}}]))
      /
      sum(rate(qontract_reconcile_function_elapsed_seconds_since_bundle_commit_count{name=~"reconcile\\.utils\\.oc\\.OC[^.]*\\.(apply|replace|delete|create)",integration!~"terraform-resources|sql-query",namespace="app-interface-production"}[{{window}}]))
 ```