### PR TITLE
terraform-resources: external resources tags

### DIFF
--- a/reconcile/gql_definitions/terraform_resources/terraform_resources_namespaces.gql
+++ b/reconcile/gql_definitions/terraform_resources/terraform_resources_namespaces.gql
@@ -23,6 +23,7 @@ query TerraformResourcesNamespaces {
             }
           }
           provider
+          tags
           ... on NamespaceTerraformResourceRDS_v1 {
             region
             identifier
@@ -448,9 +449,12 @@ query TerraformResourcesNamespaces {
     }
     environment {
       name
+      servicePhase
     }
     app {
       name
+      appCode
+      costCenter
     }
     cluster {
       name

--- a/reconcile/gql_definitions/terraform_resources/terraform_resources_namespaces.py
+++ b/reconcile/gql_definitions/terraform_resources/terraform_resources_namespaces.py
@@ -80,6 +80,7 @@ query TerraformResourcesNamespaces {
             }
           }
           provider
+          tags
           ... on NamespaceTerraformResourceRDS_v1 {
             region
             identifier
@@ -505,9 +506,12 @@ query TerraformResourcesNamespaces {
     }
     environment {
       name
+      servicePhase
     }
     app {
       name
+      appCode
+      costCenter
     }
     cluster {
       name
@@ -561,6 +565,7 @@ class NamespaceTerraformResourceGenericSecretOutputFormatV1(NamespaceTerraformRe
 class NamespaceTerraformResourceAWSV1(ConfiguredBaseModel):
     output_format: Optional[Union[NamespaceTerraformResourceGenericSecretOutputFormatV1, NamespaceTerraformResourceOutputFormatV1]] = Field(..., alias="output_format")
     provider: str = Field(..., alias="provider")
+    tags: Optional[str] = Field(..., alias="tags")
 
 
 class AWSRDSEventNotificationV1(ConfiguredBaseModel):
@@ -1076,10 +1081,13 @@ class NamespaceTerraformProviderResourceAWSV1(NamespaceExternalResourceV1):
 
 class EnvironmentV1(ConfiguredBaseModel):
     name: str = Field(..., alias="name")
+    service_phase: str = Field(..., alias="servicePhase")
 
 
 class AppV1(ConfiguredBaseModel):
     name: str = Field(..., alias="name")
+    app_code: str = Field(..., alias="appCode")
+    cost_center: str = Field(..., alias="costCenter")
 
 
 class ClusterSpecV1(ConfiguredBaseModel):

--- a/reconcile/test/test_terraform_resources.py
+++ b/reconcile/test/test_terraform_resources.py
@@ -270,6 +270,10 @@ def setup_mocks(
     mocked_queries = mocker.patch("reconcile.terraform_resources.queries")
     mocked_queries.get_aws_accounts.return_value = aws_accounts
     mocked_queries.get_app_interface_settings.return_value = []
+    mocked_external_resources_settings = mocker.patch(
+        "reconcile.terraform_resources.get_settings"
+    )
+    mocked_external_resources_settings.return_value.default_tags = {"tag1": "value1"}
 
     mocker.patch(
         "reconcile.terraform_resources.get_namespaces"

--- a/reconcile/test/utils/test_terrascript_aws_client.py
+++ b/reconcile/test/utils/test_terrascript_aws_client.py
@@ -103,10 +103,7 @@ def expected_default_region_aws_provider() -> dict[str, Any]:
 
 
 def test_init_with_default_tags(
-    mocker: MockerFixture,
-    default_account: dict[str, Any],
-    expected_supported_region_aws_provider: dict[str, Any],
-    expected_default_region_aws_provider: dict[str, Any],
+    mocker: MockerFixture, default_account: dict[str, Any]
 ) -> None:
     mocked_secret_reader = mocker.patch(
         "reconcile.utils.terrascript_aws_client.SecretReader",
@@ -117,16 +114,31 @@ def test_init_with_default_tags(
         "aws_secret_access_key": "some-secret-key",
     }
 
+    default_tags = {"tag1": "value1", "tag2": "value2"}
     ts = TerrascriptClient(
         "a_integration",
         "prefix",
         1,
         [default_account],
+        default_tags=default_tags,
     )
 
     assert ts.tss["account1"]["provider"]["aws"] == [
-        expected_supported_region_aws_provider,
-        expected_default_region_aws_provider,
+        {
+            "access_key": "some-key-id",
+            "secret_key": "some-secret-key",
+            "region": "us-east-1",
+            "alias": "us-east-1",
+            "skip_region_validation": True,
+            "default_tags": {"tags": default_tags},
+        },
+        {
+            "access_key": "some-key-id",
+            "secret_key": "some-secret-key",
+            "region": "us-east-1",
+            "skip_region_validation": True,
+            "default_tags": {"tags": default_tags},
+        },
     ]
 
 
@@ -203,6 +215,7 @@ def test_populate_additional_providers(
         "prefix",
         1,
         [default_account],
+        default_tags=None,
     )
     ts.populate_configs([cluster_account_no_assume_role])
     ts.populate_additional_providers(
@@ -219,7 +232,7 @@ def test_populate_additional_providers(
 
 @pytest.fixture
 def ts() -> TerrascriptClient:
-    return TerrascriptClient("", "", 1, [])
+    return TerrascriptClient("", "", 1, [], default_tags=None)
 
 
 def test_aws_username_org(ts: TerrascriptClient) -> None:
@@ -779,6 +792,7 @@ def ts_for_alb(mocker: MockerFixture) -> TerrascriptClient:
                 "resourcesDefaultRegion": "us-east-1",
             }
         ],
+        default_tags=None,
     )
 
 

--- a/reconcile/utils/terrascript_aws_client.py
+++ b/reconcile/utils/terrascript_aws_client.py
@@ -287,12 +287,6 @@ SUPPORTED_ALB_LISTENER_RULE_CONDITION_TYPE_MAPPING = {
     "source-ip": "source_ip",
 }
 
-DEFAULT_TAGS = {
-    "tags": {
-        "app": "app-sre-infra",
-    },
-}
-
 AWS_ELB_ACCOUNT_IDS = {
     "us-east-1": "127311923021",
     "us-east-2": "033677994240",
@@ -479,6 +473,7 @@ class TerrascriptClient:
         settings: Mapping[str, Any] | None = None,
         prefetch_resources_by_schemas: Iterable[str] | None = None,
         secret_reader: SecretReaderBase | None = None,
+        default_tags: Mapping[str, str] | None = None,
     ) -> None:
         self.integration = integration
         self.integration_prefix = integration_prefix
@@ -492,6 +487,9 @@ class TerrascriptClient:
         self.populate_configs(filtered_accounts)
         self.versions: dict[str, str] = {
             a["name"]: a["providerVersion"] for a in filtered_accounts
+        }
+        self.default_tags = default_tags or {
+            "app": "app-sre-infra",
         }
         tss = {}
         locks = {}
@@ -509,7 +507,7 @@ class TerrascriptClient:
                         region=region,
                         alias=region,
                         skip_region_validation=True,
-                        default_tags=DEFAULT_TAGS,
+                        default_tags={"tags": self.default_tags},
                     )
 
             # Add default region, which will be in resourcesDefaultRegion
@@ -518,7 +516,7 @@ class TerrascriptClient:
                 secret_key=config["aws_secret_access_key"],
                 region=config["resourcesDefaultRegion"],
                 skip_region_validation=True,
-                default_tags=DEFAULT_TAGS,
+                default_tags={"tags": self.default_tags},
             )
 
             ts += Terraform(
@@ -1078,7 +1076,7 @@ class TerrascriptClient:
                         alias=alias,
                         assume_role={"role_arn": assume_role},
                         skip_region_validation=True,
-                        default_tags=DEFAULT_TAGS,
+                        default_tags={"tags": self.default_tags},
                     )
                 else:
                     ts += provider.aws(
@@ -1087,7 +1085,7 @@ class TerrascriptClient:
                         region=region,
                         alias=alias,
                         skip_region_validation=True,
-                        default_tags=DEFAULT_TAGS,
+                        default_tags={"tags": self.default_tags},
                     )
 
     def populate_route53(

--- a/reconcile/utils/terrascript_aws_client.py
+++ b/reconcile/utils/terrascript_aws_client.py
@@ -488,8 +488,11 @@ class TerrascriptClient:
         self.versions: dict[str, str] = {
             a["name"]: a["providerVersion"] for a in filtered_accounts
         }
-        self.default_tags = default_tags or {
-            "app": "app-sre-infra",
+        self.default_tags = {
+            "tags": default_tags
+            or {
+                "app": "app-sre-infra",
+            }
         }
         tss = {}
         locks = {}
@@ -507,7 +510,7 @@ class TerrascriptClient:
                         region=region,
                         alias=region,
                         skip_region_validation=True,
-                        default_tags={"tags": self.default_tags},
+                        default_tags=self.default_tags,
                     )
 
             # Add default region, which will be in resourcesDefaultRegion
@@ -516,7 +519,7 @@ class TerrascriptClient:
                 secret_key=config["aws_secret_access_key"],
                 region=config["resourcesDefaultRegion"],
                 skip_region_validation=True,
-                default_tags={"tags": self.default_tags},
+                default_tags=self.default_tags,
             )
 
             ts += Terraform(
@@ -1076,7 +1079,7 @@ class TerrascriptClient:
                         alias=alias,
                         assume_role={"role_arn": assume_role},
                         skip_region_validation=True,
-                        default_tags={"tags": self.default_tags},
+                        default_tags=self.default_tags,
                     )
                 else:
                     ts += provider.aws(
@@ -1085,7 +1088,7 @@ class TerrascriptClient:
                         region=region,
                         alias=alias,
                         skip_region_validation=True,
-                        default_tags={"tags": self.default_tags},
+                        default_tags=self.default_tags,
                     )
 
     def populate_route53(


### PR DESCRIPTION
Support proper tagging for all `terraform-resources` managed external resources.
The default tags are configured in the `external-resource-settings` and custom tags can be applied via `namespace.external_resources.tags`.

Ticket: [APPSRE-12424](https://issues.redhat.com/browse/APPSRE-12424)