### PR TITLE
feat(qontract-api): add JWT subject revocation list

### DIFF
--- a/qontract_api/qontract_api/config.py
+++ b/qontract_api/qontract_api/config.py
@@ -400,6 +400,10 @@ class Settings(BaseSettings):
     jwt_expire_days: int = Field(
         default=180, description="JWT token expiration in days"
     )
+    jwt_revoked_subjects: list[str] = Field(
+        default_factory=list,
+        description="List of revoked JWT subjects. Tokens with these subjects will be rejected.",
+    )
 
     # API Task Execution
     api_task_max_timeout: int = Field(

--- a/qontract_api/qontract_api/dependencies.py
+++ b/qontract_api/qontract_api/dependencies.py
@@ -9,9 +9,11 @@ from qontract_api.auth import decode_token
 from qontract_api.cache.base import CacheBackend
 from qontract_api.config import settings
 from qontract_api.event_manager import EventManager
+from qontract_api.logger import get_logger
 from qontract_api.models import User
 from qontract_api.secret_manager import SecretManager
 
+logger = get_logger(__name__)
 security = HTTPBearer()
 
 
@@ -23,9 +25,10 @@ def get_current_user(
         token = credentials.credentials
         payload = decode_token(token)
         if payload.sub in settings.jwt_revoked_subjects:
+            logger.warning(f"Token subject '{payload.sub}' has been revoked")
             raise HTTPException(
                 status_code=status.HTTP_401_UNAUTHORIZED,
-                detail=f"Token subject '{payload.sub}' has been revoked",
+                detail="Token has been revoked",
                 headers={"WWW-Authenticate": "Bearer"},
             )
         return User(username=payload.sub)

--- a/qontract_api/qontract_api/dependencies.py
+++ b/qontract_api/qontract_api/dependencies.py
@@ -7,6 +7,7 @@ from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
 
 from qontract_api.auth import decode_token
 from qontract_api.cache.base import CacheBackend
+from qontract_api.config import settings
 from qontract_api.event_manager import EventManager
 from qontract_api.models import User
 from qontract_api.secret_manager import SecretManager
@@ -21,6 +22,12 @@ def get_current_user(
     try:
         token = credentials.credentials
         payload = decode_token(token)
+        if payload.sub in settings.jwt_revoked_subjects:
+            raise HTTPException(
+                status_code=status.HTTP_401_UNAUTHORIZED,
+                detail=f"Token subject '{payload.sub}' has been revoked",
+                headers={"WWW-Authenticate": "Bearer"},
+            )
         return User(username=payload.sub)
     except ValueError as e:
         raise HTTPException(

--- a/qontract_api/tests/test_api.py
+++ b/qontract_api/tests/test_api.py
@@ -1,6 +1,7 @@
 """Tests for API endpoints."""
 
 from http import HTTPStatus
+from unittest.mock import patch
 
 from fastapi.testclient import TestClient
 
@@ -36,3 +37,20 @@ def test_protected_endpoint_with_valid_token(client: TestClient) -> None:
     data = response.json()
     assert data["message"] == "Access granted"
     assert data["username"] == "testuser"
+
+
+def test_protected_endpoint_with_revoked_subject(client: TestClient) -> None:
+    """Test protected endpoint returns 401 when JWT subject is revoked."""
+    token_data = TokenData(sub="revoked-user")
+    token = create_access_token(data=token_data)
+
+    with patch(
+        "qontract_api.dependencies.settings.jwt_revoked_subjects",
+        ["revoked-user"],
+    ):
+        response = client.get(
+            "/api/protected", headers={"Authorization": f"Bearer {token}"}
+        )
+    assert response.status_code == HTTPStatus.UNAUTHORIZED
+    data = response.json()
+    assert "revoked" in data["detail"]


### PR DESCRIPTION
## Summary

- Add `jwt_revoked_subjects` config setting (list of JWT subjects to reject)
- Check revocation list in `get_current_user()` dependency — revoked subjects get 401
- Configurable via `QAPI_JWT_REVOKED_SUBJECTS` env var or config YAML/JSON

APPSRE-13898

## Test plan

- [x] New test: valid token with revoked subject returns 401
- [x] All 302 existing tests pass
- [x] mypy, ruff pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added JWT subject revocation: revoked subjects are rejected and protected endpoints now return 401 Unauthorized for revoked tokens with a clear revocation message.

* **Tests**
  * Added an integration test verifying revoked-token requests are rejected with a 401 response and appropriate error detail.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->