### PR TITLE
feat(template): skip render if not overwrite

### DIFF
--- a/reconcile/gql_definitions/introspection.json
+++ b/reconcile/gql_definitions/introspection.json
@@ -6452,6 +6452,18 @@
                             "deprecationReason": null
                         },
                         {
+                            "name": "externalOrgId",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "SCALAR",
+                                "name": "String",
+                                "ofType": null
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
                             "name": "environment",
                             "description": null,
                             "args": [],
@@ -34179,6 +34191,18 @@
                             "deprecationReason": null
                         },
                         {
+                            "name": "overwrite",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "SCALAR",
+                                "name": "Boolean",
+                                "ofType": null
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
                             "name": "patch",
                             "description": null,
                             "args": [],
@@ -41011,6 +41035,18 @@
                                         "ofType": null
                                     }
                                 }
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "promtool_version",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "SCALAR",
+                                "name": "String",
+                                "ofType": null
                             },
                             "isDeprecated": false,
                             "deprecationReason": null

--- a/reconcile/gql_definitions/templating/template_collection.gql
+++ b/reconcile/gql_definitions/templating/template_collection.gql
@@ -21,6 +21,7 @@ query TemplateCollection_v1($name: String) {
       autoApproved
       condition
       targetPath
+      overwrite
       patch {
         path
         identifier

--- a/reconcile/gql_definitions/templating/template_collection.py
+++ b/reconcile/gql_definitions/templating/template_collection.py
@@ -40,6 +40,7 @@ query TemplateCollection_v1($name: String) {
       autoApproved
       condition
       targetPath
+      overwrite
       patch {
         path
         identifier
@@ -92,6 +93,7 @@ class TemplateV1(ConfiguredBaseModel):
     auto_approved: Optional[bool] = Field(..., alias="autoApproved")
     condition: Optional[str] = Field(..., alias="condition")
     target_path: str = Field(..., alias="targetPath")
+    overwrite: Optional[bool] = Field(..., alias="overwrite")
     patch: Optional[TemplatePatchV1] = Field(..., alias="patch")
     template: str = Field(..., alias="template")
     template_render_options: Optional[TemplateRenderOptionsV1] = Field(..., alias="templateRenderOptions")

--- a/reconcile/gql_definitions/templating/templates.gql
+++ b/reconcile/gql_definitions/templating/templates.gql
@@ -5,6 +5,7 @@ query Templatev1 {
     name
     autoApproved
     condition
+    overwrite
     patch {
       path
       identifier

--- a/reconcile/gql_definitions/templating/templates.py
+++ b/reconcile/gql_definitions/templating/templates.py
@@ -24,6 +24,7 @@ query Templatev1 {
     name
     autoApproved
     condition
+    overwrite
     patch {
       path
       identifier
@@ -78,6 +79,7 @@ class TemplateV1(ConfiguredBaseModel):
     name: str = Field(..., alias="name")
     auto_approved: Optional[bool] = Field(..., alias="autoApproved")
     condition: Optional[str] = Field(..., alias="condition")
+    overwrite: Optional[bool] = Field(..., alias="overwrite")
     patch: Optional[TemplatePatchV1] = Field(..., alias="patch")
     target_path: str = Field(..., alias="targetPath")
     template: str = Field(..., alias="template")

--- a/reconcile/templating/renderer.py
+++ b/reconcile/templating/renderer.py
@@ -104,13 +104,16 @@ class LocalFilePersistence(FilePersistence):
     def read(self, path: str) -> str | None:
         return self._read_local_file(join_path(self.app_interface_data_path, path))
 
-    def __exit__(self, exc_type: Any, exc_value: Any, traceback: Any) -> None:
-        if self.dry_run:
-            return
+    def flush(self) -> None:
         for output in self.outputs:
             filepath = Path(join_path(self.app_interface_data_path, output.path))
             filepath.parent.mkdir(parents=True, exist_ok=True)
             filepath.write_text(output.content, encoding="utf-8")
+
+    def __exit__(self, exc_type: Any, exc_value: Any, traceback: Any) -> None:
+        if self.dry_run:
+            return
+        self.flush()
 
 
 class PersistenceTransaction(FilePersistence):

--- a/reconcile/test/fixtures/templating/full.yaml
+++ b/reconcile/test/fixtures/templating/full.yaml
@@ -1,6 +1,8 @@
 template:
   name: full
 
+  overwrite: true
+
   # test targetPath with templating, multiline and whitespaces
   targetPath: |
     {% if true %}
@@ -11,5 +13,7 @@ template:
     foo: {{ bar }}
 
   templateTest: []
+current:
+  foo: abc
 expected: |
   foo: bar

--- a/reconcile/test/fixtures/templating/full_not_overwrite.yaml
+++ b/reconcile/test/fixtures/templating/full_not_overwrite.yaml
@@ -1,0 +1,14 @@
+template:
+  name: full not overwrite
+
+  overwrite: false
+
+  targetPath: /some/saas/deploy.yml
+
+  template: |
+    foo: abc
+
+  templateTest: []
+
+current:
+  foo: bar

--- a/reconcile/test/fixtures/templating/full_not_rendering.yaml
+++ b/reconcile/test/fixtures/templating/full_not_rendering.yaml
@@ -1,0 +1,12 @@
+template:
+  name: full
+
+  targetPath: /some/saas/deploy.yml
+
+  condition: |
+    {{ 1 == 2 }}
+
+  template: |
+    foo: abc
+
+  templateTest: []

--- a/reconcile/test/fixtures/templating/patch_jsonpath_identifier_update.yaml
+++ b/reconcile/test/fixtures/templating/patch_jsonpath_identifier_update.yaml
@@ -2,6 +2,8 @@
 template:
   name: update file
 
+  overwrite: true
+
   targetPath: /some/saas/deploy.yml
 
   patch:

--- a/reconcile/test/fixtures/templating/patch_not_overwrite.yaml
+++ b/reconcile/test/fixtures/templating/patch_not_overwrite.yaml
@@ -1,7 +1,7 @@
 template:
   name: update file
 
-  overwrite: true
+  overwrite: false
 
   targetPath: /some/saas/deploy.yml
 
@@ -15,7 +15,3 @@ template:
   templateTest: []
 current:
   version: foo
-
-expected: |
-  ---
-  version: 123

--- a/reconcile/test/fixtures/templating/patch_not_rendering.yaml
+++ b/reconcile/test/fixtures/templating/patch_not_rendering.yaml
@@ -1,16 +1,16 @@
 template:
-  name: update file
+  name: patch not rendering
 
   targetPath: /some/saas/deploy.yml
 
   patch:
     path: '$.resourceTemplates[?name=="saas"].targets'
-    identifier: wrong
+    identifier: name
 
   condition: |
     {{ 1 == 2 }}
 
   template: |
-    foo: {{bar}}
+    foo: abc
 
   templateTest: []

--- a/reconcile/test/fixtures/templating/patch_overwrite_nested.yaml
+++ b/reconcile/test/fixtures/templating/patch_overwrite_nested.yaml
@@ -1,6 +1,8 @@
 template:
   name: update file
 
+  overwrite: true
+
   targetPath: /some/saas/deploy.yml
 
   patch:

--- a/reconcile/test/fixtures/templating/patch_overwrite_newline_list.yaml
+++ b/reconcile/test/fixtures/templating/patch_overwrite_newline_list.yaml
@@ -1,6 +1,8 @@
 template:
   name: update file
 
+  overwrite: true
+
   targetPath: /some/saas/deploy.yml
 
   patch:

--- a/reconcile/test/fixtures/templating/patch_updated.yaml
+++ b/reconcile/test/fixtures/templating/patch_updated.yaml
@@ -1,6 +1,8 @@
 template:
   name: update file
 
+  overwrite: true
+
   targetPath: /some/saas/deploy.yml
 
   patch:

--- a/reconcile/test/templating/lib/test_full_rendering.py
+++ b/reconcile/test/templating/lib/test_full_rendering.py
@@ -1,5 +1,7 @@
 from collections.abc import Callable
 
+import pytest
+
 from reconcile.templating.lib.rendering import FullRenderer, TemplateData
 from reconcile.utils.secret_reader import SecretReader
 
@@ -13,16 +15,28 @@ def test_full_rendering(get_fixture: Callable, secret_reader: SecretReader) -> N
         secret_reader=secret_reader,
     )
 
+    assert r.render_condition()
     assert r.render_output() == expected
     assert r.render_target_path() == "/bar/foo.yml"
 
 
-def test_full_not_rendering(get_fixture: Callable, secret_reader: SecretReader) -> None:
-    template, _, _ = get_fixture("not_rendering.yaml").values()
+@pytest.mark.parametrize(
+    "fixture_file",
+    [
+        "full_not_rendering.yaml",
+        "full_not_overwrite.yaml",
+    ],
+)
+def test_full_not_rendering(
+    get_fixture: Callable,
+    fixture_file: str,
+    secret_reader: SecretReader,
+) -> None:
+    template, current, _ = get_fixture(fixture_file).values()
 
     r = FullRenderer(
         template,
-        TemplateData(variables={"bar": "bar"}, current=None),
+        TemplateData(variables={"bar": "bar"}, current=current),
         secret_reader=secret_reader,
     )
     assert not r.render_condition()

--- a/reconcile/test/templating/lib/test_patch_rendering.py
+++ b/reconcile/test/templating/lib/test_patch_rendering.py
@@ -35,7 +35,30 @@ def test_patch_ref_update(
         secret_reader=secret_reader,
     )
 
+    assert r.render_condition()
     assert r.render_output().strip() == expected.strip()
+
+
+@pytest.mark.parametrize(
+    "fixture_file",
+    [
+        "patch_not_rendering.yaml",
+        "patch_not_overwrite.yaml",
+    ],
+)
+def test_patch_not_rendering(
+    get_fixture: Callable,
+    fixture_file: str,
+    secret_reader: SecretReader,
+) -> None:
+    template, current, _ = get_fixture(fixture_file).values()
+
+    r = PatchRenderer(
+        template,
+        TemplateData(variables={"bar": "bar", "foo": "foo"}, current=current),
+        secret_reader=secret_reader,
+    )
+    assert not r.render_condition()
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Add `overwrite` to template config, this will allow template only render if explicitly specified `overwrite: true`. Most templates are one time setup, this can avoid re-render when actual files changed such as auto promotion bumped ref.


### Enhancements to Templating Logic:
* Added an `overwrite` field to templates in GraphQL schema files (`template_collection.gql`, `templates.gql`) and corresponding Python models (`template_collection.py`, `templates.py`) to support conditional overwriting of rendered outputs. [[1]](diffhunk://#diff-7c072bb8e5e1ef2838f21e698c79f8d1f91a6a9c9313f293155f70b058869a26R24) [[2]](diffhunk://#diff-3aa7dbf26242742a4483529b690d779a0d62602c5fc230e69d73c8a09404cf03R8) [[3]](diffhunk://#diff-27c6fa0dd87838ee64fbc0913546d46c32f5cde50fafc49c6dfc339ddd215001R96) [[4]](diffhunk://#diff-ed8d575cd828b94c3c50d7d9dc286f19527b24031b8aad37a4c0c8c31c0d3318R82)
* Updated rendering logic in `reconcile/templating/lib/rendering.py` to include a new `target_exist` method and enhanced `render_condition` logic, which now respects the `overwrite` flag. [[1]](diffhunk://#diff-29d1a22f3899b8251e82525a326a71f6be4c31d519ef497d3ca233f557a55630R37) [[2]](diffhunk://#diff-29d1a22f3899b8251e82525a326a71f6be4c31d519ef497d3ca233f557a55630R82-R103) [[3]](diffhunk://#diff-29d1a22f3899b8251e82525a326a71f6be4c31d519ef497d3ca233f557a55630R114-R119)

### Improvements to Rendering Functionality:
* Refactored the `PatchRenderer` class to handle JSONPath-based patch updates more effectively, including adding helper methods like `_find_index` and `_get_identifier` for improved readability and functionality. [[1]](diffhunk://#diff-29d1a22f3899b8251e82525a326a71f6be4c31d519ef497d3ca233f557a55630L108-R165) [[2]](diffhunk://#diff-29d1a22f3899b8251e82525a326a71f6be4c31d519ef497d3ca233f557a55630L139-R191)
* Introduced the `cached_property` decorator to optimize repeated computations in rendering logic.

### Test Coverage Enhancements:
* Added new test fixtures to validate the behavior of the `overwrite` flag and rendering conditions, covering both overwrite and non-overwrite scenarios. [[1]](diffhunk://#diff-3a9291ba80d48af685d0afb18d23c51f7d5f60ecc33ed444a2379fe4a9b92149R16-R17) [[2]](diffhunk://#diff-e4d5d49ae38a2cbb1aba584d7c1e65d0a92da6dd2e42f7206c0e04fa1b8bf06eR1-R14) [[3]](diffhunk://#diff-a506700593b38edb9bce0f6c3f63671ab7552059a86aa1446c97f7b9f3d87d52R1-R17) [[4]](diffhunk://#diff-67546c279a17f42cb57dbfef7e63cda09c110ebd9ab08696d3b058e718c261cbR4-R5)
* Updated and parameterized test cases in `test_full_rendering.py` and `test_patch_rendering.py` to include scenarios for non-rendering and non-overwriting conditions. [[1]](diffhunk://#diff-369a67ba71827ed53d89f81e37faf283c782422d012628ee97949640366b08cbR18-R39) [[2]](diffhunk://#diff-29a9c552d9878f22c4fcddded3d0be6e8f5c97df4bcd87d8d121ab88a8a4f6c4R38-R63)

### GraphQL Schema Updates:
* Added new fields (`externalOrgId`, `overwrite`, `promtool_version`) to the GraphQL introspection schema (`introspection.json`) to support additional functionalities. [[1]](diffhunk://#diff-ab7a9bde7283bf3d91d82485eae3dd095f6bf46d3b5f4933be39e4cc48261276R6454-R6465) [[2]](diffhunk://#diff-ab7a9bde7283bf3d91d82485eae3dd095f6bf46d3b5f4933be39e4cc48261276R34193-R34204) [[3]](diffhunk://#diff-ab7a9bde7283bf3d91d82485eae3dd095f6bf46d3b5f4933be39e4cc48261276R41041-R41052)

### Codebase Maintenance:
* Updated the `FilePersistence` class in `reconcile/templating/renderer.py` to include a `flush` method for better handling of file writes and refactored the `__exit__` method to use it.

[APPSRE-12219](https://issues.redhat.com/browse/APPSRE-12219)