### PR TITLE
Revert "RHCLOUD-39268 status-board-exporter add saas-files to metadata"

### DIFF
--- a/reconcile/gql_definitions/status_board/status_board.gql
+++ b/reconcile/gql_definitions/status_board/status_board.gql
@@ -32,18 +32,10 @@ query StatusBoard {
             childrenApps {
               name
               onboardingStatus
-              saasFiles {
-                name
-                managedResourceTypes
-              }
             }
             parentApp {
               name
               onboardingStatus
-            }
-            saasFiles {
-              name
-              managedResourceTypes
             }
           }
         }

--- a/reconcile/gql_definitions/status_board/status_board.py
+++ b/reconcile/gql_definitions/status_board/status_board.py
@@ -51,18 +51,10 @@ query StatusBoard {
             childrenApps {
               name
               onboardingStatus
-              saasFiles {
-                name
-                managedResourceTypes
-              }
             }
             parentApp {
               name
               onboardingStatus
-            }
-            saasFiles {
-              name
-              managedResourceTypes
             }
           }
         }
@@ -104,15 +96,9 @@ class ProductV1(ConfiguredBaseModel):
     name: str = Field(..., alias="name")
 
 
-class SaasFileV2(ConfiguredBaseModel):
-    name: str = Field(..., alias="name")
-    managed_resource_types: list[str] = Field(..., alias="managedResourceTypes")
-
-
 class AppV1_AppV1(ConfiguredBaseModel):
     name: str = Field(..., alias="name")
     onboarding_status: str = Field(..., alias="onboardingStatus")
-    saas_files: Optional[list[SaasFileV2]] = Field(..., alias="saasFiles")
 
 
 class NamespaceV1_AppV1_AppV1(ConfiguredBaseModel):
@@ -120,17 +106,11 @@ class NamespaceV1_AppV1_AppV1(ConfiguredBaseModel):
     onboarding_status: str = Field(..., alias="onboardingStatus")
 
 
-class AppV1_SaasFileV2(ConfiguredBaseModel):
-    name: str = Field(..., alias="name")
-    managed_resource_types: list[str] = Field(..., alias="managedResourceTypes")
-
-
 class AppV1(ConfiguredBaseModel):
     name: str = Field(..., alias="name")
     onboarding_status: str = Field(..., alias="onboardingStatus")
     children_apps: Optional[list[AppV1_AppV1]] = Field(..., alias="childrenApps")
     parent_app: Optional[NamespaceV1_AppV1_AppV1] = Field(..., alias="parentApp")
-    saas_files: Optional[list[AppV1_SaasFileV2]] = Field(..., alias="saasFiles")
 
 
 class NamespaceV1(ConfiguredBaseModel):

