### PR TITLE
:sparkles: external-resources: tagging support

### DIFF
--- a/reconcile/external_resources/model.py
+++ b/reconcile/external_resources/model.py
@@ -144,7 +144,7 @@ class ExternalResourcesInventory(MutableMapping):
                     MODULE_OVERRIDES,
                 }
             ),
-            namespace=namespace.dict(),
+            namespace=namespace.dict(by_alias=True),
         )
         spec.metadata[FLAG_DELETE_RESOURCE] = resource.delete
         spec.metadata[MODULE_OVERRIDES] = resource.module_overrides

--- a/reconcile/gql_definitions/external_resources/external_resources_namespaces.gql
+++ b/reconcile/gql_definitions/external_resources/external_resources_namespaces.gql
@@ -61,6 +61,7 @@ query ExternalResourcesNamespaces {
               ...VaultSecret
             }
             annotations
+            tags
             event_notifications {
               destination
               source_type
@@ -93,6 +94,7 @@ query ExternalResourcesNamespaces {
             output_resource_name
             storage_class
             annotations
+            tags
           }
           ... on NamespaceTerraformResourceElastiCache_v1 {
             identifier
@@ -102,6 +104,7 @@ query ExternalResourcesNamespaces {
             overrides
             output_resource_name
             annotations
+            tags
             managed_by_erv2
             delete
             module_overrides {
@@ -115,6 +118,7 @@ query ExternalResourcesNamespaces {
             user_policy
             output_resource_name
             annotations
+            tags
             aws_infrastructure_access {
               cluster {
                 name
@@ -128,6 +132,7 @@ query ExternalResourcesNamespaces {
             secrets_prefix
             output_resource_name
             annotations
+            tags
           }
           ... on NamespaceTerraformResourceRole_v1 {
             identifier
@@ -141,6 +146,7 @@ query ExternalResourcesNamespaces {
             inline_policy
             output_resource_name
             annotations
+            tags
             managed_by_erv2
             max_session_duration
           }
@@ -149,6 +155,7 @@ query ExternalResourcesNamespaces {
             identifier
             output_resource_name
             annotations
+            tags
             specs {
               defaults
               queues {
@@ -165,6 +172,7 @@ query ExternalResourcesNamespaces {
             fifo_topic
             inline_policy
             annotations
+            tags
             subscriptions {
               protocol
               endpoint
@@ -175,6 +183,7 @@ query ExternalResourcesNamespaces {
             identifier
             output_resource_name
             annotations
+            tags
             specs {
               defaults
               tables {
@@ -189,6 +198,7 @@ query ExternalResourcesNamespaces {
             output_resource_name
             public
             annotations
+            tags
           }
           ... on NamespaceTerraformResourceS3CloudFront_v1 {
             region
@@ -197,6 +207,7 @@ query ExternalResourcesNamespaces {
             output_resource_name
             storage_class
             annotations
+            tags
           }
           ... on NamespaceTerraformResourceS3SQS_v1 {
             region
@@ -206,6 +217,7 @@ query ExternalResourcesNamespaces {
             output_resource_name
             storage_class
             annotations
+            tags
           }
           ... on NamespaceTerraformResourceCloudWatch_v1 {
             region
@@ -220,6 +232,7 @@ query ExternalResourcesNamespaces {
             }
             output_resource_name
             annotations
+            tags
           }
           ... on NamespaceTerraformResourceKMS_v1 {
             region
@@ -228,6 +241,7 @@ query ExternalResourcesNamespaces {
             overrides
             output_resource_name
             annotations
+            tags
             managed_by_erv2
             delete
             module_overrides {
@@ -240,6 +254,7 @@ query ExternalResourcesNamespaces {
             defaults
             output_resource_name
             annotations
+            tags
             publish_log_types
           }
           ... on NamespaceTerraformResourceACM_v1 {
@@ -254,6 +269,7 @@ query ExternalResourcesNamespaces {
             }
             output_resource_name
             annotations
+            tags
           }
           ... on NamespaceTerraformResourceKinesis_v1 {
             region
@@ -262,6 +278,7 @@ query ExternalResourcesNamespaces {
             es_identifier
             output_resource_name
             annotations
+            tags
           }
           ... on NamespaceTerraformResourceS3CloudFrontPublicKey_v1 {
             region
@@ -271,6 +288,7 @@ query ExternalResourcesNamespaces {
             }
             output_resource_name
             annotations
+            tags
           }
           ... on NamespaceTerraformResourceALB_v1 {
             region
@@ -329,6 +347,7 @@ query ExternalResourcesNamespaces {
             }
             output_resource_name
             annotations
+            tags
           }
           ... on NamespaceTerraformResourceSecretsManager_v1 {
             region
@@ -338,6 +357,7 @@ query ExternalResourcesNamespaces {
             }
             output_resource_name
             annotations
+            tags
           }
           ... on NamespaceTerraformResourceASG_v1 {
             region
@@ -374,6 +394,7 @@ query ExternalResourcesNamespaces {
             }
             output_resource_name
             annotations
+            tags
           }
           ... on NamespaceTerraformResourceRoute53Zone_v1 {
             region
@@ -381,6 +402,7 @@ query ExternalResourcesNamespaces {
             name
             output_resource_name
             annotations
+            tags
             records {
               name
               type
@@ -414,6 +436,7 @@ query ExternalResourcesNamespaces {
             insights_callback_urls
             output_resource_name
             annotations
+            tags
             vpc_id
             subnet_ids
             vpce_id
@@ -426,6 +449,7 @@ query ExternalResourcesNamespaces {
             vpc_id
             output_resource_name
             annotations
+            tags
             defaults
           }
           ... on NamespaceTerraformResourceMsk_v1 {
@@ -434,6 +458,7 @@ query ExternalResourcesNamespaces {
             output_resource_name
             defaults
             annotations
+            tags
             users {
               name
               secret {
@@ -452,10 +477,13 @@ query ExternalResourcesNamespaces {
     environment {
       name
       labels
+      servicePhase
     }
     app {
       path
       name
+      appCode
+      costCenter
     }
     cluster {
       name

--- a/reconcile/gql_definitions/external_resources/external_resources_namespaces.py
+++ b/reconcile/gql_definitions/external_resources/external_resources_namespaces.py
@@ -143,6 +143,7 @@ query ExternalResourcesNamespaces {
               ...VaultSecret
             }
             annotations
+            tags
             event_notifications {
               destination
               source_type
@@ -175,6 +176,7 @@ query ExternalResourcesNamespaces {
             output_resource_name
             storage_class
             annotations
+            tags
           }
           ... on NamespaceTerraformResourceElastiCache_v1 {
             identifier
@@ -184,6 +186,7 @@ query ExternalResourcesNamespaces {
             overrides
             output_resource_name
             annotations
+            tags
             managed_by_erv2
             delete
             module_overrides {
@@ -197,6 +200,7 @@ query ExternalResourcesNamespaces {
             user_policy
             output_resource_name
             annotations
+            tags
             aws_infrastructure_access {
               cluster {
                 name
@@ -210,6 +214,7 @@ query ExternalResourcesNamespaces {
             secrets_prefix
             output_resource_name
             annotations
+            tags
           }
           ... on NamespaceTerraformResourceRole_v1 {
             identifier
@@ -223,6 +228,7 @@ query ExternalResourcesNamespaces {
             inline_policy
             output_resource_name
             annotations
+            tags
             managed_by_erv2
             max_session_duration
           }
@@ -231,6 +237,7 @@ query ExternalResourcesNamespaces {
             identifier
             output_resource_name
             annotations
+            tags
             specs {
               defaults
               queues {
@@ -247,6 +254,7 @@ query ExternalResourcesNamespaces {
             fifo_topic
             inline_policy
             annotations
+            tags
             subscriptions {
               protocol
               endpoint
@@ -257,6 +265,7 @@ query ExternalResourcesNamespaces {
             identifier
             output_resource_name
             annotations
+            tags
             specs {
               defaults
               tables {
@@ -271,6 +280,7 @@ query ExternalResourcesNamespaces {
             output_resource_name
             public
             annotations
+            tags
           }
           ... on NamespaceTerraformResourceS3CloudFront_v1 {
             region
@@ -279,6 +289,7 @@ query ExternalResourcesNamespaces {
             output_resource_name
             storage_class
             annotations
+            tags
           }
           ... on NamespaceTerraformResourceS3SQS_v1 {
             region
@@ -288,6 +299,7 @@ query ExternalResourcesNamespaces {
             output_resource_name
             storage_class
             annotations
+            tags
           }
           ... on NamespaceTerraformResourceCloudWatch_v1 {
             region
@@ -302,6 +314,7 @@ query ExternalResourcesNamespaces {
             }
             output_resource_name
             annotations
+            tags
           }
           ... on NamespaceTerraformResourceKMS_v1 {
             region
@@ -310,6 +323,7 @@ query ExternalResourcesNamespaces {
             overrides
             output_resource_name
             annotations
+            tags
             managed_by_erv2
             delete
             module_overrides {
@@ -322,6 +336,7 @@ query ExternalResourcesNamespaces {
             defaults
             output_resource_name
             annotations
+            tags
             publish_log_types
           }
           ... on NamespaceTerraformResourceACM_v1 {
@@ -336,6 +351,7 @@ query ExternalResourcesNamespaces {
             }
             output_resource_name
             annotations
+            tags
           }
           ... on NamespaceTerraformResourceKinesis_v1 {
             region
@@ -344,6 +360,7 @@ query ExternalResourcesNamespaces {
             es_identifier
             output_resource_name
             annotations
+            tags
           }
           ... on NamespaceTerraformResourceS3CloudFrontPublicKey_v1 {
             region
@@ -353,6 +370,7 @@ query ExternalResourcesNamespaces {
             }
             output_resource_name
             annotations
+            tags
           }
           ... on NamespaceTerraformResourceALB_v1 {
             region
@@ -411,6 +429,7 @@ query ExternalResourcesNamespaces {
             }
             output_resource_name
             annotations
+            tags
           }
           ... on NamespaceTerraformResourceSecretsManager_v1 {
             region
@@ -420,6 +439,7 @@ query ExternalResourcesNamespaces {
             }
             output_resource_name
             annotations
+            tags
           }
           ... on NamespaceTerraformResourceASG_v1 {
             region
@@ -456,6 +476,7 @@ query ExternalResourcesNamespaces {
             }
             output_resource_name
             annotations
+            tags
           }
           ... on NamespaceTerraformResourceRoute53Zone_v1 {
             region
@@ -463,6 +484,7 @@ query ExternalResourcesNamespaces {
             name
             output_resource_name
             annotations
+            tags
             records {
               name
               type
@@ -496,6 +518,7 @@ query ExternalResourcesNamespaces {
             insights_callback_urls
             output_resource_name
             annotations
+            tags
             vpc_id
             subnet_ids
             vpce_id
@@ -508,6 +531,7 @@ query ExternalResourcesNamespaces {
             vpc_id
             output_resource_name
             annotations
+            tags
             defaults
           }
           ... on NamespaceTerraformResourceMsk_v1 {
@@ -516,6 +540,7 @@ query ExternalResourcesNamespaces {
             output_resource_name
             defaults
             annotations
+            tags
             users {
               name
               secret {
@@ -534,10 +559,13 @@ query ExternalResourcesNamespaces {
     environment {
       name
       labels
+      servicePhase
     }
     app {
       path
       name
+      appCode
+      costCenter
     }
     cluster {
       name
@@ -643,6 +671,7 @@ class NamespaceTerraformResourceRDSV1(NamespaceTerraformResourceAWSV1):
     reset_password: Optional[str] = Field(..., alias="reset_password")
     ca_cert: Optional[VaultSecret] = Field(..., alias="ca_cert")
     annotations: Optional[str] = Field(..., alias="annotations")
+    tags: Optional[str] = Field(..., alias="tags")
     event_notifications: Optional[list[AWSRDSEventNotificationV1]] = Field(..., alias="event_notifications")
     data_classification: Optional[AWSRDSDataClassificationV1] = Field(..., alias="data_classification")
     managed_by_erv2: Optional[bool] = Field(..., alias="managed_by_erv2")
@@ -670,6 +699,7 @@ class NamespaceTerraformResourceS3V1(NamespaceTerraformResourceAWSV1):
     output_resource_name: Optional[str] = Field(..., alias="output_resource_name")
     storage_class: Optional[str] = Field(..., alias="storage_class")
     annotations: Optional[str] = Field(..., alias="annotations")
+    tags: Optional[str] = Field(..., alias="tags")
 
 
 class NamespaceTerraformResourceElastiCacheV1(NamespaceTerraformResourceAWSV1):
@@ -680,6 +710,7 @@ class NamespaceTerraformResourceElastiCacheV1(NamespaceTerraformResourceAWSV1):
     overrides: Optional[str] = Field(..., alias="overrides")
     output_resource_name: Optional[str] = Field(..., alias="output_resource_name")
     annotations: Optional[str] = Field(..., alias="annotations")
+    tags: Optional[str] = Field(..., alias="tags")
     managed_by_erv2: Optional[bool] = Field(..., alias="managed_by_erv2")
     delete: Optional[bool] = Field(..., alias="delete")
     module_overrides: Optional[ExternalResourcesModuleOverrides] = Field(..., alias="module_overrides")
@@ -702,6 +733,7 @@ class NamespaceTerraformResourceServiceAccountV1(NamespaceTerraformResourceAWSV1
     user_policy: Optional[str] = Field(..., alias="user_policy")
     output_resource_name: Optional[str] = Field(..., alias="output_resource_name")
     annotations: Optional[str] = Field(..., alias="annotations")
+    tags: Optional[str] = Field(..., alias="tags")
     aws_infrastructure_access: Optional[NamespaceTerraformResourceServiceAccountAWSInfrastructureAccessV1] = Field(..., alias="aws_infrastructure_access")
 
 
@@ -710,6 +742,7 @@ class NamespaceTerraformResourceSecretsManagerServiceAccountV1(NamespaceTerrafor
     secrets_prefix: str = Field(..., alias="secrets_prefix")
     output_resource_name: Optional[str] = Field(..., alias="output_resource_name")
     annotations: Optional[str] = Field(..., alias="annotations")
+    tags: Optional[str] = Field(..., alias="tags")
 
 
 class AssumeRoleV1(ConfiguredBaseModel):
@@ -726,6 +759,7 @@ class NamespaceTerraformResourceRoleV1(NamespaceTerraformResourceAWSV1):
     inline_policy: Optional[str] = Field(..., alias="inline_policy")
     output_resource_name: Optional[str] = Field(..., alias="output_resource_name")
     annotations: Optional[str] = Field(..., alias="annotations")
+    tags: Optional[str] = Field(..., alias="tags")
     managed_by_erv2: Optional[bool] = Field(..., alias="managed_by_erv2")
     max_session_duration: Optional[int] = Field(..., alias="max_session_duration")
 
@@ -745,6 +779,7 @@ class NamespaceTerraformResourceSQSV1(NamespaceTerraformResourceAWSV1):
     identifier: str = Field(..., alias="identifier")
     output_resource_name: Optional[str] = Field(..., alias="output_resource_name")
     annotations: Optional[str] = Field(..., alias="annotations")
+    tags: Optional[str] = Field(..., alias="tags")
     specs: list[SQSQueuesSpecsV1] = Field(..., alias="specs")
 
 
@@ -761,6 +796,7 @@ class NamespaceTerraformResourceSNSTopicV1(NamespaceTerraformResourceAWSV1):
     fifo_topic: Optional[bool] = Field(..., alias="fifo_topic")
     inline_policy: Optional[str] = Field(..., alias="inline_policy")
     annotations: Optional[str] = Field(..., alias="annotations")
+    tags: Optional[str] = Field(..., alias="tags")
     subscriptions: Optional[list[NamespaceTerraformResourceSNSSubscriptionV1]] = Field(..., alias="subscriptions")
 
 
@@ -779,6 +815,7 @@ class NamespaceTerraformResourceDynamoDBV1(NamespaceTerraformResourceAWSV1):
     identifier: str = Field(..., alias="identifier")
     output_resource_name: Optional[str] = Field(..., alias="output_resource_name")
     annotations: Optional[str] = Field(..., alias="annotations")
+    tags: Optional[str] = Field(..., alias="tags")
     specs: list[DynamoDBTableSpecsV1] = Field(..., alias="specs")
 
 
@@ -788,6 +825,7 @@ class NamespaceTerraformResourceECRV1(NamespaceTerraformResourceAWSV1):
     output_resource_name: Optional[str] = Field(..., alias="output_resource_name")
     public: Optional[bool] = Field(..., alias="public")
     annotations: Optional[str] = Field(..., alias="annotations")
+    tags: Optional[str] = Field(..., alias="tags")
 
 
 class NamespaceTerraformResourceS3CloudFrontV1(NamespaceTerraformResourceAWSV1):
@@ -797,6 +835,7 @@ class NamespaceTerraformResourceS3CloudFrontV1(NamespaceTerraformResourceAWSV1):
     output_resource_name: Optional[str] = Field(..., alias="output_resource_name")
     storage_class: Optional[str] = Field(..., alias="storage_class")
     annotations: Optional[str] = Field(..., alias="annotations")
+    tags: Optional[str] = Field(..., alias="tags")
 
 
 class NamespaceTerraformResourceS3SQSV1(NamespaceTerraformResourceAWSV1):
@@ -807,6 +846,7 @@ class NamespaceTerraformResourceS3SQSV1(NamespaceTerraformResourceAWSV1):
     output_resource_name: Optional[str] = Field(..., alias="output_resource_name")
     storage_class: Optional[str] = Field(..., alias="storage_class")
     annotations: Optional[str] = Field(..., alias="annotations")
+    tags: Optional[str] = Field(..., alias="tags")
 
 
 class NamespaceTerraformResourceCloudWatchV1(NamespaceTerraformResourceAWSV1):
@@ -820,6 +860,7 @@ class NamespaceTerraformResourceCloudWatchV1(NamespaceTerraformResourceAWSV1):
     module_overrides: Optional[ExternalResourcesModuleOverrides] = Field(..., alias="module_overrides")
     output_resource_name: Optional[str] = Field(..., alias="output_resource_name")
     annotations: Optional[str] = Field(..., alias="annotations")
+    tags: Optional[str] = Field(..., alias="tags")
 
 
 class NamespaceTerraformResourceKMSV1(NamespaceTerraformResourceAWSV1):
@@ -829,6 +870,7 @@ class NamespaceTerraformResourceKMSV1(NamespaceTerraformResourceAWSV1):
     overrides: Optional[str] = Field(..., alias="overrides")
     output_resource_name: Optional[str] = Field(..., alias="output_resource_name")
     annotations: Optional[str] = Field(..., alias="annotations")
+    tags: Optional[str] = Field(..., alias="tags")
     managed_by_erv2: Optional[bool] = Field(..., alias="managed_by_erv2")
     delete: Optional[bool] = Field(..., alias="delete")
     module_overrides: Optional[ExternalResourcesModuleOverrides] = Field(..., alias="module_overrides")
@@ -840,6 +882,7 @@ class NamespaceTerraformResourceElasticSearchV1(NamespaceTerraformResourceAWSV1)
     defaults: str = Field(..., alias="defaults")
     output_resource_name: Optional[str] = Field(..., alias="output_resource_name")
     annotations: Optional[str] = Field(..., alias="annotations")
+    tags: Optional[str] = Field(..., alias="tags")
     publish_log_types: Optional[list[str]] = Field(..., alias="publish_log_types")
 
 
@@ -855,6 +898,7 @@ class NamespaceTerraformResourceACMV1(NamespaceTerraformResourceAWSV1):
     domain: Optional[ACMDomainV1] = Field(..., alias="domain")
     output_resource_name: Optional[str] = Field(..., alias="output_resource_name")
     annotations: Optional[str] = Field(..., alias="annotations")
+    tags: Optional[str] = Field(..., alias="tags")
 
 
 class NamespaceTerraformResourceKinesisV1(NamespaceTerraformResourceAWSV1):
@@ -864,6 +908,7 @@ class NamespaceTerraformResourceKinesisV1(NamespaceTerraformResourceAWSV1):
     es_identifier: Optional[str] = Field(..., alias="es_identifier")
     output_resource_name: Optional[str] = Field(..., alias="output_resource_name")
     annotations: Optional[str] = Field(..., alias="annotations")
+    tags: Optional[str] = Field(..., alias="tags")
 
 
 class NamespaceTerraformResourceS3CloudFrontPublicKeyV1(NamespaceTerraformResourceAWSV1):
@@ -872,6 +917,7 @@ class NamespaceTerraformResourceS3CloudFrontPublicKeyV1(NamespaceTerraformResour
     secret: Optional[VaultSecret] = Field(..., alias="secret")
     output_resource_name: Optional[str] = Field(..., alias="output_resource_name")
     annotations: Optional[str] = Field(..., alias="annotations")
+    tags: Optional[str] = Field(..., alias="tags")
 
 
 class NamespaceTerraformResourceALBTargetsV1(ConfiguredBaseModel):
@@ -949,6 +995,7 @@ class NamespaceTerraformResourceALBV1(NamespaceTerraformResourceAWSV1):
     rules: list[NamespaceTerraformResourceALBRulesV1] = Field(..., alias="rules")
     output_resource_name: Optional[str] = Field(..., alias="output_resource_name")
     annotations: Optional[str] = Field(..., alias="annotations")
+    tags: Optional[str] = Field(..., alias="tags")
 
 
 class NamespaceTerraformResourceSecretsManagerV1(NamespaceTerraformResourceAWSV1):
@@ -957,6 +1004,7 @@ class NamespaceTerraformResourceSecretsManagerV1(NamespaceTerraformResourceAWSV1
     secret: Optional[VaultSecret] = Field(..., alias="secret")
     output_resource_name: Optional[str] = Field(..., alias="output_resource_name")
     annotations: Optional[str] = Field(..., alias="annotations")
+    tags: Optional[str] = Field(..., alias="tags")
 
 
 class CloudinitConfigV1(ConfiguredBaseModel):
@@ -1002,6 +1050,7 @@ class NamespaceTerraformResourceASGV1(NamespaceTerraformResourceAWSV1):
     image: list[Union[ASGImageGitV1, ASGImageStaticV1, ASGImageV1]] = Field(..., alias="image")
     output_resource_name: Optional[str] = Field(..., alias="output_resource_name")
     annotations: Optional[str] = Field(..., alias="annotations")
+    tags: Optional[str] = Field(..., alias="tags")
 
 
 class DnsRecordAliasV1(ConfiguredBaseModel):
@@ -1037,6 +1086,7 @@ class NamespaceTerraformResourceRoute53ZoneV1(NamespaceTerraformResourceAWSV1):
     name: str = Field(..., alias="name")
     output_resource_name: Optional[str] = Field(..., alias="output_resource_name")
     annotations: Optional[str] = Field(..., alias="annotations")
+    tags: Optional[str] = Field(..., alias="tags")
     records: Optional[list[DnsRecordV1]] = Field(..., alias="records")
 
 
@@ -1052,6 +1102,7 @@ class NamespaceTerraformResourceRosaAuthenticatorV1(NamespaceTerraformResourceAW
     insights_callback_urls: Optional[list[str]] = Field(..., alias="insights_callback_urls")
     output_resource_name: Optional[str] = Field(..., alias="output_resource_name")
     annotations: Optional[str] = Field(..., alias="annotations")
+    tags: Optional[str] = Field(..., alias="tags")
     vpc_id: str = Field(..., alias="vpc_id")
     subnet_ids: list[str] = Field(..., alias="subnet_ids")
     vpce_id: Optional[str] = Field(..., alias="vpce_id")
@@ -1065,6 +1116,7 @@ class NamespaceTerraformResourceRosaAuthenticatorVPCEV1(NamespaceTerraformResour
     vpc_id: str = Field(..., alias="vpc_id")
     output_resource_name: Optional[str] = Field(..., alias="output_resource_name")
     annotations: Optional[str] = Field(..., alias="annotations")
+    tags: Optional[str] = Field(..., alias="tags")
     defaults: str = Field(..., alias="defaults")
 
 
@@ -1079,6 +1131,7 @@ class NamespaceTerraformResourceMskV1(NamespaceTerraformResourceAWSV1):
     output_resource_name: Optional[str] = Field(..., alias="output_resource_name")
     defaults: str = Field(..., alias="defaults")
     annotations: Optional[str] = Field(..., alias="annotations")
+    tags: Optional[str] = Field(..., alias="tags")
     users: Optional[list[MskSecretParametersV1]] = Field(..., alias="users")
     managed_by_erv2: Optional[bool] = Field(..., alias="managed_by_erv2")
     delete: Optional[bool] = Field(..., alias="delete")
@@ -1093,11 +1146,14 @@ class NamespaceTerraformProviderResourceAWSV1(NamespaceExternalResourceV1):
 class EnvironmentV1(ConfiguredBaseModel):
     name: str = Field(..., alias="name")
     labels: str = Field(..., alias="labels")
+    service_phase: str = Field(..., alias="servicePhase")
 
 
 class AppV1(ConfiguredBaseModel):
     path: str = Field(..., alias="path")
     name: str = Field(..., alias="name")
+    app_code: str = Field(..., alias="appCode")
+    cost_center: str = Field(..., alias="costCenter")
 
 
 class ClusterSpecV1(ConfiguredBaseModel):

--- a/reconcile/gql_definitions/introspection.json
+++ b/reconcile/gql_definitions/introspection.json
@@ -16215,6 +16215,38 @@
                             "deprecationReason": null
                         },
                         {
+                            "name": "appCode",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "NON_NULL",
+                                "name": null,
+                                "ofType": {
+                                    "kind": "SCALAR",
+                                    "name": "String",
+                                    "ofType": null
+                                }
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "costCenter",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "NON_NULL",
+                                "name": null,
+                                "ofType": {
+                                    "kind": "SCALAR",
+                                    "name": "String",
+                                    "ofType": null
+                                }
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
                             "name": "statusPageComponents",
                             "description": null,
                             "args": [],
@@ -16704,6 +16736,22 @@
                                 "kind": "OBJECT",
                                 "name": "Environment_v1",
                                 "ofType": null
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "servicePhase",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "NON_NULL",
+                                "name": null,
+                                "ofType": {
+                                    "kind": "SCALAR",
+                                    "name": "String",
+                                    "ofType": null
+                                }
                             },
                             "isDeprecated": false,
                             "deprecationReason": null
@@ -23754,6 +23802,30 @@
                                     "name": "String",
                                     "ofType": null
                                 }
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "SLIErrorQuery",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "SCALAR",
+                                "name": "String",
+                                "ofType": null
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "SLITotalQuery",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "SCALAR",
+                                "name": "String",
+                                "ofType": null
                             },
                             "isDeprecated": false,
                             "deprecationReason": null
@@ -41262,6 +41334,18 @@
                             },
                             "isDeprecated": false,
                             "deprecationReason": null
+                        },
+                        {
+                            "name": "tags",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "SCALAR",
+                                "name": "JSON",
+                                "ofType": null
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
                         }
                     ],
                     "inputFields": null,
@@ -43230,6 +43314,18 @@
                             },
                             "isDeprecated": false,
                             "deprecationReason": null
+                        },
+                        {
+                            "name": "tags",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "SCALAR",
+                                "name": "JSON",
+                                "ofType": null
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
                         }
                     ],
                     "inputFields": null,
@@ -43602,6 +43698,18 @@
                             },
                             "isDeprecated": false,
                             "deprecationReason": null
+                        },
+                        {
+                            "name": "tags",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "SCALAR",
+                                "name": "JSON",
+                                "ofType": null
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
                         }
                     ],
                     "inputFields": null,
@@ -43702,6 +43810,18 @@
                         },
                         {
                             "name": "annotations",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "SCALAR",
+                                "name": "JSON",
+                                "ofType": null
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "tags",
                             "description": null,
                             "args": [],
                             "type": {
@@ -43823,6 +43943,18 @@
                         },
                         {
                             "name": "annotations",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "SCALAR",
+                                "name": "JSON",
+                                "ofType": null
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "tags",
                             "description": null,
                             "args": [],
                             "type": {
@@ -43962,6 +44094,18 @@
                                         "ofType": null
                                     }
                                 }
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "tags",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "SCALAR",
+                                "name": "JSON",
+                                "ofType": null
                             },
                             "isDeprecated": false,
                             "deprecationReason": null
@@ -44130,6 +44274,18 @@
                             "type": {
                                 "kind": "OBJECT",
                                 "name": "ExternalResourcesModuleOverrides_v1",
+                                "ofType": null
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "tags",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "SCALAR",
+                                "name": "JSON",
                                 "ofType": null
                             },
                             "isDeprecated": false,
@@ -44655,6 +44811,18 @@
                             },
                             "isDeprecated": false,
                             "deprecationReason": null
+                        },
+                        {
+                            "name": "tags",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "SCALAR",
+                                "name": "JSON",
+                                "ofType": null
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
                         }
                     ],
                     "inputFields": null,
@@ -45034,6 +45202,18 @@
                             },
                             "isDeprecated": false,
                             "deprecationReason": null
+                        },
+                        {
+                            "name": "tags",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "SCALAR",
+                                "name": "JSON",
+                                "ofType": null
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
                         }
                     ],
                     "inputFields": null,
@@ -45222,6 +45402,18 @@
                             },
                             "isDeprecated": false,
                             "deprecationReason": null
+                        },
+                        {
+                            "name": "tags",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "SCALAR",
+                                "name": "JSON",
+                                "ofType": null
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
                         }
                     ],
                     "inputFields": null,
@@ -45377,6 +45569,18 @@
                         },
                         {
                             "name": "annotations",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "SCALAR",
+                                "name": "JSON",
+                                "ofType": null
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "tags",
                             "description": null,
                             "args": [],
                             "type": {
@@ -45591,6 +45795,18 @@
                             },
                             "isDeprecated": false,
                             "deprecationReason": null
+                        },
+                        {
+                            "name": "tags",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "SCALAR",
+                                "name": "JSON",
+                                "ofType": null
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
                         }
                     ],
                     "inputFields": null,
@@ -45764,6 +45980,18 @@
                             },
                             "isDeprecated": false,
                             "deprecationReason": null
+                        },
+                        {
+                            "name": "tags",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "SCALAR",
+                                "name": "JSON",
+                                "ofType": null
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
                         }
                     ],
                     "inputFields": null,
@@ -45927,6 +46155,18 @@
                         },
                         {
                             "name": "annotations",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "SCALAR",
+                                "name": "JSON",
+                                "ofType": null
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "tags",
                             "description": null,
                             "args": [],
                             "type": {
@@ -46136,6 +46376,18 @@
                             },
                             "isDeprecated": false,
                             "deprecationReason": null
+                        },
+                        {
+                            "name": "tags",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "SCALAR",
+                                "name": "JSON",
+                                "ofType": null
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
                         }
                     ],
                     "inputFields": null,
@@ -46308,6 +46560,18 @@
                             },
                             "isDeprecated": false,
                             "deprecationReason": null
+                        },
+                        {
+                            "name": "tags",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "SCALAR",
+                                "name": "JSON",
+                                "ofType": null
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
                         }
                     ],
                     "inputFields": null,
@@ -46420,6 +46684,18 @@
                         },
                         {
                             "name": "annotations",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "SCALAR",
+                                "name": "JSON",
+                                "ofType": null
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "tags",
                             "description": null,
                             "args": [],
                             "type": {
@@ -46545,6 +46821,18 @@
                         },
                         {
                             "name": "annotations",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "SCALAR",
+                                "name": "JSON",
+                                "ofType": null
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "tags",
                             "description": null,
                             "args": [],
                             "type": {
@@ -46682,6 +46970,18 @@
                         },
                         {
                             "name": "annotations",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "SCALAR",
+                                "name": "JSON",
+                                "ofType": null
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "tags",
                             "description": null,
                             "args": [],
                             "type": {
@@ -46864,6 +47164,18 @@
                             },
                             "isDeprecated": false,
                             "deprecationReason": null
+                        },
+                        {
+                            "name": "tags",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "SCALAR",
+                                "name": "JSON",
+                                "ofType": null
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
                         }
                     ],
                     "inputFields": null,
@@ -47025,6 +47337,18 @@
                             },
                             "isDeprecated": false,
                             "deprecationReason": null
+                        },
+                        {
+                            "name": "tags",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "SCALAR",
+                                "name": "JSON",
+                                "ofType": null
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
                         }
                     ],
                     "inputFields": null,
@@ -47153,6 +47477,18 @@
                         },
                         {
                             "name": "annotations",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "SCALAR",
+                                "name": "JSON",
+                                "ofType": null
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "tags",
                             "description": null,
                             "args": [],
                             "type": {
@@ -47477,6 +47813,18 @@
                         },
                         {
                             "name": "annotations",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "SCALAR",
+                                "name": "JSON",
+                                "ofType": null
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "tags",
                             "description": null,
                             "args": [],
                             "type": {
@@ -47972,6 +48320,18 @@
                             },
                             "isDeprecated": false,
                             "deprecationReason": null
+                        },
+                        {
+                            "name": "tags",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "SCALAR",
+                                "name": "JSON",
+                                "ofType": null
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
                         }
                     ],
                     "inputFields": null,
@@ -48289,6 +48649,18 @@
                             },
                             "isDeprecated": false,
                             "deprecationReason": null
+                        },
+                        {
+                            "name": "tags",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "SCALAR",
+                                "name": "JSON",
+                                "ofType": null
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
                         }
                     ],
                     "inputFields": null,
@@ -48439,6 +48811,18 @@
                                     "name": "String",
                                     "ofType": null
                                 }
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "tags",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "SCALAR",
+                                "name": "JSON",
+                                "ofType": null
                             },
                             "isDeprecated": false,
                             "deprecationReason": null
@@ -49271,6 +49655,18 @@
                                     "name": "NamespaceTerraformResourceModulePoCSpec_v1",
                                     "ofType": null
                                 }
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "tags",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "SCALAR",
+                                "name": "JSON",
+                                "ofType": null
                             },
                             "isDeprecated": false,
                             "deprecationReason": null


### PR DESCRIPTION
Add tagging support to all ERv2-managed external resources:

The compliance mandatory ones:
* `app-code`
* `cost-center`
* `service-phase`

And allow custom tags directly on the external resources via the new `tag` attribute.

Ticket: [APPSRE-12423](https://issues.redhat.com/browse/APPSRE-12423)
