### PR TITLE
Revert "APPSRE-11020 konflux pypi push"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -85,6 +85,13 @@ clean: ## Clean up the local development environment
 	@find . -name "__pycache__" -type d -print0 | xargs -0 rm -rf
 	@find . -name "*.pyc" -delete
 
+pypi-release:
+	@$(CONTAINER_ENGINE) build --progress=plain --build-arg TWINE_USERNAME --build-arg TWINE_PASSWORD --target pypi -f dockerfiles/Dockerfile .
+
+pypi:
+	uv build --sdist --wheel
+	UV_PUBLISH_TOKEN=$(TWINE_PASSWORD) uv publish
+
 pypi-konflux:
 	uv build --sdist --wheel
 	uv publish

--- a/build_deploy.sh
+++ b/build_deploy.sh
@@ -12,3 +12,5 @@ make test build push sqs
 
 # and a fips version
 make IMAGE_NAME=quay.io/app-sre/qontract-reconcile-fips BUILD_TARGET=fips-prod-image build push
+
+make pypi-release

--- a/dockerfiles/Dockerfile
+++ b/dockerfiles/Dockerfile
@@ -1,4 +1,3 @@
-# TODO: decommission once we remove ci.ext job completely
 ###############################################################################
 # STAGE 1 - build-image
 ###############################################################################
@@ -117,5 +116,4 @@ ARG TWINE_PASSWORD
 # TODO: use --mount=source=.git,target=.git,type=bind
 # podman does not support --mount=type=bind
 # qontract-reconcile version depends on git tags!
-# Handled by konflux
-#RUN make pypi
+RUN make pypi

--- a/dockerfiles/Dockerfile.konflux
+++ b/dockerfiles/Dockerfile.konflux
@@ -124,7 +124,8 @@ RUN echo "true" > /is_pypi_pushed
 
 # qontract-reconcile version depends on git tags!
 # The .git dir should already be part of the test image
-RUN --mount=type=secret,id=app-sre-pypi-credentials/token export UV_PUBLISH_TOKEN=$(cat /run/secrets/app-sre-pypi-credentials/token); make pypi-konflux
+# TODO: re-enable to take over from ci.ext
+#RUN --mount=type=secret,id=app-sre-pypi-credentials/token export UV_PUBLISH_TOKEN=$(cat /run/secrets/app-sre-pypi-credentials/token); make pypi-konflux
 
 ###############################################################################
 # STAGE 8 - tested and pypi pushed prod image


### PR DESCRIPTION
Reverts app-sre/qontract-reconcile#5132

I believe this MR is creating an undesired and currently-unclear-to-me version bump requirement for new builds of QR.

[Example error](https://konflux-ui.apps.stone-prd-rh01.pg1f.p1.openshiftapps.com/ns/app-sre-tenant/applications/qontract-reconcile-master/pipelineruns/qontract-reconcile-master-on-pull-request-ztckn/logs?task=build-container) from [this MR](https://github.com/app-sre/qontract-reconcile/pull/5131).

```
=================================== FAILURES ===================================
______________________________ test_version_bump _______________________________

    @pytest.mark.skipif(
        os.getuid() != 0,
        reason="This test is only for CI environments",
    )
    def test_version_bump():
        current_version = version("qontract-reconcile")
        pypi_version = requests.get(
            "https://pypi.org/pypi/qontract-reconcile/json", timeout=60
        ).json()["info"]["version"]
>       assert pep440.Version(current_version) > pep440.Version(pypi_version)
E       AssertionError: assert <Version('0.0.1.dev4860')> > <Version('0.10.1')>
E        +  where <Version('0.0.1.dev4860')> = <class 'packaging.version.Version'>('0.0.1.dev4860')
E        +    where <class 'packaging.version.Version'> = pep440.Version
E        +  and   <Version('0.10.1')> = <class 'packaging.version.Version'>('0.10.1')
E        +    where <class 'packaging.version.Version'> = pep440.Version

reconcile/test/test_version_bump.py:18: AssertionError
```