--- a/reconcile/status_board.py
+++ b/reconcile/status_board.py
@@ -6,9 +6,6 @@ from abc import (
 from collections.abc import Iterable, Mapping
 from enum import Enum
 from itertools import chain
-from typing import (
-    Any,
-)
 
 from pydantic import BaseModel
 
@@ -16,7 +13,7 @@ from reconcile.gql_definitions.slo_documents.slo_documents import SLODocumentV1
 from reconcile.gql_definitions.status_board.status_board import StatusBoardV1
 from reconcile.typed_queries.slo_documents import get_slo_documents
 from reconcile.typed_queries.status_board import (
-    get_selected_app_data,
+    get_selected_app_names,
     get_status_board,
 )
 from reconcile.utils.differ import diff_mappings
@@ -34,7 +31,6 @@ from reconcile.utils.ocm.status_board import (
     get_application_services,
     get_managed_products,
     get_product_applications,
-    update_application,
     update_service,
 )
 from reconcile.utils.ocm_base_client import (
@@ -59,7 +55,6 @@ class AbstractStatusBoard(ABC, BaseModel):
     id: str | None
     name: str
     fullname: str
-    metadata: dict[str, Any] | ServiceMetadataSpec | None
 
     @abstractmethod
     def create(self, ocm: OCMBaseClient) -> None:
@@ -127,7 +122,6 @@ class Product(AbstractStatusBoard):
 class Application(AbstractStatusBoard):
     product: Product
     services: list["Service"] | None
-    metadata: dict[str, Any]
 
     def create(self, ocm: OCMBaseClient) -> None:
         if self.product.id:
@@ -137,11 +131,9 @@ class Application(AbstractStatusBoard):
             logging.warning("Missing product id for application")
 
     def update(self, ocm: OCMBaseClient) -> None:
-        if not self.id:
-            logging.error(f'Trying to update Application "{self.name}" without id')
-            return
-        spec = self.to_ocm_spec()
-        update_application(ocm, self.id, spec)
+        err_msg = "Called update on StatusBoardHandler that doesn't have update method"
+        logging.error(err_msg)
+        raise UpdateNotSupportedError(err_msg)
 
     def delete(self, ocm: OCMBaseClient) -> None:
         if not self.id:
@@ -157,7 +149,6 @@ class Application(AbstractStatusBoard):
         return {
             "name": self.name,
             "fullname": self.fullname,
-            "metadata": self.metadata,
             "product": {"id": product_id},
         }
 
@@ -257,14 +248,12 @@ class StatusBoardExporterIntegration(QontractReconcileIntegration):
         return QONTRACT_INTEGRATION
 
     @staticmethod
-    def get_product_apps(
-        sb: StatusBoardV1,
-    ) -> dict[str, dict[str, dict[str, dict[str, set[str]]]]]:
+    def get_product_apps(sb: StatusBoardV1) -> dict[str, set[str]]:
         global_selectors = (
             sb.global_app_selectors.exclude or [] if sb.global_app_selectors else []
         )
         return {
-            p.product_environment.product.name: get_selected_app_data(
+            p.product_environment.product.name: get_selected_app_names(
                 global_selectors, p
             )
             for p in sb.products
@@ -298,7 +287,7 @@ class StatusBoardExporterIntegration(QontractReconcileIntegration):
 
     @staticmethod
     def desired_abstract_status_board_map(
-        desired_product_apps: Mapping[str, dict[str, dict[str, dict[str, set[str]]]]],
+        desired_product_apps: Mapping[str, set[str]],
         slodocs: list[SLODocumentV1],
     ) -> dict[str, AbstractStatusBoard]:
         """
@@ -310,11 +299,7 @@ class StatusBoardExporterIntegration(QontractReconcileIntegration):
         desired_abstract_status_board_map: dict[str, AbstractStatusBoard] = {}
         for product_name, apps in desired_product_apps.items():
             product = Product(
-                id=None,
-                name=product_name,
-                fullname=product_name,
-                applications=[],
-                metadata={},
+                id=None, name=product_name, fullname=product_name, applications=[]
             )
             desired_abstract_status_board_map[product_name] = product
             for a in apps:
@@ -325,7 +310,6 @@ class StatusBoardExporterIntegration(QontractReconcileIntegration):
                     fullname=key,
                     services=[],
                     product=product,
-                    metadata=apps[a]["metadata"],
                 )
         for slodoc in slodocs:
             products = [
@@ -390,99 +374,6 @@ class StatusBoardExporterIntegration(QontractReconcileIntegration):
         return return_value
 
     @staticmethod
-    def _compare_metadata(
-        current_metadata: dict[str, Any] | ServiceMetadataSpec,
-        desired_metadata: dict[str, Any] | ServiceMetadataSpec,
-    ) -> bool:
-        """
-        Compare metadata dictionaries with deep equality checking for nested structures.
-
-        :param current_metadata: The current metadata dictionary
-        :param desired_metadata: The desired metadata dictionary
-        :return: True if metadata are equal, False otherwise
-        """
-        # Convert TypedDict to regular dict to allow variable key access
-        current_dict = dict(current_metadata)
-        desired_dict = dict(desired_metadata)
-
-        if current_dict.keys() != desired_dict.keys():
-            return False
-
-        for key, current_value in current_dict.items():
-            desired_value = desired_dict[key]
-
-            # Handle None values
-            if current_value is None or desired_value is None:
-                if current_value is not desired_value:
-                    return False
-                continue
-
-            # Handle sets
-            if isinstance(current_value, set) and isinstance(desired_value, set):
-                if current_value != desired_value:
-                    return False
-            # Handle lists and tuples
-            elif isinstance(current_value, (list, tuple)) and isinstance(
-                desired_value, (list, tuple)
-            ):
-                if len(current_value) != len(desired_value):
-                    return False
-
-                try:
-                    sorted_current = sorted(current_value, key=repr)
-                    sorted_desired = sorted(desired_value, key=repr)
-                except Exception:
-                    # Fallback: compare without sorting
-                    sorted_current = list(current_value)
-                    sorted_desired = list(desired_value)
-
-                for c, d in zip(sorted_current, sorted_desired, strict=True):
-                    if isinstance(c, dict) and isinstance(d, dict):
-                        if not StatusBoardExporterIntegration._compare_metadata(c, d):
-                            return False
-                    elif isinstance(c, (list, tuple)) and isinstance(d, (list, tuple)):
-                        if not StatusBoardExporterIntegration._compare_metadata(
-                            {"x": c}, {"x": d}
-                        ):
-                            return False
-                    elif c != d:
-                        return False
-            # Handle nested dictionaries
-            elif isinstance(current_value, dict) and isinstance(desired_value, dict):
-                if not StatusBoardExporterIntegration._compare_metadata(
-                    current_value, desired_value
-                ):
-                    return False
-            # Handle primitive types
-            elif current_value != desired_value:
-                return False
-
-        return True
-
-    @staticmethod
-    def _status_board_objects_equal(
-        current: AbstractStatusBoard, desired: AbstractStatusBoard
-    ) -> bool:
-        """
-        Check if two AbstractStatusBoard objects are equal, including metadata comparison.
-
-        :param current: The current AbstractStatusBoard object
-        :param desired: The desired AbstractStatusBoard object
-        :return: True if objects are equal, False otherwise
-        """
-        # Check basic equality first (name, fullname)
-        if current.name != desired.name or current.fullname != desired.fullname:
-            return False
-
-        # Compare metadata with deep equality
-        if current.metadata and desired.metadata:
-            return StatusBoardExporterIntegration._compare_metadata(
-                current.metadata, desired.metadata
-            )
-        else:
-            return True
-
-    @staticmethod
     def get_diff(
         desired_abstract_status_board_map: Mapping[str, AbstractStatusBoard],
         current_abstract_status_board_map: Mapping[str, AbstractStatusBoard],
@@ -492,7 +383,6 @@ class StatusBoardExporterIntegration(QontractReconcileIntegration):
         diff_result = diff_mappings(
             current_abstract_status_board_map,
             desired_abstract_status_board_map,
-            equal=StatusBoardExporterIntegration._status_board_objects_equal,
         )
 
         for pair in chain(diff_result.identical.values(), diff_result.change.values()):
@@ -506,18 +396,6 @@ class StatusBoardExporterIntegration(QontractReconcileIntegration):
         return_list.extend(
             StatusBoardHandler(action=Action.delete, status_board_object=o)
             for o in diff_result.delete.values()
-        )
-
-        # Handle Applications that need updates (metadata changes)
-        applications_to_update = [
-            a.desired
-            for _, a in diff_result.change.items()
-            if isinstance(a.desired, Application)
-        ]
-
-        return_list.extend(
-            StatusBoardHandler(action=Action.update, status_board_object=a)
-            for a in applications_to_update
         )
 
         services_to_update = [
@@ -567,9 +445,7 @@ class StatusBoardExporterIntegration(QontractReconcileIntegration):
             ocm_api = init_ocm_base_client(sb.ocm, self.secret_reader)
 
             # Desired state
-            desired_product_apps: dict[
-                str, dict[str, dict[str, dict[str, set[str]]]]
-            ] = self.get_product_apps(sb)
+            desired_product_apps: dict[str, set[str]] = self.get_product_apps(sb)
             desired_abstract_status_board_map = self.desired_abstract_status_board_map(
                 desired_product_apps, slodocs
             )

--- a/reconcile/test/test_status_board.py
+++ b/reconcile/test/test_status_board.py
@@ -169,7 +169,7 @@ def slo_documents(gql_class_factory: Callable[..., SLODocumentV1]) -> SLODocumen
 
 
 @pytest.fixture
-def basic_metadata_spec() -> ServiceMetadataSpec:
+def basic_service_metadata_spec() -> ServiceMetadataSpec:
     return {
         "sli_specification": "specification",
         "target_unit": "unit",
@@ -184,9 +184,7 @@ def test_status_board_handler(mocker: MockerFixture) -> None:
     ocm = mocker.patch("reconcile.status_board.OCMBaseClient")
     h = StatusBoardHandler(
         action=Action.create,
-        status_board_object=StatusBoardStub(
-            id=None, name="foo", fullname="foo", metadata={}
-        ),
+        status_board_object=StatusBoardStub(name="foo", fullname="foo", metadata={}),
     )
 
     h.act(dry_run=False, ocm=ocm)
@@ -196,9 +194,7 @@ def test_status_board_handler(mocker: MockerFixture) -> None:
 
     h = StatusBoardHandler(
         action=Action.delete,
-        status_board_object=StatusBoardStub(
-            id=None, name="foo", fullname="foo", metadata={}
-        ),
+        status_board_object=StatusBoardStub(name="foo", fullname="foo"),
     )
 
     h.act(dry_run=False, ocm=ocm)
@@ -225,10 +221,7 @@ def test_status_board_handler(mocker: MockerFixture) -> None:
             name="bar",
             fullname="bar",
             services=[],
-            product=Product(
-                id=None, name="baz", fullname="baz", applications=[], metadata={}
-            ),
-            metadata={},
+            product=Product(name="baz", fullname="baz", applications=[]),
         ),
         metadata=metadata,
     )
@@ -242,30 +235,7 @@ def test_status_board_handler(mocker: MockerFixture) -> None:
 
 def test_get_product_apps(status_board: StatusBoardV1) -> None:
     p = StatusBoardExporterIntegration.get_product_apps(status_board)
-    assert p == {
-        "foo": {
-            "foo": {
-                "metadata": {
-                    "managedBy": "qontract-reconcile",
-                    "deploymentSaasFiles": set(),
-                }
-            },
-            "foo-bar": {
-                "metadata": {
-                    "managedBy": "qontract-reconcile",
-                    "deploymentSaasFiles": set(),
-                }
-            },
-        },
-        "bar": {
-            "bar": {
-                "metadata": {
-                    "managedBy": "qontract-reconcile",
-                    "deploymentSaasFiles": set(),
-                }
-            }
-        },
-    }
+    assert p == {"foo": {"foo", "foo-bar"}, "bar": {"bar"}}
 
 
 def test_get_current_products_applications_services(mocker: MockerFixture) -> None:
@@ -275,32 +245,17 @@ def test_get_current_products_applications_services(mocker: MockerFixture) -> No
     mock_get_services = mocker.patch("reconcile.status_board.get_application_services")
 
     mock_get_products.return_value = [
-        {"name": "product_1", "fullname": "product_1", "id": "1", "metadata": {}},
-        {"name": "product_2", "fullname": "product_2", "id": "2", "metadata": {}},
+        {"name": "product_1", "fullname": "product_1", "id": "1"},
+        {"name": "product_2", "fullname": "product_2", "id": "2"},
     ]
 
     apps_mapping = {
         "1": [
-            {
-                "name": "app_1",
-                "fullname": "product_1/app_1",
-                "id": "1_1",
-                "metadata": {},
-            },
-            {
-                "name": "app_2",
-                "fullname": "product_1/app_2",
-                "id": "1_2",
-                "metadata": {},
-            },
+            {"name": "app_1", "fullname": "product_1/app_1", "id": "1_1"},
+            {"name": "app_2", "fullname": "product_1/app_2", "id": "1_2"},
         ],
         "2": [
-            {
-                "name": "app_3",
-                "fullname": "product_2/app_3",
-                "id": "2_3",
-                "metadata": {},
-            },
+            {"name": "app_3", "fullname": "product_2/app_3", "id": "2_3"},
         ],
     }
 
@@ -352,18 +307,24 @@ def test_get_current_products_applications_services(mocker: MockerFixture) -> No
         "target_unit": "unit",
         "window": "1h",
     }
+
     product_1 = Product(
-        name="product_1", fullname="product_1", id="1", applications=[], metadata={}
+        name="product_1",
+        fullname="product_1",
+        id="1",
+        applications=[],
     )
     product_2 = Product(
-        name="product_2", fullname="product_2", id="2", applications=[], metadata={}
+        name="product_2",
+        fullname="product_2",
+        id="2",
+        applications=[],
     )
     app_1 = Application(
         name="app_1",
         fullname="product_1/app_1",
         id="1_1",
         services=[],
-        metadata={},
         product=product_1,
     )
     app_2 = Application(
@@ -371,7 +332,6 @@ def test_get_current_products_applications_services(mocker: MockerFixture) -> No
         fullname="product_1/app_2",
         id="1_2",
         services=[],
-        metadata={},
         product=product_1,
     )
     app_3 = Application(
@@ -379,7 +339,6 @@ def test_get_current_products_applications_services(mocker: MockerFixture) -> No
         fullname="product_2/app_3",
         id="2_3",
         services=[],
-        metadata={},
         product=product_2,
     )
     service_1 = Service(
@@ -414,10 +373,16 @@ def test_current_abstract_status_board_map() -> None:
     }
 
     product_1 = Product(
-        name="product_1", fullname="product_1", id=None, applications=[], metadata={}
+        name="product_1",
+        fullname="product_1",
+        id=None,
+        applications=[],
     )
     product_2 = Product(
-        name="product_2", fullname="product_2", id="2", applications=[], metadata={}
+        name="product_2",
+        fullname="product_2",
+        id="2",
+        applications=[],
     )
     app_1 = Application(
         name="app_1",
@@ -425,7 +390,6 @@ def test_current_abstract_status_board_map() -> None:
         id="1_1",
         services=[],
         product=product_1,
-        metadata={},
     )
     app_2 = Application(
         name="app_2",
@@ -433,7 +397,6 @@ def test_current_abstract_status_board_map() -> None:
         id="1_2",
         services=[],
         product=product_1,
-        metadata={},
     )
     app_3 = Application(
         name="app_3",
@@ -441,7 +404,6 @@ def test_current_abstract_status_board_map() -> None:
         id="2_3",
         services=[],
         product=product_2,
-        metadata={},
     )
     service_1 = Service(
         name="service_1",
@@ -468,14 +430,16 @@ def test_current_abstract_status_board_map() -> None:
 
     assert flat_map == {
         "product_1": Product(
-            name="product_1", fullname="product_1", id="1", applications=[], metadata={}
+            name="product_1",
+            fullname="product_1",
+            id="1",
+            applications=[],
         ),
         "product_1/app_1": Application(
             name="app_1",
             fullname="product_1/app_1",
             id="1_1",
             services=[],
-            metadata={},
             product=product_1,
         ),
         "product_1/app_1/service_1": Service(
@@ -497,27 +461,26 @@ def test_current_abstract_status_board_map() -> None:
             fullname="product_1/app_2",
             id="1_2",
             services=[],
-            metadata={},
             product=product_1,
         ),
         "product_2": Product(
-            name="product_2", fullname="product_2", id="2", applications=[], metadata={}
+            name="product_2",
+            fullname="product_2",
+            id="2",
+            applications=[],
         ),
         "product_2/app_3": Application(
             name="app_3",
             fullname="product_2/app_3",
             id="2_3",
             services=[],
-            metadata={},
             product=product_2,
         ),
     }
 
 
 def test_get_diff_create_app() -> None:
-    foo_product = Product(
-        name="foo", fullname="foo", applications=[], id=None, metadata={}
-    )
+    foo_product = Product(name="foo", fullname="foo", applications=[])
     h = StatusBoardExporterIntegration.get_diff(
         desired_abstract_status_board_map={
             "foo": foo_product,
@@ -526,22 +489,16 @@ def test_get_diff_create_app() -> None:
                 fullname="foo/bar",
                 services=[],
                 product=foo_product,
-                id=None,
-                metadata={},
             ),
             "foo/foo": Application(
                 name="foo",
                 fullname="foo/foo",
                 services=[],
                 product=foo_product,
-                id=None,
-                metadata={},
             ),
         },
         current_abstract_status_board_map={
-            "foo": Product(
-                name="foo", fullname="foo", applications=[], id=None, metadata={}
-            ),
+            "foo": Product(name="foo", fullname="foo", applications=[]),
         },
     )
 
@@ -561,39 +518,25 @@ def test_get_diff_create_app() -> None:
 
 
 def test_get_diff_create_one_app() -> None:
-    foo_product = Product(
-        name="foo", fullname="foo", applications=[], id=None, metadata={}
-    )
+    foo_product = Product(name="foo", fullname="foo", applications=[])
     current_foo = Product(
-        id="1", name="foo", fullname="foo", applications=[], metadata={}
+        id="1",
+        name="foo",
+        fullname="foo",
+        applications=[],
     )
     current_app = Application(
-        id="2",
-        name="bar",
-        fullname="foo/bar",
-        services=[],
-        product=current_foo,
-        metadata={},
+        id="2", name="bar", fullname="foo/bar", services=[], product=current_foo
     )
     current_foo.applications = [current_app]
     h = StatusBoardExporterIntegration.get_diff(
         desired_abstract_status_board_map={
             "foo": foo_product,
             "foo/bar": Application(
-                name="bar",
-                fullname="foo/bar",
-                services=[],
-                product=foo_product,
-                id=None,
-                metadata={},
+                name="bar", fullname="foo/bar", services=[], product=foo_product
             ),
             "foo/foo": Application(
-                name="foo",
-                fullname="foo/foo",
-                services=[],
-                product=foo_product,
-                id=None,
-                metadata={},
+                name="foo", fullname="foo/foo", services=[], product=foo_product
             ),
         },
         current_abstract_status_board_map={
@@ -609,27 +552,15 @@ def test_get_diff_create_one_app() -> None:
 
 
 def test_get_diff_create_product_and_apps() -> None:
-    foo_product = Product(
-        name="foo", fullname="foo", applications=[], id=None, metadata={}
-    )
+    foo_product = Product(name="foo", fullname="foo", applications=[])
     h = StatusBoardExporterIntegration.get_diff(
         desired_abstract_status_board_map={
             "foo": foo_product,
             "foo/bar": Application(
-                name="bar",
-                fullname="foo/bar",
-                services=[],
-                product=foo_product,
-                id=None,
-                metadata={},
+                name="bar", fullname="foo/bar", services=[], product=foo_product
             ),
             "foo/foo": Application(
-                name="foo",
-                fullname="foo/foo",
-                services=[],
-                product=foo_product,
-                id=None,
-                metadata={},
+                name="foo", fullname="foo/foo", services=[], product=foo_product
             ),
         },
         current_abstract_status_board_map={},
@@ -657,37 +588,24 @@ def test_get_diff_create_product_and_apps() -> None:
 
 
 def test_get_diff_create_product_app_and_service(
-    basic_metadata_spec: ServiceMetadataSpec,
+    basic_service_metadata_spec: ServiceMetadataSpec,
 ) -> None:
-    foo_product = Product(
-        name="foo", fullname="foo", applications=[], id=None, metadata={}
-    )
+    foo_product = Product(name="foo", fullname="foo", applications=[])
     bar_app = Application(
-        name="bar",
-        fullname="foo/bar",
-        services=[],
-        product=foo_product,
-        id=None,
-        metadata={},
+        name="bar", fullname="foo/bar", services=[], product=foo_product
     )
     h = StatusBoardExporterIntegration.get_diff(
         desired_abstract_status_board_map={
             "foo": foo_product,
             "foo/bar": bar_app,
             "foo/foo": Application(
-                name="foo",
-                fullname="foo/foo",
-                services=[],
-                product=foo_product,
-                id=None,
-                metadata={},
+                name="foo", fullname="foo/foo", services=[], product=foo_product
             ),
             "foo/bar/baz": Service(
                 name="baz",
                 fullname="foo/bar/baz",
-                metadata=basic_metadata_spec,
+                metadata=basic_service_metadata_spec,
                 application=bar_app,
-                id=None,
             ),
         },
         current_abstract_status_board_map={},
@@ -729,20 +647,16 @@ def test_get_diff_update_service() -> None:
         "window": "window",
         "target": 0.99,
     }
-    foo_product = Product(name="foo", fullname="foo", applications=[], metadata={})
+    foo_product = Product(name="foo", fullname="foo", applications=[])
     foo_bar_app = Application(
-        name="bar", fullname="foo/bar", services=[], product=foo_product, metadata={}
+        name="bar", fullname="foo/bar", services=[], product=foo_product
     )
     h = StatusBoardExporterIntegration.get_diff(
         desired_abstract_status_board_map={
             "foo": foo_product,
             "foo/bar": foo_bar_app,
             "foo/foo": Application(
-                name="foo",
-                fullname="foo/foo",
-                services=[],
-                product=foo_product,
-                metadata={},
+                name="foo", fullname="foo/foo", services=[], product=foo_product
             ),
             "foo/bar/baz": Service(
                 name="baz",
@@ -755,11 +669,7 @@ def test_get_diff_update_service() -> None:
             "foo": foo_product,
             "foo/bar": foo_bar_app,
             "foo/foo": Application(
-                name="foo",
-                fullname="foo/foo",
-                services=[],
-                product=foo_product,
-                metadata={},
+                name="foo", fullname="foo/foo", services=[], product=foo_product
             ),
             "foo/bar/baz": Service(
                 name="baz",
@@ -776,31 +686,22 @@ def test_get_diff_update_service() -> None:
 
 
 def test_get_diff_noop() -> None:
-    foo_product = Product(
-        name="foo", fullname="foo", applications=[], id=None, metadata={}
-    )
+    foo_product = Product(name="foo", fullname="foo", applications=[])
     current_foo = Product(
-        id="1", name="foo", fullname="foo", applications=[], metadata={}
+        id="1",
+        name="foo",
+        fullname="foo",
+        applications=[],
     )
     current_app = Application(
-        id="2",
-        name="bar",
-        fullname="foo/bar",
-        services=[],
-        product=current_foo,
-        metadata={},
+        id="2", name="bar", fullname="foo/bar", services=[], product=current_foo
     )
     current_foo.applications = [current_app]
     h = StatusBoardExporterIntegration.get_diff(
         desired_abstract_status_board_map={
             "foo": foo_product,
             "foo/bar": Application(
-                name="bar",
-                fullname="foo/bar",
-                services=[],
-                product=foo_product,
-                id=None,
-                metadata={},
+                name="bar", fullname="foo/bar", services=[], product=foo_product
             ),
         },
         current_abstract_status_board_map={
@@ -812,19 +713,15 @@ def test_get_diff_noop() -> None:
 
 
 def test_get_diff_delete_app() -> None:
-    foo_product = Product(
-        name="foo", fullname="foo", applications=[], id=None, metadata={}
-    )
+    foo_product = Product(name="foo", fullname="foo", applications=[])
     current_foo = Product(
-        id="1", name="foo", fullname="foo", applications=[], metadata={}
+        id="1",
+        name="foo",
+        fullname="foo",
+        applications=[],
     )
     current_app = Application(
-        id="2",
-        name="bar",
-        fullname="foo/bar",
-        services=[],
-        product=current_foo,
-        metadata={},
+        id="2", name="bar", fullname="foo/bar", services=[], product=current_foo
     )
     current_foo.applications = [current_app]
     h = StatusBoardExporterIntegration.get_diff(
@@ -834,12 +731,7 @@ def test_get_diff_delete_app() -> None:
         current_abstract_status_board_map={
             "foo": current_foo,
             "foo/bar": Application(
-                id="2",
-                name="bar",
-                fullname="foo/bar",
-                services=[],
-                product=current_foo,
-                metadata={},
+                id="2", name="bar", fullname="foo/bar", services=[], product=current_foo
             ),
         },
     )
@@ -852,15 +744,13 @@ def test_get_diff_delete_app() -> None:
 
 def test_get_diff_delete_apps_and_product() -> None:
     current_foo = Product(
-        id="1", name="foo", fullname="foo", applications=[], metadata={}
+        id="1",
+        name="foo",
+        fullname="foo",
+        applications=[],
     )
     current_app = Application(
-        id="2",
-        name="bar",
-        fullname="foo/bar",
-        services=[],
-        product=current_foo,
-        metadata={},
+        id="2", name="bar", fullname="foo/bar", services=[], product=current_foo
     )
     current_foo.applications = [current_app]
     h = StatusBoardExporterIntegration.get_diff(
@@ -868,12 +758,7 @@ def test_get_diff_delete_apps_and_product() -> None:
         current_abstract_status_board_map={
             "foo": current_foo,
             "foo/bar": Application(
-                id="2",
-                name="bar",
-                fullname="foo/bar",
-                services=[],
-                product=current_foo,
-                metadata={},
+                id="2", name="bar", fullname="foo/bar", services=[], product=current_foo
             ),
         },
     )
@@ -902,15 +787,13 @@ def test_get_diff_delete_product_app_and_service() -> None:
         "target": 0.99,
     }
     current_foo = Product(
-        id="1", name="foo", fullname="foo", applications=[], metadata={}
+        id="1",
+        name="foo",
+        fullname="foo",
+        applications=[],
     )
     current_bar = Application(
-        id="2",
-        name="bar",
-        fullname="foo/bar",
-        services=[],
-        product=current_foo,
-        metadata={},
+        id="2", name="bar", fullname="foo/bar", services=[], product=current_foo
     )
     current_service = Service(
         id="3",
@@ -960,14 +843,12 @@ def test_apply_sorted(mocker: MockerFixture) -> None:
     ocm = mocker.patch("reconcile.status_board.OCMBaseClient", autospec=True)
     logging = mocker.patch("reconcile.status_board.logging", autospec=True)
 
-    product = Product(name="foo", fullname="foo", applications=[], id=None, metadata={})
+    product = Product(name="foo", fullname="foo", applications=[])
     application = Application(
         name="bar",
         fullname="foo/bar",
         product=product,
         services=[],
-        id=None,
-        metadata={},
     )
     metadata: ServiceMetadataSpec = {
         "sli_type": "type",
@@ -984,7 +865,6 @@ def test_apply_sorted(mocker: MockerFixture) -> None:
                 name="baz",
                 fullname="foo/bar/baz",
                 metadata=metadata,
-                id=None,
                 application=application,
             ),
         ),
@@ -1046,20 +926,15 @@ def test_run_integration(
     )
 
     mock_get_products.return_value = [
-        {"name": "product_1", "fullname": "product_1", "id": "1", "metadata": {}},
-        {"name": "bar", "fullname": "bar", "id": "2", "metadata": {}},
+        {"name": "product_1", "fullname": "product_1", "id": "1"},
+        {"name": "bar", "fullname": "bar", "id": "2"},
     ]
 
     apps_mapping = {
         "1": [
-            {
-                "name": "app_1",
-                "fullname": "product_1/app_1",
-                "id": "1_1",
-                "metadata": {},
-            },
+            {"name": "app_1", "fullname": "product_1/app_1", "id": "1_1"},
         ],
-        "2": [{"name": "bar", "fullname": "bar/bar", "id": "2_1", "metadata": {}}],
+        "2": [{"name": "bar", "fullname": "bar/bar", "id": "2_1"}],
     }
 
     services_mapping = {
@@ -1121,10 +996,6 @@ def test_run_integration(
                 spec={
                     "fullname": "foo/foo-bar",
                     "name": "foo-bar",
-                    "metadata": {
-                        "deploymentSaasFiles": set(),
-                        "managedBy": "qontract-reconcile",
-                    },
                     "product": {"id": "1"},
                 },
             ),
@@ -1133,10 +1004,6 @@ def test_run_integration(
                 spec={
                     "fullname": "foo/foo",
                     "name": "foo",
-                    "metadata": {
-                        "deploymentSaasFiles": set(),
-                        "managedBy": "qontract-reconcile",
-                    },
                     "product": {"id": "1"},
                 },
             ),
@@ -1226,15 +1093,15 @@ def test_run_integration_create_services(
     )
 
     mock_get_products.return_value = [
-        {"name": "foo", "fullname": "foo", "id": "1", "metadata": {}},
-        {"name": "bar", "fullname": "bar", "id": "2", "metadata": {}},
+        {"name": "foo", "fullname": "foo", "id": "1"},
+        {"name": "bar", "fullname": "bar", "id": "2"},
     ]
 
     apps_mapping = {
         "1": [
-            {"name": "foo", "fullname": "foo/foo", "id": "1_1", "metadata": {}},
+            {"name": "foo", "fullname": "foo/foo", "id": "1_1"},
         ],
-        "2": [{"name": "bar", "fullname": "bar/bar", "id": "2_1", "metadata": {}}],
+        "2": [{"name": "bar", "fullname": "bar/bar", "id": "2_1"}],
     }
 
     mock_get_apps.side_effect = lambda _, product_id: apps_mapping.get(product_id, [])
@@ -1295,197 +1162,3 @@ def test_run_integration_create_services(
         ],
         any_order=True,
     )
-
-
-@pytest.fixture
-def status_board_with_saas_file(
-    gql_class_factory: Callable[..., StatusBoardV1],
-) -> StatusBoardV1:
-    """StatusBoard fixture for app 'foo' under product 'bar' with saas-file 'baz'"""
-    return gql_class_factory(
-        StatusBoardV1,
-        {
-            "name": "test-board",
-            "ocm": {
-                "url": "https://test.com",
-                "accessTokenUrl": "test",
-                "accessTokenClientId": "test",
-                "accessTokenClientSecret": {
-                    "path": "test",
-                    "field": "test",
-                    "version": "1",
-                    "format": "test",
-                },
-            },
-            "products": [
-                {
-                    "productEnvironment": {
-                        "name": "bar",
-                        "labels": '{"environment": "production"}',
-                        "namespaces": [
-                            {
-                                "app": {
-                                    "name": "foo",
-                                    "onboardingStatus": "OnBoarded",
-                                    "saasFiles": [
-                                        {
-                                            "name": "baz",
-                                            "managedResourceTypes": ["Deployment"],
-                                        }
-                                    ],
-                                }
-                            }
-                        ],
-                        "product": {
-                            "name": "bar",
-                        },
-                    },
-                },
-            ],
-        },
-    )
-
-
-@pytest.fixture
-def status_board_with_multiple_saas_files(
-    gql_class_factory: Callable[..., StatusBoardV1],
-) -> StatusBoardV1:
-    """StatusBoard fixture for app 'foo' under product 'bar' with multiple saas-files"""
-    return gql_class_factory(
-        StatusBoardV1,
-        {
-            "name": "test-board",
-            "ocm": {
-                "url": "https://test.com",
-                "accessTokenUrl": "test",
-                "accessTokenClientId": "test",
-                "accessTokenClientSecret": {
-                    "path": "test",
-                    "field": "test",
-                    "version": "1",
-                    "format": "test",
-                },
-            },
-            "products": [
-                {
-                    "productEnvironment": {
-                        "name": "bar",
-                        "labels": '{"environment": "production"}',
-                        "namespaces": [
-                            {
-                                "app": {
-                                    "name": "foo",
-                                    "onboardingStatus": "OnBoarded",
-                                    "saasFiles": [
-                                        {
-                                            "name": "baz",
-                                            "managedResourceTypes": ["Deployment"],
-                                        },
-                                        {
-                                            "name": "qux",
-                                            "managedResourceTypes": ["Deployment"],
-                                        },
-                                    ],
-                                }
-                            }
-                        ],
-                        "product": {
-                            "name": "bar",
-                        },
-                    },
-                },
-            ],
-        },
-    )
-
-
-def test_get_diff_create_app_with_saas_file(
-    status_board_with_saas_file: StatusBoardV1,
-) -> None:
-    """Test creating app 'foo' under product 'bar' with deployment saas-file 'baz'"""
-    # Get desired state from status board
-    desired_product_apps = StatusBoardExporterIntegration.get_product_apps(
-        status_board_with_saas_file
-    )
-    desired_abstract_status_board_map = (
-        StatusBoardExporterIntegration.desired_abstract_status_board_map(
-            desired_product_apps, []
-        )
-    )
-
-    # No current state (creating from scratch)
-    current_abstract_status_board_map: dict[str, AbstractStatusBoard] = {}
-
-    h = StatusBoardExporterIntegration.get_diff(
-        desired_abstract_status_board_map, current_abstract_status_board_map
-    )
-
-    assert len(h) == 2
-
-    # Should create product first
-    product_handler = next(
-        (handler for handler in h if isinstance(handler.status_board_object, Product)),
-        None,
-    )
-    assert product_handler is not None
-    assert product_handler.action == Action.create
-    assert product_handler.status_board_object.name == "bar"
-
-    # Should create application with saas file
-    app_handler = next(
-        (
-            handler
-            for handler in h
-            if isinstance(handler.status_board_object, Application)
-        ),
-        None,
-    )
-    assert app_handler is not None
-    assert app_handler.action == Action.create
-    assert isinstance(app_handler.status_board_object, Application)
-    assert app_handler.status_board_object.name == "foo"
-    assert "baz" in app_handler.status_board_object.metadata["deploymentSaasFiles"]
-    assert app_handler.status_board_object.metadata["managedBy"] == "qontract-reconcile"
-
-
-def test_get_diff_update_app_with_additional_saas_file(
-    status_board_with_saas_file: StatusBoardV1,
-    status_board_with_multiple_saas_files: StatusBoardV1,
-) -> None:
-    """Test updating app 'foo' to add another saas-file and assert update call is made"""
-
-    # Current state: app with one saas file
-    current_product_apps = StatusBoardExporterIntegration.get_product_apps(
-        status_board_with_saas_file
-    )
-    current_abstract_status_board_map = (
-        StatusBoardExporterIntegration.desired_abstract_status_board_map(
-            current_product_apps, []
-        )
-    )
-
-    # Desired state: app with two saas files
-    desired_product_apps = StatusBoardExporterIntegration.get_product_apps(
-        status_board_with_multiple_saas_files
-    )
-    desired_abstract_status_board_map = (
-        StatusBoardExporterIntegration.desired_abstract_status_board_map(
-            desired_product_apps, []
-        )
-    )
-
-    h = StatusBoardExporterIntegration.get_diff(
-        desired_abstract_status_board_map, current_abstract_status_board_map
-    )
-
-    assert len(h) == 1
-
-    # Should update the application
-    app_handler = h[0]
-    assert app_handler.action == Action.update
-    assert isinstance(app_handler.status_board_object, Application)
-    app_obj = app_handler.status_board_object
-    assert app_obj.name == "foo"
-    assert "baz" in app_obj.metadata["deploymentSaasFiles"]
-    assert "qux" in app_obj.metadata["deploymentSaasFiles"]
-    assert app_obj.metadata["managedBy"] == "qontract-reconcile"

--- a/reconcile/test/test_typed_queries/test_status_board.py
+++ b/reconcile/test/test_typed_queries/test_status_board.py
@@ -3,7 +3,7 @@ from collections.abc import Callable
 import pytest
 
 from reconcile.gql_definitions.status_board.status_board import StatusBoardProductV1
-from reconcile.typed_queries.status_board import get_selected_app_data
+from reconcile.typed_queries.status_board import get_selected_app_names
 
 
 @pytest.fixture
@@ -61,55 +61,11 @@ def status_board_product(
     )
 
 
-def test_get_selected_app_data(status_board_product):
-    app_names = get_selected_app_data(
+def test_get_selected_app_names(status_board_product):
+    app_names = get_selected_app_names(
         ['apps[?@.name=="excluded"]'], status_board_product
     )
-    assert app_names == {
-        "oof-bar": {
-            "metadata": {
-                "managedBy": "qontract-reconcile",
-                "deploymentSaasFiles": set(),
-            }
-        },
-        "bar-oof-bar": {
-            "metadata": {
-                "managedBy": "qontract-reconcile",
-                "deploymentSaasFiles": set(),
-            }
-        },
-        "foo": {
-            "metadata": {
-                "managedBy": "qontract-reconcile",
-                "deploymentSaasFiles": set(),
-            }
-        },
-    }
+    assert app_names == {"bar-oof-bar", "oof-bar", "foo"}
 
-    app_names = get_selected_app_data([], status_board_product)
-    assert app_names == {
-        "excluded": {
-            "metadata": {
-                "managedBy": "qontract-reconcile",
-                "deploymentSaasFiles": set(),
-            }
-        },
-        "oof-bar": {
-            "metadata": {
-                "managedBy": "qontract-reconcile",
-                "deploymentSaasFiles": set(),
-            }
-        },
-        "bar-oof-bar": {
-            "metadata": {
-                "managedBy": "qontract-reconcile",
-                "deploymentSaasFiles": set(),
-            }
-        },
-        "foo": {
-            "metadata": {
-                "managedBy": "qontract-reconcile",
-                "deploymentSaasFiles": set(),
-            }
-        },
-    }
+    app_names = get_selected_app_names([], status_board_product)
+    assert app_names == {"excluded", "bar-oof-bar", "oof-bar", "foo"}

--- a/reconcile/typed_queries/status_board.py
+++ b/reconcile/typed_queries/status_board.py
@@ -9,10 +9,6 @@ from reconcile.gql_definitions.status_board.status_board import (
     query,
 )
 from reconcile.utils import gql
-from reconcile.utils.ocm.status_board import (
-    METADATA_MANAGED_BY_KEY,
-    METADATA_MANAGED_BY_VALUE,
-)
 
 
 def get_status_board(
@@ -23,11 +19,11 @@ def get_status_board(
     return query(query_func).status_board_v1 or []
 
 
-def get_selected_app_data(
+def get_selected_app_names(
     global_selectors: Iterable[str],
     product: StatusBoardProductV1,
-) -> dict[str, dict[str, dict[str, set[str]]]]:
-    selected_app_data: dict[str, dict[str, dict[str, Any]]] = {}
+) -> set[str]:
+    selected_app_names: set[str] = set()
 
     apps: dict[str, Any] = {"apps": []}
     for namespace in product.product_environment.namespaces or []:
@@ -35,45 +31,15 @@ def get_selected_app_data(
         if namespace.app.parent_app:
             prefix = f"{namespace.app.parent_app.name}-"
         name = f"{prefix}{namespace.app.name}"
-
-        deployment_saas_files = set()
-        if namespace.app.saas_files:
-            deployment_saas_files = {
-                saas_file.name
-                for saas_file in namespace.app.saas_files
-                if "Deployment" in saas_file.managed_resource_types
-                or "ClowdApp" in saas_file.managed_resource_types
-            }
-
-        selected_app_data[name] = {
-            "metadata": {
-                METADATA_MANAGED_BY_KEY: METADATA_MANAGED_BY_VALUE,
-                "deploymentSaasFiles": set(deployment_saas_files),
-            },
-        }
-
+        selected_app_names.add(name)
         app = namespace.app.dict(by_alias=True)
         app["name"] = name
         apps["apps"].append(app)
 
         for child in namespace.app.children_apps or []:
             name = f"{namespace.app.name}-{child.name}"
-            if name not in selected_app_data:
-                deployment_saas_files = set()
-                if child.saas_files:
-                    deployment_saas_files = {
-                        saas_file.name
-                        for saas_file in child.saas_files
-                        if "Deployment" in saas_file.managed_resource_types
-                    }
-
-                selected_app_data[name] = {
-                    "metadata": {
-                        METADATA_MANAGED_BY_KEY: METADATA_MANAGED_BY_VALUE,
-                        "deploymentSaasFiles": set(deployment_saas_files),
-                    },
-                }
-
+            if name not in selected_app_names:
+                selected_app_names.add(f"{namespace.app.name}-{child.name}")
                 child_dict = child.dict(by_alias=True)
                 child_dict["name"] = name
                 apps["apps"].append(child_dict)
@@ -86,7 +52,6 @@ def get_selected_app_data(
         apps_to_remove: set[str] = set()
         results = parser.parse(selector).find(apps)
         apps_to_remove.update(match.value["name"] for match in results)
-        for app_name in apps_to_remove:
-            selected_app_data.pop(app_name, None)
+        selected_app_names -= apps_to_remove
 
-    return selected_app_data
+    return selected_app_names

--- a/reconcile/utils/ocm/status_board.py
+++ b/reconcile/utils/ocm/status_board.py
@@ -21,7 +21,6 @@ class IDSpec(TypedDict):
 
 
 class ApplicationOCMSpec(BaseOCMSpec):
-    metadata: dict[str, Any]
     product: IDSpec
 
 
@@ -116,18 +115,6 @@ def create_service(ocm_api: OCMBaseClient, spec: ServiceOCMSpec) -> str:
 
     resp = ocm_api.post("/api/status-board/v1/services/", data=data)
     return resp["id"]
-
-
-def update_application(
-    ocm_api: OCMBaseClient,
-    application_id: str,
-    spec: ApplicationOCMSpec,
-) -> None:
-    data = spec | {
-        "metadata": spec.get("metadata", {})
-        | {METADATA_MANAGED_BY_KEY: METADATA_MANAGED_BY_VALUE}
-    }
-    ocm_api.patch(f"/api/status-board/v1/applications/{application_id}", data=data)
 
 
 def update_service(

--- a/tools/qontract_cli.py
+++ b/tools/qontract_cli.py
@@ -2772,7 +2772,7 @@ def slo_document_services(ctx: click.Context, status_board_instance: str) -> Non
         print(f"Status-board instance '{status_board_instance}' not found.")
         sys.exit(1)
 
-    desired_product_apps: dict[str, dict[str, dict[str, dict[str, set[str]]]]] = (
+    desired_product_apps: dict[str, set[str]] = (
         StatusBoardExporterIntegration.get_product_apps(sb)
     )
 


### PR DESCRIPTION
Reverts app-sre/qontract-reconcile#5064

error

```text
Traceback (most recent call last):
  File "/work/reconcile/cli.py", line 584, in run_class_integration
    run_integration_cfg(
  File "/work/reconcile/utils/runtime/runner.py", line 156, in run_integration_cfg
    _integration_wet_run(run_cfg.integration)
  File "/work/reconcile/utils/runtime/runner.py", line 165, in _integration_wet_run
    integration.run(False)
  File "/work/reconcile/status_board.py", line 589, in run
    self.apply_diff(dry_run, ocm_api, diff)
  File "/work/reconcile/status_board.py", line 562, in apply_diff
    d.act(dry_run, ocm_api)
  File "/work/reconcile/status_board.py", line 251, in act
    self.status_board_object.update(ocm)
  File "/work/reconcile/status_board.py", line 144, in update
    update_application(ocm, self.id, spec)
  File "/work/reconcile/utils/ocm/status_board.py", line 130, in update_application
    ocm_api.patch(f"/api/status-board/v1/applications/{application_id}", data=data)
  File "/work/reconcile/utils/ocm_base_client.py", line 135, in patch
    r = self._session.patch(
        ^^^^^^^^^^^^^^^^^^^^
  File "/work/.venv/lib64/python3.11/site-packages/requests/sessions.py", line 661, in patch
    return self.request("PATCH", url, data=data, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/work/.venv/lib64/python3.11/site-packages/requests/sessions.py", line 575, in request
    prep = self.prepare_request(req)
           ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/work/.venv/lib64/python3.11/site-packages/requests/sessions.py", line 484, in prepare_request
    p.prepare(
  File "/work/.venv/lib64/python3.11/site-packages/requests/models.py", line 370, in prepare
    self.prepare_body(data, files, json)
  File "/work/.venv/lib64/python3.11/site-packages/requests/models.py", line 510, in prepare_body
    body = complexjson.dumps(json, allow_nan=False)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib64/python3.11/json/__init__.py", line 238, in dumps
    **kw).encode(obj)
          ^^^^^^^^^^^
  File "/usr/lib64/python3.11/json/encoder.py", line 200, in encode
    chunks = self.iterencode(o, _one_shot=True)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib64/python3.11/json/encoder.py", line 258, in iterencode
    return _iterencode(o, 0)
           ^^^^^^^^^^^^^^^^^
  File "/usr/lib64/python3.11/json/encoder.py", line 180, in default
    raise TypeError(f'Object of type {o.__class__.__name__} '
```

`set` is not JSON serializable, the implementation of `metadata` is too complex, just use sorted list in both model and request payload, no need to reimplement equal check. Or use pydantic model to proper handle json, that requires more changes in this integration.