### PR TITLE
refactor: set severity high for sloth ticketing alerts

### DIFF
--- a/reconcile/test/fixtures/jinja2/sloth_alerts_expected_result.yaml
+++ b/reconcile/test/fixtures/jinja2/sloth_alerts_expected_result.yaml
@@ -179,7 +179,7 @@ groups:
       )
     labels:
       service: test-app
-      severity: medium
+      severity: high
       slo: Availability
     annotations:
       dashboard: https://example.com/dashboard
@@ -362,7 +362,7 @@ groups:
       )
     labels:
       service: test-app
-      severity: medium
+      severity: high
       slo: Latency
     annotations:
       dashboard: https://example.com/dashboard

--- a/reconcile/utils/sloth.py
+++ b/reconcile/utils/sloth.py
@@ -200,7 +200,7 @@ def generate_sloth_rules(
                 },
                 "ticket_alert": {
                     "labels": {
-                        "severity": "medium",
+                        "severity": "high",
                         "service": service,
                         "slo": slo["name"],
                     }


### PR DESCRIPTION
Increase severity for "ticket level" alerts generated by sloth from medium to high. 