### PR TITLE
ocm: default openid name claim

### DIFF
--- a/reconcile/utils/ocm/base.py
+++ b/reconcile/utils/ocm/base.py
@@ -572,7 +572,7 @@ class OCMOIdentityProviderGithub(OCMOIdentityProvider):
 
 class OCMOIdentityProviderOidcOpenIdClaims(BaseModel):
     email: list[str]
-    name: list[str]
+    name: list[str] = []
     preferred_username: list[str]
     groups: list[str] = []
 


### PR DESCRIPTION
Fix an `ocm-oidc-idp` bug:

```
pydantic.error_wrappers.ValidationError: 1 validation error for OCMOIdentityProviderOidc
open_id -> claims -> name
  field required (type=value_error.missing)
```

Some dev SSO issuers don't have the `name` claim!


Ticket: [ASIC-666](https://issues.redhat.com/browse/ASIC-666)