### PR TITLE
feat(erv2): merge default tags into tags

### DIFF
--- a/reconcile/external_resources/factories.py
+++ b/reconcile/external_resources/factories.py
@@ -2,7 +2,6 @@ from abc import (
     ABC,
     abstractmethod,
 )
-from collections.abc import Mapping
 from typing import Generic, TypeVar
 
 from reconcile.external_resources.aws import (
@@ -116,7 +115,7 @@ class AWSExternalResourceFactory(ExternalResourceFactory):
         secret_reader: SecretReaderBase,
         provision_factories: ObjectFactory[ModuleProvisionDataFactory],
         resource_factories: ObjectFactory[AWSResourceFactory],
-        default_tags: Mapping[str, str],
+        default_tags: dict[str, str],
     ):
         self.provision_factories = provision_factories
         self.resource_factories = resource_factories
@@ -132,8 +131,7 @@ class AWSExternalResourceFactory(ExternalResourceFactory):
     ) -> ExternalResource:
         f = self.resource_factories.get_factory(spec.provider)
         data = f.resolve(spec, module_conf)
-        data["tags"] = spec.tags(integration=QONTRACT_INTEGRATION)
-        data["default_tags"] = [{"tags": self.default_tags}]
+        data["tags"] = self.default_tags | spec.tags(integration=QONTRACT_INTEGRATION)
 
         region = data.get("region")
         if region:

--- a/reconcile/external_resources/manager.py
+++ b/reconcile/external_resources/manager.py
@@ -2,6 +2,7 @@ import logging
 from collections import Counter
 from collections.abc import Iterable
 from datetime import UTC, datetime
+from typing import cast
 
 from sretoolbox.utils import threaded
 
@@ -67,7 +68,7 @@ def setup_factories(
                 resource_factories=setup_aws_resource_factories(
                     er_inventory, secret_reader
                 ),
-                default_tags=settings.default_tags,
+                default_tags=cast("dict[str, str]", settings.default_tags),
             )
         }
     )

