### PR TITLE
Use internal ca image from konflux

### DIFF
--- a/helm/qontract-reconcile/templates/template.yaml
+++ b/helm/qontract-reconcile/templates/template.yaml
@@ -884,7 +884,7 @@ parameters:
 - name: USE_NATIVE_CLIENT
   value: ""
 - name: INTERNAL_CERTIFICATES_IMAGE
-  value: quay.io/app-sre/internal-redhat-ca
+  value: quay.io/redhat-services-prod/app-sre-tenant/container-images-int-master/internal-redhat-ca-master
 - name: INTERNAL_CERTIFICATES_IMAGE_TAG
   value: latest
 - name: INTERNAL_CERTIFICATES_IMAGE_PULL_POLICY

--- a/openshift/qontract-manager-fedramp.yaml
+++ b/openshift/qontract-manager-fedramp.yaml
@@ -437,7 +437,7 @@ parameters:
 - name: USE_NATIVE_CLIENT
   value: ""
 - name: INTERNAL_CERTIFICATES_IMAGE
-  value: quay.io/app-sre/internal-redhat-ca
+  value: quay.io/redhat-services-prod/app-sre-tenant/container-images-int-master/internal-redhat-ca-master
 - name: INTERNAL_CERTIFICATES_IMAGE_TAG
   value: latest
 - name: INTERNAL_CERTIFICATES_IMAGE_PULL_POLICY

--- a/openshift/qontract-manager.yaml
+++ b/openshift/qontract-manager.yaml
@@ -337,7 +337,7 @@ parameters:
 - name: USE_NATIVE_CLIENT
   value: ""
 - name: INTERNAL_CERTIFICATES_IMAGE
-  value: quay.io/app-sre/internal-redhat-ca
+  value: quay.io/redhat-services-prod/app-sre-tenant/container-images-int-master/internal-redhat-ca-master
 - name: INTERNAL_CERTIFICATES_IMAGE_TAG
   value: latest
 - name: INTERNAL_CERTIFICATES_IMAGE_PULL_POLICY

--- a/reconcile/test/fixtures/container_images_report/app-sre-observability-stage-pods.yaml
+++ b/reconcile/test/fixtures/container_images_report/app-sre-observability-stage-pods.yaml
@@ -25,8 +25,8 @@
     containers:
     - image: quay.io/redhat-services-prod/app-sre-tenant/gitlab-project-exporter-main/gitlab-project-exporter-main:4175d51
       name: gitlab-project-exporter
-    - image: quay.io/app-sre/internal-redhat-ca:0.2.0
+    - image: quay.io/redhat-services-prod/app-sre-tenant/container-images-int-master/internal-redhat-ca-master:0.2.0
       name: certificates
     initContainers:
-    - image: quay.io/app-sre/internal-redhat-ca:0.2.0
+    - image: quay.io/redhat-services-prod/app-sre-tenant/container-images-int-master/internal-redhat-ca-master:0.2.0
       name: certificates

--- a/reconcile/test/fixtures/container_images_report/app-sre-pipelines-pods.yaml
+++ b/reconcile/test/fixtures/container_images_report/app-sre-pipelines-pods.yaml
@@ -21,7 +21,7 @@
     namespace: app-sre-pipelines
   spec:
     containers:
-    - image: quay.io/app-sre/internal-redhat-ca:0.3.0
+    - image: quay.io/redhat-services-prod/app-sre-tenant/container-images-int-master/internal-redhat-ca-master:0.5.0-1
       name: step-init-dast-config
     - image: quay.io/redhatproductsecurity/rapidast:latest
       name: step-dast-scan

--- a/reconcile/test/fixtures/helm/aws_account_shard_disabled.yml
+++ b/reconcile/test/fixtures/helm/aws_account_shard_disabled.yml
@@ -501,7 +501,7 @@ parameters:
 - name: USE_NATIVE_CLIENT
   value: ""
 - name: INTERNAL_CERTIFICATES_IMAGE
-  value: quay.io/app-sre/internal-redhat-ca
+  value: quay.io/redhat-services-prod/app-sre-tenant/container-images-int-master/internal-redhat-ca-master
 - name: INTERNAL_CERTIFICATES_IMAGE_TAG
   value: latest
 - name: INTERNAL_CERTIFICATES_IMAGE_PULL_POLICY

