### PR TITLE
feat: add msk-connect provider to external resources

### DIFF
--- a/reconcile/external_resources/aws.py
+++ b/reconcile/external_resources/aws.py
@@ -374,7 +374,7 @@ class AWSMskConnectFactory(AWSResourceFactory):
         data = rvr.resolve()
 
         # Resolve MSK cluster reference → bootstrap servers + VPC config
-        msk_cluster_identifier = data.pop("msk_cluster")
+        msk_cluster_identifier = data["msk_cluster"]
         msk_cluster_spec = self._get_msk_cluster_spec(
             spec.provisioner_name, msk_cluster_identifier
         )

--- a/reconcile/external_resources/aws.py
+++ b/reconcile/external_resources/aws.py
@@ -319,3 +319,102 @@ class AWSMskFactory(AWSDefaultResourceFactory):
                 raise ValueError(
                     f"MSK user '{user}' secret must contain only 'username' and 'password' keys!"
                 )
+
+    def find_linked_resources(
+        self, spec: ExternalResourceSpec
+    ) -> set[ExternalResourceKey]:
+        return {
+            k
+            for k, s in self.er_inventory.items()
+            if s.provision_provider == "aws"
+            and s.provider == "msk-connect"
+            and s.resource.get("msk_cluster") == spec.identifier
+            and not s.marked_to_delete
+        }
+
+
+class AWSMskConnectFactory(AWSResourceFactory):
+    def __init__(
+        self,
+        er_inventory: ExternalResourcesInventory,
+        secret_reader: SecretReaderBase,
+        vault_secrets_path: str,
+    ):
+        super().__init__(er_inventory, secret_reader)
+        self.vault_secrets_path = vault_secrets_path
+
+    def _get_msk_cluster_spec(
+        self, provisioner: str, identifier: str
+    ) -> ExternalResourceSpec:
+        return self.er_inventory.get_inventory_spec(
+            "aws", provisioner, "msk", identifier
+        )
+
+    def _get_msk_cluster_output_secret(
+        self, msk_cluster_spec: ExternalResourceSpec
+    ) -> dict[str, str]:
+        """Read the MSK cluster terraform output secret from vault."""
+        vault_path = (
+            f"{self.vault_secrets_path}"
+            f"/{msk_cluster_spec.cluster_name}"
+            f"/{msk_cluster_spec.namespace_name}"
+            f"/{msk_cluster_spec.output_resource_name}"
+        )
+        return self.secret_reader.read_all({"path": vault_path})
+
+    def _build_s3_bucket_arn(self, bucket_name: str) -> str:
+        return f"arn:aws:s3:::{bucket_name}"
+
+    def resolve(
+        self,
+        spec: ExternalResourceSpec,
+        module_conf: ExternalResourceModuleConfiguration,
+    ) -> dict[str, Any]:
+        rvr = ResourceValueResolver(spec=spec, identifier_as_value=True)
+        data = rvr.resolve()
+
+        # Resolve MSK cluster reference → bootstrap servers + VPC config
+        msk_cluster_identifier = data.pop("msk_cluster")
+        msk_cluster_spec = self._get_msk_cluster_spec(
+            spec.provisioner_name, msk_cluster_identifier
+        )
+
+        # Read bootstrap servers from MSK cluster output secret in vault
+        msk_output = self._get_msk_cluster_output_secret(msk_cluster_spec)
+        if not (bootstrap_servers := msk_output.get("bootstrap_brokers_sasl_iam", "")):
+            raise ValueError(
+                f"MSK cluster '{msk_cluster_identifier}' does not have IAM authentication enabled. "
+                f"MSK Connect requires IAM auth (bootstrap_brokers_sasl_iam). "
+                f"Enable client_authentication.sasl.iam on the MSK cluster."
+            )
+        data["kafka_cluster_bootstrap_servers"] = bootstrap_servers
+
+        # Read VPC config (subnets + security groups) from MSK cluster defaults
+        msk_data = ResourceValueResolver(
+            spec=msk_cluster_spec, identifier_as_value=True
+        ).resolve()
+        broker_node_info = msk_data["broker_node_group_info"]
+        data["vpc"] = {
+            "subnets": broker_node_info["client_subnets"],
+            "security_groups": broker_node_info["security_groups"],
+        }
+
+        # Build S3 bucket ARN from bucket name
+        if custom_plugin := data["custom_plugin"]:
+            s3_bucket = custom_plugin.pop("s3_bucket")
+            custom_plugin["s3_bucket_arn"] = self._build_s3_bucket_arn(s3_bucket)
+
+        return data
+
+    def validate(
+        self,
+        resource: ExternalResource,
+        module_conf: ExternalResourceModuleConfiguration,
+    ) -> None:
+        data = resource.data
+        if not data.get("kafka_cluster_bootstrap_servers"):
+            raise ValueError(
+                "Failed to resolve kafka_cluster_bootstrap_servers from MSK cluster output."
+            )
+        if not data.get("connector_configuration"):
+            raise ValueError("connector_configuration must not be empty.")

