### PR TITLE
:bug: rhidp: ignore clusters with enabled external auth

### DIFF
--- a/reconcile/rhidp/common.py
+++ b/reconcile/rhidp/common.py
@@ -140,6 +140,8 @@ def build_cluster_objects(
         for cluster in cluster_details
         # we can't calculate the redirect url w/o a console url
         if cluster.ocm_cluster.console
+        # we can't configure an identity provider if external auth is enabled
+        and not cluster.ocm_cluster.external_auth_enabled
     ]
 
 

--- a/reconcile/test/ocm/fixtures.py
+++ b/reconcile/test/ocm/fixtures.py
@@ -21,6 +21,7 @@ from reconcile.utils.ocm.base import (
     OCMClusterFlag,
     OCMClusterState,
     OCMClusterVersion,
+    OCMExternalAuthConfig,
     OCMModelLink,
 )
 from reconcile.utils.ocm.labels import (
@@ -121,6 +122,8 @@ def build_ocm_cluster(
     available_upgrades: list[str] | None = None,
     cluster_product: str = PRODUCT_ID_ROSA,
     hypershift: bool = False,
+    console_url: str | None = "https://console.foobar.com",
+    external_auth_enabled: bool | None = None,
 ) -> OCMCluster:
     aws_config = None
     if aws_cluster:
@@ -147,7 +150,10 @@ def build_ocm_cluster(
             available_upgrades=available_upgrades or [],
         ),
         hypershift=OCMClusterFlag(enabled=hypershift),
-        console=OCMClusterConsole(url="https://console.foobar.com"),
+        console=OCMClusterConsole(url=console_url) if console_url else None,
+        external_auth_config=OCMExternalAuthConfig(enabled=external_auth_enabled)
+        if external_auth_enabled is not None
+        else None,
     )
 
 
@@ -161,6 +167,8 @@ def build_cluster_details(
     cluster_product: str = PRODUCT_ID_ROSA,
     hypershift: bool = False,
     capabilitites: dict[str, str] | None = None,
+    console_url: str | None = "https://console.foobar.com",
+    external_auth_enabled: bool | None = None,
 ) -> ClusterDetails:
     return ClusterDetails(
         ocm_cluster=build_ocm_cluster(
@@ -170,6 +178,8 @@ def build_cluster_details(
             sts_cluster=sts_cluster,
             cluster_product=cluster_product,
             hypershift=hypershift,
+            console_url=console_url,
+            external_auth_enabled=external_auth_enabled,
         ),
         organization_id=org_id,
         capabilities={

--- a/reconcile/test/rhidp/test_common.py
+++ b/reconcile/test/rhidp/test_common.py
@@ -268,6 +268,38 @@ def test_rhidp_common_build_cluster_objects() -> None:
         ),
         organization_id=ORG,
     )
+
+    # external auth disabled
+    cluster_external_auth_disabled = build_cluster_details(
+        cluster_name="external-auth-disabled",
+        subscription_labels=RHIDP_LABELS_CONTAINER,
+        org_id=ORG,
+        external_auth_enabled=False,
+    )
+    cluster_external_auth_disabled_expected = Cluster(
+        ocm_cluster=cluster_external_auth_disabled.ocm_cluster,
+        auth=ClusterAuth(name=AN, issuer=IURL, status=StatusValue.ENABLED.value),
+        organization_id=ORG,
+    )
+
+    #
+    # excluded clusters
+    #
+
+    # no console url
+    cluster_no_console = build_cluster_details(
+        cluster_name="no-console",
+        subscription_labels=RHIDP_LABELS_CONTAINER,
+        org_id=ORG,
+        console_url=None,
+    )
+    # external auth enabled
+    cluster_external_auth = build_cluster_details(
+        cluster_name="external-auth",
+        subscription_labels=RHIDP_LABELS_CONTAINER,
+        org_id=ORG,
+        external_auth_enabled=True,
+    )
     assert common.build_cluster_objects(
         [
             cluster_enabled,
@@ -278,6 +310,10 @@ def test_rhidp_common_build_cluster_objects() -> None:
             cluster_deprecated_rhidp_disabled,
             cluster_auth_name,
             cluster_issuer_url,
+            cluster_external_auth_disabled,
+            # excluded cluster
+            cluster_no_console,
+            cluster_external_auth,
         ],
         AN,
         IURL,
@@ -290,6 +326,7 @@ def test_rhidp_common_build_cluster_objects() -> None:
         cluster_deprecated_rhidp_disabled_expected,
         cluster_auth_name_expected,
         cluster_issuer_url_expected,
+        cluster_external_auth_disabled_expected,
     ]
 
 

--- a/reconcile/utils/ocm/base.py
+++ b/reconcile/utils/ocm/base.py
@@ -215,7 +215,7 @@ class OCMExternalConfiguration(BaseModel):
     syncsets: dict
 
 
-class OCExternalAuthConfig(BaseModel):
+class OCMExternalAuthConfig(BaseModel):
     enabled: bool
 
 
@@ -278,7 +278,7 @@ class OCMCluster(BaseModel):
 
     external_configuration: OCMExternalConfiguration | None
 
-    external_auth_config: OCExternalAuthConfig | None
+    external_auth_config: OCMExternalAuthConfig | None
 
     def minor_version(self) -> str:
         version_info = parse_semver(self.version.raw_id)

--- a/reconcile/utils/ocm/base.py
+++ b/reconcile/utils/ocm/base.py
@@ -215,6 +215,10 @@ class OCMExternalConfiguration(BaseModel):
     syncsets: dict
 
 
+class OCExternalAuthConfig(BaseModel):
+    enabled: bool
+
+
 PRODUCT_ID_OSD = "osd"
 PRODUCT_ID_ROSA = "rosa"
 
@@ -274,6 +278,8 @@ class OCMCluster(BaseModel):
 
     external_configuration: OCMExternalConfiguration | None
 
+    external_auth_config: OCExternalAuthConfig | None
+
     def minor_version(self) -> str:
         version_info = parse_semver(self.version.raw_id)
         return f"{version_info.major}.{version_info.minor}"
@@ -314,6 +320,10 @@ class OCMCluster(BaseModel):
     @property
     def base_domain(self) -> str | None:
         return self.dns.base_domain if self.dns else None
+
+    @property
+    def external_auth_enabled(self) -> bool:
+        return self.external_auth_config.enabled if self.external_auth_config else False
 
 
 class OCMLabel(BaseModel):


### PR DESCRIPTION
If a ROSA cluster has external authentication enabled, we can't list the identity providers:
```
requests.exceptions.HTTPError: 400 Client Error: Bad Request for url: https://api.openshift.com/api/clusters_mgmt/v1/clusters/XXX/identity_providers?size=100
```

```
$ ocm get /api/clusters_mgmt/v1/clusters/XXXX/identity_providers
{
  "kind":"Error",
  "id":"400",
  "href":"/api/clusters_mgmt/v1/errors/400",
  "code":"CLUSTERS-MGMT-400",
  "reason":"Listing identity providers is not supported for clusters with external authentication configured",
  "operation_id":"270dba7f-8b96-49fb-8a74-dac923dd9c36",
  "timestamp":"2025-07-31T07:04:32.191403696Z"
}
```

This PR filters out all clusters with an enabled external authentication.