### PR TITLE
set default tags on all AWS resources

### DIFF
--- a/reconcile/aws_iam_keys.py
+++ b/reconcile/aws_iam_keys.py
@@ -65,6 +65,7 @@ def init_tf_working_dirs(
         thread_pool_size,
         accounts,
         settings=settings,
+        default_tags=None,
     )
     return ts.dump()
 

--- a/reconcile/jenkins_worker_fleets.py
+++ b/reconcile/jenkins_worker_fleets.py
@@ -195,6 +195,7 @@ def run(dry_run: bool) -> None:
         accounts=[],
         settings=settings,
         prefetch_resources_by_schemas=["/aws/asg-defaults-1.yml"],
+        default_tags=None,
     )
 
     for instance in jenkins_instances:

--- a/reconcile/sql_query.py
+++ b/reconcile/sql_query.py
@@ -229,6 +229,7 @@ def collect_queries(
         accounts=[],
         prefetch_resources_by_schemas=["/aws/rds-defaults-1.yml"],
         secret_reader=secret_reader,
+        default_tags=None,
     )
 
     for sql_query in sql_queries:

--- a/reconcile/terraform_aws_route53.py
+++ b/reconcile/terraform_aws_route53.py
@@ -9,6 +9,7 @@ from typing import Any
 
 from reconcile import queries
 from reconcile.status import ExitCodes
+from reconcile.typed_queries.external_resources import get_settings
 from reconcile.utils import dnsutils
 from reconcile.utils.aws_api import AWSApi
 from reconcile.utils.constants import DEFAULT_THREAD_POOL_SIZE
@@ -227,13 +228,18 @@ def run(
             f"No participating AWS accounts found, consider disabling this integration, account name: {account_name}"
         )
         return
-
+    try:
+        default_tags = get_settings().default_tags
+    except ValueError:
+        # no external resources settings found
+        default_tags = None
     ts = Terrascript(
         QONTRACT_INTEGRATION,
         "",
         thread_pool_size,
         participating_accounts,
         settings=settings,
+        default_tags=default_tags,
     )
 
     desired_state = build_desired_state(zones, all_accounts, settings)

--- a/reconcile/terraform_tgw_attachments.py
+++ b/reconcile/terraform_tgw_attachments.py
@@ -32,6 +32,7 @@ from reconcile.typed_queries.app_interface_vault_settings import (
     get_app_interface_vault_settings,
 )
 from reconcile.typed_queries.clusters_with_peering import get_clusters_with_peering
+from reconcile.typed_queries.external_resources import get_settings
 from reconcile.typed_queries.terraform_tgw_attachments.aws_accounts import (
     get_aws_accounts,
 )
