### PR TITLE
feat(cli): add --within option to cidr-blocks for scoped CIDR allocation

### DIFF
--- a/tools/qontract_cli.py
+++ b/tools/qontract_cli.py
@@ -1113,8 +1113,19 @@ def network_reservations(ctx: click.Context) -> None:
     type=int,
     default=24,
 )
+@click.option(
+    "--within",
+    help="Parent CIDR block to find the first available sub-block within (e.g. 10.0.0.0/8).",
+    type=str,
+    default=None,
+)
 @click.pass_context
-def cidr_blocks(ctx: click.Context, for_cluster: int, mask: int) -> None:
+def cidr_blocks(
+    ctx: click.Context,
+    for_cluster: int,
+    mask: int,
+    within: str | None,
+) -> None:
     import ipaddress
 
     from reconcile.typed_queries.aws_vpcs import get_aws_vpcs
@@ -1184,23 +1195,48 @@ def cidr_blocks(ctx: click.Context, for_cluster: int, mask: int) -> None:
     cidrs.sort(key=lambda item: ipaddress.ip_network(item["cidr"]))
 
     if for_cluster:
+        parent_network: ipaddress.IPv4Network | None = None
+        if within:
+            try:
+                parent_network = ipaddress.IPv4Network(within)
+            except ValueError:
+                print(f"ERROR: Invalid CIDR block: {within}")
+                sys.exit(1)
+
         latest_cluster_cidr = next(
-            (item for item in reversed(cidrs) if item["type"] == "cluster"),
+            (
+                item
+                for item in reversed(cidrs)
+                if item["type"] == "cluster"
+                and (
+                    parent_network is None
+                    or ipaddress.IPv4Network(item["cidr"]).subnet_of(parent_network)
+                )
+            ),
             None,
         )
 
-        if not latest_cluster_cidr:
+        if latest_cluster_cidr:
+            avail_addr = ipaddress.ip_address(latest_cluster_cidr["to"]) + 1
+        elif parent_network is not None:
+            avail_addr = parent_network.network_address
+        else:
             print("ERROR: Unable to find any existing cluster CIDR block.")
             sys.exit(1)
 
-        avail_addr = ipaddress.ip_address(latest_cluster_cidr["to"]) + 1
-
         print(f"INFO: Latest available network address: {avail_addr!s}")
         try:
-            result_cidr_block = str(ipaddress.ip_network((avail_addr, mask)))
+            result_cidr_block = ipaddress.IPv4Network((avail_addr, mask))
         except ValueError:
             print(f"ERROR: Invalid CIDR Mask {mask} Provided.")
             sys.exit(1)
+
+        if parent_network is not None and not result_cidr_block.subnet_of(
+            parent_network
+        ):
+            print(f"ERROR: No available /{mask} block within {within}.")
+            sys.exit(1)
+
         print(f"INFO: You are reserving {2 ** (32 - mask)!s} network addresses.")
         print(f"\nYou can use: {result_cidr_block!s}")
     else:

--- a/tools/test/test_qontract_cli.py
+++ b/tools/test/test_qontract_cli.py
@@ -8,6 +8,16 @@ from reconcile.utils.early_exit_cache import CacheHeadResult, CacheKey, CacheSta
 from tools import qontract_cli
 
 
