### PR TITLE
feat: :lock: disable IAM access keys with App-Interface

### DIFF
--- a/reconcile/gql_definitions/introspection.json
+++ b/reconcile/gql_definitions/introspection.json
@@ -10237,6 +10237,26 @@
                             "deprecationReason": null
                         },
                         {
+                            "name": "disableKeys",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "LIST",
+                                "name": null,
+                                "ofType": {
+                                    "kind": "NON_NULL",
+                                    "name": null,
+                                    "ofType": {
+                                        "kind": "SCALAR",
+                                        "name": "String",
+                                        "ofType": null
+                                    }
+                                }
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
                             "name": "resetPasswords",
                             "description": null,
                             "args": [],
@@ -16215,6 +16235,38 @@
                             "deprecationReason": null
                         },
                         {
+                            "name": "appCode",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "NON_NULL",
+                                "name": null,
+                                "ofType": {
+                                    "kind": "SCALAR",
+                                    "name": "String",
+                                    "ofType": null
+                                }
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "costCenter",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "NON_NULL",
+                                "name": null,
+                                "ofType": {
+                                    "kind": "SCALAR",
+                                    "name": "String",
+                                    "ofType": null
+                                }
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
                             "name": "statusPageComponents",
                             "description": null,
                             "args": [],
@@ -16704,6 +16756,22 @@
                                 "kind": "OBJECT",
                                 "name": "Environment_v1",
                                 "ofType": null
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "servicePhase",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "NON_NULL",
+                                "name": null,
+                                "ofType": {
+                                    "kind": "SCALAR",
+                                    "name": "String",
+                                    "ofType": null
+                                }
                             },
                             "isDeprecated": false,
                             "deprecationReason": null
@@ -23754,6 +23822,30 @@
                                     "name": "String",
                                     "ofType": null
                                 }
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "SLIErrorQuery",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "SCALAR",
+                                "name": "String",
+                                "ofType": null
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "SLITotalQuery",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "SCALAR",
+                                "name": "String",
+                                "ofType": null
                             },
                             "isDeprecated": false,
                             "deprecationReason": null
@@ -41262,6 +41354,18 @@
                             },
                             "isDeprecated": false,
                             "deprecationReason": null
+                        },
+                        {
+                            "name": "tags",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "SCALAR",
+                                "name": "JSON",
+                                "ofType": null
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
                         }
                     ],
                     "inputFields": null,
@@ -43230,6 +43334,18 @@
                             },
                             "isDeprecated": false,
                             "deprecationReason": null
+                        },
+                        {
+                            "name": "tags",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "SCALAR",
+                                "name": "JSON",
+                                "ofType": null
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
                         }
                     ],
                     "inputFields": null,
@@ -43602,6 +43718,18 @@
                             },
                             "isDeprecated": false,
                             "deprecationReason": null
+                        },
+                        {
+                            "name": "tags",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "SCALAR",
+                                "name": "JSON",
+                                "ofType": null
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
                         }
                     ],
                     "inputFields": null,
@@ -43702,6 +43830,18 @@
                         },
                         {
                             "name": "annotations",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "SCALAR",
+                                "name": "JSON",
+                                "ofType": null
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "tags",
                             "description": null,
                             "args": [],
                             "type": {
@@ -43823,6 +43963,18 @@
                         },
                         {
                             "name": "annotations",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "SCALAR",
+                                "name": "JSON",
+                                "ofType": null
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "tags",
                             "description": null,
                             "args": [],
                             "type": {
@@ -43962,6 +44114,18 @@
                                         "ofType": null
                                     }
                                 }
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "tags",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "SCALAR",
+                                "name": "JSON",
+                                "ofType": null
                             },
                             "isDeprecated": false,
                             "deprecationReason": null
@@ -44130,6 +44294,18 @@
                             "type": {
                                 "kind": "OBJECT",
                                 "name": "ExternalResourcesModuleOverrides_v1",
+                                "ofType": null
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "tags",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "SCALAR",
+                                "name": "JSON",
                                 "ofType": null
                             },
                             "isDeprecated": false,
@@ -44655,6 +44831,18 @@
                             },
                             "isDeprecated": false,
                             "deprecationReason": null
+                        },
+                        {
+                            "name": "tags",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "SCALAR",
+                                "name": "JSON",
+                                "ofType": null
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
                         }
                     ],
                     "inputFields": null,
@@ -45034,6 +45222,18 @@
                             },
                             "isDeprecated": false,
                             "deprecationReason": null
+                        },
+                        {
+                            "name": "tags",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "SCALAR",
+                                "name": "JSON",
+                                "ofType": null
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
                         }
                     ],
                     "inputFields": null,
@@ -45222,6 +45422,18 @@
                             },
                             "isDeprecated": false,
                             "deprecationReason": null
+                        },
+                        {
+                            "name": "tags",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "SCALAR",
+                                "name": "JSON",
+                                "ofType": null
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
                         }
                     ],
                     "inputFields": null,