--- a/reconcile/test/fixtures/helm/aws_account_shard_spec_override.yml
+++ b/reconcile/test/fixtures/helm/aws_account_shard_spec_override.yml
@@ -501,7 +501,7 @@ parameters:
 - name: USE_NATIVE_CLIENT
   value: ""
 - name: INTERNAL_CERTIFICATES_IMAGE
-  value: quay.io/app-sre/internal-redhat-ca
+  value: quay.io/redhat-services-prod/app-sre-tenant/container-images-int-master/internal-redhat-ca-master
 - name: INTERNAL_CERTIFICATES_IMAGE_TAG
   value: latest
 - name: INTERNAL_CERTIFICATES_IMAGE_PULL_POLICY

--- a/reconcile/test/fixtures/helm/aws_account_shards.yml
+++ b/reconcile/test/fixtures/helm/aws_account_shards.yml
@@ -501,7 +501,7 @@ parameters:
 - name: USE_NATIVE_CLIENT
   value: ""
 - name: INTERNAL_CERTIFICATES_IMAGE
-  value: quay.io/app-sre/internal-redhat-ca
+  value: quay.io/redhat-services-prod/app-sre-tenant/container-images-int-master/internal-redhat-ca-master
 - name: INTERNAL_CERTIFICATES_IMAGE_TAG
   value: latest
 - name: INTERNAL_CERTIFICATES_IMAGE_PULL_POLICY

--- a/reconcile/test/fixtures/helm/basic.yml
+++ b/reconcile/test/fixtures/helm/basic.yml
@@ -292,7 +292,7 @@ parameters:
 - name: USE_NATIVE_CLIENT
   value: ""
 - name: INTERNAL_CERTIFICATES_IMAGE
-  value: quay.io/app-sre/internal-redhat-ca
+  value: quay.io/redhat-services-prod/app-sre-tenant/container-images-int-master/internal-redhat-ca-master
 - name: INTERNAL_CERTIFICATES_IMAGE_TAG
   value: latest
 - name: INTERNAL_CERTIFICATES_IMAGE_PULL_POLICY

--- a/reconcile/test/fixtures/helm/cache.yml
+++ b/reconcile/test/fixtures/helm/cache.yml
@@ -303,7 +303,7 @@ parameters:
 - name: USE_NATIVE_CLIENT
   value: ""
 - name: INTERNAL_CERTIFICATES_IMAGE
-  value: quay.io/app-sre/internal-redhat-ca
+  value: quay.io/redhat-services-prod/app-sre-tenant/container-images-int-master/internal-redhat-ca-master
 - name: INTERNAL_CERTIFICATES_IMAGE_TAG
   value: latest
 - name: INTERNAL_CERTIFICATES_IMAGE_PULL_POLICY

--- a/reconcile/test/fixtures/helm/cache_storage_vars.yml
+++ b/reconcile/test/fixtures/helm/cache_storage_vars.yml
@@ -303,7 +303,7 @@ parameters:
 - name: USE_NATIVE_CLIENT
   value: ""
 - name: INTERNAL_CERTIFICATES_IMAGE
-  value: quay.io/app-sre/internal-redhat-ca
+  value: quay.io/redhat-services-prod/app-sre-tenant/container-images-int-master/internal-redhat-ca-master
 - name: INTERNAL_CERTIFICATES_IMAGE_TAG
   value: latest
 - name: INTERNAL_CERTIFICATES_IMAGE_PULL_POLICY

--- a/reconcile/test/fixtures/helm/command.yml
+++ b/reconcile/test/fixtures/helm/command.yml
@@ -294,7 +294,7 @@ parameters:
 - name: USE_NATIVE_CLIENT
   value: ""
 - name: INTERNAL_CERTIFICATES_IMAGE
-  value: quay.io/app-sre/internal-redhat-ca
+  value: quay.io/redhat-services-prod/app-sre-tenant/container-images-int-master/internal-redhat-ca-master
 - name: INTERNAL_CERTIFICATES_IMAGE_TAG
   value: latest
 - name: INTERNAL_CERTIFICATES_IMAGE_PULL_POLICY

--- a/reconcile/test/fixtures/helm/concurrency_policy.yml
+++ b/reconcile/test/fixtures/helm/concurrency_policy.yml
@@ -156,7 +156,7 @@ parameters:
 - name: USE_NATIVE_CLIENT
   value: ""
 - name: INTERNAL_CERTIFICATES_IMAGE