--- a/reconcile/test/external_resources/conftest.py
+++ b/reconcile/test/external_resources/conftest.py
@@ -111,9 +111,9 @@ def state(
 @fixture
 def module() -> ExternalResourcesModuleV1:
     return ExternalResourcesModuleV1(
-        module_type="cdktf",
+        module_type="terraform",
         provision_provider="aws",
-        provider="aws-iam-role",
+        provider="rds",
         reconcile_drift_interval_minutes=60,
         reconcile_timeout_minutes=60,
         outputs_secret_sync=True,

--- a/reconcile/test/external_resources/test_aws_external_resource_factory.py
+++ b/reconcile/test/external_resources/test_aws_external_resource_factory.py
@@ -1,0 +1,108 @@
+from typing import cast
+from unittest.mock import Mock
+
+from reconcile.external_resources.aws import (
+    AWSDefaultResourceFactory,
+    AWSRdsFactory,
+    AWSResourceFactory,
+)
+from reconcile.external_resources.factories import (
+    AWSExternalResourceFactory,
+    ModuleProvisionDataFactory,
+    ObjectFactory,
+    TerraformModuleProvisionDataFactory,
+)
+from reconcile.external_resources.model import (
+    ExternalResource,
+    ExternalResourceModuleConfiguration,
+    ExternalResourceProvision,
+    ExternalResourcesInventory,
+    ModuleInventory,
+    TerraformModuleProvisionData,
+)
+from reconcile.gql_definitions.external_resources.external_resources_settings import (
+    ExternalResourcesSettingsV1,
+)
+from reconcile.utils.external_resource_spec import ExternalResourceSpec
+
+
+def test_create_external_resource(
+    secret_reader: Mock,
+    settings: ExternalResourcesSettingsV1,
+    module_inventory: ModuleInventory,
+) -> None:
+    tf_factory = TerraformModuleProvisionDataFactory(settings=settings)
+    er_inventory = ExternalResourcesInventory([])
+    factory = AWSExternalResourceFactory(
+        module_inventory=module_inventory,
+        er_inventory=er_inventory,
+        secret_reader=secret_reader,
+        provision_factories=ObjectFactory[ModuleProvisionDataFactory](
+            factories={"terraform": tf_factory, "cdktf": tf_factory}
+        ),
+        resource_factories=ObjectFactory[AWSResourceFactory](
+            factories={
+                "rds": AWSRdsFactory(er_inventory, secret_reader),
+            },
+            default_factory=AWSDefaultResourceFactory(er_inventory, secret_reader),
+        ),
+        default_tags=cast("dict[str, str]", settings.default_tags),
+    )
+    spec = ExternalResourceSpec(
+        provision_provider="aws",
+        provisioner={"name": "test", "resources_default_region": "us-east-1"},
+        resource={"identifier": "test-rds", "provider": "rds"},
+        namespace={
+            "cluster": {"name": "test_cluster"},
+            "name": "test_namespace",
+            "environment": {"name": "test_env"},
+            "app": {
+                "name": "test_app",
+            },
+        },
+    )
+    module_conf = ExternalResourceModuleConfiguration(
+        image="stable-image",
+        version="1.0.0",
+        outputs_secret_image="path/to/er-output-secret-image",
+        outputs_secret_version="er-output-secret-version",
+        reconcile_timeout_minutes=60,
+        reconcile_drift_interval_minutes=60,
+    )
+
+    result = factory.create_external_resource(
+        spec=spec,
+        module_conf=module_conf,
+    )
+
+    assert result == ExternalResource(
+        data={
+            "identifier": "test-rds",
+            "output_prefix": "test-rds-rds",
+            "timeouts": {"create": "55m", "update": "55m", "delete": "55m"},
+            "tags": {
+                "managed_by_integration": "external_resources",
+                "cluster": "test_cluster",
+                "namespace": "test_namespace",
+                "environment": "test_env",
+                "env": "test",
+                "app": "test_app",
+            },
+            "region": "us-east-1",
+        },
+        provision=ExternalResourceProvision(
+            provision_provider="aws",
+            provisioner="test",
+            provider="rds",
+            identifier="test-rds",
+            target_cluster="test_cluster",
+            target_namespace="test_namespace",
+            target_secret_name="test-rds-rds",
+            module_provision_data=TerraformModuleProvisionData(
+                tf_state_bucket=settings.tf_state_bucket,
+                tf_state_region=settings.tf_state_region,
+                tf_state_dynamodb_table=settings.tf_state_dynamodb_table,
+                tf_state_key="aws/test/rds/test-rds/terraform.tfstate",
+            ),
+        ),
+    )


### PR DESCRIPTION
Merge `default_tags` from settings and spec `tags` as final `tags` to external resource module. So `tags` means the tags set on all resources created by module, avoid confusing merge tags logic in each module.

**Tag handling and type consistency:**

* Changed the type of `default_tags` from `Mapping[str, str]` to `dict[str, str]` in the constructor of `AWSExternalResourceFactory` to ensure stricter type enforcement and compatibility with dictionary operations.
* Updated the merging logic for tags in `create_external_resource` to use dictionary union (`|`), combining `default_tags` and resource-specific tags into a single dictionary, removing the previous nested structure.
* Applied a `cast` to `settings.default_tags` in the manager setup to guarantee it is treated as a dictionary, matching the updated type expectations.

**Testing improvements:**

* Added a comprehensive unit test for `AWSExternalResourceFactory.create_external_resource`, verifying correct tag merging and resource creation for an RDS resource.
* Updated the test fixture in `conftest.py` to use `"terraform"` as `module_type` and `"rds"` as `provider`, reflecting current usage patterns.

**Code cleanup:**

* Removed an unused import of `Mapping` from `factories.py` after changing the type of `default_tags`.
* Added an import of `cast` in `manager.py` to support the explicit casting of `default_tags`.



[APPSRE-12469](https://issues.redhat.com/browse/APPSRE-12469)