--- a/reconcile/external_resources/aws.py
+++ b/reconcile/external_resources/aws.py
@@ -412,9 +412,5 @@ class AWSMskConnectFactory(AWSResourceFactory):
         module_conf: ExternalResourceModuleConfiguration,
     ) -> None:
         data = resource.data
-        if not data.get("kafka_cluster_bootstrap_servers"):
-            raise ValueError(
-                "Failed to resolve kafka_cluster_bootstrap_servers from MSK cluster output."
-            )
         if not data.get("connector_configuration"):
             raise ValueError("connector_configuration must not be empty.")

--- a/reconcile/external_resources/aws.py
+++ b/reconcile/external_resources/aws.py
@@ -339,7 +339,7 @@ class AWSMskConnectFactory(AWSResourceFactory):
         er_inventory: ExternalResourcesInventory,
         secret_reader: SecretReaderBase,
         vault_secrets_path: str,
-    ):
+    ) -> None:
         super().__init__(er_inventory, secret_reader)
         self.vault_secrets_path = vault_secrets_path
 
@@ -372,6 +372,7 @@ class AWSMskConnectFactory(AWSResourceFactory):
     ) -> dict[str, Any]:
         rvr = ResourceValueResolver(spec=spec, identifier_as_value=True)
         data = rvr.resolve()
+        data["output_prefix"] = spec.output_prefix
 
         # Resolve MSK cluster reference → bootstrap servers + VPC config
         msk_cluster_identifier = data["msk_cluster"]

--- a/reconcile/external_resources/factories.py
+++ b/reconcile/external_resources/factories.py
@@ -7,6 +7,7 @@ from typing import TypeVar
 from reconcile.external_resources.aws import (
     AWSDefaultResourceFactory,
     AWSElasticacheFactory,
+    AWSMskConnectFactory,
     AWSMskFactory,
     AWSRdsFactory,
     AWSResourceFactory,
@@ -99,13 +100,18 @@ class TerraformModuleProvisionDataFactory(ModuleProvisionDataFactory):
 
 
 def setup_aws_resource_factories(
-    er_inventory: ExternalResourcesInventory, secret_reader: SecretReaderBase
+    er_inventory: ExternalResourcesInventory,
+    secret_reader: SecretReaderBase,
+    vault_secrets_path: str,
 ) -> ObjectFactory[AWSResourceFactory]:
     return ObjectFactory[AWSResourceFactory](
         factories={
             "elasticache": AWSElasticacheFactory(er_inventory, secret_reader),
             "rds": AWSRdsFactory(er_inventory, secret_reader),
             "msk": AWSMskFactory(er_inventory, secret_reader),
+            "msk-connect": AWSMskConnectFactory(
+                er_inventory, secret_reader, vault_secrets_path
+            ),
         },
         default_factory=AWSDefaultResourceFactory(er_inventory, secret_reader),
     )

--- a/reconcile/external_resources/manager.py
+++ b/reconcile/external_resources/manager.py
@@ -69,7 +69,7 @@ def setup_factories(
                 secret_reader=secret_reader,
                 provision_factories=provision_factories,
                 resource_factories=setup_aws_resource_factories(
-                    er_inventory, secret_reader
+                    er_inventory, secret_reader, settings.vault_secrets_path
                 ),
                 default_tags=cast("dict[str, str]", settings.default_tags),
             ),

--- a/reconcile/external_resources/model.py
+++ b/reconcile/external_resources/model.py
@@ -21,6 +21,7 @@ from reconcile.gql_definitions.external_resources.external_resources_namespaces 
     NamespaceTerraformResourceCloudWatchV1,
     NamespaceTerraformResourceElastiCacheV1,
     NamespaceTerraformResourceKMSV1,
+    NamespaceTerraformResourceMskConnectV1,
     NamespaceTerraformResourceMskV1,
     NamespaceTerraformResourceRDSProxyV1,
     NamespaceTerraformResourceRDSV1,
@@ -100,6 +101,7 @@ SUPPORTED_RESOURCE_PROVIDERS = (
 SUPPORTED_RESOURCE_TYPES = (
     NamespaceTerraformResourceRDSV1
     | NamespaceTerraformResourceMskV1
+    | NamespaceTerraformResourceMskConnectV1
     | NamespaceTerraformResourceElastiCacheV1
     | NamespaceTerraformResourceKMSV1
     | NamespaceTerraformResourceCloudWatchV1

--- a/reconcile/gql_definitions/external_resources/external_resources_namespaces.gql
+++ b/reconcile/gql_definitions/external_resources/external_resources_namespaces.gql
@@ -486,6 +486,21 @@ query ExternalResourcesNamespaces {
               ...ExternalResourcesModuleOverrides
             }
           }
+          ... on NamespaceTerraformResourceMskConnect_v1 {
+            region
+            identifier
+            output_resource_name
+            defaults
+            annotations
+            tags
+            msk_cluster
+            service_execution_role
+            managed_by_erv2
+            delete
+            module_overrides {
+              ...ExternalResourcesModuleOverrides
+            }
+          }
         }
       }
       ... on NamespaceTerraformProviderResourceCloudflare_v1 {

--- a/reconcile/gql_definitions/external_resources/external_resources_namespaces.py
+++ b/reconcile/gql_definitions/external_resources/external_resources_namespaces.py
@@ -568,6 +568,21 @@ query ExternalResourcesNamespaces {
               ...ExternalResourcesModuleOverrides
             }
           }
