### PR TITLE
make cluster.spec.fips optional

### DIFF
--- a/reconcile/utils/ocm/products.py
+++ b/reconcile/utils/ocm/products.py
@@ -178,7 +178,7 @@ class OCMProductOsd(OCMProduct):
             ],
             provision_shard_id=provision_shard_id,
             hypershift=cluster["hypershift"]["enabled"],
-            fips=cluster["fips"],
+            fips=cluster.get("fips", False),
         )
 
         if not cluster["ccs"]["enabled"]:
@@ -429,7 +429,7 @@ class OCMProductRosa(OCMProduct):
             subnet_ids=cluster["aws"].get("subnet_ids"),
             availability_zones=cluster["nodes"].get("availability_zones"),
             oidc_endpoint_url=oidc_endpoint_url,
-            fips=cluster["fips"],
+            fips=cluster.get("fips", False),
         )
 
         machine_pools = [
@@ -706,7 +706,7 @@ class OCMProductHypershift(OCMProduct):
             availability_zones=cluster["nodes"].get("availability_zones"),
             hypershift=cluster["hypershift"]["enabled"],
             oidc_endpoint_url=oidc_endpoint_url,
-            fips=cluster["fips"],
+            fips=cluster.get("fips", False),
         )
 
         network = OCMClusterNetwork(


### PR DESCRIPTION
We don't need the `fips` attribute everywhere. Make it optional to avoid touching so many GQL queries.

Fixes #5204