### PR TITLE
fix(change-log-tracking): add processed-commits map to avoid redundant GitLab API calls

### DIFF
--- a/reconcile/change_owners/change_log_tracking.py
+++ b/reconcile/change_owners/change_log_tracking.py
@@ -35,6 +35,7 @@ from reconcile.utils.state import init_state
 
 QONTRACT_INTEGRATION = "change-log-tracking"
 BUNDLE_DIFFS_OBJ = "bundle-diffs.json"
+PROCESSED_COMMITS_OBJ = "processed-commits.json"
 DEFAULT_MERGE_COMMIT_PREFIX = "Merge branch '"
 
 
@@ -122,8 +123,14 @@ class ChangeLogIntegration(QontractReconcileIntegration[ChangeLogIntegrationPara
             defer(diff_state.cleanup)
             defer(gl.cleanup)
 
+        existing_change_log = ChangeLog()
+        # commit sha -> committed_date for commits older than lookback_days;
+        # lets normal runs skip stale commits without a GitLab API call.
+        # ignored when --process-existing rebuilds state from scratch.
+        processed_commits: dict[str, str] = {}
         if not self.params.process_existing:
             existing_change_log = ChangeLog(**integration_state.get(BUNDLE_DIFFS_OBJ))
+            processed_commits = integration_state.get(PROCESSED_COMMITS_OBJ, {})
 
         change_log = ChangeLog()
         for item in diff_state.ls():
@@ -139,13 +146,16 @@ class ChangeLogIntegration(QontractReconcileIntegration[ChangeLogIntegrationPara
                     logging.debug(f"Found existing commit {commit}")
                     change_log.items.append(existing_change_log_item)
                     continue
+                if commit in processed_commits:
+                    logging.debug(f"Skipping already processed commit {commit}")
+                    continue
 
             logging.info(f"Processing commit {commit}")
             gl_commit = gl.project.commits.get(commit)
-            if self.params.process_existing:
-                cutoff = datetime.now(UTC) - timedelta(days=self.params.lookback_days)
-                if datetime.fromisoformat(gl_commit.committed_date) < cutoff:
-                    continue
+            cutoff = datetime.now(UTC) - timedelta(days=self.params.lookback_days)
+            if datetime.fromisoformat(gl_commit.committed_date) < cutoff:
+                processed_commits[commit] = gl_commit.committed_date
+                continue
             change_log_item = ChangeLogItem(
                 commit=commit,
                 merged_at=gl_commit.committed_date,
@@ -247,3 +257,4 @@ class ChangeLogIntegration(QontractReconcileIntegration[ChangeLogIntegrationPara
         )
         if not dry_run:
             integration_state.add(BUNDLE_DIFFS_OBJ, change_log.model_dump(), force=True)
+            integration_state.add(PROCESSED_COMMITS_OBJ, processed_commits, force=True)

--- a/reconcile/change_owners/change_log_tracking.py
+++ b/reconcile/change_owners/change_log_tracking.py
@@ -132,6 +132,7 @@ class ChangeLogIntegration(QontractReconcileIntegration[ChangeLogIntegrationPara
             existing_change_log = ChangeLog(**integration_state.get(BUNDLE_DIFFS_OBJ))
             processed_commits = integration_state.get(PROCESSED_COMMITS_OBJ, {})
 
+        cutoff = datetime.now(UTC) - timedelta(days=self.params.lookback_days)
         change_log = ChangeLog()
         for item in diff_state.ls():
             key = item.lstrip("/")
@@ -147,12 +148,14 @@ class ChangeLogIntegration(QontractReconcileIntegration[ChangeLogIntegrationPara
                     change_log.items.append(existing_change_log_item)
                     continue
                 if commit in processed_commits:
-                    logging.debug(f"Skipping already processed commit {commit}")
-                    continue
+                    if datetime.fromisoformat(processed_commits[commit]) < cutoff:
+                        logging.debug(f"Skipping already processed commit {commit}")
+                        continue
+                    # lookback_days was increased — commit is now within window, re-process
+                    del processed_commits[commit]
 
             logging.info(f"Processing commit {commit}")
             gl_commit = gl.project.commits.get(commit)
-            cutoff = datetime.now(UTC) - timedelta(days=self.params.lookback_days)
             if datetime.fromisoformat(gl_commit.committed_date) < cutoff:
                 processed_commits[commit] = gl_commit.committed_date
                 continue

--- a/reconcile/test/change_owners/test_change_log_tracking.py
+++ b/reconcile/test/change_owners/test_change_log_tracking.py
@@ -12,6 +12,8 @@ from gitlab.v4.objects import (
 from pytest_mock import MockerFixture
 
 from reconcile.change_owners.change_log_tracking import (
+    BUNDLE_DIFFS_OBJ,
+    PROCESSED_COMMITS_OBJ,
     ChangeLog,
     ChangeLogIntegration,
     ChangeLogIntegrationParams,
@@ -149,10 +151,8 @@ def test_change_log_tracking_with_deleted_app(
 
     integration.run(dry_run=False)
 
-    mocks["state"].add.assert_called_once_with(
-        "bundle-diffs.json",
-        expected_change_log.model_dump(),
-        force=True,
+    mocks["state"].add.assert_any_call(
+        BUNDLE_DIFFS_OBJ, expected_change_log.model_dump(), force=True
     )
 
 
@@ -180,8 +180,84 @@ def test_change_log_tracking_filters_old_commits(
 
     integration.run(dry_run=False)
 
-    mocks["state"].add.assert_called_once_with(
-        "bundle-diffs.json",
-        ChangeLog().model_dump(),
-        force=True,
+    mocks["state"].add.assert_any_call(
+        BUNDLE_DIFFS_OBJ, ChangeLog().model_dump(), force=True
+    )
+    mocks["state"].add.assert_any_call(
+        PROCESSED_COMMITS_OBJ, {COMMIT_SHA: MERGED_AT_OLD}, force=True
+    )
+
+
+def test_change_log_tracking_adds_old_commit_to_processed_map(
+    mocker: MockerFixture,
+    gql_api_builder: Callable[..., GqlApi],
+    gql_class_factory: Callable[..., ChangeTypesQueryData],
+) -> None:
+    """Old commit not yet in the processed map: fetches from GitLab, filters it, records it."""
+    mocks = setup_mocks(
+        mocker,
+        gql_api_builder,
+        gql_class_factory,
+        apps=[],
+        datafiles={},
+        commit_message="some change",
+        committed_date=MERGED_AT_OLD,
+    )
+    mocks["state"].get.side_effect = lambda key, default=None: {
+        BUNDLE_DIFFS_OBJ: {"items": []},
+        PROCESSED_COMMITS_OBJ: {},
+    }.get(key, default)
+
+    integration = ChangeLogIntegration(
+        ChangeLogIntegrationParams(
+            gitlab_project_id="test",
+            process_existing=False,
+            commit=None,
+        )
+    )
+
+    integration.run(dry_run=False)
+
+    mocks["gl"].project.commits.get.assert_called_once_with(COMMIT_SHA)
+    mocks["state"].add.assert_any_call(
+        BUNDLE_DIFFS_OBJ, ChangeLog().model_dump(), force=True
+    )
+    mocks["state"].add.assert_any_call(
+        PROCESSED_COMMITS_OBJ, {COMMIT_SHA: MERGED_AT_OLD}, force=True
+    )
+
+
+def test_change_log_tracking_skips_processed_commits_without_api_call(
+    mocker: MockerFixture,
+    gql_api_builder: Callable[..., GqlApi],
+    gql_class_factory: Callable[..., ChangeTypesQueryData],
+) -> None:
+    """Old commit already in the processed map: skipped without a GitLab API call."""
+    mocks = setup_mocks(
+        mocker,
+        gql_api_builder,
+        gql_class_factory,
+        apps=[],
+        datafiles={},
+        commit_message="some change",
+        committed_date=MERGED_AT_OLD,
+    )
+    mocks["state"].get.side_effect = lambda key, default=None: {
+        BUNDLE_DIFFS_OBJ: {"items": []},
+        PROCESSED_COMMITS_OBJ: {COMMIT_SHA: MERGED_AT_OLD},
+    }.get(key, default)
+
+    integration = ChangeLogIntegration(
+        ChangeLogIntegrationParams(
+            gitlab_project_id="test",
+            process_existing=False,
+            commit=None,
+        )
+    )
+
+    integration.run(dry_run=False)
+
+    mocks["gl"].project.commits.get.assert_not_called()
+    mocks["state"].add.assert_any_call(
+        PROCESSED_COMMITS_OBJ, {COMMIT_SHA: MERGED_AT_OLD}, force=True
     )


### PR DESCRIPTION
## Summary

- Follow-up to #5504: after `--process-existing` prunes `bundle-diffs.json` to 30 days, normal runs would encounter all historical commits in `bundle-archive/diff/` that are no longer in `existing_change_log`, triggering a GitLab API call for each one just to skip them
- Introduces `processed-commits.json` in state: a `{sha: committed_date}` map of commits that were fetched and found to be older than `lookback_days`
- Normal runs check this map before calling the GitLab API — if a commit is there, it's skipped with no API call
- `--process-existing` populates the map as a side effect (it already fetches every commit), so the very first normal run after the daily cron has a fully populated map

## Test plan

- [ ] `test_change_log_tracking_adds_old_commit_to_processed_map`: old commit not yet in map triggers API call and gets recorded
- [ ] `test_change_log_tracking_skips_processed_commits_without_api_call`: old commit already in map is skipped with no API call

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed commit processing cutoff logic to apply consistently across all execution modes, previously this was applied only conditionally.
  * Enhanced performance by implementing persistent tracking for processed commits, enabling the system to efficiently skip previously processed items in subsequent runs.
  * Improved state management to maintain commit processing history alongside existing tracking data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->