### PR TITLE
automated-actions: external-resource-rds-logs action support

### DIFF
--- a/reconcile/automated_actions/config/integration.py
+++ b/reconcile/automated_actions/config/integration.py
@@ -18,6 +18,7 @@ import reconcile.openshift_base as ob
 from reconcile.gql_definitions.automated_actions.instance import (
     AutomatedActionActionListV1,
     AutomatedActionExternalResourceFlushElastiCacheV1,
+    AutomatedActionExternalResourceRdsLogsV1,
     AutomatedActionExternalResourceRdsRebootV1,
     AutomatedActionExternalResourceRdsSnapshotV1,
     AutomatedActionOpenshiftWorkloadDeleteV1,
@@ -178,6 +179,17 @@ class AutomatedActionsConfigIntegration(
                             parameters.append({
                                 "account": f"^{ec_er.provisioner.name}$",
                                 "identifier": ec_arg.identifier,
+                            })
+                case AutomatedActionExternalResourceRdsLogsV1():
+                    for rds_logs_arg in action.external_resource_rds_logs_arguments:
+                        for rds_logs_er in (
+                            rds_logs_arg.namespace.external_resources or []
+                        ):
+                            if not isinstance(rds_logs_er.provisioner, AWSAccountV1):
+                                continue
+                            parameters.append({
+                                "account": f"^{rds_logs_er.provisioner.name}$",
+                                "identifier": rds_logs_arg.identifier,
                             })
                 case AutomatedActionExternalResourceRdsRebootV1():
                     for rds_reboot_arg in action.external_resource_rds_reboot_arguments:

--- a/reconcile/gql_definitions/automated_actions/instance.gql
+++ b/reconcile/gql_definitions/automated_actions/instance.gql
@@ -46,6 +46,20 @@ query AutomatedActionsInstances {
           identifier
         }
       }
+      ... on AutomatedActionExternalResourceRdsLogs_v1 {
+        external_resource_rds_logs_arguments: arguments {
+          namespace {
+            externalResources {
+              provisioner {
+                ... on AWSAccount_v1 {
+                  name
+                }
+              }
+            }
+          }
+          identifier
+        }
+      }
       ... on AutomatedActionExternalResourceRdsReboot_v1 {
         external_resource_rds_reboot_arguments: arguments {
           namespace {

--- a/reconcile/gql_definitions/automated_actions/instance.py
+++ b/reconcile/gql_definitions/automated_actions/instance.py
@@ -104,6 +104,20 @@ query AutomatedActionsInstances {
           identifier
         }
       }
+      ... on AutomatedActionExternalResourceRdsLogs_v1 {
+        external_resource_rds_logs_arguments: arguments {
+          namespace {
+            externalResources {
+              provisioner {
+                ... on AWSAccount_v1 {
+                  name
+                }
+              }
+            }
+          }
+          identifier
+        }
+      }
       ... on AutomatedActionExternalResourceRdsReboot_v1 {
         external_resource_rds_reboot_arguments: arguments {
           namespace {
@@ -243,6 +257,31 @@ class AutomatedActionExternalResourceFlushElastiCacheV1(AutomatedActionV1):
     external_resource_flush_elasticache_arguments: list[AutomatedActionExternalResourceArgumentV1] = Field(..., alias="external_resource_flush_elasticache_arguments")
 
 
+class AutomatedActionExternalResourceRdsLogsV1_AutomatedActionExternalResourceArgumentV1_NamespaceV1_NamespaceExternalResourceV1_ExternalResourcesProvisionerV1(ConfiguredBaseModel):
+    ...
+
+
+class AutomatedActionExternalResourceRdsLogsV1_AutomatedActionExternalResourceArgumentV1_NamespaceV1_NamespaceExternalResourceV1_ExternalResourcesProvisionerV1_AWSAccountV1(AutomatedActionExternalResourceRdsLogsV1_AutomatedActionExternalResourceArgumentV1_NamespaceV1_NamespaceExternalResourceV1_ExternalResourcesProvisionerV1):
+    name: str = Field(..., alias="name")
+
+
+class AutomatedActionExternalResourceRdsLogsV1_AutomatedActionExternalResourceArgumentV1_NamespaceV1_NamespaceExternalResourceV1(ConfiguredBaseModel):
+    provisioner: Union[AutomatedActionExternalResourceRdsLogsV1_AutomatedActionExternalResourceArgumentV1_NamespaceV1_NamespaceExternalResourceV1_ExternalResourcesProvisionerV1_AWSAccountV1, AutomatedActionExternalResourceRdsLogsV1_AutomatedActionExternalResourceArgumentV1_NamespaceV1_NamespaceExternalResourceV1_ExternalResourcesProvisionerV1] = Field(..., alias="provisioner")
+
+
+class AutomatedActionExternalResourceRdsLogsV1_AutomatedActionExternalResourceArgumentV1_NamespaceV1(ConfiguredBaseModel):
+    external_resources: Optional[list[AutomatedActionExternalResourceRdsLogsV1_AutomatedActionExternalResourceArgumentV1_NamespaceV1_NamespaceExternalResourceV1]] = Field(..., alias="externalResources")
+
+
+class AutomatedActionExternalResourceRdsLogsV1_AutomatedActionExternalResourceArgumentV1(ConfiguredBaseModel):
+    namespace: AutomatedActionExternalResourceRdsLogsV1_AutomatedActionExternalResourceArgumentV1_NamespaceV1 = Field(..., alias="namespace")
+    identifier: str = Field(..., alias="identifier")
+
+
+class AutomatedActionExternalResourceRdsLogsV1(AutomatedActionV1):
+    external_resource_rds_logs_arguments: list[AutomatedActionExternalResourceRdsLogsV1_AutomatedActionExternalResourceArgumentV1] = Field(..., alias="external_resource_rds_logs_arguments")
+
+
 class AutomatedActionExternalResourceRdsRebootV1_AutomatedActionExternalResourceArgumentV1_NamespaceV1_NamespaceExternalResourceV1_ExternalResourcesProvisionerV1(ConfiguredBaseModel):
     ...
 
@@ -347,7 +386,7 @@ class AutomatedActionOpenshiftWorkloadRestartV1(AutomatedActionV1):
 class AutomatedActionsInstanceV1(ConfiguredBaseModel):
     name: str = Field(..., alias="name")
     deployment: NamespaceV1 = Field(..., alias="deployment")
-    actions: Optional[list[Union[AutomatedActionActionListV1, AutomatedActionExternalResourceFlushElastiCacheV1, AutomatedActionExternalResourceRdsRebootV1, AutomatedActionExternalResourceRdsSnapshotV1, AutomatedActionOpenshiftWorkloadDeleteV1, AutomatedActionOpenshiftWorkloadRestartV1, AutomatedActionV1]]] = Field(..., alias="actions")
+    actions: Optional[list[Union[AutomatedActionActionListV1, AutomatedActionExternalResourceFlushElastiCacheV1, AutomatedActionExternalResourceRdsLogsV1, AutomatedActionExternalResourceRdsRebootV1, AutomatedActionExternalResourceRdsSnapshotV1, AutomatedActionOpenshiftWorkloadDeleteV1, AutomatedActionOpenshiftWorkloadRestartV1, AutomatedActionV1]]] = Field(..., alias="actions")
 
 
 class AutomatedActionsInstancesQueryData(ConfiguredBaseModel):

--- a/reconcile/gql_definitions/introspection.json
+++ b/reconcile/gql_definitions/introspection.json
@@ -5693,6 +5693,11 @@
                         },
                         {
                             "kind": "OBJECT",
+                            "name": "AutomatedActionExternalResourceRdsLogs_v1",
+                            "ofType": null
+                        },
+                        {
+                            "kind": "OBJECT",
                             "name": "AutomatedActionExternalResourceRdsReboot_v1",
                             "ofType": null
                         },
@@ -27313,6 +27318,11 @@
                         {
                             "kind": "OBJECT",
                             "name": "AutomatedActionExternalResourceFlushElastiCache_v1",
+                            "ofType": null
+                        },
+                        {
+                            "kind": "OBJECT",
+                            "name": "AutomatedActionExternalResourceRdsLogs_v1",
                             "ofType": null
                         },
                         {
@@ -53449,6 +53459,172 @@
                     ],
                     "inputFields": null,
                     "interfaces": [],
+                    "enumValues": null,
+                    "possibleTypes": null
+                },
+                {
+                    "kind": "OBJECT",
+                    "name": "AutomatedActionExternalResourceRdsLogs_v1",
+                    "description": null,
+                    "fields": [
+                        {
+                            "name": "schema",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "NON_NULL",
+                                "name": null,
+                                "ofType": {
+                                    "kind": "SCALAR",
+                                    "name": "String",
+                                    "ofType": null
+                                }
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "path",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "NON_NULL",
+                                "name": null,
+                                "ofType": {
+                                    "kind": "SCALAR",
+                                    "name": "String",
+                                    "ofType": null
+                                }
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "type",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "NON_NULL",
+                                "name": null,
+                                "ofType": {
+                                    "kind": "SCALAR",
+                                    "name": "String",
+                                    "ofType": null
+                                }
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "description",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "SCALAR",
+                                "name": "String",
+                                "ofType": null
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "maxOps",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "NON_NULL",
+                                "name": null,
+                                "ofType": {
+                                    "kind": "SCALAR",
+                                    "name": "Int",
+                                    "ofType": null
+                                }
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "instances",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "NON_NULL",
+                                "name": null,
+                                "ofType": {
+                                    "kind": "LIST",
+                                    "name": null,
+                                    "ofType": {
+                                        "kind": "NON_NULL",
+                                        "name": null,
+                                        "ofType": {
+                                            "kind": "OBJECT",
+                                            "name": "AutomatedActionsInstance_v1",
+                                            "ofType": null
+                                        }
+                                    }
+                                }
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "permissions",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "LIST",
+                                "name": null,
+                                "ofType": {
+                                    "kind": "NON_NULL",
+                                    "name": null,
+                                    "ofType": {
+                                        "kind": "OBJECT",
+                                        "name": "PermissionAutomatedActions_v1",
+                                        "ofType": null
+                                    }
+                                }
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "arguments",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "NON_NULL",
+                                "name": null,
+                                "ofType": {
+                                    "kind": "LIST",
+                                    "name": null,
+                                    "ofType": {
+                                        "kind": "NON_NULL",
+                                        "name": null,
+                                        "ofType": {
+                                            "kind": "OBJECT",
+                                            "name": "AutomatedActionExternalResourceArgument_v1",
+                                            "ofType": null
+                                        }
+                                    }
+                                }
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        }
+                    ],
+                    "inputFields": null,
+                    "interfaces": [
+                        {
+                            "kind": "INTERFACE",
+                            "name": "AutomatedAction_v1",
+                            "ofType": null
+                        },
+                        {
+                            "kind": "INTERFACE",
+                            "name": "DatafileObject_v1",
+                            "ofType": null
+                        }
+                    ],
                     "enumValues": null,
                     "possibleTypes": null
                 },


### PR DESCRIPTION
Support the `external-resource-rds-logs` automated-action

Ticket: [APPSRE-12231](https://issues.redhat.com/browse/APPSRE-12231)

Depends on: https://github.com/app-sre/qontract-schemas/pull/907