### PR TITLE
fix(vpc-peering): tolerate both HCP security groups on VPC endpoint

### DIFF
--- a/reconcile/test/utils/test_aws_api.py
+++ b/reconcile/test/utils/test_aws_api.py
@@ -536,3 +536,112 @@ def test_get_cluster_vpc_details_with_hcp_security_group(
     assert route_table_ids is None
     assert subnets_id_az is None
     assert api_security_group_id == expected_sg_id
+
+
+def test_get_cluster_vpc_details_with_both_hcp_security_groups(
+    mocker: MockerFixture,
+    aws_api: AWSApi,
+) -> None:
+    """When both legacy -default-sg and newer -vpce-private-router SGs are
+    attached to the VPC endpoint, prefer -default-sg because existing
+    peering/TGW ingress rules are configured on that SG."""
+    expected_vpc_id = "id"
+    mocker.patch.object(
+        aws_api,
+        "get_account_vpcs",
+        return_value=[
+            {
+                "CidrBlock": "cidr",
+                "VpcId": expected_vpc_id,
+            }
+        ],
+    )
+    mocker.patch.object(
+        AWSApi,
+        "_get_vpc_endpoints",
+        return_value=[
+            {
+                "VpcEndpointId": "vpce-id",
+                "Groups": [
+                    {
+                        "GroupName": "abc-default-sg",
+                        "GroupId": "sg-legacy",
+                    },
+                    {
+                        "GroupName": "abc-vpce-private-router",
+                        "GroupId": "sg-new",
+                    },
+                ],
+            }
+        ],
+    )
+
+    vpc_id, route_table_ids, subnets_id_az, api_security_group_id = (
+        aws_api.get_cluster_vpc_details(
+            {
+                "name": "some-account",
+                "assume_region": "us-east-1",
+                "assume_cidr": "cidr",
+            },
+            hcp_vpc_endpoint_sg=True,
+        )
+    )
+
+    assert vpc_id == expected_vpc_id
+    assert route_table_ids is None
+    assert subnets_id_az is None
+    assert api_security_group_id == "sg-legacy"
+
+
+@pytest.mark.parametrize(
+    "duplicate_suffix",
+    [
+        "-vpce-private-router",
+        "-default-sg",
+    ],
+)
+def test_get_cluster_vpc_details_duplicate_hcp_sg_raises(
+    mocker: MockerFixture,
+    aws_api: AWSApi,
+    duplicate_suffix: str,
+) -> None:
+    """Two SGs with the same recognised suffix should fail fast."""
+    mocker.patch.object(
+        aws_api,
+        "get_account_vpcs",
+        return_value=[
+            {
+                "CidrBlock": "cidr",
+                "VpcId": "id",
+            }
+        ],
+    )
+    mocker.patch.object(
+        AWSApi,
+        "_get_vpc_endpoints",
+        return_value=[
+            {
+                "VpcEndpointId": "vpce-id",
+                "Groups": [
+                    {
+                        "GroupName": f"first{duplicate_suffix}",
+                        "GroupId": "sg-1",
+                    },
+                    {
+                        "GroupName": f"second{duplicate_suffix}",
+                        "GroupId": "sg-2",
+                    },
+                ],
+            }
+        ],
+    )
+
+    with pytest.raises(ValueError, match="multiple VPC endpoint security groups"):
+        aws_api.get_cluster_vpc_details(
+            {
+                "name": "some-account",
+                "assume_region": "us-east-1",
+                "assume_cidr": "cidr",
+            },
+            hcp_vpc_endpoint_sg=True,
+        )

--- a/reconcile/utils/aws_api.py
+++ b/reconcile/utils/aws_api.py
@@ -931,19 +931,28 @@ class AWSApi:
         subnets: bool = False,
         hcp_vpc_endpoint_sg: bool = False,
     ) -> tuple[str | None, list[str] | None, list[dict[str, str]] | None, str | None]:
