### PR TITLE
fix(tekton): remove unused retention field

### DIFF
--- a/reconcile/queries.py
+++ b/reconcile/queries.py
@@ -2215,10 +2215,6 @@ PIPELINES_PROVIDERS_QUERY = """
     provider
     ...on PipelinesProviderTekton_v1 {
       defaults {
-        retention {
-          days
-          minimum
-        }
         taskTemplates {
           ...on PipelinesProviderTektonObjectTemplate_v1 {
             name
@@ -2267,10 +2263,6 @@ PIPELINES_PROVIDERS_QUERY = """
             integrations
           }
         }
-      }
-      retention {
-        days
-        minimum
       }
       taskTemplates {
         ...on PipelinesProviderTektonObjectTemplate_v1 {

--- a/reconcile/test/fixtures/openshift_tekton_resources/provider1.json
+++ b/reconcile/test/fixtures/openshift_tekton_resources/provider1.json
@@ -2,10 +2,6 @@
   "name": "provider1",
   "provider": "tekton",
   "defaults": {
-    "retention": {
-      "days": 7,
-      "minimum": 100
-    },
     "taskTemplates": [
       {
         "name": "openshift-saas-deploy",

--- a/reconcile/test/fixtures/openshift_tekton_resources/provider2-with-resources.json
+++ b/reconcile/test/fixtures/openshift_tekton_resources/provider2-with-resources.json
@@ -1,12 +1,7 @@
 {
   "name": "provider2-with-resources",
   "provider": "tekton",
-  "defaults": null,
   "defaults": {
-    "retention": {
-      "days": 7,
-      "minimum": 100
-    },
     "taskTemplates": [
       {
         "name": "openshift-saas-deploy",

--- a/reconcile/test/fixtures/openshift_tekton_resources/provider4-with-task-duplicates.json
+++ b/reconcile/test/fixtures/openshift_tekton_resources/provider4-with-task-duplicates.json
@@ -2,10 +2,6 @@
   "name": "provider4-with-task-duplicates",
   "provider": "tekton",
   "defaults": {
-    "retention": {
-      "days": 7,
-      "minimum": 100
-    },
     "taskTemplates": [
       {
         "name": "openshift-saas-deploy",

--- a/reconcile/test/fixtures/openshift_tekton_resources/provider5-with-unknown-task.json
+++ b/reconcile/test/fixtures/openshift_tekton_resources/provider5-with-unknown-task.json
@@ -2,10 +2,6 @@
   "name": "provider5-with-unknown-task",
   "provider": "tekton",
   "defaults": {
-    "retention": {
-      "days": 7,
-      "minimum": 100
-    },
     "taskTemplates": [
       {
         "name": "openshift-saas-deploy",

--- a/reconcile/test/fixtures/openshift_tekton_resources/provider6-too-long-pipeline-name.yaml
+++ b/reconcile/test/fixtures/openshift_tekton_resources/provider6-too-long-pipeline-name.yaml
@@ -2,10 +2,6 @@
   "name": "provider6-too-long-pipeline-name",
   "provider": "tekton",
   "defaults": {
-    "retention": {
-      "days": 7,
-      "minimum": 100
-    },
     "taskTemplates": [
       {
         "name": "openshift-saas-deploy",

--- a/reconcile/test/fixtures/openshift_tekton_resources/provider7-deleted-namespace.json
+++ b/reconcile/test/fixtures/openshift_tekton_resources/provider7-deleted-namespace.json
@@ -2,10 +2,6 @@
   "name": "provider7-deleted-namespace",
   "provider": "tekton",
   "defaults": {
-    "retention": {
-      "days": 7,
-      "minimum": 100
-    },
     "taskTemplates": [
       {
         "name": "openshift-saas-deploy",

--- a/reconcile/test/fixtures/queries/pipelines_providers_all_defaults.json
+++ b/reconcile/test/fixtures/queries/pipelines_providers_all_defaults.json
@@ -4,10 +4,6 @@
       "name": "provider1",
       "provider": "tekton",
       "defaults": {
-        "retention": {
-          "days": 7,
-          "minimum": 100
-        },
         "taskTemplates": [
           {
             "name": "openshift-saas-deploy",

--- a/reconcile/test/fixtures/queries/pipelines_providers_mixed.json
+++ b/reconcile/test/fixtures/queries/pipelines_providers_mixed.json
@@ -4,10 +4,6 @@
       "name": "provider1",
       "provider": "tekton",
       "defaults": {
-        "retention": {
-          "days": 7,
-          "minimum": 100
-        },
         "taskTemplates": [
           {
             "name": "openshift-saas-deploy",
@@ -55,10 +51,6 @@
           "internal": true,
           "disable": null
         }
-      },
-      "retention": {
-        "days": 99,
-        "minimum": 999
       },
       "deployResources": {
         "requests": {

--- a/reconcile/test/test_queries.py
+++ b/reconcile/test/test_queries.py
@@ -39,7 +39,7 @@ class TestQueries:
         self.fixture_data = deepcopy(data)
         pps = queries.get_pipelines_providers()
 
-        for k in ["retention", "taskTemplates", "pipelineTemplates", "deployResources"]:
+        for k in ["taskTemplates", "pipelineTemplates", "deployResources"]:
             assert data["pipelines_providers"][0]["defaults"][k] == pps[0][k]
 
     def test_get_pipelines_providers_mixed(self) -> None:
@@ -51,5 +51,5 @@ class TestQueries:
         for k in ["taskTemplates", "pipelineTemplates"]:
             assert data["pipelines_providers"][0]["defaults"][k] == pps[0][k]
 
-        for k in ["retention", "deployResources"]:
+        for k in ["deployResources"]:
             assert data["pipelines_providers"][0][k] == pps[0][k]


### PR DESCRIPTION
Missed `retention` cleanup in not typed queries in https://github.com/app-sre/qontract-reconcile/pull/5494

https://redhat.atlassian.net/browse/APPSRE-11692

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed retention configuration fields from pipeline provider settings and queries.

* **Tests**
  * Updated test fixtures and validation assertions to reflect configuration changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->