+          ... on NamespaceTerraformResourceMskConnect_v1 {
+            region
+            identifier
+            output_resource_name
+            defaults
+            annotations
+            tags
+            msk_cluster
+            service_execution_role
+            managed_by_erv2
+            delete
+            module_overrides {
+              ...ExternalResourcesModuleOverrides
+            }
+          }
         }
       }
       ... on NamespaceTerraformProviderResourceCloudflare_v1 {
@@ -1198,9 +1213,23 @@ class NamespaceTerraformResourceMskV1(NamespaceTerraformResourceAWSV1):
     module_overrides: Optional[ExternalResourcesModuleOverrides] = Field(..., alias="module_overrides")
 
 
+class NamespaceTerraformResourceMskConnectV1(NamespaceTerraformResourceAWSV1):
+    region: Optional[str] = Field(..., alias="region")
+    identifier: str = Field(..., alias="identifier")
+    output_resource_name: Optional[str] = Field(..., alias="output_resource_name")
+    defaults: str = Field(..., alias="defaults")
+    annotations: Optional[str] = Field(..., alias="annotations")
+    tags: Optional[str] = Field(..., alias="tags")
+    msk_cluster: str = Field(..., alias="msk_cluster")
+    service_execution_role: str = Field(..., alias="service_execution_role")
+    managed_by_erv2: Optional[bool] = Field(..., alias="managed_by_erv2")
+    delete: Optional[bool] = Field(..., alias="delete")
+    module_overrides: Optional[ExternalResourcesModuleOverrides] = Field(..., alias="module_overrides")
+
+
 class NamespaceTerraformProviderResourceAWSV1(NamespaceExternalResourceV1):
     provisioner: AWSAccountV1 = Field(..., alias="provisioner")
-    resources: list[Union[NamespaceTerraformResourceRDSV1, NamespaceTerraformResourceRosaAuthenticatorV1, NamespaceTerraformResourceALBV1, NamespaceTerraformResourceS3V1, NamespaceTerraformResourceElastiCacheV1, NamespaceTerraformResourceCloudWatchV1, NamespaceTerraformResourceASGV1, NamespaceTerraformResourceRDSProxyV1, NamespaceTerraformResourceRoleV1, NamespaceTerraformResourceKMSV1, NamespaceTerraformResourceMskV1, NamespaceTerraformResourceSNSTopicV1, NamespaceTerraformResourceServiceAccountV1, NamespaceTerraformResourceS3SQSV1, NamespaceTerraformResourceKinesisV1, NamespaceTerraformResourceRosaAuthenticatorVPCEV1, NamespaceTerraformResourceS3CloudFrontV1, NamespaceTerraformResourceElasticSearchV1, NamespaceTerraformResourceACMV1, NamespaceTerraformResourceRoute53ZoneV1, NamespaceTerraformResourceSQSV1, NamespaceTerraformResourceDynamoDBV1, NamespaceTerraformResourceECRV1, NamespaceTerraformResourceS3CloudFrontPublicKeyV1, NamespaceTerraformResourceSecretsManagerV1, NamespaceTerraformResourceSecretsManagerServiceAccountV1, NamespaceTerraformResourceAWSV1]] = Field(..., alias="resources")
+    resources: list[Union[NamespaceTerraformResourceRDSV1, NamespaceTerraformResourceRosaAuthenticatorV1, NamespaceTerraformResourceALBV1, NamespaceTerraformResourceS3V1, NamespaceTerraformResourceElastiCacheV1, NamespaceTerraformResourceCloudWatchV1, NamespaceTerraformResourceASGV1, NamespaceTerraformResourceMskConnectV1, NamespaceTerraformResourceRDSProxyV1, NamespaceTerraformResourceRoleV1, NamespaceTerraformResourceKMSV1, NamespaceTerraformResourceMskV1, NamespaceTerraformResourceSNSTopicV1, NamespaceTerraformResourceServiceAccountV1, NamespaceTerraformResourceS3SQSV1, NamespaceTerraformResourceKinesisV1, NamespaceTerraformResourceRosaAuthenticatorVPCEV1, NamespaceTerraformResourceS3CloudFrontV1, NamespaceTerraformResourceElasticSearchV1, NamespaceTerraformResourceACMV1, NamespaceTerraformResourceRoute53ZoneV1, NamespaceTerraformResourceSQSV1, NamespaceTerraformResourceDynamoDBV1, NamespaceTerraformResourceECRV1, NamespaceTerraformResourceS3CloudFrontPublicKeyV1, NamespaceTerraformResourceSecretsManagerV1, NamespaceTerraformResourceSecretsManagerServiceAccountV1, NamespaceTerraformResourceAWSV1]] = Field(..., alias="resources")
 
 
 class CloudflareAccountV1(ConfiguredBaseModel):

--- a/reconcile/gql_definitions/introspection.json
+++ b/reconcile/gql_definitions/introspection.json
@@ -41608,6 +41608,11 @@
                         },
                         {
                             "kind": "OBJECT",
+                            "name": "NamespaceTerraformResourceMskConnect_v1",
+                            "ofType": null
+                        },
+                        {
+                            "kind": "OBJECT",
                             "name": "NamespaceTerraformResourceRDS_v1",
                             "ofType": null
                         },