-        """
-        Returns a cluster VPC details:
-            - VPC ID
-            - Route table IDs (optional)
-            - Subnets list including Subnet ID and Subnet Availability zone
-            - VPC Endpoint default security group of the private API router (optional)
-        :param account: a dictionary containing the following keys:
-                        - name - name of the AWS account
-                        - assume_role - role to assume to get access
-                                        to the cluster's AWS account
-                        - assume_region - region in which to operate
-                        - assume_cidr - CIDR block of the cluster to
-                                        use to find the matching VPC
+        """Return cluster VPC details as a 4-tuple.
+
+        Returns:
+            vpc_id: VPC ID matching *assume_cidr*, or ``None``.
+            route_table_ids: Route table IDs when *route_tables* is True.
+            subnets_id_az: Subnet ID / AZ pairs when *subnets* is True.
+            api_security_group_id: Security group ID of the private API
+                router VPC endpoint when *hcp_vpc_endpoint_sg* is True.
+                Resolves to either the ``*-default-sg`` or
+                ``*-vpce-private-router`` HyperShift SG, preferring
+                ``-default-sg`` when both are present (existing peering
+                and TGW ingress rules live on that SG).  Raises
+                ``ValueError`` on multiple endpoints, duplicate suffixes,
+                or no matching SG.
+
+        Args:
+            account: Dict with keys *name*, *assume_role*,
+                *assume_region*, and *assume_cidr*.
+            route_tables: Fetch route table IDs for the VPC.
+            subnets: Fetch subnet details for the VPC.
+            hcp_vpc_endpoint_sg: Look up the private-router VPC
+                endpoint security group (private HCP clusters only).
         """
         assume_role_data = self._get_account_assume_data(account)
         assumed_ec2 = self._get_assumed_role_client(
@@ -982,6 +991,18 @@ class AWSApi:
     def _get_api_security_group_id(
         self, assumed_ec2: EC2Client, vpc_id: str
     ) -> str | None:
+        """Return the security group ID for the private-router VPC endpoint.
+
+        HyperShift attaches a security group to the private-router VPC
+        endpoint that controls access to the cluster API.  Older clusters
+        use a ``*-default-sg`` name while newer ones use
+        ``*-vpce-private-router``.  During migration both may coexist on
+        the same endpoint; this method prefers ``-default-sg`` because
+        existing peering/TGW ingress rules are configured on that SG.
+
+        Raises ``ValueError`` when the endpoint state is unexpected
+        (multiple endpoints, duplicate suffixes, or no matching SG).
+        """
         endpoints = AWSApi._get_vpc_endpoints(
             [
                 {"Name": "vpc-id", "Values": [vpc_id]},
@@ -1002,18 +1023,33 @@ class AWSApi:
         vpc_endpoint_id = endpoint["VpcEndpointId"]
         # https://github.com/openshift/hypershift/blob/c855f68e84e78924ccc9c2132b75dc7e30c4e1d8/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go#L4243
         # https://github.com/openshift/hypershift/blob/2569f3353ef5ac0858eace9ee77310c3cc38b8e0/control-plane-operator/controllers/awsprivatelink/awsprivatelink_controller.go#L787
-        security_groups = [
-            sg
-            for sg in endpoint["Groups"]
-            if sg["GroupName"].endswith("-default-sg")
-            or sg["GroupName"].endswith("-vpce-private-router")
-        ]
-        if len(security_groups) != 1:
+        vpce_sg = None
+        default_sg = None
+        for sg in endpoint["Groups"]:
+            if sg["GroupName"].endswith("-vpce-private-router"):
+                if vpce_sg is not None:
+                    raise ValueError(
+                        f"multiple VPC endpoint security groups matching "
+                        f"'-vpce-private-router' for private API router "
+                        f"{vpc_endpoint_id} in VPC {vpc_id}"
+                    )
+                vpce_sg = sg
+            elif sg["GroupName"].endswith("-default-sg"):
+                if default_sg is not None:
+                    raise ValueError(
+                        f"multiple VPC endpoint security groups matching "
+                        f"'-default-sg' for private API router "
+                        f"{vpc_endpoint_id} in VPC {vpc_id}"
+                    )
+                default_sg = sg
+        selected = default_sg or vpce_sg
+        if selected is None:
             raise ValueError(
-                f"exactly one VPC endpoint default security group for private API router {vpc_endpoint_id} "
-                f"in VPC {vpc_id} expected but {len(security_groups)} found"
+                f"no VPC endpoint security group matching '-default-sg' or "
+                f"'-vpce-private-router' for private API router {vpc_endpoint_id} "
+                f"in VPC {vpc_id}"
             )
-        return security_groups[0]["GroupId"]
+        return selected["GroupId"]
 
     def get_cluster_nat_gateways_egress_ips(
         self, account: dict[str, Any], vpc_id: str


### PR DESCRIPTION
## Summary

- The HyperShift control plane operator is migrating private-router VPC endpoint security groups from the legacy `-default-sg` naming to `-vpce-private-router`. During the transition, both SGs are attached simultaneously.
- `_get_api_security_group_id` crashes with `ValueError` when it finds 2 matching SGs instead of the expected 1, blocking `terraform-vpc-peerings` reconciliation across multiple shards (`app-sre-stage`, `stonesoup-stage-private-1`, `app-sre`).
- Fix: when both SGs are present, prefer the legacy `-default-sg` because existing peering and TGW ingress rules (21 rules, 38+ CIDR ranges) are configured on that SG. Clusters that have fully migrated (only `-vpce-private-router` present) continue to work as the sole match. Duplicate suffix detection raises `ValueError` to fail fast on unexpected state.

## Context

CloudTrail confirms the HyperShift control plane operator added  `vpce-private-router` sg to VPC endpoint  alongside the existing `default-sg`.

Alerts:
- `QontractReconcileError [FIRING:4]` - terraform-vpc-peerings, terraform-tgw-attachments

## Test plan

- [x] `test_get_cluster_vpc_details_with_hcp_security_group` — single SG (parametrized: `-default-sg`, `-vpce-private-router`)
- [x] `test_get_cluster_vpc_details_with_both_hcp_security_groups` — both SGs present, asserts `-default-sg` is selected
- [x] `test_get_cluster_vpc_details_duplicate_hcp_sg_raises` — duplicate suffix detection (parametrized: both suffixes)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved security group selection for VPC endpoints to properly handle multiple configuration types
  * Added validation to detect and report duplicate or conflicting security group configurations

* **Tests**
  * Added test coverage for VPC endpoint security group selection scenarios

<!-- end of auto-generated comment: release notes by coderabbit.ai -->