### PR TITLE
fix(erv2): read credentials from the right vault paths in qontract-cli

### DIFF
--- a/tools/qontract_cli.py
+++ b/tools/qontract_cli.py
@@ -83,6 +83,9 @@ from reconcile.gql_definitions.common.app_interface_vault_settings import (
     AppInterfaceSettingsV1,
 )
 from reconcile.gql_definitions.common.clusters import ClusterSpecROSAV1
+from reconcile.gql_definitions.external_resources.aws_accounts import (
+    query as aws_accounts_query,
+)
 from reconcile.gql_definitions.glitchtip.glitchtip_instance import (
     query as glitchtip_instance_query,
 )
@@ -103,6 +106,7 @@ from reconcile.typed_queries.app_quay_repos_escalation_policies import (
     get_apps_quay_repos_escalation_policies,
 )
 from reconcile.typed_queries.clusters import get_clusters
+from reconcile.typed_queries.external_resources import get_settings as get_er_settings
 from reconcile.typed_queries.saas_files import get_saas_files
 from reconcile.typed_queries.slo_documents import get_slo_documents
 from reconcile.typed_queries.status_board import get_status_board
@@ -168,6 +172,7 @@ from reconcile.utils.saasherder.models import TargetSpec
 from reconcile.utils.saasherder.saasherder import SaasHerder
 from reconcile.utils.secret_reader import (
     SecretReader,
+    SecretReaderBase,
     create_secret_reader,
 )
 from reconcile.utils.semver_helper import parse_semver
@@ -4419,14 +4424,39 @@ def get_input(ctx: click.Context) -> None:
 
 
 def _get_external_resources_credentials(
-    secret_reader: SecretReader,
+    secret_reader: SecretReaderBase,
     provisioner: str,
 ) -> str:
-    return secret_reader.read_with_parameters(
-        path=f"app-sre/external-resources/{provisioner}",
-        field="credentials",
-        format=None,
-        version=None,
+    query_func = gql.get_api().query
+
+    # Fetch provisioner account credentials ([default] profile)
+    provisioner_accounts = aws_accounts_query(
+        query_func, variables={"filter": {"name": provisioner}}
+    ).accounts
+    if not provisioner_accounts:
+        raise ValueError(f"AWS account '{provisioner}' not found")
+    provisioner_token = secret_reader.read_all_secret(
+        provisioner_accounts[0].automation_token
+    )
+
+    # Fetch state account credentials ([external-resources-state] profile)
+    er_settings = get_er_settings(query_func=query_func)
+    state_account_name = er_settings.state_dynamodb_account.name
+    state_accounts = aws_accounts_query(
+        query_func, variables={"filter": {"name": state_account_name}}
+    ).accounts
+    if not state_accounts:
+        raise ValueError(f"State AWS account '{state_account_name}' not found")
+    state_token = secret_reader.read_all_secret(state_accounts[0].automation_token)
+
+    return (
+        "[default]\n"
+        f"aws_access_key_id={provisioner_token['aws_access_key_id']}\n"
+        f"aws_secret_access_key={provisioner_token['aws_secret_access_key']}\n"
+        "\n"
+        "[external-resources-state]\n"
+        f"aws_access_key_id={state_token['aws_access_key_id']}\n"
+        f"aws_secret_access_key={state_token['aws_secret_access_key']}\n"
     )
 
 

--- a/tools/test/test_qontract_cli.py
+++ b/tools/test/test_qontract_cli.py
@@ -243,11 +243,28 @@ def test_get_openshift_cost_optimization_report(
 def test_external_resources_get_credentials(
     mock_get_app_interface_vault_settings: Mock,
     mock_create_secret_reader: Mock,
+    mocker: MockerFixture,
 ) -> None:
-    mock_secret_read = mock_create_secret_reader.return_value.read_with_parameters
-    mock_secret_read.return_value = "expected"
-    runner = CliRunner()
+    mocker.patch("tools.qontract_cli.gql")
 
+    provisioner_account = Mock()
+    state_account = Mock()
+    mock_aws_accounts_query = mocker.patch("tools.qontract_cli.aws_accounts_query")
+    mock_aws_accounts_query.side_effect = [
+        Mock(accounts=[provisioner_account]),
+        Mock(accounts=[state_account]),
+    ]
+
+    mock_get_settings = mocker.patch("tools.qontract_cli.get_er_settings")
+    mock_get_settings.return_value.state_dynamodb_account.name = "state-account"
+
+    mock_read_all = mock_create_secret_reader.return_value.read_all_secret
+    mock_read_all.side_effect = [
+        {"aws_access_key_id": "PROV_KEY", "aws_secret_access_key": "PROV_SECRET"},
+        {"aws_access_key_id": "STATE_KEY", "aws_secret_access_key": "STATE_SECRET"},
+    ]
+
+    runner = CliRunner()
     result = runner.invoke(
         qontract_cli.external_resources,
         "--provisioner provisioner --provider elasticache --identifier i get-credentials",
@@ -255,13 +272,16 @@ def test_external_resources_get_credentials(
     )
 
     assert result.exit_code == 0
-    assert result.output == "expected\n"
-    mock_secret_read.assert_called_once_with(
-        path="app-sre/external-resources/provisioner",
-        field="credentials",
-        format=None,
-        version=None,
+    expected = (
+        "[default]\n"
+        "aws_access_key_id=PROV_KEY\n"
+        "aws_secret_access_key=PROV_SECRET\n"
+        "\n"
+        "[external-resources-state]\n"
+        "aws_access_key_id=STATE_KEY\n"
+        "aws_secret_access_key=STATE_SECRET\n"
     )
+    assert result.output == expected + "\n"
 
 
 @pytest.fixture


### PR DESCRIPTION
## Summary

- `_get_external_resources_credentials` was reading from a legacy Vault path (`app-sre/external-resources/{provisioner}`) that does not match the runtime credential source
- At runtime, the K8s secret (`credentials-aws-{provisioner}`) is populated by `aws-credentials-v2.j2`, which reads from two separate Vault sources
- Updated the function to compose the credentials file the same way the template does: the provisioner account's `automationToken` for the `[default]` profile, and the state account's `automationToken` for the `[external-resources-state]` profile

## Test plan

- [ ] Existing unit test updated to mock the new GQL lookups and `read_all_secret` calls
- [ ] `pytest tools/test/test_qontract_cli.py::test_external_resources_get_credentials` passes
- [ ] `ruff check` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Changes**
  * Credential generation now looks up AWS automation tokens via GraphQL and builds a shared-credentials output dynamically instead of using a fixed secret path.
  * Credentials output now includes multiple profiles (default and external-resources-state) in the credentials file.
  * Improved validation with clear errors when required AWS accounts cannot be located.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->