### PR TITLE
add availability_zones to vpc resources

### DIFF
--- a/reconcile/gql_definitions/introspection.json
+++ b/reconcile/gql_definitions/introspection.json
@@ -27648,6 +27648,26 @@
                             },
                             "isDeprecated": false,
                             "deprecationReason": null
+                        },
+                        {
+                            "name": "availability_zones",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "LIST",
+                                "name": null,
+                                "ofType": {
+                                    "kind": "NON_NULL",
+                                    "name": null,
+                                    "ofType": {
+                                        "kind": "SCALAR",
+                                        "name": "String",
+                                        "ofType": null
+                                    }
+                                }
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
                         }
                     ],
                     "inputFields": null,

--- a/reconcile/terraform_vpc_resources/integration.py
+++ b/reconcile/terraform_vpc_resources/integration.py
@@ -93,6 +93,7 @@ class TerraformVpcResources(QontractReconcileIntegration[TerraformVpcResourcesPa
             public_subnets = outputs_per_account.get(
                 f"{request.identifier}-public_subnets", {}
             ).get("value", [])
+            availability_zones: list[str] = []
 
             if request.subnets:
                 private_subnet_tags = VPC_REQUEST_DEFAULT_PRIVATE_SUBNET_TAGS | (
@@ -101,6 +102,7 @@ class TerraformVpcResources(QontractReconcileIntegration[TerraformVpcResourcesPa
                 public_subnet_tags = VPC_REQUEST_DEFAULT_PUBLIC_SUBNET_TAGS | (
                     request.subnets.public_subnet_tags or {}
                 )
+                availability_zones = request.subnets.availability_zones or []
             else:
                 private_subnet_tags = VPC_REQUEST_DEFAULT_PRIVATE_SUBNET_TAGS
                 public_subnet_tags = VPC_REQUEST_DEFAULT_PUBLIC_SUBNET_TAGS
@@ -116,6 +118,7 @@ class TerraformVpcResources(QontractReconcileIntegration[TerraformVpcResourcesPa
                         "public": public_subnets,
                         "private_subnet_tags": private_subnet_tags,
                         "public_subnet_tags": public_subnet_tags,
+                        "availability_zones": availability_zones,
                     },
                     "account_name": request.account.name,
                     "region": request.region,

--- a/reconcile/test/terraform_vpc_resources/test_terraform_vpc_resources_integration.py
+++ b/reconcile/test/terraform_vpc_resources/test_terraform_vpc_resources_integration.py
@@ -313,3 +313,6 @@ def test_vpc_and_subnet_tags(
     expected_public_tags = {"kubernetes.io/role/elb": "1", "Type": "public"}
     assert subnets["private_subnet_tags"] == expected_private_tags
     assert subnets["public_subnet_tags"] == expected_public_tags
+
+    expected_availability_zones = ["us-east-1a", "us-east-1b"]
+    assert subnets["availability_zones"] == expected_availability_zones


### PR DESCRIPTION
depends on https://github.com/app-sre/qontract-schemas/pull/915

Adding availability_zones to the vpc output file so it can be used in the following cluster provision template