-  value: quay.io/app-sre/internal-redhat-ca
+  value: quay.io/redhat-services-prod/app-sre-tenant/container-images-int-master/internal-redhat-ca-master
 - name: INTERNAL_CERTIFICATES_IMAGE_TAG
   value: latest
 - name: INTERNAL_CERTIFICATES_IMAGE_PULL_POLICY

--- a/reconcile/test/fixtures/helm/cron.yml
+++ b/reconcile/test/fixtures/helm/cron.yml
@@ -156,7 +156,7 @@ parameters:
 - name: USE_NATIVE_CLIENT
   value: ""
 - name: INTERNAL_CERTIFICATES_IMAGE
-  value: quay.io/app-sre/internal-redhat-ca
+  value: quay.io/redhat-services-prod/app-sre-tenant/container-images-int-master/internal-redhat-ca-master
 - name: INTERNAL_CERTIFICATES_IMAGE_TAG
   value: latest
 - name: INTERNAL_CERTIFICATES_IMAGE_PULL_POLICY

--- a/reconcile/test/fixtures/helm/dashdotdb.yml
+++ b/reconcile/test/fixtures/helm/dashdotdb.yml
@@ -161,7 +161,7 @@ parameters:
 - name: USE_NATIVE_CLIENT
   value: ""
 - name: INTERNAL_CERTIFICATES_IMAGE
-  value: quay.io/app-sre/internal-redhat-ca
+  value: quay.io/redhat-services-prod/app-sre-tenant/container-images-int-master/internal-redhat-ca-master
 - name: INTERNAL_CERTIFICATES_IMAGE_TAG
   value: latest
 - name: INTERNAL_CERTIFICATES_IMAGE_PULL_POLICY

--- a/reconcile/test/fixtures/helm/disable_unleash.yml
+++ b/reconcile/test/fixtures/helm/disable_unleash.yml
@@ -280,7 +280,7 @@ parameters:
 - name: USE_NATIVE_CLIENT
   value: ""
 - name: INTERNAL_CERTIFICATES_IMAGE
-  value: quay.io/app-sre/internal-redhat-ca
+  value: quay.io/redhat-services-prod/app-sre-tenant/container-images-int-master/internal-redhat-ca-master
 - name: INTERNAL_CERTIFICATES_IMAGE_TAG
   value: latest
 - name: INTERNAL_CERTIFICATES_IMAGE_PULL_POLICY

--- a/reconcile/test/fixtures/helm/enable_google_chat.yml
+++ b/reconcile/test/fixtures/helm/enable_google_chat.yml
@@ -335,7 +335,7 @@ parameters:
 - name: USE_NATIVE_CLIENT
   value: ""
 - name: INTERNAL_CERTIFICATES_IMAGE
-  value: quay.io/app-sre/internal-redhat-ca
+  value: quay.io/redhat-services-prod/app-sre-tenant/container-images-int-master/internal-redhat-ca-master
 - name: INTERNAL_CERTIFICATES_IMAGE_TAG
   value: latest
 - name: INTERNAL_CERTIFICATES_IMAGE_PULL_POLICY

--- a/reconcile/test/fixtures/helm/enable_pushgateway.yml
+++ b/reconcile/test/fixtures/helm/enable_pushgateway.yml
@@ -173,7 +173,7 @@ parameters:
 - name: USE_NATIVE_CLIENT
   value: ""
 - name: INTERNAL_CERTIFICATES_IMAGE
-  value: quay.io/app-sre/internal-redhat-ca
+  value: quay.io/redhat-services-prod/app-sre-tenant/container-images-int-master/internal-redhat-ca-master
 - name: INTERNAL_CERTIFICATES_IMAGE_TAG
   value: latest
 - name: INTERNAL_CERTIFICATES_IMAGE_PULL_POLICY

--- a/reconcile/test/fixtures/helm/environment_aware.yml
+++ b/reconcile/test/fixtures/helm/environment_aware.yml
@@ -324,7 +324,7 @@ parameters:
 - name: USE_NATIVE_CLIENT
   value: ""
 - name: INTERNAL_CERTIFICATES_IMAGE
-  value: quay.io/app-sre/internal-redhat-ca
+  value: quay.io/redhat-services-prod/app-sre-tenant/container-images-int-master/internal-redhat-ca-master
 - name: INTERNAL_CERTIFICATES_IMAGE_TAG
   value: latest
 - name: INTERNAL_CERTIFICATES_IMAGE_PULL_POLICY