@@ -444,13 +445,18 @@ def setup(
         raise RuntimeError("Could not find VPC ID for cluster")
 
     _validate_tgw_connection_names(desired_state)
-
+    try:
+        default_tags = get_settings().default_tags
+    except ValueError:
+        # no external resources settings found
+        default_tags = None
     ts = Terrascript(
         QONTRACT_INTEGRATION,
         "",
         thread_pool_size,
         tgw_accounts,
         settings=vault_settings.dict(by_alias=True),
+        default_tags=default_tags,
     )
     tgw_rosa_cluster_accounts = [
         account_by_name[c.spec.account.name]

--- a/reconcile/terraform_users.py
+++ b/reconcile/terraform_users.py
@@ -11,6 +11,7 @@ from reconcile import (
 )
 from reconcile.change_owners.diff import IDENTIFIER_FIELD_NAME
 from reconcile.gql_definitions.common.pgp_reencryption_settings import query
+from reconcile.typed_queries.external_resources import get_settings
 from reconcile.utils import (
     expiration,
     gql,
@@ -126,12 +127,18 @@ def setup(
     participating_aws_accounts = _filter_participating_aws_accounts(accounts, roles)
 
     settings = queries.get_app_interface_settings()
+    try:
+        default_tags = get_settings().default_tags
+    except ValueError:
+        # no external resources settings found
+        default_tags = None
     ts = Terrascript(
         QONTRACT_INTEGRATION,
         QONTRACT_TF_PREFIX,
         thread_pool_size,
         participating_aws_accounts,
         settings=settings,
+        default_tags=default_tags,
     )
     err = ts.populate_users(
         roles,

--- a/reconcile/terraform_vpc_peerings.py
+++ b/reconcile/terraform_vpc_peerings.py
@@ -7,6 +7,7 @@ from typing import Any, TypedDict
 import reconcile.utils.terraform_client as terraform
 import reconcile.utils.terrascript_aws_client as terrascript
 from reconcile import queries
+from reconcile.typed_queries import external_resources
 from reconcile.utils import (
     aws_api,
     ocm,
@@ -654,8 +655,18 @@ def run(
         ])
 
     account_by_name = {a["name"]: a for a in accounts}
+    try:
+        default_tags = external_resources.get_settings().default_tags
+    except ValueError:
+        # no external resources settings found
+        default_tags = None
     with terrascript.TerrascriptClient(
-        QONTRACT_INTEGRATION, "", thread_pool_size, infra_accounts, settings=settings
+        QONTRACT_INTEGRATION,
+        "",
+        thread_pool_size,
+        infra_accounts,
+        settings=settings,
+        default_tags=default_tags,
     ) as ts:
         rosa_cluster_accounts = [
             account_by_name[c["spec"]["account"]["name"]]

--- a/reconcile/test/terraform_vpc_resources/test_terraform_vpc_resources_integration.py
+++ b/reconcile/test/terraform_vpc_resources/test_terraform_vpc_resources_integration.py
@@ -161,6 +161,10 @@ def test_dry_run(
         autospec=True,
     )
     mocked_query.return_value = [gql_class_factory(VPCRequest, vpc_request_dict())]
+    mocked_get_settings = mocker.patch(
+        "reconcile.terraform_vpc_resources.integration.get_settings"
+    )
+    mocked_get_settings.return_value.default_tags = None
 
     secret_reader = mocker.Mock(SecretReaderBase)
     secret_reader.read_all.side_effect = secret_reader_side_effect

--- a/reconcile/test/test_jenkins_worker_fleets.py
+++ b/reconcile/test/test_jenkins_worker_fleets.py
@@ -31,7 +31,7 @@ def test_jenkins_worker_fleets(
     instance = fixture.get_anymarkup("gql-queries.yml")["gql_response"]["instances"][0]
     jenkins = JenkinsApi("url", "user", "password")
     terrascript = Terrascript(
-        "jenkins-worker-fleets", "", 1, accounts=[], settings=None
+        "jenkins-worker-fleets", "", 1, accounts=[], settings=None, default_tags=None
     )
     current_state = get_current_state(jenkins)
     worker_fleets = instance.get("workerFleets", [])
@@ -52,7 +52,7 @@ def test_jenkins_worker_fleets(
 def test_jenkins_worker_fleets_error() -> None:
     instance = fixture.get_anymarkup("gql-queries.yml")["gql_response"]["instances"][1]
     terrascript = Terrascript(
-        "jenkins-worker-fleets", "", 1, accounts=[], settings=None
+        "jenkins-worker-fleets", "", 1, accounts=[], settings=None, default_tags=None
     )
     worker_fleets = instance.get("workerFleets", [])
     with pytest.raises(ValueError):

--- a/reconcile/test/test_terraform_tgw_attachments.py
+++ b/reconcile/test/test_terraform_tgw_attachments.py
@@ -528,6 +528,11 @@ def _setup_mocks(
     )
     mocked_get_aws_accounts.return_value = accounts or []
 
+    mocked_get_settings = mocker.patch(
+        "reconcile.terraform_tgw_attachments.get_settings"
+    )
+    mocked_get_settings.return_value.default_tags = None
+
     mocked_secret_reader = create_autospec(SecretReaderBase)
     mocker.patch(
         "reconcile.terraform_tgw_attachments.create_secret_reader"

--- a/reconcile/test/test_terraform_users.py
+++ b/reconcile/test/test_terraform_users.py
@@ -133,6 +133,8 @@ def test_setup(
     mocked_queries.get_app_interface_settings.return_value = None
     mocked_ts = mocker.patch("reconcile.terraform_users.Terrascript", autospec=True)
     mocked_aws = mocker.patch("reconcile.terraform_users.AWSApi", autospec=True)
+    mocked_get_settings = mocker.patch("reconcile.terraform_users.get_settings")
+    mocked_get_settings.return_value.default_tags = None
     thread_pool_size = 1
 
     accounts, working_dirs, setup_err, aws_api = integ.setup(None, thread_pool_size, [])
@@ -148,6 +150,7 @@ def test_setup(
         thread_pool_size,
         [test_aws_account],
         settings=None,
+        default_tags=None,
     )
     mocked_ts.return_value.populate_users.assert_called_once_with(
         [test_aws_account_role],

--- a/reconcile/test/test_terraform_vpc_peerings.py
+++ b/reconcile/test/test_terraform_vpc_peerings.py
@@ -10,6 +10,7 @@ import reconcile.utils.terraform_client as terraform
 import reconcile.utils.terrascript_aws_client as terrascript
 from reconcile import queries
 from reconcile.terraform_vpc_peerings import BadTerraformPeeringStateError
+from reconcile.typed_queries import external_resources
 from reconcile.utils import (
     aws_api,
     ocm,
@@ -427,7 +428,9 @@ class TestRun(testslide.TestCase):
             .to_return_value({})
             .and_assert_called_once()
         )
-
+        self.mock_callable(external_resources, "get_settings").to_raise(
+            ValueError("No external resources settings found")
+        )
         self.mock_callable(self.terrascript, "populate_vpc_peerings").to_return_value(
             None
         ).and_assert_called_once()

--- a/reconcile/test/test_wrong_region.py
+++ b/reconcile/test/test_wrong_region.py
@@ -68,7 +68,7 @@ def terrascript(
         "reconcile.utils.terrascript_aws_client.SecretReader", autospec=True
     )
     mock_secret_reader.return_value.read_all.return_value = secret
-    return TerrascriptClient("", "", 1, accounts)
+    return TerrascriptClient("", "", 1, accounts, default_tags=None)
 
 
 def test_wrong_region_aws_api(

--- a/reconcile/utils/terrascript_aws_client.py
+++ b/reconcile/utils/terrascript_aws_client.py
@@ -470,10 +470,10 @@ class TerrascriptClient:
         integration_prefix: str,
         thread_pool_size: int,
         accounts: Iterable[MutableMapping[str, Any]],
+        default_tags: Mapping[str, str] | None,
         settings: Mapping[str, Any] | None = None,
         prefetch_resources_by_schemas: Iterable[str] | None = None,
         secret_reader: SecretReaderBase | None = None,
-        default_tags: Mapping[str, str] | None = None,
     ) -> None:
         self.integration = integration
         self.integration_prefix = integration_prefix


### PR DESCRIPTION
Set the default tags on other AWS resources. Not managed by erv2 or terraform-resources.

Ticket: [APPSRE-12425](https://issues.redhat.com/browse/APPSRE-12425)
Depends on #5209