@@ -43722,6 +43727,199 @@
                     ],
                     "inputFields": null,
                     "interfaces": [],
+                    "enumValues": null,
+                    "possibleTypes": null
+                },
+                {
+                    "kind": "OBJECT",
+                    "name": "NamespaceTerraformResourceMskConnect_v1",
+                    "description": null,
+                    "fields": [
+                        {
+                            "name": "provider",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "NON_NULL",
+                                "name": null,
+                                "ofType": {
+                                    "kind": "SCALAR",
+                                    "name": "String",
+                                    "ofType": null
+                                }
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "region",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "SCALAR",
+                                "name": "String",
+                                "ofType": null
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "identifier",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "NON_NULL",
+                                "name": null,
+                                "ofType": {
+                                    "kind": "SCALAR",
+                                    "name": "String",
+                                    "ofType": null
+                                }
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "defaults",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "NON_NULL",
+                                "name": null,
+                                "ofType": {
+                                    "kind": "SCALAR",
+                                    "name": "String",
+                                    "ofType": null
+                                }
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "output_resource_name",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "SCALAR",
+                                "name": "String",
+                                "ofType": null
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "output_format",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "INTERFACE",
+                                "name": "NamespaceTerraformResourceOutputFormat_v1",
+                                "ofType": null
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "annotations",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "SCALAR",
+                                "name": "JSON",
+                                "ofType": null
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "msk_cluster",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "NON_NULL",
+                                "name": null,
+                                "ofType": {
+                                    "kind": "SCALAR",
+                                    "name": "String",
+                                    "ofType": null
+                                }
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "service_execution_role",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "NON_NULL",
+                                "name": null,
+                                "ofType": {
+                                    "kind": "SCALAR",
+                                    "name": "String",
+                                    "ofType": null
+                                }
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "managed_by_erv2",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "SCALAR",
+                                "name": "Boolean",
+                                "ofType": null
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "delete",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "SCALAR",
+                                "name": "Boolean",
+                                "ofType": null
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "module_overrides",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "OBJECT",
+                                "name": "ExternalResourcesModuleOverrides_v1",
+                                "ofType": null
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "tags",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "SCALAR",
+                                "name": "JSON",
+                                "ofType": null
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        }
+                    ],
+                    "inputFields": null,
+                    "interfaces": [
+                        {
+                            "kind": "INTERFACE",
+                            "name": "NamespaceTerraformResourceAWS_v1",
+                            "ofType": null
+                        }
+                    ],
                     "enumValues": null,
                     "possibleTypes": null
                 },