--- a/reconcile/test/fixtures/helm/exclude_service.yml
+++ b/reconcile/test/fixtures/helm/exclude_service.yml
@@ -278,7 +278,7 @@ parameters:
 - name: USE_NATIVE_CLIENT
   value: ""
 - name: INTERNAL_CERTIFICATES_IMAGE
-  value: quay.io/app-sre/internal-redhat-ca
+  value: quay.io/redhat-services-prod/app-sre-tenant/container-images-int-master/internal-redhat-ca-master
 - name: INTERNAL_CERTIFICATES_IMAGE_TAG
   value: latest
 - name: INTERNAL_CERTIFICATES_IMAGE_PULL_POLICY

--- a/reconcile/test/fixtures/helm/extra_args.yml
+++ b/reconcile/test/fixtures/helm/extra_args.yml
@@ -294,7 +294,7 @@ parameters:
 - name: USE_NATIVE_CLIENT
   value: ""
 - name: INTERNAL_CERTIFICATES_IMAGE
-  value: quay.io/app-sre/internal-redhat-ca
+  value: quay.io/redhat-services-prod/app-sre-tenant/container-images-int-master/internal-redhat-ca-master
 - name: INTERNAL_CERTIFICATES_IMAGE_TAG
   value: latest
 - name: INTERNAL_CERTIFICATES_IMAGE_PULL_POLICY

--- a/reconcile/test/fixtures/helm/extra_args_with_embedded_quotes.yml
+++ b/reconcile/test/fixtures/helm/extra_args_with_embedded_quotes.yml
@@ -294,7 +294,7 @@ parameters:
 - name: USE_NATIVE_CLIENT
   value: ""
 - name: INTERNAL_CERTIFICATES_IMAGE
-  value: quay.io/app-sre/internal-redhat-ca
+  value: quay.io/redhat-services-prod/app-sre-tenant/container-images-int-master/internal-redhat-ca-master
 - name: INTERNAL_CERTIFICATES_IMAGE_TAG
   value: latest
 - name: INTERNAL_CERTIFICATES_IMAGE_PULL_POLICY

--- a/reconcile/test/fixtures/helm/extra_env.yml
+++ b/reconcile/test/fixtures/helm/extra_env.yml
@@ -299,7 +299,7 @@ parameters:
 - name: USE_NATIVE_CLIENT
   value: ""
 - name: INTERNAL_CERTIFICATES_IMAGE
-  value: quay.io/app-sre/internal-redhat-ca
+  value: quay.io/redhat-services-prod/app-sre-tenant/container-images-int-master/internal-redhat-ca-master
 - name: INTERNAL_CERTIFICATES_IMAGE_TAG
   value: latest
 - name: INTERNAL_CERTIFICATES_IMAGE_PULL_POLICY

--- a/reconcile/test/fixtures/helm/failure_history.yml
+++ b/reconcile/test/fixtures/helm/failure_history.yml
@@ -156,7 +156,7 @@ parameters:
 - name: USE_NATIVE_CLIENT
   value: ""
 - name: INTERNAL_CERTIFICATES_IMAGE
-  value: quay.io/app-sre/internal-redhat-ca
+  value: quay.io/redhat-services-prod/app-sre-tenant/container-images-int-master/internal-redhat-ca-master
 - name: INTERNAL_CERTIFICATES_IMAGE_TAG
   value: latest
 - name: INTERNAL_CERTIFICATES_IMAGE_PULL_POLICY

--- a/reconcile/test/fixtures/helm/integrations_manager.yml
+++ b/reconcile/test/fixtures/helm/integrations_manager.yml
@@ -300,7 +300,7 @@ parameters:
 - name: USE_NATIVE_CLIENT
   value: ""
 - name: INTERNAL_CERTIFICATES_IMAGE
-  value: quay.io/app-sre/internal-redhat-ca
+  value: quay.io/redhat-services-prod/app-sre-tenant/container-images-int-master/internal-redhat-ca-master
 - name: INTERNAL_CERTIFICATES_IMAGE_TAG
   value: latest
 - name: INTERNAL_CERTIFICATES_IMAGE_PULL_POLICY

--- a/reconcile/test/fixtures/helm/internal_certificates.yml
+++ b/reconcile/test/fixtures/helm/internal_certificates.yml
@@ -312,7 +312,7 @@ parameters:
 - name: USE_NATIVE_CLIENT
   value: ""
 - name: INTERNAL_CERTIFICATES_IMAGE