@@ -45377,6 +45589,18 @@
                         },
                         {
                             "name": "annotations",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "SCALAR",
+                                "name": "JSON",
+                                "ofType": null
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "tags",
                             "description": null,
                             "args": [],
                             "type": {
@@ -45591,6 +45815,18 @@
                             },
                             "isDeprecated": false,
                             "deprecationReason": null
+                        },
+                        {
+                            "name": "tags",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "SCALAR",
+                                "name": "JSON",
+                                "ofType": null
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
                         }
                     ],
                     "inputFields": null,
@@ -45764,6 +46000,18 @@
                             },
                             "isDeprecated": false,
                             "deprecationReason": null
+                        },
+                        {
+                            "name": "tags",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "SCALAR",
+                                "name": "JSON",
+                                "ofType": null
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
                         }
                     ],
                     "inputFields": null,
@@ -45927,6 +46175,18 @@
                         },
                         {
                             "name": "annotations",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "SCALAR",
+                                "name": "JSON",
+                                "ofType": null
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "tags",
                             "description": null,
                             "args": [],
                             "type": {
@@ -46136,6 +46396,18 @@
                             },
                             "isDeprecated": false,
                             "deprecationReason": null
+                        },
+                        {
+                            "name": "tags",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "SCALAR",
+                                "name": "JSON",
+                                "ofType": null
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
                         }
                     ],
                     "inputFields": null,
@@ -46308,6 +46580,18 @@
                             },
                             "isDeprecated": false,
                             "deprecationReason": null
+                        },
+                        {
+                            "name": "tags",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "SCALAR",
+                                "name": "JSON",
+                                "ofType": null
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
                         }
                     ],
                     "inputFields": null,
@@ -46420,6 +46704,18 @@
                         },
                         {
                             "name": "annotations",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "SCALAR",
+                                "name": "JSON",
+                                "ofType": null
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "tags",
                             "description": null,
                             "args": [],
                             "type": {
@@ -46545,6 +46841,18 @@
                         },
                         {
                             "name": "annotations",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "SCALAR",
+                                "name": "JSON",
+                                "ofType": null
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "tags",
                             "description": null,
                             "args": [],
                             "type": {
@@ -46682,6 +46990,18 @@
                         },
                         {
                             "name": "annotations",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "SCALAR",
+                                "name": "JSON",
+                                "ofType": null
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "tags",
                             "description": null,
                             "args": [],
                             "type": {
@@ -46864,6 +47184,18 @@
                             },
                             "isDeprecated": false,
                             "deprecationReason": null
+                        },
+                        {
+                            "name": "tags",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "SCALAR",
+                                "name": "JSON",
+                                "ofType": null
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
                         }
                     ],
                     "inputFields": null,
@@ -47025,6 +47357,18 @@
                             },
                             "isDeprecated": false,
                             "deprecationReason": null
+                        },
+                        {
+                            "name": "tags",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "SCALAR",
+                                "name": "JSON",
+                                "ofType": null
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
                         }
                     ],
                     "inputFields": null,
@@ -47153,6 +47497,18 @@
                         },
                         {
                             "name": "annotations",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "SCALAR",
+                                "name": "JSON",
+                                "ofType": null
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "tags",
                             "description": null,
                             "args": [],
                             "type": {
@@ -47477,6 +47833,18 @@
                         },
                         {
                             "name": "annotations",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "SCALAR",
+                                "name": "JSON",
+                                "ofType": null
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "tags",
                             "description": null,
                             "args": [],
                             "type": {
@@ -47972,6 +48340,18 @@
                             },
                             "isDeprecated": false,
                             "deprecationReason": null
+                        },
+                        {
+                            "name": "tags",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "SCALAR",
+                                "name": "JSON",
+                                "ofType": null
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
                         }
                     ],
                     "inputFields": null,
@@ -48289,6 +48669,18 @@
                             },
                             "isDeprecated": false,
                             "deprecationReason": null
+                        },
+                        {
+                            "name": "tags",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "SCALAR",
+                                "name": "JSON",
+                                "ofType": null
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
                         }
                     ],
                     "inputFields": null,
@@ -48439,6 +48831,18 @@
                                     "name": "String",
                                     "ofType": null
                                 }
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "tags",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "SCALAR",
+                                "name": "JSON",
+                                "ofType": null
                             },
                             "isDeprecated": false,
                             "deprecationReason": null
@@ -49271,6 +49675,18 @@
                                     "name": "NamespaceTerraformResourceModulePoCSpec_v1",
                                     "ofType": null
                                 }
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "tags",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "SCALAR",
+                                "name": "JSON",
+                                "ofType": null
                             },
                             "isDeprecated": false,
                             "deprecationReason": null

