### PR TITLE
feat(aus): remove cluster upgrade policy deletion

### DIFF
--- a/reconcile/aus/base.py
+++ b/reconcile/aus/base.py
@@ -83,8 +83,6 @@ from reconcile.utils.ocm.upgrades import (
     create_control_plane_upgrade_policy,
     create_node_pool_upgrade_policy,
     create_upgrade_policy,
-    delete_control_plane_upgrade_policy,
-    delete_upgrade_policy,
     get_control_plane_upgrade_policies,
     get_node_pool_upgrade_policies,
     get_upgrade_policies,
@@ -467,7 +465,7 @@ class AddonUpgradePolicy(AbstractUpgradePolicy):
 
 
 class ClusterUpgradePolicy(AbstractUpgradePolicy):
-    """Class to create and delete ClusterUpgradePolicies in OCM"""
+    """Class to create ClusterUpgradePolicies in OCM"""
 
     def create(self, ocm_api: OCMBaseClient) -> None:
         policy = {
@@ -478,11 +476,7 @@ class ClusterUpgradePolicy(AbstractUpgradePolicy):
         create_upgrade_policy(ocm_api, self.cluster.id, policy)
 
     def delete(self, ocm_api: OCMBaseClient) -> None:
-        if not self.id:
-            raise ValueError(
-                "Cannot delete cluster upgrade policy without id (not created yet)"
-            )
-        delete_upgrade_policy(ocm_api, self.cluster.id, self.id)
+        raise NotImplementedError("ClusterUpgradePolicy.delete() not implemented")
 
     def summarize(self) -> str:
         details = {
@@ -509,11 +503,7 @@ class ControlPlaneUpgradePolicy(AbstractUpgradePolicy):
         create_control_plane_upgrade_policy(ocm_api, self.cluster.id, policy)
 
     def delete(self, ocm_api: OCMBaseClient) -> None:
-        if not self.id:
-            raise ValueError(
-                "Cannot delete controlplane upgrade policy without id (not created yet)"
-            )
-        delete_control_plane_upgrade_policy(ocm_api, self.cluster.id, self.id)
+        raise NotImplementedError("ControlPlaneUpgradePolicy.delete() not implemented")
 
     def summarize(self) -> str:
         details = {
@@ -527,7 +517,7 @@ class ControlPlaneUpgradePolicy(AbstractUpgradePolicy):
 
 class NodePoolUpgradePolicy(AbstractUpgradePolicy):
     node_pool: str
-    """Class to create and delete NodePoolUpgradePolicies in OCM"""
+    """Class to create NodePoolUpgradePolicies in OCM"""
 
     def create(self, ocm_api: OCMBaseClient) -> None:
         policy = {
@@ -910,38 +900,21 @@ def upgradeable_version(
 def verify_current_should_skip(
     current_state: Sequence[AbstractUpgradePolicy],
     desired: ClusterUpgradeSpec,
-    now: datetime,
-    addon_id: str = "",
-) -> tuple[bool, UpgradePolicyHandler | None]:
+) -> bool:
     current_policies = [c for c in current_state if c.cluster.id == desired.cluster.id]
     if not current_policies:
-        return False, None
+        return False
 
     # there can only be one upgrade policy per cluster
     if len(current_policies) != 1:
         raise ValueError(
             f"[{desired.org.org_id}/{desired.cluster.name}] expected only one upgrade policy"
         )
-    current = current_policies[0]
-    version = current.version  # may not exist in automatic upgrades
-    if version and not addon_id and desired.version_blocked(version):
-        next_run = current.next_run
-        if next_run and datetime.strptime(next_run, "%Y-%m-%dT%H:%M:%SZ") < now:
-            logging.warning(
-                f"[{desired.org.org_id}/{desired.org.name}/{desired.cluster.name}] currently upgrading to blocked version '{version}'"
-            )
-            return True, None
-        logging.debug(
-            f"[{desired.org.org_id}/{desired.org.name}/{desired.cluster.name}] found planned upgrade policy "
-            + f"with blocked version {version}"
-        )
-        return False, UpgradePolicyHandler(action="delete", policy=current)
 
-    # else
     logging.debug(
         f"[{desired.org.org_id}/{desired.org.name}/{desired.cluster.name}] skipping cluster with existing upgrade policy"
     )
-    return True, None
+    return True
 
 
 def verify_schedule_should_skip(
@@ -1129,14 +1102,8 @@ def calculate_diff(
                 set_upgrading(spec.cluster.id, spec.effective_mutexes, sector_name)
                 continue
 
-        # ignore clusters with an existing upgrade policy
-        skip, delete_policy = verify_current_should_skip(
-            current_state, spec, now, addon_id
-        )
-        if skip:
+        if verify_current_should_skip(current_state, spec):
             continue
-        if delete_policy:
-            diffs.append(delete_policy)
 
         next_schedule = verify_schedule_should_skip(spec, now, addon_id)
         if not next_schedule:

--- a/reconcile/test/ocm/aus/test_base.py
+++ b/reconcile/test/ocm/aus/test_base.py
@@ -688,26 +688,6 @@ def test_policy_handler_create_cluster_upgrade(
     )
 
 
-def test_policy_handler_delete_cluster_upgrade(
-    cluster_upgrade_policy: ClusterUpgradePolicy,
-    ocm_api: OCMBaseClient,
-    mocker: MockerFixture,
-) -> None:
-    delete_upgrade_policy_mock = mocker.patch.object(
-        base, "delete_upgrade_policy", autospec=True
-    )
-    handler = base.UpgradePolicyHandler(
-        policy=cluster_upgrade_policy,
-        action="delete",
-    )
-    base.act(dry_run=False, diffs=[handler], ocm_api=ocm_api)
-    delete_upgrade_policy_mock.assert_called_once_with(
-        ocm_api,
-        cluster_upgrade_policy.cluster.id,
-        cluster_upgrade_policy.id,
-    )
-
-
 def test_policy_handler_create_control_plane_upgrade(
     control_plane_upgrade_policy: ControlPlaneUpgradePolicy,
     ocm_api: OCMBaseClient,
@@ -731,26 +711,6 @@ def test_policy_handler_create_control_plane_upgrade(
             "cluster_id": control_plane_upgrade_policy.cluster.id,
             "upgrade_type": "ControlPlane",
         },
-    )
-
-
-def test_policy_handler_delete_control_plane_upgrade(
-    control_plane_upgrade_policy: ControlPlaneUpgradePolicy,
-    ocm_api: OCMBaseClient,
-    mocker: MockerFixture,
-) -> None:
-    delete_control_plane_upgrade_policy_mock = mocker.patch.object(
-        base, "delete_control_plane_upgrade_policy", autospec=True
-    )
-    handler = base.UpgradePolicyHandler(
-        policy=control_plane_upgrade_policy,
-        action="delete",
-    )
-    base.act(dry_run=False, diffs=[handler], ocm_api=ocm_api)
-    delete_control_plane_upgrade_policy_mock.assert_called_once_with(
-        ocm_api,
-        control_plane_upgrade_policy.cluster.id,
-        control_plane_upgrade_policy.id,
     )
 
 

--- a/reconcile/utils/ocm/upgrades.py
+++ b/reconcile/utils/ocm/upgrades.py
@@ -77,15 +77,6 @@ def create_upgrade_policy(ocm_api: OCMBaseClient, cluster_id: str, spec: dict) -
     ocm_api.post(f"{build_cluster_url(cluster_id)}/upgrade_policies", spec)
 
 
-def delete_upgrade_policy(
-    ocm_api: OCMBaseClient, cluster_id: str, policy_id: str
-) -> None:
-    """
-    Deletes an existing Upgrade Policy
-    """
-    ocm_api.delete(f"{build_cluster_url(cluster_id)}/upgrade_policies/{policy_id}")
-
-
 #
 # CONTROL PLANE UPGRADE POLICIES
 #
@@ -117,17 +108,6 @@ def create_control_plane_upgrade_policy(
     """
     ocm_api.post(
         f"{build_cluster_url(cluster_id)}/control_plane/upgrade_policies", spec
-    )
-
-
-def delete_control_plane_upgrade_policy(
-    ocm_api: OCMBaseClient, cluster_id: str, upgrade_policy_id: str
-) -> None:
-    """
-    Deletes an existing Control Plane Upgrade Policy
-    """
-    ocm_api.delete(
-        f"{build_cluster_url(cluster_id)}/control_plane/upgrade_policies/{upgrade_policy_id}"
     )
 
 


### PR DESCRIPTION
For AUS managed cluster upgrade, we should co exist with manually scheduled upgrades instead of delete them, this is useful when we want to try some blocked version for a dev cluster without changing blocked version config.

### Changes to Upgrade Policy Handling:
* Removed the ability to delete cluster, control plane, and node pool upgrade policies. The `delete` methods in `ClusterUpgradePolicy`, `ControlPlaneUpgradePolicy`, and `NodePoolUpgradePolicy` now raise `NotImplementedError`. (`reconcile/aus/base.py`: [[1]](diffhunk://#diff-1116e0b2a36737253acab520cca7b58ded278ae79b94d06027fe4b60e4b88624L481-R479) [[2]](diffhunk://#diff-1116e0b2a36737253acab520cca7b58ded278ae79b94d06027fe4b60e4b88624L512-R506)
* Updated the class docstrings for `ClusterUpgradePolicy` and `NodePoolUpgradePolicy` to reflect the removal of delete functionality. (`reconcile/aus/base.py`: [[1]](diffhunk://#diff-1116e0b2a36737253acab520cca7b58ded278ae79b94d06027fe4b60e4b88624L470-R468) [[2]](diffhunk://#diff-1116e0b2a36737253acab520cca7b58ded278ae79b94d06027fe4b60e4b88624L530-R520)

### Simplification of Logic:
* Refactored `verify_current_should_skip` to only return a boolean, removing logic related to handling blocked versions and associated policy deletions. (`reconcile/aus/base.py`: [reconcile/aus/base.pyL913-R917](diffhunk://#diff-1116e0b2a36737253acab520cca7b58ded278ae79b94d06027fe4b60e4b88624L913-R917))
* Updated `calculate_diff` to align with the simplified `verify_current_should_skip` function. (`reconcile/aus/base.py`: [reconcile/aus/base.pyL1132-L1139](diffhunk://#diff-1116e0b2a36737253acab520cca7b58ded278ae79b94d06027fe4b60e4b88624L1132-L1139))

### Test Case Updates:
* Removed test cases for deleting cluster and control plane upgrade policies, as this functionality is no longer supported. (`reconcile/test/ocm/aus/test_base.py`: [[1]](diffhunk://#diff-561f0310509f80ba7cade2b9e23a7499a48d3cf1252af4d032403cac36b05c7aL691-L710) [[2]](diffhunk://#diff-561f0310509f80ba7cade2b9e23a7499a48d3cf1252af4d032403cac36b05c7aL737-L756)

### Utility Function Cleanup:
* Deleted the `delete_upgrade_policy` and `delete_control_plane_upgrade_policy` utility functions, as they are no longer used. (`reconcile/utils/ocm/upgrades.py`: [[1]](diffhunk://#diff-d362fdc7fdade1a503a5e3ddc6eaa51a9d36749988d01901e2118d27eb62e8d4L80-L88) [[2]](diffhunk://#diff-d362fdc7fdade1a503a5e3ddc6eaa51a9d36749988d01901e2118d27eb62e8d4L123-L133)

[APPSRE-10436](https://issues.redhat.com/browse/APPSRE-10436)