-  value: quay.io/app-sre/internal-redhat-ca
+  value: quay.io/redhat-services-prod/app-sre-tenant/container-images-int-master/internal-redhat-ca-master
 - name: INTERNAL_CERTIFICATES_IMAGE_TAG
   value: latest
 - name: INTERNAL_CERTIFICATES_IMAGE_PULL_POLICY

--- a/reconcile/test/fixtures/helm/logs_slack.yml
+++ b/reconcile/test/fixtures/helm/logs_slack.yml
@@ -315,7 +315,7 @@ parameters:
 - name: USE_NATIVE_CLIENT
   value: ""
 - name: INTERNAL_CERTIFICATES_IMAGE
-  value: quay.io/app-sre/internal-redhat-ca
+  value: quay.io/redhat-services-prod/app-sre-tenant/container-images-int-master/internal-redhat-ca-master
 - name: INTERNAL_CERTIFICATES_IMAGE_TAG
   value: latest
 - name: INTERNAL_CERTIFICATES_IMAGE_PULL_POLICY

--- a/reconcile/test/fixtures/helm/restart_policy.yml
+++ b/reconcile/test/fixtures/helm/restart_policy.yml
@@ -156,7 +156,7 @@ parameters:
 - name: USE_NATIVE_CLIENT
   value: ""
 - name: INTERNAL_CERTIFICATES_IMAGE
-  value: quay.io/app-sre/internal-redhat-ca
+  value: quay.io/redhat-services-prod/app-sre-tenant/container-images-int-master/internal-redhat-ca-master
 - name: INTERNAL_CERTIFICATES_IMAGE_TAG
   value: latest
 - name: INTERNAL_CERTIFICATES_IMAGE_PULL_POLICY

--- a/reconcile/test/fixtures/helm/shards.yml
+++ b/reconcile/test/fixtures/helm/shards.yml
@@ -497,7 +497,7 @@ parameters:
 - name: USE_NATIVE_CLIENT
   value: ""
 - name: INTERNAL_CERTIFICATES_IMAGE
-  value: quay.io/app-sre/internal-redhat-ca
+  value: quay.io/redhat-services-prod/app-sre-tenant/container-images-int-master/internal-redhat-ca-master
 - name: INTERNAL_CERTIFICATES_IMAGE_TAG
   value: latest
 - name: INTERNAL_CERTIFICATES_IMAGE_PULL_POLICY

--- a/reconcile/test/fixtures/helm/sleep_duration.yml
+++ b/reconcile/test/fixtures/helm/sleep_duration.yml
@@ -292,7 +292,7 @@ parameters:
 - name: USE_NATIVE_CLIENT
   value: ""
 - name: INTERNAL_CERTIFICATES_IMAGE
-  value: quay.io/app-sre/internal-redhat-ca
+  value: quay.io/redhat-services-prod/app-sre-tenant/container-images-int-master/internal-redhat-ca-master
 - name: INTERNAL_CERTIFICATES_IMAGE_TAG
   value: latest
 - name: INTERNAL_CERTIFICATES_IMAGE_PULL_POLICY

--- a/reconcile/test/fixtures/helm/state.yml
+++ b/reconcile/test/fixtures/helm/state.yml
@@ -330,7 +330,7 @@ parameters:
 - name: USE_NATIVE_CLIENT
   value: ""
 - name: INTERNAL_CERTIFICATES_IMAGE
-  value: quay.io/app-sre/internal-redhat-ca
+  value: quay.io/redhat-services-prod/app-sre-tenant/container-images-int-master/internal-redhat-ca-master
 - name: INTERNAL_CERTIFICATES_IMAGE_TAG
   value: latest
 - name: INTERNAL_CERTIFICATES_IMAGE_PULL_POLICY

--- a/reconcile/test/fixtures/helm/storage.yml
+++ b/reconcile/test/fixtures/helm/storage.yml
@@ -292,7 +292,7 @@ parameters:
 - name: USE_NATIVE_CLIENT
   value: ""
 - name: INTERNAL_CERTIFICATES_IMAGE
-  value: quay.io/app-sre/internal-redhat-ca
+  value: quay.io/redhat-services-prod/app-sre-tenant/container-images-int-master/internal-redhat-ca-master
 - name: INTERNAL_CERTIFICATES_IMAGE_TAG
   value: latest
 - name: INTERNAL_CERTIFICATES_IMAGE_PULL_POLICY

