### PR TITLE
Fix: Enable VPC and Subnets tagging in the VPC management

### DIFF
--- a/reconcile/utils/terrascript_aws_client.py
+++ b/reconcile/utils/terrascript_aws_client.py
@@ -1343,13 +1343,13 @@ class TerrascriptClient:
                     vpc_module_values["public_subnets"] = request.subnets.public
                     vpc_module_values["public_subnet_tags"] = (
                         VPC_REQUEST_DEFAULT_PUBLIC_SUBNET_TAGS
-                        | (request.subnets.public_subnet_tags or {}),
+                        | (request.subnets.public_subnet_tags or {})
                     )
                 if request.subnets.private:
                     vpc_module_values["private_subnets"] = request.subnets.private
                     vpc_module_values["private_subnet_tags"] = (
                         VPC_REQUEST_DEFAULT_PRIVATE_SUBNET_TAGS
-                        | (request.subnets.private_subnet_tags or {}),
+                        | (request.subnets.private_subnet_tags or {})
                     )
                 if request.subnets.availability_zones:
                     vpc_module_values["azs"] = request.subnets.availability_zones


### PR DESCRIPTION
The trailing comma was causing the value to be a tuple instead of a dict. 