### PR TITLE
fix(terrascript): upgrade time and random Terraform provider versions

### DIFF
--- a/dockerfiles/Dockerfile
+++ b/dockerfiles/Dockerfile
@@ -28,7 +28,7 @@ RUN UV_DYNAMIC_VERSIONING_BYPASS="0.0.0" uv sync --frozen --no-group dev
 ###############################################################################
 # STAGE 2 - dev-image
 ###############################################################################
-FROM quay.io/redhat-services-prod/app-sre-tenant/container-images-master/qontract-reconcile-base-master:1.5.1-1@sha256:2a2a15f47273bc3a5119b2cd936e87749103567207ba84692d3fec1d88050a31 AS dev-image
+FROM quay.io/redhat-services-prod/app-sre-tenant/container-images-master/qontract-reconcile-base-master:1.5.2-1@sha256:feb8c631c26c0d9ad1ec24903baf0afc20028bd98b0826625ca5389e8ffc6676 AS dev-image
 COPY --from=ghcr.io/astral-sh/uv:0.11.7@sha256:240fb85ab0f263ef12f492d8476aa3a2e4e1e333f7d67fbdd923d00a506a516a /uv /bin/uv
 
 ENV \
@@ -59,7 +59,7 @@ ENTRYPOINT ["/work/dev/run.sh"]
 ###############################################################################
 # STAGE 3 - prod-image-pre-test
 ###############################################################################
-FROM quay.io/redhat-services-prod/app-sre-tenant/container-images-master/qontract-reconcile-base-master:1.5.1-1@sha256:2a2a15f47273bc3a5119b2cd936e87749103567207ba84692d3fec1d88050a31 AS prod-image-pre-test
+FROM quay.io/redhat-services-prod/app-sre-tenant/container-images-master/qontract-reconcile-base-master:1.5.2-1@sha256:feb8c631c26c0d9ad1ec24903baf0afc20028bd98b0826625ca5389e8ffc6676 AS prod-image-pre-test
 
 # Tini
 ENV TINI_VERSION=v0.19.0

--- a/reconcile/utils/terrascript_aws_client.py
+++ b/reconcile/utils/terrascript_aws_client.py
@@ -540,11 +540,11 @@ class TerrascriptClient:
                     # https://github.com/hashicorp/terraform-provider-aws/pull/20926
                     "time": {
                         "source": "hashicorp/time",
-                        "version": "0.9.1",
+                        "version": "0.13.1",
                     },
                     "random": {
                         "source": "hashicorp/random",
-                        "version": "3.4.3",
+                        "version": "3.8.1",
                     },
                     "cloudinit": {
                         "source": "hashicorp/cloudinit",


### PR DESCRIPTION
## Summary

- **Upgrade `hashicorp/time`** provider version from 0.9.1 to 0.13.1 in terrascript required_providers
- **Upgrade `hashicorp/random`** provider version from 3.4.3 to 3.8.1 in terrascript required_providers

## Context

ACS flagged critical fixable CVEs in the `qontract-reconcile-master` image running in `gabi-pipelines` on `appsrep09ue1`. The root cause is old Terraform providers compiled with vulnerable Go versions (< 1.19.9). The old `time` (0.9.1) and `random` (3.4.3) providers were built with Go 1.18.5, which is affected by CVE-2023-24538, CVE-2023-24540, CVE-2024-24790, and others.

## Dependency

This PR requires the updated `qontract-reconcile-base` container image (with the new provider versions available in the plugin directory) to be published first. See companion PR: app-sre/container-images#TBD

The qontract-reconcile Dockerfile base image digest will also need to be updated to reference the new base image once it is published.

## Test plan

- [ ] Verify `terraform init` succeeds with new provider versions
- [ ] Verify terrascript generates correct `required_providers` blocks
- [ ] Verify ACS CVE alerts clear after deployment


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated Terraform provider version constraints for temporary providers to ensure compatibility and receive recent fixes.
  * Bumped base images used for development and pre-test builds to a newer revision for improved stability and build consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->