--- a/reconcile/gql_definitions/introspection.json
+++ b/reconcile/gql_definitions/introspection.json
@@ -21152,18 +21152,6 @@
                             "deprecationReason": null
                         },
                         {
-                            "name": "managePermissions",
-                            "description": null,
-                            "args": [],
-                            "type": {
-                                "kind": "SCALAR",
-                                "name": "Boolean",
-                                "ofType": null
-                            },
-                            "isDeprecated": false,
-                            "deprecationReason": null
-                        },
-                        {
                             "name": "blockedVersions",
                             "description": null,
                             "args": [],

--- a/reconcile/gql_definitions/terraform_resources/terraform_resources_namespaces.gql
+++ b/reconcile/gql_definitions/terraform_resources/terraform_resources_namespaces.gql
@@ -458,6 +458,14 @@ query TerraformResourcesNamespaces {
             }
             managed_by_erv2
           }
+          ... on NamespaceTerraformResourceMskConnect_v1 {
+            region
+            identifier
+            output_resource_name
+            defaults
+            annotations
+            managed_by_erv2
+          }
         }
       }
     }

--- a/reconcile/gql_definitions/terraform_resources/terraform_resources_namespaces.py
+++ b/reconcile/gql_definitions/terraform_resources/terraform_resources_namespaces.py
@@ -515,6 +515,14 @@ query TerraformResourcesNamespaces {
             }
             managed_by_erv2
           }
+          ... on NamespaceTerraformResourceMskConnect_v1 {
+            region
+            identifier
+            output_resource_name
+            defaults
+            annotations
+            managed_by_erv2
+          }
         }
       }
     }
@@ -1104,8 +1112,17 @@ class NamespaceTerraformResourceMskV1(NamespaceTerraformResourceAWSV1):
     managed_by_erv2: Optional[bool] = Field(..., alias="managed_by_erv2")
 
 
+class NamespaceTerraformResourceMskConnectV1(NamespaceTerraformResourceAWSV1):
+    region: Optional[str] = Field(..., alias="region")
+    identifier: str = Field(..., alias="identifier")
+    output_resource_name: Optional[str] = Field(..., alias="output_resource_name")
+    defaults: str = Field(..., alias="defaults")
+    annotations: Optional[str] = Field(..., alias="annotations")
+    managed_by_erv2: Optional[bool] = Field(..., alias="managed_by_erv2")
+
+
 class NamespaceTerraformProviderResourceAWSV1(NamespaceExternalResourceV1):
-    resources: list[Union[NamespaceTerraformResourceRDSV1, NamespaceTerraformResourceALBV1, NamespaceTerraformResourceRosaAuthenticatorV1, NamespaceTerraformResourceRoleV1, NamespaceTerraformResourceS3V1, NamespaceTerraformResourceASGV1, NamespaceTerraformResourceRDSProxyV1, NamespaceTerraformResourceElastiCacheV1, NamespaceTerraformResourceSNSTopicV1, NamespaceTerraformResourceCloudWatchV1, NamespaceTerraformResourceServiceAccountV1, NamespaceTerraformResourceS3CloudFrontV1, NamespaceTerraformResourceS3SQSV1, NamespaceTerraformResourceKMSV1, NamespaceTerraformResourceKinesisV1, NamespaceTerraformResourceRosaAuthenticatorVPCEV1, NamespaceTerraformResourceMskV1, NamespaceTerraformResourceElasticSearchV1, NamespaceTerraformResourceACMV1, NamespaceTerraformResourceSecretsManagerV1, NamespaceTerraformResourceRoute53ZoneV1, NamespaceTerraformResourceSQSV1, NamespaceTerraformResourceDynamoDBV1, NamespaceTerraformResourceECRV1, NamespaceTerraformResourceS3CloudFrontPublicKeyV1, NamespaceTerraformResourceSecretsManagerServiceAccountV1, NamespaceTerraformResourceAWSV1]] = Field(..., alias="resources")
+    resources: list[Union[NamespaceTerraformResourceRDSV1, NamespaceTerraformResourceALBV1, NamespaceTerraformResourceRosaAuthenticatorV1, NamespaceTerraformResourceRoleV1, NamespaceTerraformResourceS3V1, NamespaceTerraformResourceASGV1, NamespaceTerraformResourceRDSProxyV1, NamespaceTerraformResourceElastiCacheV1, NamespaceTerraformResourceSNSTopicV1, NamespaceTerraformResourceCloudWatchV1, NamespaceTerraformResourceServiceAccountV1, NamespaceTerraformResourceS3CloudFrontV1, NamespaceTerraformResourceS3SQSV1, NamespaceTerraformResourceKMSV1, NamespaceTerraformResourceKinesisV1, NamespaceTerraformResourceRosaAuthenticatorVPCEV1, NamespaceTerraformResourceMskV1, NamespaceTerraformResourceElasticSearchV1, NamespaceTerraformResourceACMV1, NamespaceTerraformResourceSecretsManagerV1, NamespaceTerraformResourceRoute53ZoneV1, NamespaceTerraformResourceMskConnectV1, NamespaceTerraformResourceSQSV1, NamespaceTerraformResourceDynamoDBV1, NamespaceTerraformResourceECRV1, NamespaceTerraformResourceS3CloudFrontPublicKeyV1, NamespaceTerraformResourceSecretsManagerServiceAccountV1, NamespaceTerraformResourceAWSV1]] = Field(..., alias="resources")
 
 
 class EnvironmentV1(ConfiguredBaseModel):