--- a/reconcile/queries.py
+++ b/reconcile/queries.py
@@ -476,6 +476,7 @@ AWS_ACCOUNTS_QUERY = """
     disable {
       integrations
     }
+    disableKeys
     deleteKeys
     {% if reset_passwords %}
     resetPasswords {

--- a/reconcile/test/test_aws_iam_keys.py
+++ b/reconcile/test/test_aws_iam_keys.py
@@ -78,3 +78,61 @@ def test_update_state(state: StateMock) -> None:
     keys_to_update = {"a": ["k1"]}
     integ.update_state(state, keys_to_update)
     assert state.data == keys_to_update
+
+
+def test_filter_accounts_with_disable_keys() -> None:
+    a: dict[str, Any] = {"name": "a", "disableKeys": ["AKIA"]}
+    b: dict[str, Any] = {"name": "b", "deleteKeys": ["AKIA"]}
+    c: dict[str, Any] = {"name": "c"}
+    accounts = [a, b, c]
+    filtered = integ.filter_accounts(accounts, None)
+    assert filtered == [a, b]
+
+
+def test_filter_accounts_with_both_disable_and_delete_keys() -> None:
+    a: dict[str, Any] = {"name": "a", "disableKeys": ["AKIA1"], "deleteKeys": ["AKIA2"]}
+    b: dict[str, Any] = {"name": "b"}
+    accounts = [a, b]
+    filtered = integ.filter_accounts(accounts, None)
+    assert filtered == [a]
+
+
+def test_get_keys_to_disable() -> None:
+    a: dict[str, Any] = {"name": "a", "disableKeys": ["k1", "k2"]}
+    b: dict[str, Any] = {"name": "b", "disableKeys": None}
+    c: dict[str, Any] = {"name": "c", "disableKeys": []}
+    d: dict[str, Any] = {"name": "d"}
+    accounts = [a, b, c, d]
+    expected_result = {a["name"]: a["disableKeys"]}
+    keys_to_disable = integ.get_keys_to_disable(accounts)
+    assert keys_to_disable == expected_result
+
+
+def test_should_run_with_disable_keys_true(state: StateMock) -> None:
+    keys_to_delete = {"a": ["k1"]}
+    keys_to_disable = {"b": ["k2"]}
+    assert integ.should_run(state, keys_to_delete, keys_to_disable) is True
+
+
+def test_should_run_with_disable_keys_false(state: StateMock) -> None:
+    keys_to_delete = {"a": ["k1"]}
+    keys_to_disable = {"b": ["k2"]}
+    state.data.update(keys_to_delete)
+    state.data["b_disable"] = keys_to_disable["b"]
+    assert integ.should_run(state, keys_to_delete, keys_to_disable) is False
+
+
+def test_should_run_with_disable_keys_changed(state: StateMock) -> None:
+    keys_to_delete = {"a": ["k1"]}
+    keys_to_disable = {"b": ["k2"]}
+    state.data.update(keys_to_delete)
+    state.data["b_disable"] = ["k3"]  # Different key
+    assert integ.should_run(state, keys_to_delete, keys_to_disable) is True
+
+
+def test_update_state_with_disable_keys(state: StateMock) -> None:
+    keys_to_update = {"a": ["k1"]}
+    keys_to_disable = {"b": ["k2"]}
+    integ.update_state(state, keys_to_update, keys_to_disable)
+    expected_data = {"a": ["k1"], "b_disable": ["k2"]}
+    assert state.data == expected_data

--- a/reconcile/utils/aws_api.py
+++ b/reconcile/utils/aws_api.py
@@ -583,6 +583,40 @@ class AWSApi:
 
         return error, service_account_recycle_complete
 
+    def disable_keys(
+        self,
+        dry_run: bool,
+        keys_to_disable: Mapping,
+    ) -> bool:
+        error = False
+        users_keys = self.get_users_keys()
+        for account, s in self.sessions.items():
+            iam = self.get_session_client(s, "iam")
+            keys = keys_to_disable.get(account, [])
+            for key in keys:
+                user_and_user_keys = [
+                    (user, user_keys)
+                    for user, user_keys in users_keys[account].items()
+                    if key in user_keys
+                ]
+                if not user_and_user_keys:
+                    continue
+                if len(user_and_user_keys) > 1:
+                    raise RuntimeError(
+                        f"key {key} returned multiple users: {user_and_user_keys}"
+                    )
+                user = user_and_user_keys[0][0]
+                key_status = self.get_user_key_status(iam, user, key)
+                if key_status == "Active":
+                    logging.info(["disable_key", account, user, key])
+                    if not dry_run:
+                        iam.update_access_key(
+                            UserName=user, AccessKeyId=key, Status="Inactive"
+                        )
+                else:
+                    logging.info(["key_already_disabled", account, user, key])
+        return error
+
     def get_users_keys(self) -> dict:
         users_keys = {}
         for account, s in self.sessions.items():


### PR DESCRIPTION
Allow users to self-service disabling AWS IAM keys (but not deleting them) via qontract-reconcile for improved security.

https://issues.redhat.com/browse/PROJQUAY-9354

Schemas PR: https://github.com/app-sre/qontract-schemas/pull/924

*Claude Code assisted*