### PR TITLE
fix(database-access-manager): unique state key and vault path

### DIFF
--- a/reconcile/database_access_manager.py
+++ b/reconcile/database_access_manager.py
@@ -455,7 +455,7 @@ def _generate_password() -> str:
     return "".join(choices(ascii_letters + digits, k=32))
 
 
-class _DBDonnections(TypedDict):
+class DBConnections(TypedDict):
     user: DatabaseConnectionParameters
     admin: DatabaseConnectionParameters
 
@@ -465,7 +465,7 @@ def _create_database_connection_parameter(
     namespace_name: str,
     oc: OCClient,
     admin_secret_name: str,
-) -> _DBDonnections:
+) -> DBConnections:
     def _decode_secret_value(value: str) -> str:
         return base64.b64decode(value).decode("utf-8")
 
@@ -481,7 +481,7 @@ def _create_database_connection_parameter(
     user = db_access.username
     password = _generate_password()
     database = db_access.database
-    return _DBDonnections(
+    return DBConnections(
         user=DatabaseConnectionParameters(
             host=host,
             port=port,

--- a/reconcile/test/test_database_access_manager.py
+++ b/reconcile/test/test_database_access_manager.py
@@ -8,6 +8,7 @@ from pytest_mock import MockerFixture
 
 from reconcile.database_access_manager import (
     DatabaseConnectionParameters,
+    DBConnections,
     JobData,
     JobFailedError,
     JobStatus,
@@ -15,7 +16,6 @@ from reconcile.database_access_manager import (
     PSQLScriptGenerator,
     _create_database_connection_parameter,
     _db_access_access_is_valid,
-    _DBDonnections,
     _generate_password,
     _populate_resources,
     _process_db_access,
@@ -430,7 +430,7 @@ def dbam_process_mocks(
 ) -> OpenshiftResource:
     mocker.patch(
         "reconcile.database_access_manager._create_database_connection_parameter",
-        return_value=_DBDonnections(
+        return_value=DBConnections(
             user=db_connection_parameter,
             admin=db_admin_connection_parameter,
         ),

--- a/reconcile/test/test_database_access_manager.py
+++ b/reconcile/test/test_database_access_manager.py
@@ -15,7 +15,7 @@ from reconcile.database_access_manager import (
     JobStatusCondition,
     PSQLScriptGenerator,
     _create_database_connection_parameter,
-    _db_access_acccess_is_valid,
+    _db_access_access_is_valid,
     _DBDonnections,
     _generate_password,
     _populate_resources,
@@ -317,13 +317,13 @@ def test_generate_delete_complete(
     _assert_revoke_access(script)
 
 
-def test_db_access_acccess_is_valid(
+def test_db_access_access_is_valid(
     db_access_complete: DatabaseAccessV1, db_access_access: DatabaseAccessAccessV1
 ) -> None:
     assert db_access_complete.access
-    assert _db_access_acccess_is_valid(db_access_complete)
+    assert _db_access_access_is_valid(db_access_complete)
     db_access_complete.access.append(db_access_access)
-    assert not _db_access_acccess_is_valid(db_access_complete)
+    assert not _db_access_access_is_valid(db_access_complete)
 
 
 def test_job_completion() -> None:
@@ -508,7 +508,8 @@ def test__process_db_access_job_pass(
     _process_db_access(
         False,
         dbam_state,
-        db_access,
+        state_key="test-provisioner/test-db/test",
+        db_access=db_access,
         namespace=db_access_namespace,
         admin_secret_name="db-secret",
         engine="postgres",
@@ -519,7 +520,7 @@ def test__process_db_access_job_pass(
 
     vault_mock.write.assert_called_once_with(
         {
-            "path": "foo/database-access-manager/test-cluster/test-namespace/test",
+            "path": "foo/database-access-manager/test-provisioner/test-db/test",
             "data": {
                 "host": "localhost",
                 "port": "5432",
@@ -563,7 +564,8 @@ def test__process_db_access_job_error(
         _process_db_access(
             False,
             dbam_state,
-            db_access,
+            state_key="test-provisioner/test-db/test",
+            db_access=db_access,
             namespace=db_access_namespace,
             admin_secret_name="db-secret",
             engine="postgres",
@@ -597,7 +599,8 @@ def test__process_db_access_state_diff(
     _process_db_access(
         False,
         dbam_state,
-        db_access,
+        state_key="test-provisioner/test-db/test",
+        db_access=db_access,
         namespace=db_access_namespace,
         admin_secret_name="db-secret",
         engine="postgres",
@@ -636,7 +639,8 @@ def test__process_db_access_value_error_database(
         _process_db_access(
             False,
             dbam_state,
-            db_access,
+            state_key="test-provisioner/test-db/test",
+            db_access=db_access,
             namespace=db_access_namespace,
             admin_secret_name="db-secret",
             engine="postgres",
@@ -658,7 +662,8 @@ def test__process_db_access_state_exists_matched(
     _process_db_access(
         False,
         dbam_state,
-        db_access,
+        state_key="test-provisioner/test-db/test",
+        db_access=db_access,
         namespace=db_access_namespace,
         admin_secret_name="db-secret",
         engine="postgres",


### PR DESCRIPTION
Use `external_resource.provisioner.name/resource.identifier/db_access.name` as state key and vault path to ensure one database instance secrets won't overwrite another one.

This integration is only responsible to put secrets to vault, remove the feature to write secret to cluster namespace, as run job once per change won't cover cluster/namespace migration, lead to secrets missing in new cluster/namespace. Sync secrets from vault to cluster can be done by other integrations such as openshift resources vault secret.

**Resource handling and code simplification:**

* Removed the `DBAMResource` class and changed all resource management logic to use plain `OpenshiftResource` objects, simplifying resource creation and deletion throughout the codebase. (_[[1]](diffhunk://#diff-73bc4a8dbcbc69bacb661ec19f5ed301ce9ec9f5d51d293d71004cac98f0dc89L394-L401) [[2]](diffhunk://#diff-73bc4a8dbcbc69bacb661ec19f5ed301ce9ec9f5d51d293d71004cac98f0dc89L427-R424) [[3]](diffhunk://#diff-73bc4a8dbcbc69bacb661ec19f5ed301ce9ec9f5d51d293d71004cac98f0dc89L449-R534)_)
* Updated the `_populate_resources` and related functions to return lists of `OpenshiftResource` instead of `DBAMResource`, and adjusted resource cleanup logic accordingly. (_[[1]](diffhunk://#diff-73bc4a8dbcbc69bacb661ec19f5ed301ce9ec9f5d51d293d71004cac98f0dc89L427-R424) [[2]](diffhunk://#diff-73bc4a8dbcbc69bacb661ec19f5ed301ce9ec9f5d51d293d71004cac98f0dc89L655-R660)_)

**Naming and consistency improvements:**

* Standardized job naming by switching from `name_suffix` to `name` in `JobData`, and ensured consistent usage of `resource_prefix` derived from a new `state_key`. This affects job creation, resource referencing, and vault secret paths. (_[[1]](diffhunk://#diff-73bc4a8dbcbc69bacb661ec19f5ed301ce9ec9f5d51d293d71004cac98f0dc89L228-R228) [[2]](diffhunk://#diff-73bc4a8dbcbc69bacb661ec19f5ed301ce9ec9f5d51d293d71004cac98f0dc89L237-R237) [[3]](diffhunk://#diff-73bc4a8dbcbc69bacb661ec19f5ed301ce9ec9f5d51d293d71004cac98f0dc89L603-R607) [[4]](diffhunk://#diff-73bc4a8dbcbc69bacb661ec19f5ed301ce9ec9f5d51d293d71004cac98f0dc89L645-R649) [[5]](diffhunk://#diff-73bc4a8dbcbc69bacb661ec19f5ed301ce9ec9f5d51d293d71004cac98f0dc89L668-R696) [[6]](diffhunk://#diff-73bc4a8dbcbc69bacb661ec19f5ed301ce9ec9f5d51d293d71004cac98f0dc89R738-R742)_)
* Fixed typos in function names and variables (e.g., `_db_access_acccess_is_valid` to `_db_access_access_is_valid`) and updated all references accordingly. (_[[1]](diffhunk://#diff-73bc4a8dbcbc69bacb661ec19f5ed301ce9ec9f5d51d293d71004cac98f0dc89L560-R566) [[2]](diffhunk://#diff-8aacc5b3c72d0b3a0f505f9a1265d98e2a8aaf906cd42d38f74370d5f2efcf3bL11-R18) [[3]](diffhunk://#diff-8aacc5b3c72d0b3a0f505f9a1265d98e2a8aaf906cd42d38f74370d5f2efcf3bL320-R325)_)

**Helper functions and password handling:**

* Added `_build_user_connection` and refactored password generation and secret decoding logic to improve clarity and ensure correct user connection parameters are built from secrets. (_[[1]](diffhunk://#diff-73bc4a8dbcbc69bacb661ec19f5ed301ce9ec9f5d51d293d71004cac98f0dc89L449-R534) [[2]](diffhunk://#diff-73bc4a8dbcbc69bacb661ec19f5ed301ce9ec9f5d51d293d71004cac98f0dc89L529-R551)_)

**Test updates and reliability:**

* Updated test fixtures and mocks to use the new resource handling approach, renamed fixtures for clarity, and adjusted assertions to match direct `OpenshiftResource` usage and new naming conventions. (_[[1]](diffhunk://#diff-8aacc5b3c72d0b3a0f505f9a1265d98e2a8aaf906cd42d38f74370d5f2efcf3bL119-R118) [[2]](diffhunk://#diff-8aacc5b3c72d0b3a0f505f9a1265d98e2a8aaf906cd42d38f74370d5f2efcf3bL349-R352) [[3]](diffhunk://#diff-8aacc5b3c72d0b3a0f505f9a1265d98e2a8aaf906cd42d38f74370d5f2efcf3bL373-R372) [[4]](diffhunk://#diff-8aacc5b3c72d0b3a0f505f9a1265d98e2a8aaf906cd42d38f74370d5f2efcf3bL456-R471) [[5]](diffhunk://#diff-8aacc5b3c72d0b3a0f505f9a1265d98e2a8aaf906cd42d38f74370d5f2efcf3bL490-R488) [[6]](diffhunk://#diff-8aacc5b3c72d0b3a0f505f9a1265d98e2a8aaf906cd42d38f74370d5f2efcf3bL511-R510) [[7]](diffhunk://#diff-8aacc5b3c72d0b3a0f505f9a1265d98e2a8aaf906cd42d38f74370d5f2efcf3bL522-R521) [[8]](diffhunk://#diff-8aacc5b3c72d0b3a0f505f9a1265d98e2a8aaf906cd42d38f74370d5f2efcf3bL541-R540)_)

**State management and integration:**

* Changed state tracking to use a composite `state_key` for better uniqueness and traceability, updating all state access and vault secret path logic accordingly. (_[[1]](diffhunk://#diff-73bc4a8dbcbc69bacb661ec19f5ed301ce9ec9f5d51d293d71004cac98f0dc89R581) [[2]](diffhunk://#diff-73bc4a8dbcbc69bacb661ec19f5ed301ce9ec9f5d51d293d71004cac98f0dc89L586-R595) [[3]](diffhunk://#diff-73bc4a8dbcbc69bacb661ec19f5ed301ce9ec9f5d51d293d71004cac98f0dc89L668-R696) [[4]](diffhunk://#diff-73bc4a8dbcbc69bacb661ec19f5ed301ce9ec9f5d51d293d71004cac98f0dc89R738-R742)_)

These changes collectively make the codebase easier to maintain, less error-prone, and more consistent in its resource management and integration logic.

[APPSRE-12326](https://issues.redhat.com/browse/APPSRE-12326)