### PR TITLE
Remove hard-coded  path in template rendering merge requests

### DIFF
--- a/reconcile/templating/lib/merge_request_manager.py
+++ b/reconcile/templating/lib/merge_request_manager.py
@@ -108,14 +108,14 @@ class TemplateRenderingMR(MergeRequestBase):
             if content.is_new:
                 gitlab_cli.create_file(
                     branch_name=self.branch,
-                    file_path=f"data{content.path}",
+                    file_path=content.path.lstrip("/"),
                     commit_message="termplate rendering output",
                     content=content.content,
                 )
             else:
                 gitlab_cli.update_file(
                     branch_name=self.branch,
-                    file_path=f"data{content.path}",
+                    file_path=content.path.lstrip("/"),
                     commit_message="termplate rendering output",
                     content=content.content,
                 )


### PR DESCRIPTION
https://github.com/app-sre/qontract-reconcile/pull/5153 updated logic to move to root of app-inteface repo for rendering templates. However, with `--clone-repo` set, a `ClonedRepoGitlabPersistence` instance is utilized, which lead to instantiating a MergeRequestManager that still hard coded a leading `data` directory. 

`--app-interface-root-path` was leveraged in development/testing, as well as in the pr-check, leading to this being missed.

Before root path changes, templates contained:
`targetPath: /openshift/foo/bar/cluster.yml`
after change, templates were all updated to explicitly set `data`. ex:
`targetPath: /data/openshift/foo/bar/cluster.yml`

This satisfies pr-check / local version but was yielding merge requests with
`targetPath: data/data/openshift/foo/bar/cluster.yml`