### PR TITLE
fix(vault): add type narrowing for mypy compliance

### DIFF
--- a/reconcile/utils/vault.py
+++ b/reconcile/utils/vault.py
@@ -286,7 +286,7 @@ class VaultClient:
             msg = f"permission denied accessing secret '{path}'"
             raise SecretAccessForbiddenError(msg) from None
 
-        if secret is None or "data" not in secret:
+        if secret is None or not isinstance(secret, dict) or "data" not in secret:
             raise SecretNotFoundError(path)
 
         return secret["data"]
@@ -411,7 +411,10 @@ class VaultClient:
 
     def _list(self, path: str) -> dict:
         try:
-            return self._client.list(path)
+            response = self._client.list(path)
+            if response is None or not isinstance(response, dict):
+                return {}
+            return response
         except hvac.exceptions.Forbidden:
             msg = f"permission denied accessing path '{path}'"
             raise PathAccessForbiddenError(msg) from None


### PR DESCRIPTION
## Summary
- Add `isinstance()` checks in `_read_all_v1()` and `_list()` methods to resolve mypy type errors
- Fixes mypy errors related to hvac library's broad return types (`dict | Response`)

## Test plan
- [x] `make types-test` passes with no errors
- [x] All 1197 source files pass mypy type checking

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Enhanced Vault integration stability with improved validation for secret reads and path listings
* Strengthened error handling to provide clearer feedback when Vault responses are missing or malformed

<!-- end of auto-generated comment: release notes by coderabbit.ai -->