### PR TITLE
aws-version-sync: support extended support versions

### DIFF
--- a/reconcile/aws_version_sync/integration.py
+++ b/reconcile/aws_version_sync/integration.py
@@ -356,6 +356,15 @@ class AVSIntegration(QontractReconcileIntegration[AVSIntegrationParams]):
                         # AWS ElastiCache Redis 6 could use a version like 6.x. Then, we don't need to manage it
                         continue
 
+                    if (
+                        resource.provider == SupportedResourceProvider.RDS
+                        and EXTENDED_SUPPORT_VERSION_INDICATOR
+                        in values["engine_version"]
+                    ):
+                        # AWS RDS PostgreSQL 11 and 12 extended support versions are not supported by this integration
+                        # See https://aws.amazon.com/about-aws/whats-new/2025/04/amazon-rds-postgresql-extended-support-11-22-rds-20250220-12-22-rds-20250220/
+                        continue
+
                     external_resources.append(
                         ExternalResource(
                             namespace_file=ns.path,


### PR DESCRIPTION
Follows #5118


```
Traceback (most recent call last):
  File "/work/reconcile/cli.py", line 584, in run_class_integration
    run_integration_cfg(
  File "/work/reconcile/utils/runtime/runner.py", line 156, in run_integration_cfg
    _integration_wet_run(run_cfg.integration)
  File "/work/reconcile/utils/runtime/runner.py", line 165, in _integration_wet_run
    integration.run(False)
  File "/work/reconcile/utils/defer.py", line 15, in func_wrapper
    return func(*args, defer=stack.callback, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/work/reconcile/aws_version_sync/integration.py", line 453, in run
    external_resources_app_interface = self.get_external_resource_specs(
                                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/work/reconcile/aws_version_sync/integration.py", line 360, in get_external_resource_specs
    ExternalResource(
  File "pydantic/main.py", line 347, in pydantic.main.BaseModel.__init__
pydantic.error_wrappers.ValidationError: 1 validation error for ExternalResource
resource_engine_version
  12.22-rds.20250508 is not valid SemVer string (type=value_error)
```