### PR TITLE
fix: update debug-container image to new registry path

### DIFF
--- a/reconcile/database_access_manager.py
+++ b/reconcile/database_access_manager.py
@@ -629,7 +629,7 @@ def _process_db_access(
 
         job_image = (
             sql_query_settings.get("jobImage")
-            or "quay.io/app-sre/debug-container:latest"
+            or "quay.io/redhat-services-prod/app-sre-tenant/container-images-master/debug-container-master:latest"
         )
 
         managed_resources = _populate_resources(

--- a/reconcile/sql_query.py
+++ b/reconcile/sql_query.py
@@ -859,7 +859,7 @@ def run(
         mail_address=smtp_settings.mail_address,
         timeout=smtp_settings.timeout or DEFAULT_SMTP_TIMEOUT,
     )
-    job_image = "quay.io/app-sre/debug-container:latest"
+    job_image = "quay.io/redhat-services-prod/app-sre-tenant/container-images-master/debug-container-master:latest"
 
     sql_query_settings = settings.get("sqlQuery")
     pull_secret: dict[str, Any] = {}


### PR DESCRIPTION
Replace deprecated quay.io/app-sre/debug-container:latest with quay.io/redhat-services-prod/app-sre-tenant/container-images-master/debug-container-master:latest in sql_query and database_access_manager fallback defaults.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated default container images used for database access and SQL query job execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->