--- a/reconcile/test/external_resources/test_aws_msk_connect_factory.py
+++ b/reconcile/test/external_resources/test_aws_msk_connect_factory.py
@@ -1,0 +1,248 @@
+from unittest.mock import Mock
+
+import pytest
+
+from reconcile.external_resources.aws import (
+    AWSMskConnectFactory,
+    AWSMskFactory,
+)
+from reconcile.external_resources.model import (
+    ExternalResource,
+    ExternalResourceKey,
+    ExternalResourceModuleConfiguration,
+    ExternalResourceProvision,
+    ExternalResourcesInventory,
+    TerraformModuleProvisionData,
+)
+from reconcile.utils.external_resource_spec import ExternalResourceSpec
+
+
+@pytest.fixture
+def module_conf() -> ExternalResourceModuleConfiguration:
+    return ExternalResourceModuleConfiguration(
+        image="stable-image",
+        version="1.0.0",
+        outputs_secret_image="path/to/er-output-secret-image",
+        outputs_secret_version="er-output-secret-version",
+        reconcile_timeout_minutes=60,
+        reconcile_drift_interval_minutes=60,
+    )
+
+
+@pytest.fixture
+def msk_cluster_spec() -> ExternalResourceSpec:
+    return ExternalResourceSpec(
+        provision_provider="aws",
+        provisioner={"name": "test", "resources_default_region": "us-east-1"},
+        resource={
+            "identifier": "my-kafka-cluster",
+            "provider": "msk",
+            "output_resource_name": "creds-msk1",
+            "broker_node_group_info": {
+                "client_subnets": ["subnet-1", "subnet-2", "subnet-3"],
+                "security_groups": ["sg-1"],
+                "instance_type": "kafka.t3.small",
+                "ebs_volume_size": 100,
+            },
+            "kafka_version": "3.7.x",
+            "number_of_broker_nodes": 3,
+        },
+        namespace={
+            "cluster": {"name": "test_cluster"},
+            "name": "test_namespace",
+            "environment": {"name": "test_env"},
+            "app": {"name": "test_app"},
+        },
+    )
+
+
+@pytest.fixture
+def msk_connect_spec() -> ExternalResourceSpec:
+    return ExternalResourceSpec(
+        provision_provider="aws",
+        provisioner={"name": "test", "resources_default_region": "us-east-1"},
+        resource={
+            "identifier": "my-s3-sink",
+            "provider": "msk-connect",
+            "msk_cluster": "my-kafka-cluster",
+            "service_execution_role": "my-connector-role",
+            "custom_plugin": {
+                "s3_bucket": "my-plugins-bucket",
+                "s3_key": "plugins/connector.zip",
+                "content_type": "zip",
+            },
+            "connector_configuration": {
+                "topics": "orders",
+                "s3.bucket.name": "my-data-lake",
+            },
+        },
+        namespace={
+            "cluster": {"name": "test_cluster"},
+            "name": "test_namespace",
+            "environment": {"name": "test_env"},
+            "app": {"name": "test_app"},
+        },
+    )
+
+
+@pytest.fixture
+def er_inventory(
+    msk_cluster_spec: ExternalResourceSpec,
+    msk_connect_spec: ExternalResourceSpec,
+) -> ExternalResourcesInventory:
+    inventory = ExternalResourcesInventory([])
+    inventory[ExternalResourceKey.from_spec(msk_cluster_spec)] = msk_cluster_spec
+    inventory[ExternalResourceKey.from_spec(msk_connect_spec)] = msk_connect_spec
+    return inventory
+
+
+def _make_provision(identifier: str) -> ExternalResourceProvision:
+    return ExternalResourceProvision(
+        provision_provider="aws",
+        provisioner="test",
+        provider="msk-connect",
+        identifier=identifier,
+        target_cluster="test_cluster",
+        target_namespace="test_namespace",
+        target_secret_name=f"{identifier}-msk-connect",
+        module_provision_data=TerraformModuleProvisionData(
+            tf_state_bucket="bucket",
+            tf_state_region="us-east-1",
+            tf_state_dynamodb_table="table",
+            tf_state_key=f"aws/test/msk-connect/{identifier}/terraform.tfstate",
+        ),
+    )
+
+
+def test_msk_connect_resolve(
+    er_inventory: ExternalResourcesInventory,
+    msk_connect_spec: ExternalResourceSpec,
+    module_conf: ExternalResourceModuleConfiguration,
+) -> None:
+    secret_reader = Mock()
+    secret_reader.read_all.return_value = {
+        "bootstrap_brokers_sasl_iam": "b-1.kafka:9098,b-2.kafka:9098",
+        "bootstrap_brokers_tls": "b-1.kafka:9094",
+    }
+    factory = AWSMskConnectFactory(
+        er_inventory, secret_reader, "app-sre/integration-outputs/external-resources"
+    )
+
+    data = factory.resolve(msk_connect_spec, module_conf)
+
+    # Bootstrap servers resolved from vault secret
+    assert data["kafka_cluster_bootstrap_servers"] == "b-1.kafka:9098,b-2.kafka:9098"
+
+    # VPC resolved from MSK cluster defaults
+    assert data["vpc"] == {
+        "subnets": ["subnet-1", "subnet-2", "subnet-3"],
+        "security_groups": ["sg-1"],
+    }
+
+    # Service execution role passed through as identifier
+    assert data["service_execution_role"] == "my-connector-role"
+
+    # S3 bucket name converted to ARN
+    assert data["custom_plugin"]["s3_bucket_arn"] == "arn:aws:s3:::my-plugins-bucket"
+    assert "s3_bucket" not in data["custom_plugin"]
+    assert data["custom_plugin"]["s3_key"] == "plugins/connector.zip"
+
+    # Connector config passed through
+    assert data["connector_configuration"] == {
+        "topics": "orders",
+        "s3.bucket.name": "my-data-lake",
+    }
+
+    # msk_cluster identifier removed from data (resolved into other fields)
+    assert "msk_cluster" not in data
+
+    # Vault secret was read with correct path
+    secret_reader.read_all.assert_called_once_with({
+        "path": "app-sre/integration-outputs/external-resources/test_cluster/test_namespace/creds-msk1"
+    })
+
+
+def test_msk_connect_resolve_missing_iam_auth(
+    er_inventory: ExternalResourcesInventory,
+    msk_connect_spec: ExternalResourceSpec,
+    module_conf: ExternalResourceModuleConfiguration,
+) -> None:
+    secret_reader = Mock()
+    secret_reader.read_all.return_value = {
+        "bootstrap_brokers_sasl_iam": "",
+        "bootstrap_brokers_sasl_scram": "b-1.kafka:9096",
+    }
+    factory = AWSMskConnectFactory(
+        er_inventory, secret_reader, "app-sre/integration-outputs/external-resources"
+    )
+
+    with pytest.raises(ValueError, match="does not have IAM authentication enabled"):
+        factory.resolve(msk_connect_spec, module_conf)
+
+
+def test_msk_connect_validate_empty_connector_configuration(
+    er_inventory: ExternalResourcesInventory,
+    module_conf: ExternalResourceModuleConfiguration,
+) -> None:
+    secret_reader = Mock()
+    factory = AWSMskConnectFactory(er_inventory, secret_reader, "vault/path")
+    resource = ExternalResource(
+        data={
+            "identifier": "my-s3-sink",
+            "connector_configuration": {},
+            "custom_plugin": {
+                "s3_bucket_arn": "arn:aws:s3:::bucket",
+                "s3_key": "key",
+                "content_type": "zip",
+            },
+            "kafka_cluster_bootstrap_servers": "b-1:9098",
+            "service_execution_role": "role",
+        },
+        provision=_make_provision("my-s3-sink"),
+    )
+
+    with pytest.raises(ValueError, match="connector_configuration must not be empty"):
+        factory.validate(resource, module_conf)
+
+
+def test_msk_connect_validate_valid(
+    er_inventory: ExternalResourcesInventory,
+    module_conf: ExternalResourceModuleConfiguration,
+) -> None:
+    secret_reader = Mock()
+    factory = AWSMskConnectFactory(er_inventory, secret_reader, "vault/path")
+    resource = ExternalResource(
+        data={
+            "identifier": "my-s3-sink",
+            "connector_configuration": {"topics": "orders"},
+            "custom_plugin": {
+                "s3_bucket_arn": "arn:aws:s3:::bucket",
+                "s3_key": "key",
+                "content_type": "zip",
+            },
+            "kafka_cluster_bootstrap_servers": "b-1:9098",
+            "service_execution_role": "my-role",
+        },
+        provision=_make_provision("my-s3-sink"),
+    )
+
+    factory.validate(resource, module_conf)
+
+
+def test_msk_factory_find_linked_msk_connect_resources(
+    er_inventory: ExternalResourcesInventory,
+    msk_cluster_spec: ExternalResourceSpec,
+) -> None:
+    secret_reader = Mock()
+    factory = AWSMskFactory(er_inventory, secret_reader)
+
+    linked = factory.find_linked_resources(msk_cluster_spec)
+
+    assert linked == {
+        ExternalResourceKey(
+            provision_provider="aws",
+            provisioner_name="test",
+            provider="msk-connect",
+            identifier="my-s3-sink",
+        )
+    }

