### PR TITLE
Post-Konflux-FIPS test MR

### DIFF
--- a/dockerfiles/Dockerfile.deprecated
+++ b/dockerfiles/Dockerfile.deprecated
@@ -81,6 +81,7 @@ CMD ["run-integration"]
 FROM prod-image AS fips-prod-image
 ENV OC_VERSION=4.16.2
 
+
 # oc versions sometimes have issues with FIPS enabled systems requiring us to use specific
 # versions in these environments so in this case we extract an older version of oc and kubectl
 COPY --chown=0:0 --from=quay.io/app-sre/qontract-reconcile-oc:0.3.1@sha256:b7d06973a9e058a5dd6068566d6b1358fdc1a1c9b4653e39dbac018f74f2c8d1 \


### PR DESCRIPTION
MR to test Konflux build status following:
https://gitlab.cee.redhat.com/releng/konflux-release-data/-/merge_requests/9579 and https://github.com/app-sre/qontract-reconcile/pull/5179

Ideally, Konflux tests should pass, and image should be published to both of:
* https://github.com/app-sre/qontract-reconcile/pull/quay.io/repository/redhat-services-prod/app-sre-tenant/qontract-reconcile-master/qontract-reconcile-master
* https://github.com/app-sre/qontract-reconcile/pull/quay.io/repository/redhat-services-prod/app-sre-tenant/qontract-reconcile-master/qontract-reconcile-fips-master