### PR TITLE
openshift-rhcs-certs - refactor processing of cert request

### DIFF
--- a/reconcile/test/fixtures/rhcsv2_certs/invalid_response_bad_cert.html
+++ b/reconcile/test/fixtures/rhcsv2_certs/invalid_response_bad_cert.html
@@ -1,0 +1,11 @@
+<html>
+<body>
+<script>
+outputList = new Object;
+outputList.outputId = "b64_cert";
+outputList.outputSyntax = "pretty_print";
+outputList.outputVal = "INVALID CERTIFICATE DATA - NOT A PEM FORMAT";
+outputListSet[1] = outputList;
+</script>
+</body>
+</html>

--- a/reconcile/test/fixtures/rhcsv2_certs/invalid_response_no_b64_cert.html
+++ b/reconcile/test/fixtures/rhcsv2_certs/invalid_response_no_b64_cert.html
@@ -1,0 +1,12 @@
+<html>
+<head><title>Certificate Authority - Error</title></head>
+<body>
+<script>
+outputList = new Object;
+outputList.outputId = "pretty_cert";
+outputList.outputSyntax = "pretty_print";
+outputList.outputVal = "    Error: Certificate request failed";
+outputListSet[0] = outputList;
+</script>
+</body>
+</html>

--- a/reconcile/test/fixtures/rhcsv2_certs/valid_response.html
+++ b/reconcile/test/fixtures/rhcsv2_certs/valid_response.html
@@ -1,0 +1,18 @@
+<html>
+<head><title>Certificate Authority - Certificate Request Result</title></head>
+<body>
+<script>
+outputList = new Object;
+outputList.outputId = "pretty_cert";
+outputList.outputSyntax = "pretty_print";
+outputList.outputVal = "    Certificate:\n        Data:\n            Version: 3 (0x2)\n            Serial Number:\n                01:23:45:67:89:ab:cd:ef\n        Signature Algorithm: sha256WithRSAEncryption\n        Issuer: CN=Test CA\n        Validity\n            Not Before: Jan  1 00:00:00 2024 GMT\n            Not After : Jan  1 00:00:00 2025 GMT\n        Subject: UID=testuser\n        Subject Public Key Info:\n            Public Key Algorithm: rsaEncryption\n                RSA Public-Key: (4096 bit)";
+outputListSet[0] = outputList;
+
+outputList = new Object;
+outputList.outputId = "b64_cert";
+outputList.outputSyntax = "pretty_print";
+outputList.outputVal = "-----BEGIN CERTIFICATE-----\nMIIDXTCCAkWgAwIBAgIJAKoK/heBjcOuMA0GCSqGSIb3DQEBCwUAMEUxCzAJBgNV\nBAYTAkFVMRMwEQYDVQQIDApTb21lLVN0YXRlMSEwHwYDVQQKDBhJbnRlcm5ldCBX\naWRnaXRzIFB0eSBMdGQwHhcNMTcwNTE4MTAzNzI3WhcNMTgwNTE4MTAzNzI3WjBF\nMQswCQYDVQQGEwJBVTETMBEGA1UECAwKU29tZS1TdGF0ZTEhMB8GA1UECgwYSW50\nZXJuZXQgV2lkZ2l0cyBQdHkgTHRkMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIB\nCgKCAQEA4f5wg5l2hKsTeNem/V41fGnJm6gOdrj8ym3rFkEjWT2btNioBpGU1qKo\n-----END CERTIFICATE-----\n";
+outputListSet[1] = outputList;
+</script>
+</body>
+</html>

--- a/reconcile/test/test_utils_rhcsv2_certs.py
+++ b/reconcile/test/test_utils_rhcsv2_certs.py
@@ -1,0 +1,38 @@
+from collections.abc import Callable
+from pathlib import Path
+
+import pytest
+
+from reconcile.utils.rhcsv2_certs import extract_cert
+
+
+@pytest.fixture
+def fx() -> Callable:
+    def _fx(name: str) -> str:
+        return (Path(__file__).parent / "fixtures" / "rhcsv2_certs" / name).read_text()
+
+    return _fx
+
+
+def test_extract_cert_valid_response(fx: Callable) -> None:
+    html_response = fx("valid_response.html")
+    result = extract_cert(html_response)
+    # Verify the certificate PEM was extracted correctly
+    expected_cert_pem = "-----BEGIN CERTIFICATE-----\\nMIIDXTCCAkWgAwIBAgIJAKoK/heBjcOuMA0GCSqGSIb3DQEBCwUAMEUxCzAJBgNV\\nBAYTAkFVMRMwEQYDVQQIDApTb21lLVN0YXRlMSEwHwYDVQQKDBhJbnRlcm5ldCBX\\naWRnaXRzIFB0eSBMdGQwHhcNMTcwNTE4MTAzNzI3WhcNMTgwNTE4MTAzNzI3WjBF\\nMQswCQYDVQQGEwJBVTETMBEGA1UECAwKU29tZS1TdGF0ZTEhMB8GA1UECgwYSW50\\nZXJuZXQgV2lkZ2l0cyBQdHkgTHRkMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIB\\nCgKCAQEA4f5wg5l2hKsTeNem/V41fGnJm6gOdrj8ym3rFkEjWT2btNioBpGU1qKo\\n-----END CERTIFICATE-----"
+    assert result.group(1) == expected_cert_pem
+
+
+def test_extract_cert_no_b64_cert_block(fx: Callable) -> None:
+    html_response = fx("invalid_response_no_b64_cert.html")
+    with pytest.raises(
+        ValueError, match="Could not extract certificate PEM from response"
+    ):
+        extract_cert(html_response)
+
+
+def test_extract_cert_invalid_cert_format(fx: Callable) -> None:
+    html_response = fx("invalid_response_bad_cert.html")
+    with pytest.raises(
+        ValueError, match="Could not extract certificate PEM from response"
+    ):
+        extract_cert(html_response)


### PR DESCRIPTION
## Summary
RH IT has updated the format of certificate response. This has broken current regex parsing for the certificate. 

## Changes
- Refactor regex to properly isolate attribute of response to pull for certificate
- Replace regex search for cert expiry with direct inspection of certificate