--- a/reconcile/test/external_resources/test_aws_msk_connect_factory.py
+++ b/reconcile/test/external_resources/test_aws_msk_connect_factory.py
@@ -154,7 +154,7 @@ def test_msk_connect_resolve(
     }
 
     # msk_cluster identifier removed from data (resolved into other fields)
-    assert "msk_cluster" not in data
+    assert "msk_cluster" in data
 
     # Vault secret was read with correct path
     secret_reader.read_all.assert_called_once_with({

--- a/reconcile/test/external_resources/test_aws_msk_connect_factory.py
+++ b/reconcile/test/external_resources/test_aws_msk_connect_factory.py
@@ -152,8 +152,6 @@ def test_msk_connect_resolve(
         "topics": "orders",
         "s3.bucket.name": "my-data-lake",
     }
-
-    # msk_cluster identifier removed from data (resolved into other fields)
     assert "msk_cluster" in data
 
     # Vault secret was read with correct path


### PR DESCRIPTION
## Summary

- Add `AWSMskConnectFactory` to handle MSK Connect connector resources in the ERv2 external resources pipeline
- Add `find_linked_resources()` to `AWSMskFactory` so MSK cluster changes trigger re-reconciliation of dependent connectors
- Add GraphQL type `NamespaceTerraformResourceMskConnect_v1` and GQL query fragment
- Add `msk-connect` to `SUPPORTED_RESOURCE_TYPES` and factory registration

**Depends on:** app-sre/qontract-schemas#990 (schema definitions)

## How it works

MSK Connect connectors are defined alongside their MSK cluster in the same `externalResources` block. The `msk_cluster` field references the MSK cluster by its `identifier` (same pattern as `replica_source` for RDS):

```yaml
externalResources:
- provider: aws
  provisioner:
    $ref: /aws/myteam-prod/account.yml
  resources:
  - provider: msk
    identifier: my-kafka-cluster
    defaults: /terraform/resources/msk-prod.yml
    managed_by_erv2: true

  - provider: msk-connect
    identifier: my-s3-sink
    defaults: /terraform/resources/msk-connect-s3-sink.yml
    msk_cluster: my-kafka-cluster    # resolved via er_inventory
    managed_by_erv2: true
```

### AWSMskConnectFactory

- **`resolve()`**: Resolves the `msk_cluster` identifier via `ExternalResourcesInventory.get_inventory_spec()` to pass the cluster identifier to the ERv2 Terraform module (which then uses Terraform data sources to look up bootstrap brokers, subnets, security groups)
- **`validate()`**: Ensures `connector_configuration` is not empty

### Linked resources

`AWSMskFactory.find_linked_resources()` now finds all `msk-connect` resources that reference the cluster. When the MSK cluster finishes reconciliation, all linked connectors are automatically re-reconciled.

## Test plan

- [x] 5 new tests in `test_aws_msk_connect_factory.py` — all passing
  - `test_msk_connect_resolve` — verifies identifier resolution
  - `test_msk_connect_validate_empty_connector_configuration` — rejects empty config
  - `test_msk_connect_validate_valid` — accepts valid configuration
  - `test_msk_factory_find_linked_msk_connect_resources` — verifies linked resource discovery
- [x] All 68 existing external_resources tests still pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for AWS MSK Connect as a managed external resource; linked MSK clusters now supply bootstrap servers, VPC subnets, and security groups automatically.
  * API/GraphQL now recognizes MSK Connect resource types and returns MSK Connect–specific fields.

* **Bug Fixes / Validation**
  * Connector configuration is now required for MSK Connect; resolution errors if IAM bootstrap info is missing.
  * Custom plugin S3 bucket references are converted to bucket ARNs for provisioning.

* **Tests**
  * New tests cover resolve/validate behavior and resource linking.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->