### PR TITLE
update 'INTEGRATION_EXTRA_ARGS' qr-fips quay-path in qontract-manager-fedramp.yaml (try #2)

### DIFF
--- a/openshift/qontract-manager-fedramp.yaml
+++ b/openshift/qontract-manager-fedramp.yaml
@@ -156,7 +156,7 @@ objects:
           - name: INTEGRATION_NAME
             value: integrations-manager
           - name: INTEGRATION_EXTRA_ARGS
-            value: "-i quay.io/app-sre/qontract-reconcile-fips"
+            value: "-i quay.io/redhat-services-prod/app-sre-tenant/qontract-reconcile-master/qontract-reconcile-fips-master"
           - name: SLEEP_DURATION_SECS
             value: ${SLEEP_DURATION_SECS}
           - name: GITHUB_API


### PR DESCRIPTION
Updates 'INTEGRATION_EXTRA_ARGS' qr-fips quay-path in qontract-manager-fedramp.yaml

Needed for Q-Manager to tell QR pods where to pull their images from.

This time I'll actually let the pr-check tests finish. :)