### PR TITLE
APPSRE-12383 konflux sqs message

### DIFF
--- a/.tekton/qontract-reconcile-master-push.yaml
+++ b/.tekton/qontract-reconcile-master-push.yaml
@@ -39,6 +39,12 @@ spec:
     value: '100000'
   - name: goss-container-structure-test-file
     value: dockerfiles/goss.yaml
+  - name: github-user-id
+    # https://pipelinesascode.com/docs/guide/authoringprs/
+    value: |-
+      {{sender}}
+  - name: sqs-pr-type
+    value: promote_qontract_reconcile
   pipelineRef:
     params:
     - name: url

--- a/reconcile/test/utils/test_mr.py
+++ b/reconcile/test/utils/test_mr.py
@@ -309,28 +309,14 @@ def smtp_settings() -> SmtpSettingsV1:
     )
 
 
-def test_author_email_empty(users: list[User]) -> None:
+def test_github_user_id_empty(users: list[User]) -> None:
     mr = PromoteQontractReconcileCommercial(
         version="1q2w3e4",
         commit_sha="1q2w3e4r5t6y7u8i9o0p1q2w3e4r5t6y7u8i9o0p",
     )
 
-    assert mr.author_email is None
-    assert mr.infer_author(mr.author_email, all_users=users) is None
-
-
-@patch.object(reconcile.typed_queries.smtp, "settings", autospec=True)
-def test_author_org_username(
-    settings: MagicMock, users: list[User], smtp_settings: SmtpSettingsV1
-) -> None:
-    mr = PromoteQontractReconcileCommercial(
-        version="1q2w3e4",
-        commit_sha="1q2w3e4r5t6y7u8i9o0p1q2w3e4r5t6y7u8i9o0p",
-        author_email="org_user@redhat.com",
-    )
-    settings.return_value = smtp_settings
-
-    assert mr.infer_author(author_email=mr.author_email, all_users=users) == "org_user"
+    assert mr.github_user_id is None
+    assert mr.infer_author(mr.github_user_id, all_users=users) is None
 
 
 @patch.object(reconcile.typed_queries.smtp, "settings", autospec=True)
@@ -338,10 +324,12 @@ def test_author_github_username(
     settings: MagicMock, users: list[User], smtp_settings: SmtpSettingsV1
 ) -> None:
     mr = PromoteQontractReconcileCommercial(
-        "1q2w3e4",
-        "1q2w3e4r5t6y7u8i9o0p1q2w3e4r5t6y7u8i9o0p",
-        author_email="github_user@users.noreply.github.com",
+        version="1q2w3e4",
+        commit_sha="1q2w3e4r5t6y7u8i9o0p1q2w3e4r5t6y7u8i9o0p",
+        github_user_id="github_user",
     )
     settings.return_value = smtp_settings
 
-    assert mr.infer_author(author_email=mr.author_email, all_users=users) == "org_user"
+    assert (
+        mr.infer_author(github_user_id=mr.github_user_id, all_users=users) == "org_user"
+    )

--- a/reconcile/utils/mr/base.py
+++ b/reconcile/utils/mr/base.py
@@ -11,7 +11,6 @@ from uuid import uuid4
 from gitlab.exceptions import GitlabError
 from jinja2 import Template
 
-from reconcile import typed_queries
 from reconcile.gql_definitions.fragments.user import User
 from reconcile.utils.constants import PROJ_ROOT
 from reconcile.utils.gitlab_api import GitLabApi
@@ -110,19 +109,14 @@ class MergeRequestBase(ABC):
         }
 
     def infer_author(
-        self, author_email: str | None, all_users: Iterable[User] | None = None
+        self, github_user_id: str | None, all_users: Iterable[User] | None = None
     ) -> str | None:
-        if not author_email:
+        if not github_user_id:
             return None
         if not all_users:
             return None
 
-        username = author_email.split("@")[0]
-        users = None
-        if author_email.endswith(typed_queries.smtp.settings().mail_address):
-            users = [u for u in all_users if username == u.org_username]
-        elif author_email.endswith("users.noreply.github.com"):
-            users = [u for u in all_users if username == u.github_username]
+        users = [u for u in all_users if u.github_username == github_user_id]
 
         if users:
             return users[0].org_username

--- a/reconcile/utils/mr/promote_qontract.py
+++ b/reconcile/utils/mr/promote_qontract.py
@@ -10,10 +10,10 @@ from reconcile.utils.ruamel import create_ruamel_instance
 class PromoteQontractSchemas(MergeRequestBase):
     name = "promote_qontract_schemas"
 
-    def __init__(self, version: str, author_email: str | None = None):
+    def __init__(self, version: str, github_user_id: str | None = None):
         self.path = ".env"
         self.version = version
-        self.author_email = author_email
+        self.github_user_id = github_user_id
 
         super().__init__()
 
@@ -22,13 +22,13 @@ class PromoteQontractSchemas(MergeRequestBase):
     @property
     def title(self) -> str:
         author = self.infer_author(
-            author_email=self.author_email, all_users=get_users()
+            github_user_id=self.github_user_id, all_users=get_users()
         )
         return f"[{self.name}] promote qontract-schemas to version {self.version}" + (
             f" by @{author}"
             if author
-            else f" by {self.author_email}"
-            if self.author_email
+            else f" by {self.github_user_id}"
+            if self.github_user_id
             else ""
         )
 
@@ -61,10 +61,12 @@ class PromoteQontractSchemas(MergeRequestBase):
 class PromoteQontractReconcileCommercial(MergeRequestBase):
     name = "promote_qontract_reconcile"
 
-    def __init__(self, version: str, commit_sha: str, author_email: str | None = None):
+    def __init__(
+        self, version: str, commit_sha: str, github_user_id: str | None = None
+    ):
         self.version = version
         self.commit_sha = commit_sha
-        self.author_email = author_email
+        self.github_user_id = github_user_id
 
         super().__init__()
 
@@ -73,13 +75,13 @@ class PromoteQontractReconcileCommercial(MergeRequestBase):
     @property
     def title(self) -> str:
         author = self.infer_author(
-            author_email=self.author_email, all_users=get_users()
+            github_user_id=self.github_user_id, all_users=get_users()
         )
         return f"[{self.name}] promote qontract-reconcile to version {self.version}" + (
             f" by @{author}"
             if author
-            else f" by {self.author_email}"
-            if self.author_email
+            else f" by {self.github_user_id}"
+            if self.github_user_id
             else ""
         )
 


### PR DESCRIPTION
Using konflux for SQS auto MRs.

Note, that we currently cannot run after the RPA. I.e., the SQS message will be sent before the RPA finished publishing the prod image. We trigger the SQS message as late as possible in the build pipeline, after all checks have passed. I.e., likely auto-bump MR will fail initially, but should work shortly after with a `/retest`. Note, that we have no guarantee that the RPA passed - so we cannot be sure at that point that we will actually receive a valid image. However, at least we get the MR created and pinged on it - and most of the time that should work out just fine.

Note, that we do not have author-email any longer. We now have the author id.

We could also add a ~30s timeout or some wait-for-image mechanics before opening the MR. However, I'd leave that as a follow-up optimization if needed.

Ideally, we can at some point have a finally task after RPA - that feature exists, however, we havent used it yet and Im not sure if we can transport pipelinerun args to it, such as the github-user-id. Will create a follow-up ticket to investigate post RPA pipeline for this, such as https://issues.redhat.com/browse/APPSRE-11256

Corresponding pipeline change https://github.com/app-sre/shared-pipelines/pull/289