--- a/reconcile/test/fixtures/helm/success_history.yml
+++ b/reconcile/test/fixtures/helm/success_history.yml
@@ -156,7 +156,7 @@ parameters:
 - name: USE_NATIVE_CLIENT
   value: ""
 - name: INTERNAL_CERTIFICATES_IMAGE
-  value: quay.io/app-sre/internal-redhat-ca
+  value: quay.io/redhat-services-prod/app-sre-tenant/container-images-int-master/internal-redhat-ca-master
 - name: INTERNAL_CERTIFICATES_IMAGE_TAG
   value: latest
 - name: INTERNAL_CERTIFICATES_IMAGE_PULL_POLICY

--- a/reconcile/test/fixtures/helm/trigger.yml
+++ b/reconcile/test/fixtures/helm/trigger.yml
@@ -292,7 +292,7 @@ parameters:
 - name: USE_NATIVE_CLIENT
   value: ""
 - name: INTERNAL_CERTIFICATES_IMAGE
-  value: quay.io/app-sre/internal-redhat-ca
+  value: quay.io/redhat-services-prod/app-sre-tenant/container-images-int-master/internal-redhat-ca-master
 - name: INTERNAL_CERTIFICATES_IMAGE_TAG
   value: latest
 - name: INTERNAL_CERTIFICATES_IMAGE_PULL_POLICY

--- a/tools/test/test_get_container_images.py
+++ b/tools/test/test_get_container_images.py
@@ -69,12 +69,6 @@ def test_fetch_no_filter(namespaces: list[NamespaceV1], oc_map: OCMap) -> None:
             "count": 1,
         },
         {
-            "name": "quay.io/app-sre/internal-redhat-ca",
-            "namespaces": "app-sre-observability-stage,app-sre-pipelines",
-            "namespace_apps": "app-sre,app-sre-observability",
-            "count": 3,
-        },
-        {
             "name": "quay.io/app-sre/prom-cloudwatch-exporter",
             "namespaces": "app-sre-observability-stage",
             "namespace_apps": "app-sre-observability",
@@ -91,6 +85,12 @@ def test_fetch_no_filter(namespaces: list[NamespaceV1], oc_map: OCMap) -> None:
             "namespaces": "app-sre-pipelines",
             "namespace_apps": "app-sre",
             "count": 1,
+        },
+        {
+            "name": "quay.io/redhat-services-prod/app-sre-tenant/container-images-int-master/internal-redhat-ca-master",
+            "namespaces": "app-sre-observability-stage,app-sre-pipelines",
+            "namespace_apps": "app-sre,app-sre-observability",
+            "count": 3,
         },
         {
             "name": "quay.io/redhat-services-prod/app-sre-tenant/gitlab-project-exporter-main/gitlab-project-exporter-main",
@@ -169,12 +169,6 @@ def test_fetch_exception(
 
     assert images == [
         {
-            "name": "quay.io/app-sre/internal-redhat-ca",
-            "namespaces": "app-sre-observability-stage",
-            "namespace_apps": "app-sre-observability",
-            "count": 2,
-        },
-        {
             "name": "quay.io/app-sre/prom-cloudwatch-exporter",
             "namespaces": "app-sre-observability-stage",
             "namespace_apps": "app-sre-observability",
@@ -185,6 +179,12 @@ def test_fetch_exception(
             "namespaces": "app-sre-observability-stage",
             "namespace_apps": "app-sre-observability",
             "count": 1,
+        },
+        {
+            "name": "quay.io/redhat-services-prod/app-sre-tenant/container-images-int-master/internal-redhat-ca-master",
+            "namespaces": "app-sre-observability-stage",
+            "namespace_apps": "app-sre-observability",
+            "count": 2,
         },
         {
             "name": "quay.io/redhat-services-prod/app-sre-tenant/gitlab-project-exporter-main/gitlab-project-exporter-main",


### PR DESCRIPTION
APPSRE-11234

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Configuration**
  - Updated the internal certificates container image reference used by deployment templates to the new container registry/repository path.
  - Updated certificate-related pod and init-container image fixtures to align with the new internal certificates image.

- **Tests**
  - Adjusted image discovery test expectations and updated fixtures to reflect the new internal certificates image reference.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->