### PR TITLE
[terraform-init] manage terraform state s3 bucket and tags via cloudformation

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,7 +70,7 @@ debugger = ["debugpy ~=1.6.0"]
 dev = [
     "anymarkup ~=0.8.1",
     # keep in sync project.dependencies.boto3
-    "boto3-stubs[account,dynamodb,ec2,ecr,elb,iam,logs,organizations,rds,route53,s3,service-quotas,sqs,sts,support]==1.34.94",
+    "boto3-stubs[account,cloudformation,dynamodb,ec2,ecr,elb,iam,logs,organizations,rds,route53,s3,service-quotas,sqs,sts,support]==1.34.94",
     "kubernetes-stubs==22.6.0",
     "MarkupSafe ~=2.1.1",
     "moto[ec2,iam,logs,s3,route53] ~=5.1",

--- a/reconcile/cli.py
+++ b/reconcile/cli.py
@@ -1036,12 +1036,26 @@ def aws_account_manager(
     required=True,
     default="data/templating/collections/terraform-init",
 )
+@click.option(
+    "--cloudformation-template-resource",
+    help="Resource name of the CloudFormation template to create the S3 bucket",
+    required=True,
+    default="/terraform-init/terraform-state-s3-bucket.yaml",
+)
+@click.option(
+    "--cloudformation-import-template-resource",
+    help="Resource name of the CloudFormation template to import existing S3 bucket",
+    required=True,
+    default="/terraform-init/terraform-state-s3-bucket-import.yaml",
+)
 @click.pass_context
 def terraform_init(
     ctx: click.Context,
     account_name: str | None,
     state_tmpl_resource: str,
     template_collection_root_path: str,
+    cloudformation_template_resource: str,
+    cloudformation_import_template_resource: str,
 ) -> None:
     from reconcile.terraform_init.integration import (
         TerraformInitIntegration,
@@ -1054,6 +1068,8 @@ def terraform_init(
                 account_name=account_name,
                 state_tmpl_resource=state_tmpl_resource,
                 template_collection_root_path=template_collection_root_path,
+                cloudformation_template_resource=cloudformation_template_resource,
+                cloudformation_import_template_resource=cloudformation_import_template_resource,
             )
         ),
         ctx=ctx,

--- a/reconcile/cli.py
+++ b/reconcile/cli.py
@@ -1028,7 +1028,7 @@ def aws_account_manager(
     "--state-tmpl-resource",
     help="Resource name of the state template-collection template in the app-interface.",
     required=True,
-    default="/terraform-init/terraform-state.yml",
+    default="/terraform-init/terraform-state.yml.j2",
 )
 @click.option(
     "--template-collection-root-path",

--- a/reconcile/gql_definitions/terraform_init/aws_accounts.gql
+++ b/reconcile/gql_definitions/terraform_init/aws_accounts.gql
@@ -5,6 +5,7 @@ query TerraformInitAWSAccounts {
     name
     terraformUsername
     terraformState {
+      bucket
       region
     }
     resourcesDefaultRegion

--- a/reconcile/gql_definitions/terraform_init/aws_accounts.py
+++ b/reconcile/gql_definitions/terraform_init/aws_accounts.py
@@ -33,6 +33,7 @@ query TerraformInitAWSAccounts {
     name
     terraformUsername
     terraformState {
+      bucket
       region
     }
     resourcesDefaultRegion
@@ -54,6 +55,7 @@ class ConfiguredBaseModel(BaseModel):
 
 
 class TerraformStateAWSV1(ConfiguredBaseModel):
+    bucket: str = Field(..., alias="bucket")
     region: str = Field(..., alias="region")
 
 

--- a/reconcile/terraform_init/integration.py
+++ b/reconcile/terraform_init/integration.py
@@ -145,7 +145,11 @@ class TerraformInitIntegration(
         Returns:
             None
         """
-        bucket_name = f"terraform-{account.name}"
+        bucket_name = (
+            account.terraform_state.bucket
+            if account.terraform_state
+            else f"terraform-{account.name}"
+        )
 
         if account.terraform_state is None:
             return self._provision_terraform_state(

--- a/reconcile/terraform_init/integration.py
+++ b/reconcile/terraform_init/integration.py
@@ -12,12 +12,14 @@ from reconcile.gql_definitions.terraform_init.aws_accounts import (
 from reconcile.terraform_init.merge_request import Renderer, create_parser
 from reconcile.terraform_init.merge_request_manager import MergeRequestManager, MrData
 from reconcile.typed_queries.app_interface_repo_url import get_app_interface_repo_url
+from reconcile.typed_queries.external_resources import get_settings
 from reconcile.typed_queries.github_orgs import get_github_orgs
 from reconcile.typed_queries.gitlab_instances import get_gitlab_instances
 from reconcile.utils import gql
 from reconcile.utils.aws_api_typed.api import AWSApi, AWSStaticCredentials
 from reconcile.utils.defer import defer
 from reconcile.utils.disabled_integrations import integration_is_enabled
+from reconcile.utils.gql import GqlApi
 from reconcile.utils.runtime.integration import (
     PydanticRunParams,
     QontractReconcileIntegration,
@@ -35,6 +37,12 @@ class TerraformInitIntegrationParams(PydanticRunParams):
     # To avoid the accidental deletion of the resource file, explicitly set the
     # qontract.cli option in the integration extraArgs!
     state_tmpl_resource: str = "/terraform-init/terraform-state.yml"
+    cloudformation_template_resource: str = (
+        "/terraform-init/terraform-state-s3-bucket.yaml"
+    )
+    cloudformation_import_template_resource: str = (
+        "/terraform-init/terraform-state-s3-bucket-import.yaml"
+    )
     template_collection_root_path: str = "data/templating/collections/terraform-init"
 
 
@@ -62,18 +70,28 @@ class TerraformInitIntegration(
     def get_aws_accounts(
         self, query_func: Callable, account_name: str | None = None
     ) -> list[AWSAccountV1]:
-        """Return all AWS accounts with terraform username but no terraform state set."""
+        """Return all AWS accounts with terraform username."""
         return [
             account
             for account in aws_accounts_query(query_func).accounts or []
             if integration_is_enabled(self.name, account)
             and (not account_name or account.name == account_name)
             and account.terraform_username
-            and not account.terraform_state
         ]
 
+    @staticmethod
+    def get_default_tags(gql_api: GqlApi) -> dict[str, str]:
+        try:
+            return get_settings(gql_api.query).default_tags
+        except ValueError:
+            # no settings found
+            return {}
+
+    @staticmethod
     def render_state_collection(
-        self, template: str, bucket_name: str, account: AWSAccountV1
+        template: str,
+        bucket_name: str,
+        account: AWSAccountV1,
     ) -> str:
         return jinja2.Template(
             template,
@@ -90,19 +108,103 @@ class TerraformInitIntegration(
 
     def reconcile_account(
         self,
-        account_aws_api: AWSApi,
+        aws_api: AWSApi,
         merge_request_manager: MergeRequestManager,
         dry_run: bool,
-        state_collection: str,
-        bucket_name: str,
         account: AWSAccountV1,
+        state_template: str,
+        cloudformation_template: str,
+        cloudformation_import_template: str,
+        tags: dict[str, str],
+    ) -> None:
+        """
+        Reconcile the terraform state for a given account.
+
+        Create S3 bucket via CloudFormation and Merge Request to update template file on init.
+        Import existing bucket if it exists but not managed by CloudFormation.
+        Update CloudFormation stack if tags or template body differ.
+
+        CloudFormation stack name and bucket name is `terraform-<account_name>`.
+        `cloudformation_import_template` should be minimal template with identifier fields only.
+        `cloudformation_template` should be the full template.
+        Use import template to import then update stack to match full template.
+        This will ensure imported resources match CloudFormation template.
+        And all desired changes in full template are applied.
+        Both templates must have BucketName in Parameters.
+
+        Args:
+            aws_api: AWSApi: AWS API client for the target account.
+            merge_request_manager: MergeRequestManager: Manager to handle merge requests.
+            dry_run: bool: If True, do not make any changes.
+            account: AWSAccountV1: The AWS account to reconcile.
+            state_template: str: Jinja2 template for the Terraform state configuration.
+            cloudformation_template: str: CloudFormation template to create the S3 bucket.
+            cloudformation_import_template: str: CloudFormation template to import existing S3 bucket.
+            tags: dict[str, str]: Tags to apply to the CloudFormation stack.
+
+        Returns:
+            None
+        """
+        bucket_name = f"terraform-{account.name}"
+
+        if account.terraform_state is None:
+            return self._provision_terraform_state(
+                aws_api=aws_api,
+                merge_request_manager=merge_request_manager,
+                dry_run=dry_run,
+                account=account,
+                bucket_name=bucket_name,
+                cloudformation_template=cloudformation_template,
+                state_template=state_template,
+                tags=tags,
+            )
+
+        stack = aws_api.cloudformation.get_stack(stack_name=bucket_name)
+
+        if stack is None:
+            return self._import_cloudformation_stack(
+                aws_api=aws_api,
+                dry_run=dry_run,
+                bucket_name=bucket_name,
+                cloudformation_import_template=cloudformation_import_template,
+                cloudformation_template=cloudformation_template,
+                tags=tags,
+            )
+
+        return self._reconcile_cloudformation_stack(
+            aws_api=aws_api,
+            dry_run=dry_run,
+            bucket_name=bucket_name,
+            cloudformation_template=cloudformation_template,
+            tags=tags,
+            current_tags={tag["Key"]: tag["Value"] for tag in stack.get("Tags", [])},
+        )
+
+    def _provision_terraform_state(
+        self,
+        aws_api: AWSApi,
+        merge_request_manager: MergeRequestManager,
+        dry_run: bool,
+        account: AWSAccountV1,
+        bucket_name: str,
+        cloudformation_template: str,
+        state_template: str,
+        tags: dict[str, str],
     ) -> None:
         logging.info("Creating bucket '%s' for account '%s'", bucket_name, account.name)
         if not dry_run:
-            # the creation of the bucket is idempotent
-            account_aws_api.s3.create_bucket(
-                name=bucket_name, region=account.resources_default_region
+            aws_api.cloudformation.create_stack(
+                stack_name=bucket_name,
+                change_set_name=f"create-{bucket_name}",
+                template_body=cloudformation_template,
+                parameters={"BucketName": bucket_name},
+                tags=tags,
             )
+        state_collection = self.render_state_collection(
+            template=state_template,
+            bucket_name=bucket_name,
+            account=account,
+        )
         merge_request_manager.create_merge_request(
             data=MrData(
                 account=account.name,
@@ -110,6 +212,55 @@ class TerraformInitIntegration(
                 path=f"{self.params.template_collection_root_path}/{account.name}.yml",
             )
         )
+
+    @staticmethod
+    def _import_cloudformation_stack(
+        aws_api: AWSApi,
+        dry_run: bool,
+        bucket_name: str,
+        cloudformation_import_template: str,
+        cloudformation_template: str,
+        tags: dict[str, str],
+    ) -> None:
+        logging.info("Importing existing bucket %s", bucket_name)
+        if not dry_run:
+            aws_api.cloudformation.create_stack(
+                stack_name=bucket_name,
+                change_set_name=f"import-{bucket_name}",
+                template_body=cloudformation_import_template,
+                parameters={"BucketName": bucket_name},
+                tags=tags,
+            )
+            logging.info("Syncing stack %s after import", bucket_name)
+            aws_api.cloudformation.update_stack(
+                stack_name=bucket_name,
+                template_body=cloudformation_template,
+                parameters={"BucketName": bucket_name},
+                tags=tags,
+            )
+
+    @staticmethod
+    def _reconcile_cloudformation_stack(
+        aws_api: AWSApi,
+        dry_run: bool,
+        bucket_name: str,
+        cloudformation_template: str,
+        tags: dict[str, str],
+        current_tags: dict[str, str],
+    ) -> None:
+        if (
+            current_tags != tags
+            or aws_api.cloudformation.get_template_body(stack_name=bucket_name)
+            != cloudformation_template
+        ):
+            logging.info("Updating stack %s", bucket_name)
+            if not dry_run:
+                aws_api.cloudformation.update_stack(
+                    stack_name=bucket_name,
+                    template_body=cloudformation_template,
+                    parameters={"BucketName": bucket_name},
+                    tags=tags,
+                )
 
     @defer
     def run(self, dry_run: bool, defer: Callable | None = None) -> None:
@@ -144,6 +295,14 @@ class TerraformInitIntegration(
         state_template = gql_api.get_resource(path=self.params.state_tmpl_resource)[
             "content"
         ]
+        cloudformation_template = gql_api.get_resource(
+            path=self.params.cloudformation_template_resource
+        )["content"]
+        cloudformation_import_template = gql_api.get_resource(
+            path=self.params.cloudformation_import_template_resource
+        )["content"]
+        default_tags = self.get_default_tags(gql_api)
+
         for account in accounts:
             secret = self.secret_reader.read_all_secret(account.automation_token)
             with AWSApi(
@@ -153,15 +312,13 @@ class TerraformInitIntegration(
                     region=account.resources_default_region,
                 )
             ) as account_aws_api:
-                bucket_name = f"terraform-{account.name}"
-                state_collection = self.render_state_collection(
-                    state_template, bucket_name, account
-                )
                 self.reconcile_account(
-                    account_aws_api,
-                    merge_request_manager,
-                    dry_run,
-                    state_collection,
-                    bucket_name,
-                    account,
+                    aws_api=account_aws_api,
+                    merge_request_manager=merge_request_manager,
+                    dry_run=dry_run,
+                    account=account,
+                    state_template=state_template,
+                    cloudformation_template=cloudformation_template,
+                    cloudformation_import_template=cloudformation_import_template,
+                    tags=default_tags,
                 )

--- a/reconcile/test/fixtures/terraform_init/accounts.yml
+++ b/reconcile/test/fixtures/terraform_init/accounts.yml
@@ -1,4 +1,3 @@
-
 accounts:
 - name: account-1
   terraformUsername: terraform
@@ -14,18 +13,18 @@ accounts:
   automationToken:
     path: path/to/creds
 
-# all accounts below must be irgnored
-- name: no-terraform-username
-  terraformUsername: null
-  terraformState: null
-  resourcesDefaultRegion: us-east-1
-  automationToken:
-    path: path/to/creds
-
 - name: terraform-state-already-set
   terraformUsername: terraform
   terraformState:
     region: us-east-1
+  resourcesDefaultRegion: us-east-1
+  automationToken:
+    path: path/to/creds
+
+# all accounts below must be ignored
+- name: no-terraform-username
+  terraformUsername: null
+  terraformState: null
   resourcesDefaultRegion: us-east-1
   automationToken:
     path: path/to/creds

--- a/reconcile/test/fixtures/terraform_init/accounts.yml
+++ b/reconcile/test/fixtures/terraform_init/accounts.yml
@@ -16,6 +16,7 @@ accounts:
 - name: terraform-state-already-set
   terraformUsername: terraform
   terraformState:
+    bucket: existing-bucket
     region: us-east-1
   resourcesDefaultRegion: us-east-1
   automationToken:

--- a/reconcile/test/fixtures/terraform_init/settings.yml
+++ b/reconcile/test/fixtures/terraform_init/settings.yml
@@ -1,0 +1,20 @@
+state_dynamodb_account:
+  name: account-1
+state_dynamodb_table: external-resources-state
+state_dynamodb_region: us-east-1
+workers_cluster:
+  name: test-cluster
+workers_namespace:
+  name: test-namespace
+vault_secrets_path: test-external-resources
+outputs_secret_image: some-image
+outputs_secret_version: some-version
+module_default_resources:
+  requests:
+    cpu: 100m
+    memory: 128Mi
+  limits:
+      cpu: 200m
+      memory: 256Mi
+default_tags: |
+  {"env": "test"}

--- a/reconcile/test/terraform_init/conftest.py
+++ b/reconcile/test/terraform_init/conftest.py
@@ -5,6 +5,9 @@ from unittest.mock import MagicMock
 import pytest
 from pytest_mock import MockerFixture
 
+from reconcile.gql_definitions.external_resources.external_resources_settings import (
+    ExternalResourcesSettingsV1,
+)
 from reconcile.gql_definitions.terraform_init.aws_accounts import AWSAccountV1
 from reconcile.terraform_init.integration import (
     TerraformInitIntegration,
@@ -50,6 +53,23 @@ def query_func(
         }
 
     return q
+
+
+@pytest.fixture
+def external_resource_settings(
+    fx: Fixtures,
+    data_factory: Callable[
+        [type[ExternalResourcesSettingsV1], Mapping[str, Any]], Mapping[str, Any]
+    ],
+) -> dict[str, Any]:
+    return {
+        "settings": [
+            data_factory(
+                ExternalResourcesSettingsV1,
+                fx.get_anymarkup("settings.yml"),
+            )
+        ]
+    }
 
 
 @pytest.fixture

--- a/reconcile/test/terraform_init/test_terraform_init_integration.py
+++ b/reconcile/test/terraform_init/test_terraform_init_integration.py
@@ -150,19 +150,19 @@ def test_terraform_init_integration_reconcile_account_when_import_stack(
     )
 
     aws_api.cloudformation.get_stack.assert_called_once_with(
-        stack_name="terraform-terraform-state-already-set"
+        stack_name="existing-bucket"
     )
     aws_api.cloudformation.create_stack.assert_called_once_with(
-        stack_name="terraform-terraform-state-already-set",
-        change_set_name="import-terraform-terraform-state-already-set",
+        stack_name="existing-bucket",
+        change_set_name="import-existing-bucket",
         template_body="cloudformation_import_template",
-        parameters={"BucketName": "terraform-terraform-state-already-set"},
+        parameters={"BucketName": "existing-bucket"},
         tags={"env": "test"},
     )
     aws_api.cloudformation.update_stack.assert_called_once_with(
-        stack_name="terraform-terraform-state-already-set",
+        stack_name="existing-bucket",
         template_body="cloudformation_template",
-        parameters={"BucketName": "terraform-terraform-state-already-set"},
+        parameters={"BucketName": "existing-bucket"},
         tags={"env": "test"},
     )
     merge_request_manager.create_merge_request.assert_not_called()
@@ -189,7 +189,7 @@ def test_terraform_init_integration_reconcile_account_when_import_stack_dry_run(
     )
 
     aws_api.cloudformation.get_stack.assert_called_once_with(
-        stack_name="terraform-terraform-state-already-set"
+        stack_name="existing-bucket"
     )
     aws_api.cloudformation.create_stack.assert_not_called()
     aws_api.cloudformation.update_stack.assert_not_called()
@@ -220,12 +220,12 @@ def test_terraform_init_integration_reconcile_account_when_tags_mismatch(
     )
 
     aws_api.cloudformation.get_stack.assert_called_once_with(
-        stack_name="terraform-terraform-state-already-set"
+        stack_name="existing-bucket"
     )
     aws_api.cloudformation.update_stack.assert_called_once_with(
-        stack_name="terraform-terraform-state-already-set",
+        stack_name="existing-bucket",
         template_body="cloudformation_template",
-        parameters={"BucketName": "terraform-terraform-state-already-set"},
+        parameters={"BucketName": "existing-bucket"},
         tags={"env": "test"},
     )
     aws_api.cloudformation.create_stack.assert_not_called()
@@ -257,7 +257,7 @@ def test_terraform_init_integration_reconcile_account_when_tags_mismatch_dry_run
     )
 
     aws_api.cloudformation.get_stack.assert_called_once_with(
-        stack_name="terraform-terraform-state-already-set"
+        stack_name="existing-bucket"
     )
     aws_api.cloudformation.update_stack.assert_not_called()
     aws_api.cloudformation.create_stack.assert_not_called()
@@ -290,15 +290,15 @@ def test_terraform_init_integration_reconcile_account_when_template_body_mismatc
     )
 
     aws_api.cloudformation.get_stack.assert_called_once_with(
-        stack_name="terraform-terraform-state-already-set"
+        stack_name="existing-bucket"
     )
     aws_api.cloudformation.get_template_body.assert_called_once_with(
-        stack_name="terraform-terraform-state-already-set"
+        stack_name="existing-bucket"
     )
     aws_api.cloudformation.update_stack.assert_called_once_with(
-        stack_name="terraform-terraform-state-already-set",
+        stack_name="existing-bucket",
         template_body="cloudformation_template",
-        parameters={"BucketName": "terraform-terraform-state-already-set"},
+        parameters={"BucketName": "existing-bucket"},
         tags={"env": "test"},
     )
     aws_api.cloudformation.create_stack.assert_not_called()
@@ -330,10 +330,10 @@ def test_terraform_init_integration_reconcile_account_when_template_body_mismatc
     )
 
     aws_api.cloudformation.get_stack.assert_called_once_with(
-        stack_name="terraform-terraform-state-already-set"
+        stack_name="existing-bucket"
     )
     aws_api.cloudformation.get_template_body.assert_called_once_with(
-        stack_name="terraform-terraform-state-already-set"
+        stack_name="existing-bucket"
     )
     aws_api.cloudformation.update_stack.assert_not_called()
     aws_api.cloudformation.create_stack.assert_not_called()
@@ -365,10 +365,10 @@ def test_terraform_init_integration_reconcile_account_when_no_changes(
     )
 
     aws_api.cloudformation.get_stack.assert_called_once_with(
-        stack_name="terraform-terraform-state-already-set"
+        stack_name="existing-bucket"
     )
     aws_api.cloudformation.get_template_body.assert_called_once_with(
-        stack_name="terraform-terraform-state-already-set"
+        stack_name="existing-bucket"
     )
     aws_api.cloudformation.create_stack.assert_not_called()
     aws_api.cloudformation.update_stack.assert_not_called()

--- a/reconcile/test/terraform_init/test_terraform_init_integration.py
+++ b/reconcile/test/terraform_init/test_terraform_init_integration.py
@@ -1,6 +1,6 @@
 from collections.abc import Callable
 from textwrap import dedent
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, create_autospec
 
 from dateutil import parser
 from pytest_mock import MockerFixture
@@ -8,6 +8,8 @@ from pytest_mock import MockerFixture
 from reconcile.gql_definitions.terraform_init.aws_accounts import AWSAccountV1
 from reconcile.terraform_init import integration
 from reconcile.terraform_init.integration import TerraformInitIntegration
+from reconcile.terraform_init.merge_request_manager import MrData
+from reconcile.utils.gql import GqlApi
 
 
 def test_terraform_init_integration_early_exit(
@@ -47,42 +49,327 @@ def test_terraform_init_integration_get_aws_accounts(
     query_func: Callable, intg: TerraformInitIntegration
 ) -> None:
     accounts = intg.get_aws_accounts(query_func)
-    assert len(accounts) == 2
+    assert len(accounts) == 3
     assert accounts[0].name == "account-1"
     assert accounts[1].name == "account-2"
+    assert accounts[2].name == "terraform-state-already-set"
 
 
-def test_terraform_init_integration_reconcile_account(
+def test_terraform_init_integration_get_default_tags(
+    intg: TerraformInitIntegration,
+    external_resource_settings: dict,
+) -> None:
+    mock_gql_api = create_autospec(GqlApi)
+    mock_gql_api.query.return_value = external_resource_settings
+
+    result = intg.get_default_tags(mock_gql_api)
+
+    assert result == {"env": "test"}
+
+
+def test_terraform_init_integration_reconcile_account_with_new_account(
     aws_api: MagicMock,
     merge_request_manager: MagicMock,
     intg: TerraformInitIntegration,
     aws_accounts: list[AWSAccountV1],
 ) -> None:
+    account = next(a for a in aws_accounts if a.name == "account-1")
     intg.reconcile_account(
-        account_aws_api=aws_api,
+        aws_api=aws_api,
         merge_request_manager=merge_request_manager,
         dry_run=False,
-        state_collection="template",
-        bucket_name="bucket",
-        account=aws_accounts[0],
+        account=account,
+        state_template="{{bucket_name}}",
+        cloudformation_template="cloudformation_template",
+        cloudformation_import_template="cloudformation_import_template",
+        tags={"env": "test"},
     )
-    aws_api.s3.create_bucket.assert_called()
-    merge_request_manager.create_merge_request.assert_called()
+
+    aws_api.cloudformation.create_stack.assert_called_once_with(
+        stack_name="terraform-account-1",
+        change_set_name="create-terraform-account-1",
+        template_body="cloudformation_template",
+        parameters={"BucketName": "terraform-account-1"},
+        tags={"env": "test"},
+    )
+    merge_request_manager.create_merge_request.assert_called_once_with(
+        data=MrData(
+            account="account-1",
+            content="terraform-account-1",
+            path="data/templating/collections/terraform-init/account-1.yml",
+        )
+    )
 
 
-def test_terraform_init_integration_reconcile_account_dry_run(
+def test_terraform_init_integration_reconcile_account_with_new_account_dry_run(
     aws_api: MagicMock,
     merge_request_manager: MagicMock,
     intg: TerraformInitIntegration,
     aws_accounts: list[AWSAccountV1],
 ) -> None:
+    account = next(a for a in aws_accounts if a.name == "account-1")
     intg.reconcile_account(
-        account_aws_api=aws_api,
+        aws_api=aws_api,
         merge_request_manager=merge_request_manager,
         dry_run=True,
-        state_collection="template",
-        bucket_name="bucket",
-        account=aws_accounts[0],
+        account=account,
+        state_template="{{bucket_name}}",
+        cloudformation_template="cloudformation_template",
+        cloudformation_import_template="cloudformation_import_template",
+        tags={"env": "test"},
     )
-    aws_api.s3.create_bucket.assert_not_called()
-    merge_request_manager.create_merge_request.assert_called()
+
+    aws_api.cloudformation.create_stack.assert_not_called()
+    merge_request_manager.create_merge_request.assert_called_once_with(
+        data=MrData(
+            account="account-1",
+            content="terraform-account-1",
+            path="data/templating/collections/terraform-init/account-1.yml",
+        )
+    )
+
+
+def test_terraform_init_integration_reconcile_account_when_import_stack(
+    aws_api: MagicMock,
+    merge_request_manager: MagicMock,
+    intg: TerraformInitIntegration,
+    aws_accounts: list[AWSAccountV1],
+) -> None:
+    account = next(a for a in aws_accounts if a.name == "terraform-state-already-set")
+    aws_api.cloudformation.get_stack.return_value = None
+
+    intg.reconcile_account(
+        aws_api=aws_api,
+        merge_request_manager=merge_request_manager,
+        dry_run=False,
+        account=account,
+        state_template="{{bucket_name}}",
+        cloudformation_template="cloudformation_template",
+        cloudformation_import_template="cloudformation_import_template",
+        tags={"env": "test"},
+    )
+
+    aws_api.cloudformation.get_stack.assert_called_once_with(
+        stack_name="terraform-terraform-state-already-set"
+    )
+    aws_api.cloudformation.create_stack.assert_called_once_with(
+        stack_name="terraform-terraform-state-already-set",
+        change_set_name="import-terraform-terraform-state-already-set",
+        template_body="cloudformation_import_template",
+        parameters={"BucketName": "terraform-terraform-state-already-set"},
+        tags={"env": "test"},
+    )
+    aws_api.cloudformation.update_stack.assert_called_once_with(
+        stack_name="terraform-terraform-state-already-set",
+        template_body="cloudformation_template",
+        parameters={"BucketName": "terraform-terraform-state-already-set"},
+        tags={"env": "test"},
+    )
+    merge_request_manager.create_merge_request.assert_not_called()
+
+
+def test_terraform_init_integration_reconcile_account_when_import_stack_dry_run(
+    aws_api: MagicMock,
+    merge_request_manager: MagicMock,
+    intg: TerraformInitIntegration,
+    aws_accounts: list[AWSAccountV1],
+) -> None:
+    account = next(a for a in aws_accounts if a.name == "terraform-state-already-set")
+    aws_api.cloudformation.get_stack.return_value = None
+
+    intg.reconcile_account(
+        aws_api=aws_api,
+        merge_request_manager=merge_request_manager,
+        dry_run=True,
+        account=account,
+        state_template="{{bucket_name}}",
+        cloudformation_template="cloudformation_template",
+        cloudformation_import_template="cloudformation_import_template",
+        tags={"env": "test"},
+    )
+
+    aws_api.cloudformation.get_stack.assert_called_once_with(
+        stack_name="terraform-terraform-state-already-set"
+    )
+    aws_api.cloudformation.create_stack.assert_not_called()
+    aws_api.cloudformation.update_stack.assert_not_called()
+    merge_request_manager.create_merge_request.assert_not_called()
+
+
+def test_terraform_init_integration_reconcile_account_when_tags_mismatch(
+    aws_api: MagicMock,
+    merge_request_manager: MagicMock,
+    intg: TerraformInitIntegration,
+    aws_accounts: list[AWSAccountV1],
+) -> None:
+    account = next(a for a in aws_accounts if a.name == "terraform-state-already-set")
+    aws_api.cloudformation.get_stack.return_value = {
+        "StackName": "terraform-terraform-state-already-set",
+        "Tags": [{"Key": "env", "Value": "test-old"}],
+    }
+
+    intg.reconcile_account(
+        aws_api=aws_api,
+        merge_request_manager=merge_request_manager,
+        dry_run=False,
+        account=account,
+        state_template="{{bucket_name}}",
+        cloudformation_template="cloudformation_template",
+        cloudformation_import_template="cloudformation_import_template",
+        tags={"env": "test"},
+    )
+
+    aws_api.cloudformation.get_stack.assert_called_once_with(
+        stack_name="terraform-terraform-state-already-set"
+    )
+    aws_api.cloudformation.update_stack.assert_called_once_with(
+        stack_name="terraform-terraform-state-already-set",
+        template_body="cloudformation_template",
+        parameters={"BucketName": "terraform-terraform-state-already-set"},
+        tags={"env": "test"},
+    )
+    aws_api.cloudformation.create_stack.assert_not_called()
+    aws_api.cloudformation.get_template.assert_not_called()
+    merge_request_manager.create_merge_request.assert_not_called()
+
+
+def test_terraform_init_integration_reconcile_account_when_tags_mismatch_dry_run(
+    aws_api: MagicMock,
+    merge_request_manager: MagicMock,
+    intg: TerraformInitIntegration,
+    aws_accounts: list[AWSAccountV1],
+) -> None:
+    account = next(a for a in aws_accounts if a.name == "terraform-state-already-set")
+    aws_api.cloudformation.get_stack.return_value = {
+        "StackName": "terraform-terraform-state-already-set",
+        "Tags": [{"Key": "env", "Value": "test-old"}],
+    }
+
+    intg.reconcile_account(
+        aws_api=aws_api,
+        merge_request_manager=merge_request_manager,
+        dry_run=True,
+        account=account,
+        state_template="{{bucket_name}}",
+        cloudformation_template="cloudformation_template",
+        cloudformation_import_template="cloudformation_import_template",
+        tags={"env": "test"},
+    )
+
+    aws_api.cloudformation.get_stack.assert_called_once_with(
+        stack_name="terraform-terraform-state-already-set"
+    )
+    aws_api.cloudformation.update_stack.assert_not_called()
+    aws_api.cloudformation.create_stack.assert_not_called()
+    aws_api.cloudformation.get_template.assert_not_called()
+    merge_request_manager.create_merge_request.assert_not_called()
+
+
+def test_terraform_init_integration_reconcile_account_when_template_body_mismatch(
+    aws_api: MagicMock,
+    merge_request_manager: MagicMock,
+    intg: TerraformInitIntegration,
+    aws_accounts: list[AWSAccountV1],
+) -> None:
+    account = next(a for a in aws_accounts if a.name == "terraform-state-already-set")
+    aws_api.cloudformation.get_stack.return_value = {
+        "StackName": "terraform-terraform-state-already-set",
+        "Tags": [{"Key": "env", "Value": "test"}],
+    }
+    aws_api.cloudformation.get_template_body.return_value = "old_template_body"
+
+    intg.reconcile_account(
+        aws_api=aws_api,
+        merge_request_manager=merge_request_manager,
+        dry_run=False,
+        account=account,
+        state_template="{{bucket_name}}",
+        cloudformation_template="cloudformation_template",
+        cloudformation_import_template="cloudformation_import_template",
+        tags={"env": "test"},
+    )
+
+    aws_api.cloudformation.get_stack.assert_called_once_with(
+        stack_name="terraform-terraform-state-already-set"
+    )
+    aws_api.cloudformation.get_template_body.assert_called_once_with(
+        stack_name="terraform-terraform-state-already-set"
+    )
+    aws_api.cloudformation.update_stack.assert_called_once_with(
+        stack_name="terraform-terraform-state-already-set",
+        template_body="cloudformation_template",
+        parameters={"BucketName": "terraform-terraform-state-already-set"},
+        tags={"env": "test"},
+    )
+    aws_api.cloudformation.create_stack.assert_not_called()
+    merge_request_manager.create_merge_request.assert_not_called()
+
+
+def test_terraform_init_integration_reconcile_account_when_template_body_mismatch_dry_run(
+    aws_api: MagicMock,
+    merge_request_manager: MagicMock,
+    intg: TerraformInitIntegration,
+    aws_accounts: list[AWSAccountV1],
+) -> None:
+    account = next(a for a in aws_accounts if a.name == "terraform-state-already-set")
+    aws_api.cloudformation.get_stack.return_value = {
+        "StackName": "terraform-terraform-state-already-set",
+        "Tags": [{"Key": "env", "Value": "test"}],
+    }
+    aws_api.cloudformation.get_template_body.return_value = "old_template_body"
+
+    intg.reconcile_account(
+        aws_api=aws_api,
+        merge_request_manager=merge_request_manager,
+        dry_run=True,
+        account=account,
+        state_template="{{bucket_name}}",
+        cloudformation_template="cloudformation_template",
+        cloudformation_import_template="cloudformation_import_template",
+        tags={"env": "test"},
+    )
+
+    aws_api.cloudformation.get_stack.assert_called_once_with(
+        stack_name="terraform-terraform-state-already-set"
+    )
+    aws_api.cloudformation.get_template_body.assert_called_once_with(
+        stack_name="terraform-terraform-state-already-set"
+    )
+    aws_api.cloudformation.update_stack.assert_not_called()
+    aws_api.cloudformation.create_stack.assert_not_called()
+    merge_request_manager.create_merge_request.assert_not_called()
+
+
+def test_terraform_init_integration_reconcile_account_when_no_changes(
+    aws_api: MagicMock,
+    merge_request_manager: MagicMock,
+    intg: TerraformInitIntegration,
+    aws_accounts: list[AWSAccountV1],
+) -> None:
+    account = next(a for a in aws_accounts if a.name == "terraform-state-already-set")
+    aws_api.cloudformation.get_stack.return_value = {
+        "StackName": "terraform-terraform-state-already-set",
+        "Tags": [{"Key": "env", "Value": "test"}],
+    }
+    aws_api.cloudformation.get_template_body.return_value = "cloudformation_template"
+
+    intg.reconcile_account(
+        aws_api=aws_api,
+        merge_request_manager=merge_request_manager,
+        dry_run=False,
+        account=account,
+        state_template="{{bucket_name}}",
+        cloudformation_template="cloudformation_template",
+        cloudformation_import_template="cloudformation_import_template",
+        tags={"env": "test"},
+    )
+
+    aws_api.cloudformation.get_stack.assert_called_once_with(
+        stack_name="terraform-terraform-state-already-set"
+    )
+    aws_api.cloudformation.get_template_body.assert_called_once_with(
+        stack_name="terraform-terraform-state-already-set"
+    )
+    aws_api.cloudformation.create_stack.assert_not_called()
+    aws_api.cloudformation.update_stack.assert_not_called()
+    merge_request_manager.create_merge_request.assert_not_called()

--- a/reconcile/test/utils/aws_api_typed/test_aws_api_typed_api.py
+++ b/reconcile/test/utils/aws_api_typed/test_aws_api_typed_api.py
@@ -4,6 +4,7 @@ from pytest_mock import MockerFixture
 
 from reconcile.utils.aws_api_typed.account import AWSApiAccount
 from reconcile.utils.aws_api_typed.api import AWSApi, AWSStaticCredentials, SubApi
+from reconcile.utils.aws_api_typed.cloudformation import AWSApiCloudFormation
 from reconcile.utils.aws_api_typed.dynamodb import AWSApiDynamoDB
 from reconcile.utils.aws_api_typed.iam import AWSApiIam
 from reconcile.utils.aws_api_typed.organization import AWSApiOrganizations
@@ -52,6 +53,7 @@ def test_aws_api_typed_api_close(aws_api: AWSApi, mocker: MockerFixture) -> None
     "api_cls, client_name",
     [
         (AWSApiAccount, "account"),
+        (AWSApiCloudFormation, "cloudformation"),
         (AWSApiDynamoDB, "dynamodb"),
         (AWSApiIam, "iam"),
         (AWSApiOrganizations, "organizations"),
@@ -82,6 +84,11 @@ def test_aws_api_typed_api_init_sub_api(
 def test_aws_api_typed_api_account(aws_api: AWSApi) -> None:
     sub_api = aws_api.account
     assert isinstance(sub_api, AWSApiAccount)
+
+
+def test_aws_api_typed_api_cloudformation(aws_api: AWSApi) -> None:
+    sub_api = aws_api.cloudformation
+    assert isinstance(sub_api, AWSApiCloudFormation)
 
 
 def test_aws_api_typed_api_dynamodb(aws_api: AWSApi) -> None:

--- a/reconcile/test/utils/aws_api_typed/test_aws_api_typed_cloudformation.py
+++ b/reconcile/test/utils/aws_api_typed/test_aws_api_typed_cloudformation.py
@@ -1,0 +1,192 @@
+from unittest.mock import MagicMock, call, create_autospec
+
+import pytest
+from mypy_boto3_cloudformation import (
+    CloudFormationClient,
+    StackCreateCompleteWaiter,
+    StackUpdateCompleteWaiter,
+)
+from mypy_boto3_cloudformation.waiter import ChangeSetCreateCompleteWaiter
+
+from reconcile.utils.aws_api_typed.cloudformation import AWSApiCloudFormation
+
+
+@pytest.fixture
+def mock_cloudformation_client() -> MagicMock:
+    return create_autospec(CloudFormationClient)
+
+
+def test_init(mock_cloudformation_client: MagicMock) -> None:
+    api = AWSApiCloudFormation(mock_cloudformation_client)
+    assert api.client == mock_cloudformation_client
+
+
+@pytest.fixture
+def aws_api_cloudformation(
+    mock_cloudformation_client: MagicMock,
+) -> AWSApiCloudFormation:
+    return AWSApiCloudFormation(mock_cloudformation_client)
+
+
+def test_create_stack(
+    mock_cloudformation_client: MagicMock,
+    aws_api_cloudformation: AWSApiCloudFormation,
+) -> None:
+    mock_cloudformation_client.create_change_set.return_value = {
+        "Id": "test-change-set-arn",
+        "StackId": "test-stack-id",
+    }
+    mock_change_set_create_complete_waiter = create_autospec(
+        ChangeSetCreateCompleteWaiter
+    )
+    mock_stack_create_complete_waiter = create_autospec(StackCreateCompleteWaiter)
+    mock_cloudformation_client.get_waiter.side_effect = [
+        mock_change_set_create_complete_waiter,
+        mock_stack_create_complete_waiter,
+    ]
+
+    result = aws_api_cloudformation.create_stack(
+        stack_name="test-stack",
+        change_set_name="test-change-set",
+        template_body="---\nResources: {}\n",
+        parameters={"b": "1", "a": "2"},
+        tags={"k2": "v2", "k1": "v1"},
+    )
+
+    assert result == "test-stack-id"
+    mock_cloudformation_client.create_change_set.assert_called_once_with(
+        StackName="test-stack",
+        ChangeSetName="test-change-set",
+        TemplateBody="---\nResources: {}\n",
+        ChangeSetType="CREATE",
+        Parameters=[
+            {"ParameterKey": "a", "ParameterValue": "2"},
+            {"ParameterKey": "b", "ParameterValue": "1"},
+        ],
+        Tags=[
+            {"Key": "k1", "Value": "v1"},
+            {"Key": "k2", "Value": "v2"},
+        ],
+        ImportExistingResources=True,
+    )
+    mock_cloudformation_client.execute_change_set.assert_called_once_with(
+        ChangeSetName="test-change-set-arn"
+    )
+    mock_cloudformation_client.get_waiter.assert_has_calls([
+        call("change_set_create_complete"),
+        call("stack_create_complete"),
+    ])
+    mock_change_set_create_complete_waiter.wait.assert_called_once_with(
+        ChangeSetName="test-change-set-arn"
+    )
+    mock_stack_create_complete_waiter.wait.assert_called_once_with(
+        StackName="test-stack"
+    )
+
+
+def test_update_stack(
+    mock_cloudformation_client: MagicMock,
+    aws_api_cloudformation: AWSApiCloudFormation,
+) -> None:
+    mock_cloudformation_client.update_stack.return_value = {"StackId": "test-stack-id"}
+    mock_stack_create_complete_waiter = create_autospec(StackUpdateCompleteWaiter)
+    mock_cloudformation_client.get_waiter.return_value = (
+        mock_stack_create_complete_waiter
+    )
+
+    result = aws_api_cloudformation.update_stack(
+        stack_name="test-stack",
+        template_body="---\nResources: {}\n",
+        parameters={"b": "1", "a": "2"},
+        tags={"k2": "v2", "k1": "v1"},
+    )
+
+    assert result == "test-stack-id"
+    mock_cloudformation_client.update_stack.assert_called_once_with(
+        StackName="test-stack",
+        TemplateBody="---\nResources: {}\n",
+        Parameters=[
+            {"ParameterKey": "a", "ParameterValue": "2"},
+            {"ParameterKey": "b", "ParameterValue": "1"},
+        ],
+        Tags=[
+            {"Key": "k1", "Value": "v1"},
+            {"Key": "k2", "Value": "v2"},
+        ],
+    )
+    mock_cloudformation_client.get_waiter.assert_called_once_with(
+        "stack_update_complete"
+    )
+    mock_stack_create_complete_waiter.wait.assert_called_once_with(
+        StackName="test-stack"
+    )
+
+
+def test_get_stack_exists(
+    mock_cloudformation_client: MagicMock,
+    aws_api_cloudformation: AWSApiCloudFormation,
+) -> None:
+    expected_stack = {
+        "StackName": "test-stack",
+        "StackStatus": "CREATE_COMPLETE",
+        "CreationTime": "2023-01-01T00:00:00Z",
+    }
+    mock_cloudformation_client.describe_stacks.return_value = {
+        "Stacks": [expected_stack]
+    }
+
+    result = aws_api_cloudformation.get_stack("test-stack")
+
+    assert result == expected_stack
+    mock_cloudformation_client.describe_stacks.assert_called_once_with(
+        StackName="test-stack"
+    )
+
+
+def test_get_stack_not_found(
+    mock_cloudformation_client: MagicMock,
+    aws_api_cloudformation: AWSApiCloudFormation,
+) -> None:
+    mock_cloudformation_client.exceptions.StackNotFoundException = Exception
+    mock_cloudformation_client.describe_stacks.side_effect = (
+        mock_cloudformation_client.exceptions.StackNotFoundException
+    )
+
+    result = aws_api_cloudformation.get_stack("non-existent-stack")
+
+    assert result is None
+    mock_cloudformation_client.describe_stacks.assert_called_once_with(
+        StackName="non-existent-stack"
+    )
+
+
+def test_get_template_body_with_yaml(
+    mock_cloudformation_client: MagicMock,
+    aws_api_cloudformation: AWSApiCloudFormation,
+) -> None:
+    mock_cloudformation_client.get_template.return_value = {
+        "TemplateBody": "---\nResources: {}\n"
+    }
+
+    result = aws_api_cloudformation.get_template_body("test-stack")
+
+    assert result == "---\nResources: {}\n"
+    mock_cloudformation_client.get_template.assert_called_once_with(
+        StackName="test-stack"
+    )
+
+
+def test_get_template_body_with_json(
+    mock_cloudformation_client: MagicMock,
+    aws_api_cloudformation: AWSApiCloudFormation,
+) -> None:
+    mock_cloudformation_client.get_template.return_value = {
+        "TemplateBody": {"Resources": {}}
+    }
+
+    result = aws_api_cloudformation.get_template_body("test-stack")
+
+    assert result == '{"Resources": {}}'
+    mock_cloudformation_client.get_template.assert_called_once_with(
+        StackName="test-stack"
+    )

--- a/reconcile/utils/aws_api_typed/api.py
+++ b/reconcile/utils/aws_api_typed/api.py
@@ -9,6 +9,7 @@ from boto3 import Session
 from pydantic import BaseModel
 
 import reconcile.utils.aws_api_typed.account
+import reconcile.utils.aws_api_typed.cloudformation
 import reconcile.utils.aws_api_typed.dynamodb
 import reconcile.utils.aws_api_typed.iam
 import reconcile.utils.aws_api_typed.organization
@@ -17,6 +18,7 @@ import reconcile.utils.aws_api_typed.service_quotas
 import reconcile.utils.aws_api_typed.sts
 import reconcile.utils.aws_api_typed.support
 from reconcile.utils.aws_api_typed.account import AWSApiAccount
+from reconcile.utils.aws_api_typed.cloudformation import AWSApiCloudFormation
 from reconcile.utils.aws_api_typed.dynamodb import AWSApiDynamoDB
 from reconcile.utils.aws_api_typed.iam import AWSApiIam
 from reconcile.utils.aws_api_typed.organization import AWSApiOrganizations
@@ -31,6 +33,7 @@ if TYPE_CHECKING:
 SubApi = TypeVar(
     "SubApi",
     AWSApiAccount,
+    AWSApiCloudFormation,
     AWSApiDynamoDB,
     AWSApiIam,
     AWSApiOrganizations,
@@ -176,6 +179,9 @@ class AWSApi:
             case reconcile.utils.aws_api_typed.account.AWSApiAccount:
                 client = self.session.client("account")
                 api = api_cls(client)
+            case reconcile.utils.aws_api_typed.cloudformation.AWSApiCloudFormation:
+                client = self.session.client("cloudformation")
+                api = api_cls(client)
             case reconcile.utils.aws_api_typed.dynamodb.AWSApiDynamoDB:
                 client = self.session.client("dynamodb")
                 api = api_cls(client)
@@ -205,8 +211,13 @@ class AWSApi:
 
     @cached_property
     def account(self) -> AWSApiAccount:
-        """Return an AWS Acount Api client"""
+        """Return an AWS Account Api client"""
         return self._init_sub_api(AWSApiAccount)
+
+    @cached_property
+    def cloudformation(self) -> AWSApiCloudFormation:
+        """Return an AWS CloudFormation Api client"""
+        return self._init_sub_api(AWSApiCloudFormation)
 
     @cached_property
     def dynamodb(self) -> AWSApiDynamoDB:

--- a/reconcile/utils/aws_api_typed/cloudformation.py
+++ b/reconcile/utils/aws_api_typed/cloudformation.py
@@ -1,0 +1,147 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from reconcile.utils.json import json_dumps
+
+if TYPE_CHECKING:
+    from mypy_boto3_cloudformation import CloudFormationClient
+    from mypy_boto3_cloudformation.type_defs import (
+        ParameterTypeDef,
+        StackTypeDef,
+        TagTypeDef,
+    )
+
+
+class AWSApiCloudFormation:
+    def __init__(self, client: CloudFormationClient) -> None:
+        self.client = client
+
+    def create_stack(
+        self,
+        stack_name: str,
+        change_set_name: str,
+        template_body: str,
+        parameters: dict[str, str] | None = None,
+        tags: dict[str, str] | None = None,
+    ) -> str:
+        """
+        Create a CloudFormation stack using a change set with import existing resources.
+        This method creates a change set of type "CREATE" with the provided template and parameters,
+        waits for the change set to be created, executes it, and then waits for the stack creation to complete.
+        It returns the StackId of the created stack.
+
+        Args:
+            stack_name (str): The name of the stack to create.
+            change_set_name (str): The name of the change set to create.
+            template_body (str): The CloudFormation template body as a string.
+            parameters (dict[str, str] | None): A dictionary of parameter key-value pairs for
+                the stack. Defaults to None.
+            tags (dict[str, str] | None): A dictionary of tag key-value pairs to
+                associate with the stack. Defaults to None.
+
+        Returns:
+            str: The StackId of the created stack.
+        """
+        response = self.client.create_change_set(
+            StackName=stack_name,
+            ChangeSetName=change_set_name,
+            TemplateBody=template_body,
+            ChangeSetType="CREATE",
+            Parameters=self._build_parameters(parameters or {}),
+            Tags=self._build_tags(tags or {}),
+            ImportExistingResources=True,
+        )
+        change_set_arn = response["Id"]
+        self.client.get_waiter("change_set_create_complete").wait(
+            ChangeSetName=change_set_arn
+        )
+        self.client.execute_change_set(ChangeSetName=change_set_arn)
+        self.client.get_waiter("stack_create_complete").wait(StackName=stack_name)
+        return response["StackId"]
+
+    def update_stack(
+        self,
+        stack_name: str,
+        template_body: str,
+        parameters: dict[str, str] | None = None,
+        tags: dict[str, str] | None = None,
+    ) -> str:
+        """
+        Update a CloudFormation stack with the provided template and parameters.
+        This method updates the specified stack, waits for the update to complete,
+        and returns the StackId of the updated stack.
+
+        Args:
+            stack_name (str): The name of the stack to update.
+            template_body (str): The CloudFormation template body as a string.
+            parameters (dict[str, str] | None): A dictionary of parameter key-value pairs for
+                the stack. Defaults to None.
+            tags (dict[str, str] | None): A dictionary of tag key-value pairs to
+                associate with the stack. Defaults to None.
+
+        Returns:
+            str: The StackId of the updated stack.
+        """
+        response = self.client.update_stack(
+            StackName=stack_name,
+            TemplateBody=template_body,
+            Parameters=self._build_parameters(parameters or {}),
+            Tags=self._build_tags(tags or {}),
+        )
+        self.client.get_waiter("stack_update_complete").wait(StackName=stack_name)
+        return response["StackId"]
+
+    def get_stack(self, stack_name: str) -> StackTypeDef | None:
+        """
+        Retrieve information about a CloudFormation stack by its name.
+        If the stack exists, it returns the stack details as a dictionary.
+        If the stack does not exist, it returns None.
+
+        Args:
+            stack_name (str): The name of the stack to retrieve.
+
+        Returns:
+            StackTypeDef | None: The stack details if found, otherwise None.
+        """
+        try:
+            response = self.client.describe_stacks(StackName=stack_name)
+            return response["Stacks"][0]
+        except self.client.exceptions.StackNotFoundException:
+            return None
+
+    def get_template_body(self, stack_name: str) -> str:
+        """
+        Retrieve the CloudFormation template body for a specified stack.
+
+        Args:
+            stack_name (str): The name of the stack whose template is to be retrieved.
+
+        Returns:
+            str: The CloudFormation template body as a string.
+        """
+        response = self.client.get_template(StackName=stack_name)
+        # TemplateBody is str when using yaml
+        if isinstance(response["TemplateBody"], str):
+            return response["TemplateBody"]
+        return json_dumps(response["TemplateBody"])
+
+    @staticmethod
+    def _build_parameters(parameters: dict[str, str]) -> list[ParameterTypeDef]:
+        return [
+            {
+                "ParameterKey": key,
+                "ParameterValue": value,
+            }
+            for key, value in sorted(parameters.items())
+        ]
+
+    @staticmethod
+    def _build_tags(tags: dict[str, str]) -> list[TagTypeDef]:
+        return [
+            {
+                "Key": key,
+                "Value": value,
+            }
+            for key, value in sorted(tags.items())
+        ]

--- a/reconcile/utils/aws_api_typed/cloudformation.py
+++ b/reconcile/utils/aws_api_typed/cloudformation.py
@@ -107,8 +107,10 @@ class AWSApiCloudFormation:
         try:
             response = self.client.describe_stacks(StackName=stack_name)
             return response["Stacks"][0]
-        except self.client.exceptions.StackNotFoundException:
-            return None
+        except self.client.exceptions.ClientError as e:
+            if e.response["Error"]["Code"] == "ValidationError":
+                return None
+            raise
 
     def get_template_body(self, stack_name: str) -> str:
         """

--- a/uv.lock
+++ b/uv.lock
@@ -141,6 +141,9 @@ wheels = [
 account = [
     { name = "mypy-boto3-account" },
 ]
+cloudformation = [
+    { name = "mypy-boto3-cloudformation" },
+]
 dynamodb = [
     { name = "mypy-boto3-dynamodb" },
 ]
@@ -851,6 +854,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/2c/e9/48fef7cc437a3054b3fe722035fcd983a98a241a21396fff75737f527061/mypy_boto3_account-1.34.121.tar.gz", hash = "sha256:d814012cfbdc771e42786ae5d0c80d1182a0dd1059b69e7d28e6132e13485188", size = 15754, upload-time = "2024-06-06T19:33:10.271Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b7/3e/d8a2b855817581a882261f096de4fd93da0e602d1a492f2b155ea1d794b5/mypy_boto3_account-1.34.121-py3-none-any.whl", hash = "sha256:79f4ab3fa14f8652d46edeb46eee465df6ee9b00da5fcbf350b55425a041a672", size = 21302, upload-time = "2024-06-06T19:33:01.659Z" },
+]
+
+[[package]]
+name = "mypy-boto3-cloudformation"
+version = "1.34.111"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/59/c3/f48efbcc17fb03fb167993028889be0bfbb582720e3eaa719786c5c53085/mypy_boto3_cloudformation-1.34.111.tar.gz", hash = "sha256:a02e201d1a9d9a8fb4db5b942d5c537a4e8861c611f0d986126674ac557cb9e8", size = 57941, upload-time = "2024-05-22T19:32:33.697Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3f/f3/c18601b0f21080c4b6183d924ae0052bce0d792ef97b1cbdccfb6d535313/mypy_boto3_cloudformation-1.34.111-py3-none-any.whl", hash = "sha256:526e928c504fa2880b1774aa10629a04fe0ec70ed2864ab3d3f7772386a1a925", size = 70105, upload-time = "2024-05-22T19:32:26.298Z" },
 ]
 
 [[package]]
@@ -1600,7 +1615,7 @@ debugger = [
 ]
 dev = [
     { name = "anymarkup" },
-    { name = "boto3-stubs", extra = ["account", "dynamodb", "ec2", "ecr", "elb", "iam", "logs", "organizations", "rds", "route53", "s3", "service-quotas", "sqs", "sts", "support"] },
+    { name = "boto3-stubs", extra = ["account", "cloudformation", "dynamodb", "ec2", "ecr", "elb", "iam", "logs", "organizations", "rds", "route53", "s3", "service-quotas", "sqs", "sts", "support"] },
     { name = "kubernetes-stubs" },
     { name = "markupsafe" },
     { name = "moto", extra = ["s3"] },
@@ -1675,7 +1690,7 @@ requires-dist = [
     { name = "sendgrid", specifier = ">=6.4.8,<6.5.0" },
     { name = "sentry-sdk", specifier = "~=2.0" },
     { name = "slack-sdk", specifier = ">=3.10,<4.0" },
-    { name = "sretoolbox", specifier = "==2.7" },
+    { name = "sretoolbox", specifier = "==2.7.0" },
     { name = "sshtunnel", specifier = ">=0.4.0" },
     { name = "tabulate", specifier = ">=0.8.6,<0.9.0" },
     { name = "terrascript", specifier = "==0.9.0" },
@@ -1690,7 +1705,7 @@ requires-dist = [
 debugger = [{ name = "debugpy", specifier = "~=1.6.0" }]
 dev = [
     { name = "anymarkup", specifier = "~=0.8.1" },
-    { name = "boto3-stubs", extras = ["account", "dynamodb", "ec2", "ecr", "elb", "iam", "logs", "organizations", "rds", "route53", "s3", "service-quotas", "sqs", "sts", "support"], specifier = "==1.34.94" },
+    { name = "boto3-stubs", extras = ["account", "cloudformation", "dynamodb", "ec2", "ecr", "elb", "iam", "logs", "organizations", "rds", "route53", "s3", "service-quotas", "sqs", "sts", "support"], specifier = "==1.34.94" },
     { name = "kubernetes-stubs", specifier = "==22.6.0" },
     { name = "markupsafe", specifier = "~=2.1.1" },
     { name = "moto", extras = ["ec2", "iam", "logs", "s3", "route53"], specifier = "~=5.1" },


### PR DESCRIPTION
The initial s3 bucket used for terraform state was created by calling s3 API once directly in `terraform-init` on AWS account setup stage. This change moves the bootstrap of terraform env (s3 bucket) in CloudFormation. Now we can apply tags from external resource settings and use best practices for [s3 backend](https://developer.hashicorp.com/terraform/language/backend/s3), like enable versioning and use lifecycle to cleanup non current versions. 

To handle existing S3 buckets, we need a minimal template to import first, example

```yaml
---
AWSTemplateFormatVersion: '2010-09-09'
Description: S3 bucket for Terraform state
Parameters:
  BucketName:
    Type: String
    Description: Name for the bucket
Resources:
  TerraformStateBucket:
    Type: AWS::S3::Bucket
    DeletionPolicy: RetainExceptOnCreate
    Properties:
      BucketName: !Ref BucketName
```

Use [Import AWS resources into a CloudFormation stack automatically](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/import-resources-automatically.html), we can import it without drift.

Then update stack template to be a full template to apply changes we want, tags of stack will be applied to all resources in template as well.

```yaml
---
AWSTemplateFormatVersion: '2010-09-09'
Description: S3 bucket for Terraform state
Parameters:
  BucketName:
    Type: String
    Description: Name for the bucket
Resources:
  TerraformStateBucket:
    Type: AWS::S3::Bucket
    Properties:
      BucketName: !Ref BucketName
      BucketEncryption:
        ServerSideEncryptionConfiguration:
        - ServerSideEncryptionByDefault:
            SSEAlgorithm: AES256
      VersioningConfiguration:
        Status: Enabled
      PublicAccessBlockConfiguration:
        BlockPublicAcls: true
        BlockPublicPolicy: true
        IgnorePublicAcls: true
        RestrictPublicBuckets: true
      LifecycleConfiguration:
        Rules:
        - Id: expire_noncurrent_versions
          Status: Enabled
          NoncurrentVersionExpiration:
            NoncurrentDays: 7
          AbortIncompleteMultipartUpload:
            DaysAfterInitiation: 3
          ExpiredObjectDeleteMarker: true
Outputs:
  BucketName:
    Description: S3 bucket name
    Value: !Ref TerraformStateBucket
    Export:
      Name: !Sub '${AWS::StackName}-bucket-name'
  BucketARN:
    Description: S3 bucket ARN
    Value: !GetAtt TerraformStateBucket.Arn
    Export:
      Name: !Sub '${AWS::StackName}-bucket-arn'
  BucketRegion:
    Description: S3 bucket region
    Value: !Ref 'AWS::Region'
    Export:
      Name: !Sub '${AWS::StackName}-bucket-region'

```

**CloudFormation-based S3 bucket management:**

* The integration now provisions and manages the Terraform state S3 bucket using CloudFormation stacks rather than direct S3 API calls, including logic to import existing buckets and update stacks if tags or templates change. [[1]](diffhunk://#diff-8749b4dc67116aae5cd87124041e043b08db8d0235e60448395ec11fc8638aeaL93-R210) [[2]](diffhunk://#diff-8749b4dc67116aae5cd87124041e043b08db8d0235e60448395ec11fc8638aeaR220-R268)

**Template and tagging improvements:**

* Added support for passing CloudFormation templates and import templates as CLI options and integration parameters, and for applying default tags from external resource settings. [[1]](diffhunk://#diff-2ac404c3a4f4d289c1811816c94253a70cc6559b8de427388de06546141f1f43L1031-R1058) [[2]](diffhunk://#diff-8749b4dc67116aae5cd87124041e043b08db8d0235e60448395ec11fc8638aeaR40-R45) [[3]](diffhunk://#diff-8749b4dc67116aae5cd87124041e043b08db8d0235e60448395ec11fc8638aeaR302-R309) [[4]](diffhunk://#diff-8749b4dc67116aae5cd87124041e043b08db8d0235e60448395ec11fc8638aeaL65-R94) [[5]](diffhunk://#diff-0861196018f06f45197008bff8e8a7d62b599d6755c51f49f6b2208e32fd3b2aR1-R20)

**GraphQL schema and model updates:**

* Updated the GraphQL schema and corresponding Pydantic models to include the `bucket` field in the `terraformState` object, enabling bucket name configuration and retrieval. [[1]](diffhunk://#diff-efdc969961b01e391990a629130061d90cc23aaa6677fad9039fe44b6ddd7bc1R8) [[2]](diffhunk://#diff-2bbffba6a13a0b310f73cff574f7752b67cbdf4538d4e8285f30605026f3d700R36) [[3]](diffhunk://#diff-2bbffba6a13a0b310f73cff574f7752b67cbdf4538d4e8285f30605026f3d700R58)

**Test and fixture updates:**

* Adjusted test fixtures and test code to reflect the new bucket field and settings, and added fixtures for external resource settings and tags. [[1]](diffhunk://#diff-2d5a2648b4da96c2686b2563f72035226c14c0714309d3e321b38f9428932c24L17-R32) [[2]](diffhunk://#diff-56915a8c42314b014067ea6c8a29c9e4356c479e668538fa115ec7c9d8d63e76R8-R10) [[3]](diffhunk://#diff-56915a8c42314b014067ea6c8a29c9e4356c479e668538fa115ec7c9d8d63e76R58-R74) [[4]](diffhunk://#diff-1d48ee2dbf9571d70c5846a2410630d38aa4ec939a2248ca5d63f7b9b0a58b0bL3-R12)

**Dependency update:**

* Added `cloudformation` to the list of boto3-stubs dependencies to support new CloudFormation functionality.

[APPSRE-12510](https://issues.redhat.com/browse/APPSRE-12510)