### PR TITLE
fix(change-log-tracking): limit --process-existing to last 31 days

### DIFF
--- a/reconcile/change_owners/change_log_tracking.py
+++ b/reconcile/change_owners/change_log_tracking.py
@@ -1,6 +1,7 @@
 import logging
 from collections import defaultdict
 from collections.abc import Callable
+from datetime import UTC, datetime, timedelta
 
 from gitlab.v4.objects import (
     ProjectCommit,
@@ -62,6 +63,7 @@ class ChangeLogIntegrationParams(PydanticRunParams):
     gitlab_project_id: str
     process_existing: bool = False
     commit: str | None = None
+    lookback_days: int = 31
 
 
 class ChangeLogIntegration(QontractReconcileIntegration[ChangeLogIntegrationParams]):
@@ -140,6 +142,10 @@ class ChangeLogIntegration(QontractReconcileIntegration[ChangeLogIntegrationPara
 
             logging.info(f"Processing commit {commit}")
             gl_commit = gl.project.commits.get(commit)
+            if self.params.process_existing:
+                cutoff = datetime.now(UTC) - timedelta(days=self.params.lookback_days)
+                if datetime.fromisoformat(gl_commit.committed_date) < cutoff:
+                    continue
             change_log_item = ChangeLogItem(
                 commit=commit,
                 merged_at=gl_commit.committed_date,

--- a/reconcile/test/change_owners/test_change_log_tracking.py
+++ b/reconcile/test/change_owners/test_change_log_tracking.py
@@ -1,4 +1,5 @@
 from collections.abc import Callable
+from datetime import UTC, datetime
 from typing import Any
 from unittest.mock import create_autospec
 
@@ -23,7 +24,11 @@ from reconcile.gql_definitions.common.apps import AppV1
 from reconcile.utils.gql import GqlApi
 
 APP_PATH = "/services/a/app.yml"
-MERGED_AT = "2024-01-01T00:00:00Z"
+FIXED_NOW = datetime(2024, 3, 1, 0, 0, 0, tzinfo=UTC)
+MERGED_AT = (
+    "2024-02-15T00:00:00+00:00"  # 14 days before FIXED_NOW, within 30-day window
+)
+MERGED_AT_OLD = "2024-01-01T00:00:00+00:00"  # 60 days before FIXED_NOW, outside window
 COMMIT_SHA = "commit_sha"
 
 
@@ -34,6 +39,7 @@ def setup_mocks(
     apps: list[AppV1],
     datafiles: dict[str, Any],
     commit_message: str,
+    committed_date: str = MERGED_AT,
 ) -> dict[str, Any]:
     data = gql_class_factory(ChangeTypesQueryData, {})
     mocked_gql_api = gql_api_builder(data.model_dump(by_alias=True))
@@ -71,11 +77,15 @@ def setup_mocks(
     project.commits = create_autospec(ProjectCommitManager)
     commit = create_autospec(
         ProjectCommit,
-        committed_date=MERGED_AT,
+        committed_date=committed_date,
         message=commit_message,
     )
     project.commits.get.return_value = commit
     mocked_gl.project = project
+
+    mock_datetime = mocker.patch("reconcile.change_owners.change_log_tracking.datetime")
+    mock_datetime.now.return_value = FIXED_NOW
+    mock_datetime.fromisoformat = datetime.fromisoformat
 
     return {
         "state": mocked_state,
@@ -142,5 +152,36 @@ def test_change_log_tracking_with_deleted_app(
     mocks["state"].add.assert_called_once_with(
         "bundle-diffs.json",
         expected_change_log.model_dump(),
+        force=True,
+    )
+
+
+def test_change_log_tracking_filters_old_commits(
+    mocker: MockerFixture,
+    gql_api_builder: Callable[..., GqlApi],
+    gql_class_factory: Callable[..., ChangeTypesQueryData],
+) -> None:
+    mocks = setup_mocks(
+        mocker,
+        gql_api_builder,
+        gql_class_factory,
+        apps=[],
+        datafiles={},
+        commit_message="some change",
+        committed_date=MERGED_AT_OLD,
+    )
+    integration = ChangeLogIntegration(
+        ChangeLogIntegrationParams(
+            gitlab_project_id="test",
+            process_existing=True,
+            commit=None,
+        )
+    )
+
+    integration.run(dry_run=False)
+
+    mocks["state"].add.assert_called_once_with(
+        "bundle-diffs.json",
+        ChangeLog().model_dump(),
         force=True,
     )


### PR DESCRIPTION
## Summary

- The `change-log` ConfigMap in `backstage-prod` was hitting Kubernetes' hard 1MB limit because `bundle-diffs.json` in S3 grows unboundedly
- When `--process-existing` rebuilds state from scratch, it now skips commits older than `lookback_days` (default 31)
- The daily cron that runs with `--process-existing` will keep the ConfigMap bounded going forward

## Test plan

- [ ] Existing `test_change_log_tracking_with_deleted_app` updated to mock `datetime.now` to a fixed point in time so the test remains deterministic
- [ ] New `test_change_log_tracking_filters_old_commits` verifies that commits outside the lookback window are excluded from state

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a configurable lookback window feature that filters commits based on age when processing existing change data. The new `lookback_days` parameter defaults to 31 days, controlling which historical commits are included in the change log.

* **Tests**
  * Expanded test coverage with parameterized commit dates to validate proper filtering of commits outside the lookback window.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->