### PR TITLE
feat(ocm-clusters): set default-ingress-private for private HCP cluster

### DIFF
--- a/reconcile/templates/rosa-classic-cluster-creation.sh.j2
+++ b/reconcile/templates/rosa-classic-cluster-creation.sh.j2
@@ -33,8 +33,6 @@ rosa create cluster -y --cluster-name={{ cluster_name }} \
     --sts \
     {% if cluster.spec.private -%}
     --private \
-    {% endif -%}
-    {% if cluster.spec.private -%}
     --private-link \
     {% endif -%}
     {% if cluster.spec.multi_az -%}

--- a/reconcile/templates/rosa-hcp-cluster-creation.sh.j2
+++ b/reconcile/templates/rosa-hcp-cluster-creation.sh.j2
@@ -51,6 +51,7 @@ rosa create cluster --cluster-name={{ cluster_name }} \
     --compute-machine-type {{ cluster.machine_pools[0].instance_type }} \
     {% if cluster.spec.private -%}
     --private \
+    --default-ingress-private \
     {% endif -%}
     {% if cluster.spec.disable_user_workload_monitoring -%}
     --disable-workload-monitoring \

--- a/reconcile/test/fixtures/rosa/rosa_hcp_script_result_private.sh
+++ b/reconcile/test/fixtures/rosa/rosa_hcp_script_result_private.sh
@@ -39,6 +39,7 @@ rosa create cluster --cluster-name=cluster-1 \
     --replicas 1 \
     --compute-machine-type m5.xlarge \
     --private \
+    --default-ingress-private \
     --disable-workload-monitoring \
     --properties provision_shard_id:provision_shard_id \
     --channel-group stable

--- a/tools/qontract_cli.py
+++ b/tools/qontract_cli.py
@@ -1587,11 +1587,16 @@ def rosa_create_cluster_command(ctx: click.Context, cluster_name: str) -> None:
             f"--billing-account {billing_account}",
             f"--cluster-name {cluster.name}",
             "--sts",
-            ("--private" if cluster.spec.private else ""),
             ("--hosted-cp" if cluster.spec.hypershift else ""),
+            ("--private" if cluster.spec.private else ""),
             (
                 "--private-link"
                 if cluster.spec.private and not cluster.spec.hypershift
+                else ""
+            ),
+            (
+                "--default-ingress-private"
+                if cluster.spec.private and cluster.spec.hypershift
                 else ""
             ),
             (


### PR DESCRIPTION
After changes in rosa cli https://issues.redhat.com/browse/OCM-15992, create private HCP cluster with all private subnets without `--default-ingress-private` will throw error

```text
ERR: The number of public subnets for a public hosted cluster should be at least one
```

we need both `--private` and `--default-ingress-private` to use full private subnets.

[APPSRE-12219](https://issues.redhat.com/browse/APPSRE-12219)