+def _make_cluster(name: str, vpc_cidr: str, account_name: str = "acc") -> dict:
+    return {
+        "name": name,
+        "network": {"vpc": vpc_cidr},
+        "spec": {"account": {"name": account_name}},
+        "peering": None,
+        "description": None,
+    }
+
+
 @pytest.fixture
 def env_vars(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("APP_INTERFACE_STATE_BUCKET", "some-bucket")
@@ -252,3 +262,105 @@ def test_external_resources_get_credentials(
         format=None,
         version=None,
     )
+
+
+@pytest.fixture
+def mock_cidr_deps(mocker: MockerFixture) -> Mock:
+    mock_q = mocker.patch("tools.qontract_cli.queries", autospec=True)
+    mocker.patch("reconcile.typed_queries.aws_vpcs.get_aws_vpcs", return_value=[])
+    return mock_q
+
+
+def test_cidr_blocks_for_cluster_next_block(mock_cidr_deps: Mock) -> None:
+    mock_cidr_deps.get_clusters.return_value = [
+        _make_cluster("c1", "10.0.0.0/24"),
+        _make_cluster("c2", "10.0.1.0/24"),
+    ]
+    runner = CliRunner()
+    result = runner.invoke(
+        qontract_cli.get,
+        ["cidr-blocks", "--for-cluster", "true", "--mask", "24"],
+        obj={"options": {"output": "table"}},
+    )
+    assert result.exit_code == 0
+    assert "10.0.2.0/24" in result.output
+
+
+def test_cidr_blocks_within_finds_first_available(mock_cidr_deps: Mock) -> None:
+    mock_cidr_deps.get_clusters.return_value = [
+        _make_cluster("c1", "10.0.0.0/24"),
+        _make_cluster("c2", "10.0.1.0/24"),
+    ]
+    runner = CliRunner()
+    result = runner.invoke(
+        qontract_cli.get,
+        [
+            "cidr-blocks",
+            "--for-cluster",
+            "true",
+            "--mask",
+            "24",
+            "--within",
+            "10.0.0.0/16",
+        ],
+        obj={"options": {"output": "table"}},
+    )
+    assert result.exit_code == 0
+    assert "10.0.2.0/24" in result.output
+
+
+def test_cidr_blocks_within_no_existing_clusters(mock_cidr_deps: Mock) -> None:
+    mock_cidr_deps.get_clusters.return_value = [
+        _make_cluster("c1", "10.0.0.0/24"),
+    ]
+    runner = CliRunner()
+    result = runner.invoke(
+        qontract_cli.get,
+        [
+            "cidr-blocks",
+            "--for-cluster",
+            "true",
+            "--mask",
+            "24",
+            "--within",
+            "172.16.0.0/16",
+        ],
+        obj={"options": {"output": "table"}},
+    )
+    assert result.exit_code == 0
+    assert "172.16.0.0/24" in result.output
+
+
+def test_cidr_blocks_within_exhausted(mock_cidr_deps: Mock) -> None:
+    mock_cidr_deps.get_clusters.return_value = [
+        _make_cluster("c1", "10.0.0.0/24"),
+        _make_cluster("c2", "10.0.1.0/24"),
+    ]
+    runner = CliRunner()
+    result = runner.invoke(
+        qontract_cli.get,
+        [
+            "cidr-blocks",
+            "--for-cluster",
+            "true",
+            "--mask",
+            "24",
+            "--within",
+            "10.0.0.0/23",
+        ],
+        obj={"options": {"output": "table"}},
+    )
+    assert result.exit_code != 0
+    assert "No available" in result.output
+
+
+def test_cidr_blocks_within_invalid_cidr(mock_cidr_deps: Mock) -> None:
+    mock_cidr_deps.get_clusters.return_value = []
+    runner = CliRunner()
+    result = runner.invoke(
+        qontract_cli.get,
+        ["cidr-blocks", "--for-cluster", "true", "--within", "not-a-cidr"],
+        obj={"options": {"output": "table"}},
+    )
+    assert result.exit_code != 0
+    assert "Invalid CIDR" in result.output


### PR DESCRIPTION
## Summary

- Adds `--within` option to `get cidr-blocks --for-cluster` to scope CIDR allocation within a parent network (e.g. `--within 10.128.0.0/14`)
- Finds the latest cluster CIDR within the parent range and allocates the next block after it
- Starts from the beginning of the parent range if no clusters exist within it yet
- Errors if the parent range is exhausted
- Uses `IPv4Network` explicitly to fix mypy type errors with `subnet_of`

## Test plan

- [x] `pytest tools/test/test_qontract_cli.py` — 15 tests pass
- [x] 5 new tests cover: next block allocation, `--within` scoped allocation, empty range bootstrap, exhausted range error, invalid CIDR error

https://redhat.atlassian.net/browse/APPSRE-13940

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a `--within` CLI option to constrain CIDR block selection to a specified range when used with `--for-cluster`.

* **Improvements**
  * Better handling when no existing clusters are found within the specified range so selection proceeds from the range start.
  * Validation now ensures derived CIDR blocks are subnets of the specified `--within` range, with clear errors for invalid or exhausted ranges.

* **Tests**
  * Added comprehensive tests covering valid, invalid and exhausted `--within` scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->