### PR TITLE
APPSRE 13993 pre repo rebase limit

### DIFF
--- a/reconcile/gitlab_housekeeping.py
+++ b/reconcile/gitlab_housekeeping.py
@@ -513,7 +513,7 @@ def rebase_merge_requests(
         RebaseStrategy.TOP_K: _rebase_merge_requests_top_k,
         RebaseStrategy.OLD_BURST: _rebase_merge_requests_old_burst,
     }
-    logging.info(f"rebase strategy: {strategy.value}")
+
     fn = dispatch[strategy]
     fn(
         dry_run=dry_run,

--- a/reconcile/gitlab_housekeeping.py
+++ b/reconcile/gitlab_housekeeping.py
@@ -482,22 +482,93 @@ def rebase_merge_requests(
     users_allowed_to_label: Iterable[str] | None = None,
     use_active_cap: bool = False,
 ) -> None:
+    if use_active_cap:
+        return _rebase_merge_requests_active_cap(
+            dry_run=dry_run,
+            gl=gl,
+            rebase_limit=rebase_limit,
+            state=state,
+            pipeline_timeout=pipeline_timeout,
+            wait_for_pipeline=wait_for_pipeline,
+            users_allowed_to_label=users_allowed_to_label,
+        )
 
-    all_items = get_merge_requests(
-        dry_run=dry_run,
-        gl=gl,
-        state=state,
-        users_allowed_to_label=users_allowed_to_label,
-    )
-    # top-k: only evaluate the first rebase_limit MRs in priority order
-    if not use_active_cap:
-        all_items = all_items[:rebase_limit]
+    # top-k: only evaluate the first rebase_limit MRs in priority order.
+    # The queue is already sorted by priority, so slicing to K guarantees
+    # at most K MRs are rebased across all runs.
+    merge_requests = [
+        item["mr"]
+        for item in get_merge_requests(
+            dry_run=dry_run,
+            gl=gl,
+            state=state,
+            users_allowed_to_label=users_allowed_to_label,
+        )[:rebase_limit]
+    ]
 
-    merge_requests = [item["mr"] for item in all_items]
+    for mr in merge_requests:
+        if is_rebased(mr, gl):
+            continue
+
+        pipelines = gl.get_merge_request_pipelines(mr)
+
+        # If pipeline_timeout is None no pipeline will be canceled.
+        if pipeline_timeout is not None:
+            timed_out_pipelines = get_timed_out_pipelines(pipelines, pipeline_timeout)
+            if timed_out_pipelines:
+                clean_pipelines(
+                    dry_run=dry_run,
+                    gl=gl,
+                    fork_project_id=mr.source_project_id,
+                    pipelines=timed_out_pipelines,
+                )
+
+        if wait_for_pipeline:
+            if not pipelines:
+                continue
+            # possible statuses:
+            # running, pending, success, failed, canceled, skipped
+            running_pipelines = [
+                p for p in pipelines if p.status == PipelineStatus.RUNNING
+            ]
+            if running_pipelines:
+                continue
+
+        try:
+            logging.info(["rebase", gl.project.name, mr.iid])
+            if not dry_run:
+                mr.rebase()
+                rebased_merge_requests.labels(mr.target_project_id).inc()
+        except gitlab.exceptions.GitlabMRRebaseError as e:
+            logging.error(f"unable to rebase {mr.iid}: {e}")
+
+
+def _rebase_merge_requests_active_cap(
+    dry_run: bool,
+    gl: GitLabApi,
+    rebase_limit: int,
+    state: State,
+    pipeline_timeout: int | None = None,
+    wait_for_pipeline: bool = False,
+    users_allowed_to_label: Iterable[str] | None = None,
+) -> None:
+    """Active-cap strategy: scan the full queue, count MRs with active
+    pipelines, and only rebase up to (rebase_limit - already_active)
+    additional MRs.  This treats rebase_limit as a per-repo concurrency cap
+    on in-flight pipelines rather than a visibility window."""
+    merge_requests = [
+        item["mr"]
+        for item in get_merge_requests(
+            dry_run=dry_run,
+            gl=gl,
+            state=state,
+            users_allowed_to_label=users_allowed_to_label,
+        )
+    ]
 
     # Single pass: classify MRs as already-active or needs-rebase.
-    # active-cap treats rebase_limit as a per-repo concurrency cap --
-    # "at most N MRs with active pipelines" -- not a per-run burst.
+    # rebase_limit is a per-repo concurrency cap -- "at most N MRs with
+    # active pipelines" -- not a per-run burst.
     # Rebased MRs count as active with running/pending/success pipelines
     # (success = green and waiting to merge, still occupying a slot).
     # Non-rebased MRs only count as active with running/pending pipelines
@@ -506,28 +577,18 @@ def rebase_merge_requests(
     for mr in merge_requests:
         pipelines = gl.get_merge_request_pipelines(mr)
         if is_rebased(mr, gl):
-            if (
-                use_active_cap
-                and pipelines
-                and pipelines[0].status
-                in {
-                    PipelineStatus.RUNNING,
-                    PipelineStatus.PENDING,
-                    PipelineStatus.SUCCESS,
-                }
-            ):
+            if pipelines and pipelines[0].status in {
+                PipelineStatus.RUNNING,
+                PipelineStatus.PENDING,
+                PipelineStatus.SUCCESS,
+            }:
                 already_active += 1
             continue
 
-        if (
-            use_active_cap
-            and pipelines
-            and pipelines[0].status
-            in {
-                PipelineStatus.RUNNING,
-                PipelineStatus.PENDING,
-            }
-        ):
+        if pipelines and pipelines[0].status in {
+            PipelineStatus.RUNNING,
+            PipelineStatus.PENDING,
+        }:
             already_active += 1
             continue
 
@@ -555,9 +616,7 @@ def rebase_merge_requests(
 
         needs_rebase.append(mr)
 
-    remaining_budget = (
-        max(rebase_limit - already_active, 0) if use_active_cap else len(needs_rebase)
-    )
+    remaining_budget = max(rebase_limit - already_active, 0)
     rebases = 0
     for mr in needs_rebase:
         if rebases < remaining_budget:
@@ -716,6 +775,9 @@ def run(dry_run: bool, wait_for_pipeline: bool) -> None:
     repos = queries.get_repos_gitlab_housekeeping(server=instance["url"])
     repos = [r for r in repos if is_in_shard(r["url"])]
     app_sre_usernames: Set[str] = set()
+    use_active_cap = get_feature_toggle_state(
+        "gitlab-housekeeping-rebase-active-cap", default=False
+    )
     state = init_state(QONTRACT_INTEGRATION)
 
     for repo in repos:
@@ -759,9 +821,6 @@ def run(dry_run: bool, wait_for_pipeline: bool) -> None:
             ]
             reload_toggle = ReloadToggle(reload=False)
             rebase = hk.get("rebase")
-            use_active_cap = get_feature_toggle_state(
-                "gitlab-housekeeping-rebase-active-cap", default=False
-            )
             must_pass = hk.get("must_pass")
             try:
                 merge_merge_requests(

--- a/reconcile/gitlab_housekeeping.py
+++ b/reconcile/gitlab_housekeeping.py
@@ -480,7 +480,6 @@ def rebase_merge_requests(
     wait_for_pipeline: bool = False,
     users_allowed_to_label: Iterable[str] | None = None,
 ) -> None:
-    rebases = 0
     merge_requests = [
         item["mr"]
         for item in get_merge_requests(
@@ -490,13 +489,24 @@ def rebase_merge_requests(
             users_allowed_to_label=users_allowed_to_label,
         )
     ]
+
+    # Single pass: classify MRs as already-active (rebased with a running/pending
+    # pipeline from a previous run) or needs-rebase.  rebase_limit is a per-repo
+    # concurrency cap -- "at most N MRs with active pipelines" -- not a per-run burst.
+    already_active = 0
+    needs_rebase: list[ProjectMergeRequest] = []
     for mr in merge_requests:
         if is_rebased(mr, gl):
+            pipelines = gl.get_merge_request_pipelines(mr)
+            if pipelines and pipelines[0].status in {
+                PipelineStatus.RUNNING,
+                PipelineStatus.PENDING,
+            }:
+                already_active += 1
             continue
 
         pipelines = gl.get_merge_request_pipelines(mr)
 
-        # If pipeline_timeout is None no pipeline will be canceled
         if pipeline_timeout is not None:
             timed_out_pipelines = get_timed_out_pipelines(pipelines, pipeline_timeout)
             if timed_out_pipelines:
@@ -510,15 +520,18 @@ def rebase_merge_requests(
         if wait_for_pipeline:
             if not pipelines:
                 continue
-            # possible statuses:
-            # running, pending, success, failed, canceled, skipped
             running_pipelines = [
                 p for p in pipelines if p.status == PipelineStatus.RUNNING
             ]
             if running_pipelines:
                 continue
 
-        if rebases < rebase_limit:
+        needs_rebase.append(mr)
+
+    remaining_budget = max(rebase_limit - already_active, 0)
+    rebases = 0
+    for mr in needs_rebase:
+        if rebases < remaining_budget:
             try:
                 logging.info(["rebase", gl.project.name, mr.iid])
                 if not dry_run:
@@ -532,7 +545,7 @@ def rebase_merge_requests(
                 "rebase",
                 gl.project.name,
                 mr.iid,
-                "rebase limit reached for this reconcile loop. will try next time",
+                f"rebase limit reached ({already_active} active, limit {rebase_limit}). will try next time",
             ])
 
 

--- a/reconcile/gitlab_housekeeping.py
+++ b/reconcile/gitlab_housekeeping.py
@@ -496,17 +496,20 @@ def rebase_merge_requests(
     already_active = 0
     needs_rebase: list[ProjectMergeRequest] = []
     for mr in merge_requests:
+        pipelines = gl.get_merge_request_pipelines(mr)
         if is_rebased(mr, gl):
-            pipelines = gl.get_merge_request_pipelines(mr)
+            # pipelines = gl.get_merge_request_pipelines(mr)
             if pipelines and pipelines[0].status in {
                 PipelineStatus.RUNNING,
                 PipelineStatus.PENDING,
+                PipelineStatus.SUCCESS,
             }:
                 already_active += 1
             continue
 
-        pipelines = gl.get_merge_request_pipelines(mr)
+        # pipelines = gl.get_merge_request_pipelines(mr)
 
+        # If pipeline_timeout is None no pipeline will be canceled.
         if pipeline_timeout is not None:
             timed_out_pipelines = get_timed_out_pipelines(pipelines, pipeline_timeout)
             if timed_out_pipelines:
@@ -520,6 +523,8 @@ def rebase_merge_requests(
         if wait_for_pipeline:
             if not pipelines:
                 continue
+            # possible statuses:
+            # running, pending, success, failed, canceled, skipped
             running_pipelines = [
                 p for p in pipelines if p.status == PipelineStatus.RUNNING
             ]
@@ -545,7 +550,7 @@ def rebase_merge_requests(
                 "rebase",
                 gl.project.name,
                 mr.iid,
-                f"rebase limit reached ({already_active} active, limit {rebase_limit}). will try next time",
+                f"rebase limit reached ({already_active + rebases} active/in-flight, limit {rebase_limit}). will try next time",
             ])
 
 

--- a/reconcile/gitlab_housekeeping.py
+++ b/reconcile/gitlab_housekeeping.py
@@ -490,20 +490,27 @@ def rebase_merge_requests(
         )
     ]
 
-    # Single pass: classify MRs as already-active (rebased with a running/pending
-    # pipeline from a previous run) or needs-rebase.  rebase_limit is a per-repo
-    # concurrency cap -- "at most N MRs with active pipelines" -- not a per-run burst.
+    # Single pass: classify MRs as already-active or needs-rebase.
+    # An MR counts as active when it has a running/pending/success pipeline,
+    # regardless of rebase status.  rebase_limit is a per-repo concurrency
+    # cap -- "at most N MRs with active pipelines" -- not a per-run burst.
     already_active = 0
     needs_rebase: list[ProjectMergeRequest] = []
     for mr in merge_requests:
         pipelines = gl.get_merge_request_pipelines(mr)
+        active_pipeline = pipelines and pipelines[0].status in {
+            PipelineStatus.RUNNING,
+            PipelineStatus.PENDING,
+            PipelineStatus.SUCCESS,
+        }
+
+        if active_pipeline:
+            already_active += 1
+
         if is_rebased(mr, gl):
-            if pipelines and pipelines[0].status in {
-                PipelineStatus.RUNNING,
-                PipelineStatus.PENDING,
-                PipelineStatus.SUCCESS,
-            }:
-                already_active += 1
+            continue
+
+        if active_pipeline:
             continue
 
         # If pipeline_timeout is None no pipeline will be canceled.
@@ -541,6 +548,8 @@ def rebase_merge_requests(
                     rebases += 1
                     rebased_merge_requests.labels(mr.target_project_id).inc()
             except gitlab.exceptions.GitlabMRRebaseError as e:
+                # Failed rebases don't consume budget — the MR has no
+                # in-flight pipeline, so we should try the next candidate.
                 logging.error(f"unable to rebase {mr.iid}: {e}")
         else:
             logging.info([

--- a/reconcile/gitlab_housekeeping.py
+++ b/reconcile/gitlab_housekeeping.py
@@ -491,26 +491,29 @@ def rebase_merge_requests(
     ]
 
     # Single pass: classify MRs as already-active or needs-rebase.
-    # An MR counts as active when it has a running/pending/success pipeline,
-    # regardless of rebase status.  rebase_limit is a per-repo concurrency
-    # cap -- "at most N MRs with active pipelines" -- not a per-run burst.
+    # rebase_limit is a per-repo concurrency cap -- "at most N MRs with
+    # active pipelines" -- not a per-run burst.
+    # Rebased MRs count as active with running/pending/success pipelines
+    # (success = green and waiting to merge, still occupying a slot).
+    # Non-rebased MRs only count as active with running/pending pipelines
     already_active = 0
     needs_rebase: list[ProjectMergeRequest] = []
     for mr in merge_requests:
         pipelines = gl.get_merge_request_pipelines(mr)
-        active_pipeline = pipelines and pipelines[0].status in {
-            PipelineStatus.RUNNING,
-            PipelineStatus.PENDING,
-            PipelineStatus.SUCCESS,
-        }
-
-        if active_pipeline:
-            already_active += 1
-
         if is_rebased(mr, gl):
+            if pipelines and pipelines[0].status in {
+                PipelineStatus.RUNNING,
+                PipelineStatus.PENDING,
+                PipelineStatus.SUCCESS,
+            }:
+                already_active += 1
             continue
 
-        if active_pipeline:
+        if pipelines and pipelines[0].status in {
+            PipelineStatus.RUNNING,
+            PipelineStatus.PENDING,
+        }:
+            already_active += 1
             continue
 
         # If pipeline_timeout is None no pipeline will be canceled.

--- a/reconcile/gitlab_housekeeping.py
+++ b/reconcile/gitlab_housekeeping.py
@@ -116,7 +116,7 @@ class RebaseStrategy(StrEnum):
 
 
 REBASE_STRATEGY_TOGGLE = "gitlab-housekeeping-rebase-strategy"
-DEFAULT_REBASE_STRATEGY = RebaseStrategy.ACTIVE_CAP
+DEFAULT_REBASE_STRATEGY = RebaseStrategy.OLD_BURST
 
 
 def get_rebase_strategy() -> RebaseStrategy:
@@ -526,6 +526,52 @@ def rebase_merge_requests(
     )
 
 
+def _cancel_timed_out_pipelines(
+    dry_run: bool,
+    gl: GitLabApi,
+    mr: ProjectMergeRequest,
+    pipelines: list,
+    pipeline_timeout: int | None,
+) -> None:
+    """Cancel pipelines that have exceeded the timeout threshold."""
+    if pipeline_timeout is None:
+        return
+    timed_out_pipelines = get_timed_out_pipelines(pipelines, pipeline_timeout)
+    if timed_out_pipelines:
+        clean_pipelines(
+            dry_run=dry_run,
+            gl=gl,
+            fork_project_id=mr.source_project_id,
+            pipelines=timed_out_pipelines,
+        )
+
+
+def _should_skip_for_running_pipeline(pipelines: list, wait_for_pipeline: bool) -> bool:
+    """Return True if the MR should be skipped because a pipeline is still running."""
+    if not wait_for_pipeline:
+        return False
+    if not pipelines:
+        return True
+    return any(p.status == PipelineStatus.RUNNING for p in pipelines)
+
+
+def _try_rebase(
+    dry_run: bool,
+    gl: GitLabApi,
+    mr: ProjectMergeRequest,
+) -> bool:
+    """Attempt to rebase an MR. Returns True on success, False on failure."""
+    try:
+        logging.info(["rebase", gl.project.name, mr.iid])
+        if not dry_run:
+            mr.rebase()
+            rebased_merge_requests.labels(mr.target_project_id).inc()
+        return True
+    except gitlab.exceptions.GitlabMRRebaseError as e:
+        logging.error(f"unable to rebase {mr.iid}: {e}")
+        return False
+
+
 def _rebase_merge_requests_top_k(
     dry_run: bool,
     gl: GitLabApi,
@@ -553,36 +599,12 @@ def _rebase_merge_requests_top_k(
             continue
 
         pipelines = gl.get_merge_request_pipelines(mr)
+        _cancel_timed_out_pipelines(dry_run, gl, mr, pipelines, pipeline_timeout)
 
-        # If pipeline_timeout is None no pipeline will be canceled.
-        if pipeline_timeout is not None:
-            timed_out_pipelines = get_timed_out_pipelines(pipelines, pipeline_timeout)
-            if timed_out_pipelines:
-                clean_pipelines(
-                    dry_run=dry_run,
-                    gl=gl,
-                    fork_project_id=mr.source_project_id,
-                    pipelines=timed_out_pipelines,
-                )
+        if _should_skip_for_running_pipeline(pipelines, wait_for_pipeline):
+            continue
 
-        if wait_for_pipeline:
-            if not pipelines:
-                continue
-            # possible statuses:
-            # running, pending, success, failed, canceled, skipped
-            running_pipelines = [
-                p for p in pipelines if p.status == PipelineStatus.RUNNING
-            ]
-            if running_pipelines:
-                continue
-
-        try:
-            logging.info(["rebase", gl.project.name, mr.iid])
-            if not dry_run:
-                mr.rebase()
-                rebased_merge_requests.labels(mr.target_project_id).inc()
-        except gitlab.exceptions.GitlabMRRebaseError as e:
-            logging.error(f"unable to rebase {mr.iid}: {e}")
+        _try_rebase(dry_run, gl, mr)
 
 
 def _rebase_merge_requests_active_cap(
@@ -626,27 +648,10 @@ def _rebase_merge_requests_active_cap(
                 already_active += 1
             continue
 
-        # If pipeline_timeout is None no pipeline will be canceled.
-        if pipeline_timeout is not None:
-            timed_out_pipelines = get_timed_out_pipelines(pipelines, pipeline_timeout)
-            if timed_out_pipelines:
-                clean_pipelines(
-                    dry_run=dry_run,
-                    gl=gl,
-                    fork_project_id=mr.source_project_id,
-                    pipelines=timed_out_pipelines,
-                )
+        _cancel_timed_out_pipelines(dry_run, gl, mr, pipelines, pipeline_timeout)
 
-        if wait_for_pipeline:
-            if not pipelines:
-                continue
-            # possible statuses:
-            # running, pending, success, failed, canceled, skipped
-            running_pipelines = [
-                p for p in pipelines if p.status == PipelineStatus.RUNNING
-            ]
-            if running_pipelines:
-                continue
+        if _should_skip_for_running_pipeline(pipelines, wait_for_pipeline):
+            continue
 
         needs_rebase.append(mr)
 
@@ -654,17 +659,8 @@ def _rebase_merge_requests_active_cap(
     rebases = 0
     for mr in needs_rebase:
         if rebases < remaining_budget:
-            try:
-                logging.info(["rebase", gl.project.name, mr.iid])
+            if _try_rebase(dry_run, gl, mr):
                 rebases += 1
-                if not dry_run:
-                    mr.rebase()
-                    rebased_merge_requests.labels(mr.target_project_id).inc()
-            except gitlab.exceptions.GitlabMRRebaseError as e:
-                # Failed rebases don't consume budget — the MR has no
-                # in-flight pipeline, so we should try the next candidate.
-                rebases -= 1
-                logging.error(f"unable to rebase {mr.iid}: {e}")
         else:
             logging.info([
                 "rebase",
@@ -702,36 +698,14 @@ def _rebase_merge_requests_old_burst(
             continue
 
         pipelines = gl.get_merge_request_pipelines(mr)
+        _cancel_timed_out_pipelines(dry_run, gl, mr, pipelines, pipeline_timeout)
 
-        # If pipeline_timeout is None no pipeline will be canceled.
-        if pipeline_timeout is not None:
-            timed_out_pipelines = get_timed_out_pipelines(pipelines, pipeline_timeout)
-            if timed_out_pipelines:
-                clean_pipelines(
-                    dry_run=dry_run,
-                    gl=gl,
-                    fork_project_id=mr.source_project_id,
-                    pipelines=timed_out_pipelines,
-                )
-
-        if wait_for_pipeline:
-            if not pipelines:
-                continue
-            running_pipelines = [
-                p for p in pipelines if p.status == PipelineStatus.RUNNING
-            ]
-            if running_pipelines:
-                continue
+        if _should_skip_for_running_pipeline(pipelines, wait_for_pipeline):
+            continue
 
         if rebases < rebase_limit:
-            try:
-                logging.info(["rebase", gl.project.name, mr.iid])
-                if not dry_run:
-                    mr.rebase()
-                    rebases += 1
-                    rebased_merge_requests.labels(mr.target_project_id).inc()
-            except gitlab.exceptions.GitlabMRRebaseError as e:
-                logging.error(f"unable to rebase {mr.iid}: {e}")
+            if _try_rebase(dry_run, gl, mr):
+                rebases += 1
         else:
             logging.info([
                 "rebase",

--- a/reconcile/gitlab_housekeeping.py
+++ b/reconcile/gitlab_housekeeping.py
@@ -571,7 +571,6 @@ def _rebase_merge_requests_active_cap(
     # active pipelines" -- not a per-run burst.
     # Rebased MRs count as active with running/pending/success pipelines
     # (success = green and waiting to merge, still occupying a slot).
-    # Non-rebased MRs only count as active with running/pending pipelines
     already_active = 0
     needs_rebase: list[ProjectMergeRequest] = []
     for mr in merge_requests:
@@ -583,13 +582,6 @@ def _rebase_merge_requests_active_cap(
                 PipelineStatus.SUCCESS,
             }:
                 already_active += 1
-            continue
-
-        if pipelines and pipelines[0].status in {
-            PipelineStatus.RUNNING,
-            PipelineStatus.PENDING,
-        }:
-            already_active += 1
             continue
 
         # If pipeline_timeout is None no pipeline will be canceled.
@@ -637,6 +629,7 @@ def _rebase_merge_requests_active_cap(
                 mr.iid,
                 f"rebase limit reached ({already_active + rebases} active/in-flight, limit {rebase_limit}). will try next time",
             ])
+            break
 
 
 # TODO: this retry is catching all exceptions, which isn't good. _log_exceptions is

--- a/reconcile/gitlab_housekeeping.py
+++ b/reconcile/gitlab_housekeeping.py
@@ -498,7 +498,6 @@ def rebase_merge_requests(
     for mr in merge_requests:
         pipelines = gl.get_merge_request_pipelines(mr)
         if is_rebased(mr, gl):
-            # pipelines = gl.get_merge_request_pipelines(mr)
             if pipelines and pipelines[0].status in {
                 PipelineStatus.RUNNING,
                 PipelineStatus.PENDING,
@@ -506,8 +505,6 @@ def rebase_merge_requests(
             }:
                 already_active += 1
             continue
-
-        # pipelines = gl.get_merge_request_pipelines(mr)
 
         # If pipeline_timeout is None no pipeline will be canceled.
         if pipeline_timeout is not None:

--- a/reconcile/gitlab_housekeeping.py
+++ b/reconcile/gitlab_housekeeping.py
@@ -614,13 +614,14 @@ def _rebase_merge_requests_active_cap(
         if rebases < remaining_budget:
             try:
                 logging.info(["rebase", gl.project.name, mr.iid])
+                rebases += 1
                 if not dry_run:
                     mr.rebase()
-                    rebases += 1
                     rebased_merge_requests.labels(mr.target_project_id).inc()
             except gitlab.exceptions.GitlabMRRebaseError as e:
                 # Failed rebases don't consume budget — the MR has no
                 # in-flight pipeline, so we should try the next candidate.
+                rebases -= 1
                 logging.error(f"unable to rebase {mr.iid}: {e}")
         else:
             logging.info([

--- a/reconcile/gitlab_housekeeping.py
+++ b/reconcile/gitlab_housekeeping.py
@@ -53,6 +53,7 @@ from reconcile.utils.mr.labels import (
 )
 from reconcile.utils.sharding import is_in_shard
 from reconcile.utils.state import State, init_state
+from reconcile.utils.unleash import get_feature_toggle_state
 
 MERGE_LABELS_PRIORITY = [
     prioritized_approval_label(p.value) for p in ChangeTypePriority
@@ -479,20 +480,24 @@ def rebase_merge_requests(
     pipeline_timeout: int | None = None,
     wait_for_pipeline: bool = False,
     users_allowed_to_label: Iterable[str] | None = None,
+    use_active_cap: bool = False,
 ) -> None:
-    merge_requests = [
-        item["mr"]
-        for item in get_merge_requests(
-            dry_run=dry_run,
-            gl=gl,
-            state=state,
-            users_allowed_to_label=users_allowed_to_label,
-        )
-    ]
+
+    all_items = get_merge_requests(
+        dry_run=dry_run,
+        gl=gl,
+        state=state,
+        users_allowed_to_label=users_allowed_to_label,
+    )
+    # top-k: only evaluate the first rebase_limit MRs in priority order
+    if not use_active_cap:
+        all_items = all_items[:rebase_limit]
+
+    merge_requests = [item["mr"] for item in all_items]
 
     # Single pass: classify MRs as already-active or needs-rebase.
-    # rebase_limit is a per-repo concurrency cap -- "at most N MRs with
-    # active pipelines" -- not a per-run burst.
+    # active-cap treats rebase_limit as a per-repo concurrency cap --
+    # "at most N MRs with active pipelines" -- not a per-run burst.
     # Rebased MRs count as active with running/pending/success pipelines
     # (success = green and waiting to merge, still occupying a slot).
     # Non-rebased MRs only count as active with running/pending pipelines
@@ -501,18 +506,28 @@ def rebase_merge_requests(
     for mr in merge_requests:
         pipelines = gl.get_merge_request_pipelines(mr)
         if is_rebased(mr, gl):
-            if pipelines and pipelines[0].status in {
-                PipelineStatus.RUNNING,
-                PipelineStatus.PENDING,
-                PipelineStatus.SUCCESS,
-            }:
+            if (
+                use_active_cap
+                and pipelines
+                and pipelines[0].status
+                in {
+                    PipelineStatus.RUNNING,
+                    PipelineStatus.PENDING,
+                    PipelineStatus.SUCCESS,
+                }
+            ):
                 already_active += 1
             continue
 
-        if pipelines and pipelines[0].status in {
-            PipelineStatus.RUNNING,
-            PipelineStatus.PENDING,
-        }:
+        if (
+            use_active_cap
+            and pipelines
+            and pipelines[0].status
+            in {
+                PipelineStatus.RUNNING,
+                PipelineStatus.PENDING,
+            }
+        ):
             already_active += 1
             continue
 
@@ -540,7 +555,9 @@ def rebase_merge_requests(
 
         needs_rebase.append(mr)
 
-    remaining_budget = max(rebase_limit - already_active, 0)
+    remaining_budget = (
+        max(rebase_limit - already_active, 0) if use_active_cap else len(needs_rebase)
+    )
     rebases = 0
     for mr in needs_rebase:
         if rebases < remaining_budget:
@@ -742,6 +759,9 @@ def run(dry_run: bool, wait_for_pipeline: bool) -> None:
             ]
             reload_toggle = ReloadToggle(reload=False)
             rebase = hk.get("rebase")
+            use_active_cap = get_feature_toggle_state(
+                "gitlab-housekeeping-rebase-active-cap", default=False
+            )
             must_pass = hk.get("must_pass")
             try:
                 merge_merge_requests(
@@ -787,4 +807,5 @@ def run(dry_run: bool, wait_for_pipeline: bool) -> None:
                     pipeline_timeout=pipeline_timeout,
                     wait_for_pipeline=wait_for_pipeline,
                     users_allowed_to_label=users_allowed_to_label,
+                    use_active_cap=use_active_cap,
                 )

--- a/reconcile/gitlab_housekeeping.py
+++ b/reconcile/gitlab_housekeeping.py
@@ -9,6 +9,7 @@ from datetime import (
     datetime,
     timedelta,
 )
+from enum import StrEnum
 from operator import itemgetter
 from typing import Any, cast
 
@@ -53,7 +54,7 @@ from reconcile.utils.mr.labels import (
 )
 from reconcile.utils.sharding import is_in_shard
 from reconcile.utils.state import State, init_state
-from reconcile.utils.unleash import get_feature_toggle_state
+from reconcile.utils.unleash import get_feature_variant
 
 MERGE_LABELS_PRIORITY = [
     prioritized_approval_label(p.value) for p in ChangeTypePriority
@@ -106,6 +107,31 @@ gitlab_token_expiration = Gauge(
     documentation="Time until personal access tokens expire",
     labelnames=["name"],
 )
+
+
+class RebaseStrategy(StrEnum):
+    ACTIVE_CAP = "active-cap"
+    TOP_K = "top-k"
+    OLD_BURST = "old-burst"
+
+
+REBASE_STRATEGY_TOGGLE = "gitlab-housekeeping-rebase-strategy"
+DEFAULT_REBASE_STRATEGY = RebaseStrategy.ACTIVE_CAP
+
+
+def get_rebase_strategy() -> RebaseStrategy:
+    """Resolve the rebase strategy from an Unleash feature variant."""
+    value = get_feature_variant(
+        REBASE_STRATEGY_TOGGLE, default_variant=DEFAULT_REBASE_STRATEGY.value
+    )
+    try:
+        return RebaseStrategy(value)
+    except ValueError:
+        logging.warning(
+            f"Unknown rebase strategy variant '{value}', "
+            f"falling back to {DEFAULT_REBASE_STRATEGY.value}"
+        )
+        return DEFAULT_REBASE_STRATEGY
 
 
 class InsistOnPipelineError(Exception):
@@ -480,22 +506,38 @@ def rebase_merge_requests(
     pipeline_timeout: int | None = None,
     wait_for_pipeline: bool = False,
     users_allowed_to_label: Iterable[str] | None = None,
-    use_active_cap: bool = False,
+    strategy: RebaseStrategy = DEFAULT_REBASE_STRATEGY,
 ) -> None:
-    if use_active_cap:
-        return _rebase_merge_requests_active_cap(
-            dry_run=dry_run,
-            gl=gl,
-            rebase_limit=rebase_limit,
-            state=state,
-            pipeline_timeout=pipeline_timeout,
-            wait_for_pipeline=wait_for_pipeline,
-            users_allowed_to_label=users_allowed_to_label,
-        )
+    dispatch = {
+        RebaseStrategy.ACTIVE_CAP: _rebase_merge_requests_active_cap,
+        RebaseStrategy.TOP_K: _rebase_merge_requests_top_k,
+        RebaseStrategy.OLD_BURST: _rebase_merge_requests_old_burst,
+    }
+    logging.info(f"rebase strategy: {strategy.value}")
+    fn = dispatch[strategy]
+    fn(
+        dry_run=dry_run,
+        gl=gl,
+        rebase_limit=rebase_limit,
+        state=state,
+        pipeline_timeout=pipeline_timeout,
+        wait_for_pipeline=wait_for_pipeline,
+        users_allowed_to_label=users_allowed_to_label,
+    )
 
-    # top-k: only evaluate the first rebase_limit MRs in priority order.
-    # The queue is already sorted by priority, so slicing to K guarantees
-    # at most K MRs are rebased across all runs.
+
+def _rebase_merge_requests_top_k(
+    dry_run: bool,
+    gl: GitLabApi,
+    rebase_limit: int,
+    state: State,
+    pipeline_timeout: int | None = None,
+    wait_for_pipeline: bool = False,
+    users_allowed_to_label: Iterable[str] | None = None,
+) -> None:
+    """Top-k strategy: only evaluate the first rebase_limit MRs in priority
+    order.  The queue is already sorted by priority, so slicing to K
+    guarantees at most K MRs are rebased across all runs."""
     merge_requests = [
         item["mr"]
         for item in get_merge_requests(
@@ -631,6 +673,72 @@ def _rebase_merge_requests_active_cap(
                 f"rebase limit reached ({already_active + rebases} active/in-flight, limit {rebase_limit}). will try next time",
             ])
             break
+
+
+def _rebase_merge_requests_old_burst(
+    dry_run: bool,
+    gl: GitLabApi,
+    rebase_limit: int,
+    state: State,
+    pipeline_timeout: int | None = None,
+    wait_for_pipeline: bool = False,
+    users_allowed_to_label: Iterable[str] | None = None,
+) -> None:
+    """Old-burst strategy: scan the full queue and rebase up to rebase_limit
+    MRs that are not already rebased.  This is a simple per-run burst
+    counter — it does not consider active pipelines."""
+    rebases = 0
+    merge_requests = [
+        item["mr"]
+        for item in get_merge_requests(
+            dry_run=dry_run,
+            gl=gl,
+            state=state,
+            users_allowed_to_label=users_allowed_to_label,
+        )
+    ]
+    for mr in merge_requests:
+        if is_rebased(mr, gl):
+            continue
+
+        pipelines = gl.get_merge_request_pipelines(mr)
+
+        # If pipeline_timeout is None no pipeline will be canceled.
+        if pipeline_timeout is not None:
+            timed_out_pipelines = get_timed_out_pipelines(pipelines, pipeline_timeout)
+            if timed_out_pipelines:
+                clean_pipelines(
+                    dry_run=dry_run,
+                    gl=gl,
+                    fork_project_id=mr.source_project_id,
+                    pipelines=timed_out_pipelines,
+                )
+
+        if wait_for_pipeline:
+            if not pipelines:
+                continue
+            running_pipelines = [
+                p for p in pipelines if p.status == PipelineStatus.RUNNING
+            ]
+            if running_pipelines:
+                continue
+
+        if rebases < rebase_limit:
+            try:
+                logging.info(["rebase", gl.project.name, mr.iid])
+                if not dry_run:
+                    mr.rebase()
+                    rebases += 1
+                    rebased_merge_requests.labels(mr.target_project_id).inc()
+            except gitlab.exceptions.GitlabMRRebaseError as e:
+                logging.error(f"unable to rebase {mr.iid}: {e}")
+        else:
+            logging.info([
+                "rebase",
+                gl.project.name,
+                mr.iid,
+                "rebase limit reached for this reconcile loop. will try next time",
+            ])
 
 
 # TODO: this retry is catching all exceptions, which isn't good. _log_exceptions is
@@ -769,9 +877,7 @@ def run(dry_run: bool, wait_for_pipeline: bool) -> None:
     repos = queries.get_repos_gitlab_housekeeping(server=instance["url"])
     repos = [r for r in repos if is_in_shard(r["url"])]
     app_sre_usernames: Set[str] = set()
-    use_active_cap = get_feature_toggle_state(
-        "gitlab-housekeeping-rebase-active-cap", default=False
-    )
+    rebase_strategy = get_rebase_strategy()
     state = init_state(QONTRACT_INTEGRATION)
 
     for repo in repos:
@@ -860,5 +966,5 @@ def run(dry_run: bool, wait_for_pipeline: bool) -> None:
                     pipeline_timeout=pipeline_timeout,
                     wait_for_pipeline=wait_for_pipeline,
                     users_allowed_to_label=users_allowed_to_label,
-                    use_active_cap=use_active_cap,
+                    strategy=rebase_strategy,
                 )

--- a/reconcile/test/test_gitlab_housekeeping.py
+++ b/reconcile/test/test_gitlab_housekeeping.py
@@ -826,3 +826,26 @@ def test_rebase_limit_independent_per_repo(mocker: MockerFixture, state: Mock) -
     assert repo_c_merge_requests[1].rebase.call_count == 0
     assert repo_c_merge_requests[2].rebase.call_count == 0
     assert repo_c_merge_requests[3].rebase.call_count == 0
+
+
+def test_rebase_stale_success_pipeline_does_not_block_rebase(
+    mocker: MockerFixture, gitlab_api: Mock, state: Mock
+) -> None:
+    """A non-rebased MR whose previous pipeline succeeded should be eligible
+    for rebase.  A stale SUCCESS pipeline is worthless — it ran against
+    outdated code and should not permanently block the MR or consume budget."""
+    success_pipeline = create_autospec(ProjectMergeRequestPipeline, status="success")
+    merge_requests = [_make_rebase_mr(1), _make_rebase_mr(2)]
+
+    _call_rebase(
+        mocker,
+        gitlab_api,
+        state,
+        merge_requests,
+        rebase_limit=2,
+        rebased_iids=set(),
+        pipelines={1: [success_pipeline]},
+    )
+
+    assert merge_requests[0].rebase.call_count == 1
+    assert merge_requests[1].rebase.call_count == 1

--- a/reconcile/test/test_gitlab_housekeeping.py
+++ b/reconcile/test/test_gitlab_housekeeping.py
@@ -26,6 +26,7 @@ from gitlab.v4.objects import (
 from pytest_mock import MockerFixture
 
 import reconcile.gitlab_housekeeping as gl_h
+from reconcile.gitlab_housekeeping import RebaseStrategy
 from reconcile.test.fixtures import Fixtures
 from reconcile.utils.gitlab_api import GitLabApi
 from reconcile.utils.secret_reader import SecretReader
@@ -508,7 +509,7 @@ def _call_rebase(
     dry_run: bool = False,
     pipeline_timeout: int | None = None,
     wait_for_pipeline: bool = False,
-    use_active_cap: bool = True,
+    strategy: RebaseStrategy = RebaseStrategy.ACTIVE_CAP,
 ) -> None:
     """Invoke rebase_merge_requests with standard patches.
 
@@ -537,7 +538,7 @@ def _call_rebase(
         state=state,
         pipeline_timeout=pipeline_timeout,
         wait_for_pipeline=wait_for_pipeline,
-        use_active_cap=use_active_cap,
+        strategy=strategy,
     )
 
 
@@ -897,7 +898,7 @@ def test_top_k_only_considers_first_k_mrs(
         state,
         merge_requests,
         rebase_limit=2,
-        use_active_cap=False,
+        strategy=RebaseStrategy.TOP_K,
     )
 
     assert merge_requests[0].rebase.call_count == 1

--- a/reconcile/test/test_gitlab_housekeeping.py
+++ b/reconcile/test/test_gitlab_housekeeping.py
@@ -601,6 +601,8 @@ def test_rebase_budget_exhausted(
         pipelines={1: [running_pipeline], 2: [pending_pipeline]},
     )
 
+    assert merge_requests[0].rebase.call_count == 0
+    assert merge_requests[1].rebase.call_count == 0
     assert merge_requests[2].rebase.call_count == 0
 
 

--- a/reconcile/test/test_gitlab_housekeeping.py
+++ b/reconcile/test/test_gitlab_housekeeping.py
@@ -24,6 +24,7 @@ from gitlab.v4.objects import (
     ProjectMergeRequestResourceLabelEvent,
 )
 from pytest_mock import MockerFixture
+from UnleashClient import UnleashClient
 
 import reconcile.gitlab_housekeeping as gl_h
 from reconcile.gitlab_housekeeping import RebaseStrategy
@@ -494,7 +495,7 @@ def test_verify_ondemend_tests_pass(
     state.add.assert_called_once_with("a/b/1/abc", [], force=True)
 
 
-# --- rebase_merge_requests per-repo concurrency cap tests ---
+# --- rebase_merge_requests active-cap tests ---
 
 
 def _call_rebase(
@@ -906,3 +907,68 @@ def test_top_k_only_considers_first_k_mrs(
     assert merge_requests[2].rebase.call_count == 0
     assert merge_requests[3].rebase.call_count == 0
     assert merge_requests[4].rebase.call_count == 0
+
+
+# --- get_rebase_strategy tests ---
+
+
+@pytest.fixture
+def unleash_client(monkeypatch: pytest.MonkeyPatch, mocker: MockerFixture) -> Mock:
+    """Set Unleash env vars and patch _get_unleash_api_client, returning the mock client."""
+    monkeypatch.setenv("UNLEASH_API_URL", "http://fake")
+    monkeypatch.setenv("UNLEASH_CLIENT_ACCESS_TOKEN", "fake")
+    mock_client = create_autospec(UnleashClient)
+    mocker.patch(
+        "reconcile.utils.unleash.client._get_unleash_api_client",
+        return_value=mock_client,
+    )
+    return mock_client
+
+
+def test_get_rebase_strategy_no_unleash_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Without UNLEASH_API_URL / UNLEASH_CLIENT_ACCESS_TOKEN, falls back to OLD_BURST."""
+    monkeypatch.delenv("UNLEASH_API_URL", raising=False)
+    monkeypatch.delenv("UNLEASH_CLIENT_ACCESS_TOKEN", raising=False)
+    assert gl_h.get_rebase_strategy() == RebaseStrategy.OLD_BURST
+
+
+def test_get_rebase_strategy_toggle_enabled_no_variant(
+    unleash_client: Mock,
+) -> None:
+    """Toggle enabled but no variant configured → no payload → falls back to OLD_BURST."""
+    unleash_client.get_variant.return_value = {"name": "disabled", "enabled": True}
+    assert gl_h.get_rebase_strategy() == RebaseStrategy.OLD_BURST
+
+
+def test_get_rebase_strategy_toggle_enabled_unknown_variant(
+    unleash_client: Mock,
+) -> None:
+    """Toggle enabled with unrecognized variant value → logs warning, falls back to OLD_BURST."""
+    unleash_client.get_variant.return_value = {
+        "name": "bogus",
+        "enabled": True,
+        "payload": {"type": "string", "value": "bogus-strategy"},
+    }
+    assert gl_h.get_rebase_strategy() == RebaseStrategy.OLD_BURST
+
+
+@pytest.mark.parametrize(
+    ("variant_value", "expected_strategy"),
+    [
+        ("active-cap", RebaseStrategy.ACTIVE_CAP),
+        ("top-k", RebaseStrategy.TOP_K),
+        ("old-burst", RebaseStrategy.OLD_BURST),
+    ],
+)
+def test_get_rebase_strategy_toggle_enabled_valid_variant(
+    unleash_client: Mock,
+    variant_value: str,
+    expected_strategy: RebaseStrategy,
+) -> None:
+    """Toggle enabled with a valid variant value → returns matching RebaseStrategy."""
+    unleash_client.get_variant.return_value = {
+        "name": variant_value,
+        "enabled": True,
+        "payload": {"type": "string", "value": variant_value},
+    }
+    assert gl_h.get_rebase_strategy() == expected_strategy

--- a/reconcile/test/test_gitlab_housekeeping.py
+++ b/reconcile/test/test_gitlab_housekeeping.py
@@ -508,6 +508,7 @@ def _call_rebase(
     dry_run: bool = False,
     pipeline_timeout: int | None = None,
     wait_for_pipeline: bool = False,
+    use_active_cap: bool = True,
 ) -> None:
     """Invoke rebase_merge_requests with standard patches.
 
@@ -536,6 +537,7 @@ def _call_rebase(
         state=state,
         pipeline_timeout=pipeline_timeout,
         wait_for_pipeline=wait_for_pipeline,
+        use_active_cap=use_active_cap,
     )
 
 
@@ -554,7 +556,13 @@ def test_rebase_no_active_pipelines_full_budget(
     """0 MRs have active pipelines, limit=2, 3 need rebase: exactly 2 rebased."""
     merge_requests = [_make_rebase_mr(i) for i in range(1, 4)]
 
-    _call_rebase(mocker, gitlab_api, state, merge_requests, rebase_limit=2)
+    _call_rebase(
+        mocker,
+        gitlab_api,
+        state,
+        merge_requests,
+        rebase_limit=2,
+    )
 
     assert merge_requests[0].rebase.call_count == 1
     assert merge_requests[1].rebase.call_count == 1
@@ -634,7 +642,12 @@ def test_rebase_dry_run_no_rebases(
     merge_requests = [_make_rebase_mr(i) for i in range(1, 3)]
 
     _call_rebase(
-        mocker, gitlab_api, state, merge_requests, rebase_limit=2, dry_run=True
+        mocker,
+        gitlab_api,
+        state,
+        merge_requests,
+        rebase_limit=2,
+        dry_run=True,
     )
 
     for mr in merge_requests:
@@ -679,7 +692,13 @@ def test_rebase_backward_compatible_zero_active(
     rebase up to N MRs."""
     merge_requests = [_make_rebase_mr(i) for i in range(1, 6)]
 
-    _call_rebase(mocker, gitlab_api, state, merge_requests, rebase_limit=3)
+    _call_rebase(
+        mocker,
+        gitlab_api,
+        state,
+        merge_requests,
+        rebase_limit=3,
+    )
 
     rebased_count = sum(mr.rebase.call_count for mr in merge_requests)
     assert rebased_count == 3
@@ -704,7 +723,13 @@ def test_rebase_differing_limits(
     """Verify different limit values produce different rebase counts."""
     merge_requests = [_make_rebase_mr(i) for i in range(1, 8)]
 
-    _call_rebase(mocker, gitlab_api, state, merge_requests, rebase_limit=limit)
+    _call_rebase(
+        mocker,
+        gitlab_api,
+        state,
+        merge_requests,
+        rebase_limit=limit,
+    )
 
     rebased_count = sum(mr.rebase.call_count for mr in merge_requests)
     assert rebased_count == expected_rebased, (
@@ -719,7 +744,13 @@ def test_rebase_failure_does_not_consume_budget(
     merge_requests = [_make_rebase_mr(1), _make_rebase_mr(2), _make_rebase_mr(3)]
     merge_requests[0].rebase.side_effect = GitlabMRRebaseError
 
-    _call_rebase(mocker, gitlab_api, state, merge_requests, rebase_limit=2)
+    _call_rebase(
+        mocker,
+        gitlab_api,
+        state,
+        merge_requests,
+        rebase_limit=2,
+    )
 
     assert merge_requests[0].rebase.call_count == 1
     assert merge_requests[1].rebase.call_count == 1
@@ -849,3 +880,28 @@ def test_rebase_stale_success_pipeline_does_not_block_rebase(
 
     assert merge_requests[0].rebase.call_count == 1
     assert merge_requests[1].rebase.call_count == 1
+
+
+# --- rebase_merge_requests top-K strategy tests ---
+
+
+def test_top_k_only_considers_first_k_mrs(
+    mocker: MockerFixture, gitlab_api: Mock, state: Mock
+) -> None:
+    """Top-K slices the queue to first K MRs; MRs beyond K are never rebased."""
+    merge_requests = [_make_rebase_mr(i) for i in range(1, 6)]
+
+    _call_rebase(
+        mocker,
+        gitlab_api,
+        state,
+        merge_requests,
+        rebase_limit=2,
+        use_active_cap=False,
+    )
+
+    assert merge_requests[0].rebase.call_count == 1
+    assert merge_requests[1].rebase.call_count == 1
+    assert merge_requests[2].rebase.call_count == 0
+    assert merge_requests[3].rebase.call_count == 0
+    assert merge_requests[4].rebase.call_count == 0

--- a/reconcile/test/test_gitlab_housekeeping.py
+++ b/reconcile/test/test_gitlab_housekeeping.py
@@ -490,3 +490,182 @@ def test_verify_ondemend_tests_pass(
         False, merge_request, must_pass, gitlab_api, state
     )
     state.add.assert_called_once_with("a/b/1/abc", [], force=True)
+
+
+# --- rebase_merge_requests per-repo concurrency cap tests ---
+
+
+def _make_pipeline(status: str) -> Mock:
+    return create_autospec(ProjectMergeRequestPipeline, status=status)
+
+
+def _make_mr(
+    iid: int,
+    *,
+    is_rebased: bool = False,
+    pipeline_status: str | None = None,
+) -> Mock:
+    """Create a mock MR.
+
+    is_rebased: whether is_rebased() should return True for this MR.
+    pipeline_status: if set, get_merge_request_pipelines returns a pipeline
+        with this status; otherwise returns [].
+    """
+    mr = create_autospec(ProjectMergeRequest)
+    mr.iid = iid
+    mr.target_project_id = 10
+    mr.source_project_id = 10
+    mr._test_is_rebased = is_rebased
+    mr._test_pipelines = [_make_pipeline(pipeline_status)] if pipeline_status else []
+    return mr
+
+
+class TestRebaseMergeRequests:
+    """Tests for rebase_merge_requests() with per-repo concurrency cap.
+
+    rebase_limit controls the max number of MRs with active (running/pending)
+    pipelines at any time, not the number of rebases per invocation.
+    """
+
+    @staticmethod
+    def _call(
+        mocker: MockerFixture,
+        merge_requests: list[Mock],
+        rebase_limit: int,
+        *,
+        dry_run: bool = False,
+        pipeline_timeout: int | None = None,
+        wait_for_pipeline: bool = False,
+    ) -> None:
+        """Invoke rebase_merge_requests with mocked internals."""
+        mocked_gl = create_autospec(GitLabApi)
+        mocked_project = create_autospec(Project)
+        mocked_project.name = "test-project"
+        mocked_gl.project = mocked_project
+        mocked_gl.get_merge_request_pipelines.side_effect = lambda mr: (
+            mr._test_pipelines
+        )
+        mocked_state = create_autospec(State)
+
+        mocker.patch(
+            "reconcile.gitlab_housekeeping.get_merge_requests",
+            return_value=[{"mr": mr} for mr in merge_requests],
+        )
+        mocker.patch(
+            "reconcile.gitlab_housekeeping.is_rebased",
+            side_effect=lambda mr, gl: mr._test_is_rebased,
+        )
+
+        gl_h.rebase_merge_requests(
+            dry_run=dry_run,
+            gl=mocked_gl,
+            rebase_limit=rebase_limit,
+            state=mocked_state,
+            pipeline_timeout=pipeline_timeout,
+            wait_for_pipeline=wait_for_pipeline,
+        )
+
+    def test_no_active_pipelines_full_budget(self, mocker: MockerFixture) -> None:
+        """0 MRs have active pipelines, limit=2, 3 need rebase: exactly 2 rebased."""
+        mrs = [_make_mr(1), _make_mr(2), _make_mr(3)]
+
+        self._call(mocker, mrs, rebase_limit=2)
+
+        assert mrs[0].rebase.call_count == 1
+        assert mrs[1].rebase.call_count == 1
+        assert mrs[2].rebase.call_count == 0
+
+    def test_active_pipelines_reduce_budget(self, mocker: MockerFixture) -> None:
+        """1 MR rebased with running pipeline, limit=2: only 1 additional rebase."""
+        mr_active = _make_mr(1, is_rebased=True, pipeline_status="running")
+        mr_needs_a = _make_mr(2)
+        mr_needs_b = _make_mr(3)
+        mrs = [mr_active, mr_needs_a, mr_needs_b]
+
+        self._call(mocker, mrs, rebase_limit=2)
+
+        assert mr_active.rebase.call_count == 0
+        assert mr_needs_a.rebase.call_count == 1
+        assert mr_needs_b.rebase.call_count == 0
+
+    def test_budget_exhausted(self, mocker: MockerFixture) -> None:
+        """2 MRs with running pipelines, limit=2: 0 rebases."""
+        mr_a = _make_mr(1, is_rebased=True, pipeline_status="running")
+        mr_b = _make_mr(2, is_rebased=True, pipeline_status="pending")
+        mr_c = _make_mr(3)
+        mrs = [mr_a, mr_b, mr_c]
+
+        self._call(mocker, mrs, rebase_limit=2)
+
+        assert mr_c.rebase.call_count == 0
+
+    def test_all_already_rebased(self, mocker: MockerFixture) -> None:
+        """All MRs pass is_rebased(): 0 rebases needed."""
+        mrs = [
+            _make_mr(1, is_rebased=True, pipeline_status="success"),
+            _make_mr(2, is_rebased=True, pipeline_status="success"),
+        ]
+
+        self._call(mocker, mrs, rebase_limit=2)
+
+        for mr in mrs:
+            assert mr.rebase.call_count == 0
+
+    def test_dry_run_no_rebases(self, mocker: MockerFixture) -> None:
+        """In dry run, no actual rebases happen."""
+        mrs = [_make_mr(1), _make_mr(2)]
+
+        self._call(mocker, mrs, rebase_limit=2, dry_run=True)
+
+        for mr in mrs:
+            assert mr.rebase.call_count == 0
+
+    def test_mixed_states(self, mocker: MockerFixture) -> None:
+        """Mix of rebased-with-success, rebased-with-running, and not-rebased MRs.
+
+        MR1: rebased, pipeline success (not active) -> doesn't consume budget
+        MR2: rebased, pipeline running (active) -> consumes 1 from budget
+        MR3: not rebased -> rebase candidate
+        MR4: not rebased -> rebase candidate
+        With limit=2, remaining_budget = 2 - 1 = 1, so only MR3 gets rebased.
+        """
+        mrs = [
+            _make_mr(1, is_rebased=True, pipeline_status="success"),
+            _make_mr(2, is_rebased=True, pipeline_status="running"),
+            _make_mr(3),
+            _make_mr(4),
+        ]
+
+        self._call(mocker, mrs, rebase_limit=2)
+
+        assert mrs[0].rebase.call_count == 0
+        assert mrs[1].rebase.call_count == 0
+        assert mrs[2].rebase.call_count == 1
+        assert mrs[3].rebase.call_count == 0
+
+    def test_backward_compatible_zero_active(self, mocker: MockerFixture) -> None:
+        """With 0 active pipelines, behaves identically to old per-run counter:
+        rebase up to N MRs."""
+        mrs = [_make_mr(i) for i in range(1, 6)]
+
+        self._call(mocker, mrs, rebase_limit=3)
+
+        rebased_count = sum(mr.rebase.call_count for mr in mrs)
+        assert rebased_count == 3
+        assert mrs[0].rebase.call_count == 1
+        assert mrs[1].rebase.call_count == 1
+        assert mrs[2].rebase.call_count == 1
+        assert mrs[3].rebase.call_count == 0
+        assert mrs[4].rebase.call_count == 0
+
+    def test_differing_limits(self, mocker: MockerFixture) -> None:
+        """Verify different limit values produce different rebase counts."""
+        for limit, expected_rebased in [(1, 1), (3, 3), (5, 5), (10, 7)]:
+            mrs = [_make_mr(i) for i in range(1, 8)]
+
+            self._call(mocker, mrs, rebase_limit=limit)
+
+            rebased_count = sum(mr.rebase.call_count for mr in mrs)
+            assert rebased_count == expected_rebased, (
+                f"limit={limit}: expected {expected_rebased} rebases, got {rebased_count}"
+            )

--- a/reconcile/test/test_gitlab_housekeeping.py
+++ b/reconcile/test/test_gitlab_housekeeping.py
@@ -11,6 +11,7 @@ from unittest.mock import (
     patch,
 )
 
+import gitlab
 import pytest
 from gitlab import Gitlab
 from gitlab.v4.objects import (
@@ -669,3 +670,49 @@ class TestRebaseMergeRequests:
             assert rebased_count == expected_rebased, (
                 f"limit={limit}: expected {expected_rebased} rebases, got {rebased_count}"
             )
+
+    def test_rebase_failure_does_not_consume_budget(
+        self, mocker: MockerFixture
+    ) -> None:
+        """A failed rebase doesn't consume a budget slot; subsequent MRs still get tried."""
+        mr_fail = _make_mr(1)
+        mr_fail.rebase.side_effect = gitlab.exceptions.GitlabMRRebaseError
+        mr_ok_a = _make_mr(2)
+        mr_ok_b = _make_mr(3)
+        mrs = [mr_fail, mr_ok_a, mr_ok_b]
+
+        self._call(mocker, mrs, rebase_limit=2)
+
+        assert mr_fail.rebase.call_count == 1
+        assert mr_ok_a.rebase.call_count == 1
+        assert mr_ok_b.rebase.call_count == 1
+
+    def test_over_committed_clamps_to_zero(self, mocker: MockerFixture) -> None:
+        """When already_active > limit, remaining_budget clamps to 0."""
+        mrs = [
+            _make_mr(1, is_rebased=True, pipeline_status="running"),
+            _make_mr(2, is_rebased=True, pipeline_status="running"),
+            _make_mr(3, is_rebased=True, pipeline_status="pending"),
+            _make_mr(4),
+            _make_mr(5),
+        ]
+
+        self._call(mocker, mrs, rebase_limit=2)
+
+        assert mrs[3].rebase.call_count == 0
+        assert mrs[4].rebase.call_count == 0
+
+    def test_rebased_mr_without_pipelines_not_counted_active(
+        self, mocker: MockerFixture
+    ) -> None:
+        """A rebased MR with no pipelines doesn't count toward already_active."""
+        mr_rebased_no_pipeline = _make_mr(1, is_rebased=True)
+        mr_needs_a = _make_mr(2)
+        mr_needs_b = _make_mr(3)
+        mrs = [mr_rebased_no_pipeline, mr_needs_a, mr_needs_b]
+
+        self._call(mocker, mrs, rebase_limit=2)
+
+        assert mr_rebased_no_pipeline.rebase.call_count == 0
+        assert mr_needs_a.rebase.call_count == 1
+        assert mr_needs_b.rebase.call_count == 1

--- a/reconcile/test/test_gitlab_housekeeping.py
+++ b/reconcile/test/test_gitlab_housekeeping.py
@@ -521,198 +521,202 @@ def _make_mr(
     return mr
 
 
-class TestRebaseMergeRequests:
-    """Tests for rebase_merge_requests() with per-repo concurrency cap.
+def _call_rebase(
+    mocker: MockerFixture,
+    merge_requests: list[Mock],
+    rebase_limit: int,
+    *,
+    dry_run: bool = False,
+    pipeline_timeout: int | None = None,
+    wait_for_pipeline: bool = False,
+) -> None:
+    """Invoke rebase_merge_requests with mocked internals."""
+    mocked_gl = create_autospec(GitLabApi)
+    mocked_project = create_autospec(Project)
+    mocked_project.name = "test-project"
+    mocked_gl.project = mocked_project
+    mocked_gl.get_merge_request_pipelines.side_effect = lambda mr: mr._test_pipelines
+    mocked_state = create_autospec(State)
 
-    rebase_limit controls the max number of MRs with active (running/pending)
-    pipelines at any time, not the number of rebases per invocation.
+    mocker.patch(
+        "reconcile.gitlab_housekeeping.get_merge_requests",
+        return_value=[{"mr": mr} for mr in merge_requests],
+    )
+    mocker.patch(
+        "reconcile.gitlab_housekeeping.is_rebased",
+        side_effect=lambda mr, gl: mr._test_is_rebased,
+    )
+
+    gl_h.rebase_merge_requests(
+        dry_run=dry_run,
+        gl=mocked_gl,
+        rebase_limit=rebase_limit,
+        state=mocked_state,
+        pipeline_timeout=pipeline_timeout,
+        wait_for_pipeline=wait_for_pipeline,
+    )
+
+
+def test_rebase_no_active_pipelines_full_budget(mocker: MockerFixture) -> None:
+    """0 MRs have active pipelines, limit=2, 3 need rebase: exactly 2 rebased."""
+    mrs = [_make_mr(1), _make_mr(2), _make_mr(3)]
+
+    _call_rebase(mocker, mrs, rebase_limit=2)
+
+    assert mrs[0].rebase.call_count == 1
+    assert mrs[1].rebase.call_count == 1
+    assert mrs[2].rebase.call_count == 0
+
+
+def test_rebase_active_pipelines_reduce_budget(mocker: MockerFixture) -> None:
+    """1 MR rebased with running pipeline, limit=2: only 1 additional rebase."""
+    mr_active = _make_mr(1, is_rebased=True, pipeline_status="running")
+    mr_needs_a = _make_mr(2)
+    mr_needs_b = _make_mr(3)
+    mrs = [mr_active, mr_needs_a, mr_needs_b]
+
+    _call_rebase(mocker, mrs, rebase_limit=2)
+
+    assert mr_active.rebase.call_count == 0
+    assert mr_needs_a.rebase.call_count == 1
+    assert mr_needs_b.rebase.call_count == 0
+
+
+def test_rebase_budget_exhausted(mocker: MockerFixture) -> None:
+    """2 MRs with running pipelines, limit=2: 0 rebases."""
+    mr_a = _make_mr(1, is_rebased=True, pipeline_status="running")
+    mr_b = _make_mr(2, is_rebased=True, pipeline_status="pending")
+    mr_c = _make_mr(3)
+    mrs = [mr_a, mr_b, mr_c]
+
+    _call_rebase(mocker, mrs, rebase_limit=2)
+
+    assert mr_c.rebase.call_count == 0
+
+
+def test_rebase_all_already_rebased(mocker: MockerFixture) -> None:
+    """All MRs pass is_rebased(): 0 rebases needed."""
+    mrs = [
+        _make_mr(1, is_rebased=True, pipeline_status="success"),
+        _make_mr(2, is_rebased=True, pipeline_status="success"),
+    ]
+
+    _call_rebase(mocker, mrs, rebase_limit=2)
+
+    for mr in mrs:
+        assert mr.rebase.call_count == 0
+
+
+def test_rebase_dry_run_no_rebases(mocker: MockerFixture) -> None:
+    """In dry run, no actual rebases happen."""
+    mrs = [_make_mr(1), _make_mr(2)]
+
+    _call_rebase(mocker, mrs, rebase_limit=2, dry_run=True)
+
+    for mr in mrs:
+        assert mr.rebase.call_count == 0
+
+
+def test_rebase_mixed_states(mocker: MockerFixture) -> None:
+    """Mix of rebased-with-success, rebased-with-running, and not-rebased MRs.
+
+    MR1: rebased, pipeline success (not active) -> doesn't consume budget
+    MR2: rebased, pipeline running (active) -> consumes 1 from budget
+    MR3: not rebased -> rebase candidate
+    MR4: not rebased -> rebase candidate
+    With limit=2, remaining_budget = 2 - 1 = 1, so only MR3 gets rebased.
     """
+    mrs = [
+        _make_mr(1, is_rebased=True, pipeline_status="success"),
+        _make_mr(2, is_rebased=True, pipeline_status="running"),
+        _make_mr(3),
+        _make_mr(4),
+    ]
 
-    @staticmethod
-    def _call(
-        mocker: MockerFixture,
-        merge_requests: list[Mock],
-        rebase_limit: int,
-        *,
-        dry_run: bool = False,
-        pipeline_timeout: int | None = None,
-        wait_for_pipeline: bool = False,
-    ) -> None:
-        """Invoke rebase_merge_requests with mocked internals."""
-        mocked_gl = create_autospec(GitLabApi)
-        mocked_project = create_autospec(Project)
-        mocked_project.name = "test-project"
-        mocked_gl.project = mocked_project
-        mocked_gl.get_merge_request_pipelines.side_effect = lambda mr: (
-            mr._test_pipelines
-        )
-        mocked_state = create_autospec(State)
+    _call_rebase(mocker, mrs, rebase_limit=2)
 
-        mocker.patch(
-            "reconcile.gitlab_housekeeping.get_merge_requests",
-            return_value=[{"mr": mr} for mr in merge_requests],
-        )
-        mocker.patch(
-            "reconcile.gitlab_housekeeping.is_rebased",
-            side_effect=lambda mr, gl: mr._test_is_rebased,
-        )
+    assert mrs[0].rebase.call_count == 0
+    assert mrs[1].rebase.call_count == 0
+    assert mrs[2].rebase.call_count == 1
+    assert mrs[3].rebase.call_count == 0
 
-        gl_h.rebase_merge_requests(
-            dry_run=dry_run,
-            gl=mocked_gl,
-            rebase_limit=rebase_limit,
-            state=mocked_state,
-            pipeline_timeout=pipeline_timeout,
-            wait_for_pipeline=wait_for_pipeline,
-        )
 
-    def test_no_active_pipelines_full_budget(self, mocker: MockerFixture) -> None:
-        """0 MRs have active pipelines, limit=2, 3 need rebase: exactly 2 rebased."""
-        mrs = [_make_mr(1), _make_mr(2), _make_mr(3)]
+def test_rebase_backward_compatible_zero_active(mocker: MockerFixture) -> None:
+    """With 0 active pipelines, behaves identically to old per-run counter:
+    rebase up to N MRs."""
+    mrs = [_make_mr(i) for i in range(1, 6)]
 
-        self._call(mocker, mrs, rebase_limit=2)
+    _call_rebase(mocker, mrs, rebase_limit=3)
 
-        assert mrs[0].rebase.call_count == 1
-        assert mrs[1].rebase.call_count == 1
-        assert mrs[2].rebase.call_count == 0
+    rebased_count = sum(mr.rebase.call_count for mr in mrs)
+    assert rebased_count == 3
+    assert mrs[0].rebase.call_count == 1
+    assert mrs[1].rebase.call_count == 1
+    assert mrs[2].rebase.call_count == 1
+    assert mrs[3].rebase.call_count == 0
+    assert mrs[4].rebase.call_count == 0
 
-    def test_active_pipelines_reduce_budget(self, mocker: MockerFixture) -> None:
-        """1 MR rebased with running pipeline, limit=2: only 1 additional rebase."""
-        mr_active = _make_mr(1, is_rebased=True, pipeline_status="running")
-        mr_needs_a = _make_mr(2)
-        mr_needs_b = _make_mr(3)
-        mrs = [mr_active, mr_needs_a, mr_needs_b]
 
-        self._call(mocker, mrs, rebase_limit=2)
+@pytest.mark.parametrize(
+    ("limit", "expected_rebased"),
+    [(1, 1), (3, 3), (5, 5), (10, 7)],
+)
+def test_rebase_differing_limits(
+    mocker: MockerFixture, limit: int, expected_rebased: int
+) -> None:
+    """Verify different limit values produce different rebase counts."""
+    mrs = [_make_mr(i) for i in range(1, 8)]
 
-        assert mr_active.rebase.call_count == 0
-        assert mr_needs_a.rebase.call_count == 1
-        assert mr_needs_b.rebase.call_count == 0
+    _call_rebase(mocker, mrs, rebase_limit=limit)
 
-    def test_budget_exhausted(self, mocker: MockerFixture) -> None:
-        """2 MRs with running pipelines, limit=2: 0 rebases."""
-        mr_a = _make_mr(1, is_rebased=True, pipeline_status="running")
-        mr_b = _make_mr(2, is_rebased=True, pipeline_status="pending")
-        mr_c = _make_mr(3)
-        mrs = [mr_a, mr_b, mr_c]
+    rebased_count = sum(mr.rebase.call_count for mr in mrs)
+    assert rebased_count == expected_rebased, (
+        f"limit={limit}: expected {expected_rebased} rebases, got {rebased_count}"
+    )
 
-        self._call(mocker, mrs, rebase_limit=2)
 
-        assert mr_c.rebase.call_count == 0
+def test_rebase_failure_does_not_consume_budget(mocker: MockerFixture) -> None:
+    """A failed rebase doesn't consume a budget slot; subsequent MRs still get tried."""
+    mr_fail = _make_mr(1)
+    mr_fail.rebase.side_effect = gitlab.exceptions.GitlabMRRebaseError
+    mr_ok_a = _make_mr(2)
+    mr_ok_b = _make_mr(3)
+    mrs = [mr_fail, mr_ok_a, mr_ok_b]
 
-    def test_all_already_rebased(self, mocker: MockerFixture) -> None:
-        """All MRs pass is_rebased(): 0 rebases needed."""
-        mrs = [
-            _make_mr(1, is_rebased=True, pipeline_status="success"),
-            _make_mr(2, is_rebased=True, pipeline_status="success"),
-        ]
+    _call_rebase(mocker, mrs, rebase_limit=2)
 
-        self._call(mocker, mrs, rebase_limit=2)
+    assert mr_fail.rebase.call_count == 1
+    assert mr_ok_a.rebase.call_count == 1
+    assert mr_ok_b.rebase.call_count == 1
 
-        for mr in mrs:
-            assert mr.rebase.call_count == 0
 
-    def test_dry_run_no_rebases(self, mocker: MockerFixture) -> None:
-        """In dry run, no actual rebases happen."""
-        mrs = [_make_mr(1), _make_mr(2)]
+def test_rebase_over_committed_clamps_to_zero(mocker: MockerFixture) -> None:
+    """When already_active > limit, remaining_budget clamps to 0."""
+    mrs = [
+        _make_mr(1, is_rebased=True, pipeline_status="running"),
+        _make_mr(2, is_rebased=True, pipeline_status="running"),
+        _make_mr(3, is_rebased=True, pipeline_status="pending"),
+        _make_mr(4),
+        _make_mr(5),
+    ]
 
-        self._call(mocker, mrs, rebase_limit=2, dry_run=True)
+    _call_rebase(mocker, mrs, rebase_limit=2)
 
-        for mr in mrs:
-            assert mr.rebase.call_count == 0
+    assert mrs[3].rebase.call_count == 0
+    assert mrs[4].rebase.call_count == 0
 
-    def test_mixed_states(self, mocker: MockerFixture) -> None:
-        """Mix of rebased-with-success, rebased-with-running, and not-rebased MRs.
 
-        MR1: rebased, pipeline success (not active) -> doesn't consume budget
-        MR2: rebased, pipeline running (active) -> consumes 1 from budget
-        MR3: not rebased -> rebase candidate
-        MR4: not rebased -> rebase candidate
-        With limit=2, remaining_budget = 2 - 1 = 1, so only MR3 gets rebased.
-        """
-        mrs = [
-            _make_mr(1, is_rebased=True, pipeline_status="success"),
-            _make_mr(2, is_rebased=True, pipeline_status="running"),
-            _make_mr(3),
-            _make_mr(4),
-        ]
+def test_rebase_mr_without_pipelines_not_counted_active(
+    mocker: MockerFixture,
+) -> None:
+    """A rebased MR with no pipelines doesn't count toward already_active."""
+    mr_rebased_no_pipeline = _make_mr(1, is_rebased=True)
+    mr_needs_a = _make_mr(2)
+    mr_needs_b = _make_mr(3)
+    mrs = [mr_rebased_no_pipeline, mr_needs_a, mr_needs_b]
 
-        self._call(mocker, mrs, rebase_limit=2)
+    _call_rebase(mocker, mrs, rebase_limit=2)
 
-        assert mrs[0].rebase.call_count == 0
-        assert mrs[1].rebase.call_count == 0
-        assert mrs[2].rebase.call_count == 1
-        assert mrs[3].rebase.call_count == 0
-
-    def test_backward_compatible_zero_active(self, mocker: MockerFixture) -> None:
-        """With 0 active pipelines, behaves identically to old per-run counter:
-        rebase up to N MRs."""
-        mrs = [_make_mr(i) for i in range(1, 6)]
-
-        self._call(mocker, mrs, rebase_limit=3)
-
-        rebased_count = sum(mr.rebase.call_count for mr in mrs)
-        assert rebased_count == 3
-        assert mrs[0].rebase.call_count == 1
-        assert mrs[1].rebase.call_count == 1
-        assert mrs[2].rebase.call_count == 1
-        assert mrs[3].rebase.call_count == 0
-        assert mrs[4].rebase.call_count == 0
-
-    def test_differing_limits(self, mocker: MockerFixture) -> None:
-        """Verify different limit values produce different rebase counts."""
-        for limit, expected_rebased in [(1, 1), (3, 3), (5, 5), (10, 7)]:
-            mrs = [_make_mr(i) for i in range(1, 8)]
-
-            self._call(mocker, mrs, rebase_limit=limit)
-
-            rebased_count = sum(mr.rebase.call_count for mr in mrs)
-            assert rebased_count == expected_rebased, (
-                f"limit={limit}: expected {expected_rebased} rebases, got {rebased_count}"
-            )
-
-    def test_rebase_failure_does_not_consume_budget(
-        self, mocker: MockerFixture
-    ) -> None:
-        """A failed rebase doesn't consume a budget slot; subsequent MRs still get tried."""
-        mr_fail = _make_mr(1)
-        mr_fail.rebase.side_effect = gitlab.exceptions.GitlabMRRebaseError
-        mr_ok_a = _make_mr(2)
-        mr_ok_b = _make_mr(3)
-        mrs = [mr_fail, mr_ok_a, mr_ok_b]
-
-        self._call(mocker, mrs, rebase_limit=2)
-
-        assert mr_fail.rebase.call_count == 1
-        assert mr_ok_a.rebase.call_count == 1
-        assert mr_ok_b.rebase.call_count == 1
-
-    def test_over_committed_clamps_to_zero(self, mocker: MockerFixture) -> None:
-        """When already_active > limit, remaining_budget clamps to 0."""
-        mrs = [
-            _make_mr(1, is_rebased=True, pipeline_status="running"),
-            _make_mr(2, is_rebased=True, pipeline_status="running"),
-            _make_mr(3, is_rebased=True, pipeline_status="pending"),
-            _make_mr(4),
-            _make_mr(5),
-        ]
-
-        self._call(mocker, mrs, rebase_limit=2)
-
-        assert mrs[3].rebase.call_count == 0
-        assert mrs[4].rebase.call_count == 0
-
-    def test_rebased_mr_without_pipelines_not_counted_active(
-        self, mocker: MockerFixture
-    ) -> None:
-        """A rebased MR with no pipelines doesn't count toward already_active."""
-        mr_rebased_no_pipeline = _make_mr(1, is_rebased=True)
-        mr_needs_a = _make_mr(2)
-        mr_needs_b = _make_mr(3)
-        mrs = [mr_rebased_no_pipeline, mr_needs_a, mr_needs_b]
-
-        self._call(mocker, mrs, rebase_limit=2)
-
-        assert mr_rebased_no_pipeline.rebase.call_count == 0
-        assert mr_needs_a.rebase.call_count == 1
-        assert mr_needs_b.rebase.call_count == 1
+    assert mr_rebased_no_pipeline.rebase.call_count == 0
+    assert mr_needs_a.rebase.call_count == 1
+    assert mr_needs_b.rebase.call_count == 1

--- a/reconcile/test/test_gitlab_housekeeping.py
+++ b/reconcile/test/test_gitlab_housekeeping.py
@@ -11,9 +11,9 @@ from unittest.mock import (
     patch,
 )
 
-import gitlab
 import pytest
 from gitlab import Gitlab
+from gitlab.exceptions import GitlabMRRebaseError
 from gitlab.v4.objects import (
     Project,
     ProjectCommit,
@@ -496,165 +496,196 @@ def test_verify_ondemend_tests_pass(
 # --- rebase_merge_requests per-repo concurrency cap tests ---
 
 
-def _make_pipeline(status: str) -> Mock:
-    return create_autospec(ProjectMergeRequestPipeline, status=status)
-
-
-def _make_mr(
-    iid: int,
-    *,
-    is_rebased: bool = False,
-    pipeline_status: str | None = None,
-) -> Mock:
-    """Create a mock MR.
-
-    is_rebased: whether is_rebased() should return True for this MR.
-    pipeline_status: if set, get_merge_request_pipelines returns a pipeline
-        with this status; otherwise returns [].
-    """
-    mr = create_autospec(ProjectMergeRequest)
-    mr.iid = iid
-    mr.target_project_id = 10
-    mr.source_project_id = 10
-    mr._test_is_rebased = is_rebased
-    mr._test_pipelines = [_make_pipeline(pipeline_status)] if pipeline_status else []
-    return mr
-
-
 def _call_rebase(
     mocker: MockerFixture,
+    gitlab_api: Mock,
+    state: Mock,
     merge_requests: list[Mock],
     rebase_limit: int,
     *,
+    rebased_iids: set[int] | None = None,
+    pipelines: dict[int, list] | None = None,
     dry_run: bool = False,
     pipeline_timeout: int | None = None,
     wait_for_pipeline: bool = False,
 ) -> None:
-    """Invoke rebase_merge_requests with mocked internals."""
-    mocked_gl = create_autospec(GitLabApi)
-    mocked_project = create_autospec(Project)
-    mocked_project.name = "test-project"
-    mocked_gl.project = mocked_project
-    mocked_gl.get_merge_request_pipelines.side_effect = lambda mr: mr._test_pipelines
-    mocked_state = create_autospec(State)
+    """Invoke rebase_merge_requests with standard patches.
 
+    rebased_iids: iids for which is_rebased() returns True.
+    pipelines: mapping of iid -> pipeline list for get_merge_request_pipelines().
+    """
+    rebased_set = rebased_iids or set()
+    pipelines_map = pipelines or {}
+
+    gitlab_api.get_merge_request_pipelines.side_effect = lambda mr: pipelines_map.get(
+        mr.iid, []
+    )
     mocker.patch(
         "reconcile.gitlab_housekeeping.get_merge_requests",
         return_value=[{"mr": mr} for mr in merge_requests],
     )
     mocker.patch(
         "reconcile.gitlab_housekeeping.is_rebased",
-        side_effect=lambda mr, gl: mr._test_is_rebased,
+        side_effect=lambda mr, gl: mr.iid in rebased_set,
     )
 
     gl_h.rebase_merge_requests(
         dry_run=dry_run,
-        gl=mocked_gl,
+        gl=gitlab_api,
         rebase_limit=rebase_limit,
-        state=mocked_state,
+        state=state,
         pipeline_timeout=pipeline_timeout,
         wait_for_pipeline=wait_for_pipeline,
     )
 
 
-def test_rebase_no_active_pipelines_full_budget(mocker: MockerFixture) -> None:
+def _make_rebase_mr(iid: int, project_id: int = 10) -> Mock:
+    """Create a minimal autospec MR for rebase tests."""
+    mr = create_autospec(ProjectMergeRequest)
+    mr.iid = iid
+    mr.target_project_id = project_id
+    mr.source_project_id = project_id
+    return mr
+
+
+def test_rebase_no_active_pipelines_full_budget(
+    mocker: MockerFixture, gitlab_api: Mock, state: Mock
+) -> None:
     """0 MRs have active pipelines, limit=2, 3 need rebase: exactly 2 rebased."""
-    mrs = [_make_mr(1), _make_mr(2), _make_mr(3)]
+    merge_requests = [_make_rebase_mr(i) for i in range(1, 4)]
 
-    _call_rebase(mocker, mrs, rebase_limit=2)
+    _call_rebase(mocker, gitlab_api, state, merge_requests, rebase_limit=2)
 
-    assert mrs[0].rebase.call_count == 1
-    assert mrs[1].rebase.call_count == 1
-    assert mrs[2].rebase.call_count == 0
+    assert merge_requests[0].rebase.call_count == 1
+    assert merge_requests[1].rebase.call_count == 1
+    assert merge_requests[2].rebase.call_count == 0
 
 
-def test_rebase_active_pipelines_reduce_budget(mocker: MockerFixture) -> None:
+def test_rebase_active_pipelines_reduce_budget(
+    mocker: MockerFixture, gitlab_api: Mock, state: Mock
+) -> None:
     """1 MR rebased with running pipeline, limit=2: only 1 additional rebase."""
-    mr_active = _make_mr(1, is_rebased=True, pipeline_status="running")
-    mr_needs_a = _make_mr(2)
-    mr_needs_b = _make_mr(3)
-    mrs = [mr_active, mr_needs_a, mr_needs_b]
+    running_pipeline = create_autospec(ProjectMergeRequestPipeline, status="running")
+    merge_requests = [_make_rebase_mr(1), _make_rebase_mr(2), _make_rebase_mr(3)]
 
-    _call_rebase(mocker, mrs, rebase_limit=2)
+    _call_rebase(
+        mocker,
+        gitlab_api,
+        state,
+        merge_requests,
+        rebase_limit=2,
+        rebased_iids={1},
+        pipelines={1: [running_pipeline]},
+    )
 
-    assert mr_active.rebase.call_count == 0
-    assert mr_needs_a.rebase.call_count == 1
-    assert mr_needs_b.rebase.call_count == 0
+    assert merge_requests[0].rebase.call_count == 0
+    assert merge_requests[1].rebase.call_count == 1
+    assert merge_requests[2].rebase.call_count == 0
 
 
-def test_rebase_budget_exhausted(mocker: MockerFixture) -> None:
+def test_rebase_budget_exhausted(
+    mocker: MockerFixture, gitlab_api: Mock, state: Mock
+) -> None:
     """2 MRs with running pipelines, limit=2: 0 rebases."""
-    mr_a = _make_mr(1, is_rebased=True, pipeline_status="running")
-    mr_b = _make_mr(2, is_rebased=True, pipeline_status="pending")
-    mr_c = _make_mr(3)
-    mrs = [mr_a, mr_b, mr_c]
+    running_pipeline = create_autospec(ProjectMergeRequestPipeline, status="running")
+    pending_pipeline = create_autospec(ProjectMergeRequestPipeline, status="pending")
+    merge_requests = [_make_rebase_mr(1), _make_rebase_mr(2), _make_rebase_mr(3)]
 
-    _call_rebase(mocker, mrs, rebase_limit=2)
+    _call_rebase(
+        mocker,
+        gitlab_api,
+        state,
+        merge_requests,
+        rebase_limit=2,
+        rebased_iids={1, 2},
+        pipelines={1: [running_pipeline], 2: [pending_pipeline]},
+    )
 
-    assert mr_c.rebase.call_count == 0
+    assert merge_requests[2].rebase.call_count == 0
 
 
-def test_rebase_all_already_rebased(mocker: MockerFixture) -> None:
+def test_rebase_all_already_rebased(
+    mocker: MockerFixture, gitlab_api: Mock, state: Mock
+) -> None:
     """All MRs pass is_rebased(): 0 rebases needed."""
-    mrs = [
-        _make_mr(1, is_rebased=True, pipeline_status="success"),
-        _make_mr(2, is_rebased=True, pipeline_status="success"),
-    ]
+    success_pipeline = create_autospec(ProjectMergeRequestPipeline, status="success")
+    merge_requests = [_make_rebase_mr(1), _make_rebase_mr(2)]
 
-    _call_rebase(mocker, mrs, rebase_limit=2)
+    _call_rebase(
+        mocker,
+        gitlab_api,
+        state,
+        merge_requests,
+        rebase_limit=2,
+        rebased_iids={1, 2},
+        pipelines={1: [success_pipeline], 2: [success_pipeline]},
+    )
 
-    for mr in mrs:
+    for mr in merge_requests:
         assert mr.rebase.call_count == 0
 
 
-def test_rebase_dry_run_no_rebases(mocker: MockerFixture) -> None:
+def test_rebase_dry_run_no_rebases(
+    mocker: MockerFixture, gitlab_api: Mock, state: Mock
+) -> None:
     """In dry run, no actual rebases happen."""
-    mrs = [_make_mr(1), _make_mr(2)]
+    merge_requests = [_make_rebase_mr(i) for i in range(1, 3)]
 
-    _call_rebase(mocker, mrs, rebase_limit=2, dry_run=True)
+    _call_rebase(
+        mocker, gitlab_api, state, merge_requests, rebase_limit=2, dry_run=True
+    )
 
-    for mr in mrs:
+    for mr in merge_requests:
         assert mr.rebase.call_count == 0
 
 
-def test_rebase_mixed_states(mocker: MockerFixture) -> None:
+def test_rebase_mixed_states(
+    mocker: MockerFixture, gitlab_api: Mock, state: Mock
+) -> None:
     """Mix of rebased-with-success, rebased-with-running, and not-rebased MRs.
 
-    MR1: rebased, pipeline success (not active) -> doesn't consume budget
-    MR2: rebased, pipeline running (active) -> consumes 1 from budget
+    MR1: rebased, pipeline success -> consumes 1 from budget
+    MR2: rebased, pipeline running -> consumes 1 from budget
     MR3: not rebased -> rebase candidate
     MR4: not rebased -> rebase candidate
-    With limit=2, remaining_budget = 2 - 1 = 1, so only MR3 gets rebased.
+    With limit=2, remaining_budget = 2 - 2 = 0, so no MRs get rebased.
     """
-    mrs = [
-        _make_mr(1, is_rebased=True, pipeline_status="success"),
-        _make_mr(2, is_rebased=True, pipeline_status="running"),
-        _make_mr(3),
-        _make_mr(4),
-    ]
+    success_pipeline = create_autospec(ProjectMergeRequestPipeline, status="success")
+    running_pipeline = create_autospec(ProjectMergeRequestPipeline, status="running")
+    merge_requests = [_make_rebase_mr(i) for i in range(1, 5)]
 
-    _call_rebase(mocker, mrs, rebase_limit=2)
+    _call_rebase(
+        mocker,
+        gitlab_api,
+        state,
+        merge_requests,
+        rebase_limit=2,
+        rebased_iids={1, 2},
+        pipelines={1: [success_pipeline], 2: [running_pipeline]},
+    )
 
-    assert mrs[0].rebase.call_count == 0
-    assert mrs[1].rebase.call_count == 0
-    assert mrs[2].rebase.call_count == 1
-    assert mrs[3].rebase.call_count == 0
+    assert merge_requests[0].rebase.call_count == 0
+    assert merge_requests[1].rebase.call_count == 0
+    assert merge_requests[2].rebase.call_count == 0
+    assert merge_requests[3].rebase.call_count == 0
 
 
-def test_rebase_backward_compatible_zero_active(mocker: MockerFixture) -> None:
+def test_rebase_backward_compatible_zero_active(
+    mocker: MockerFixture, gitlab_api: Mock, state: Mock
+) -> None:
     """With 0 active pipelines, behaves identically to old per-run counter:
     rebase up to N MRs."""
-    mrs = [_make_mr(i) for i in range(1, 6)]
+    merge_requests = [_make_rebase_mr(i) for i in range(1, 6)]
 
-    _call_rebase(mocker, mrs, rebase_limit=3)
+    _call_rebase(mocker, gitlab_api, state, merge_requests, rebase_limit=3)
 
-    rebased_count = sum(mr.rebase.call_count for mr in mrs)
+    rebased_count = sum(mr.rebase.call_count for mr in merge_requests)
     assert rebased_count == 3
-    assert mrs[0].rebase.call_count == 1
-    assert mrs[1].rebase.call_count == 1
-    assert mrs[2].rebase.call_count == 1
-    assert mrs[3].rebase.call_count == 0
-    assert mrs[4].rebase.call_count == 0
+    assert merge_requests[0].rebase.call_count == 1
+    assert merge_requests[1].rebase.call_count == 1
+    assert merge_requests[2].rebase.call_count == 1
+    assert merge_requests[3].rebase.call_count == 0
+    assert merge_requests[4].rebase.call_count == 0
 
 
 @pytest.mark.parametrize(
@@ -662,61 +693,134 @@ def test_rebase_backward_compatible_zero_active(mocker: MockerFixture) -> None:
     [(1, 1), (3, 3), (5, 5), (10, 7)],
 )
 def test_rebase_differing_limits(
-    mocker: MockerFixture, limit: int, expected_rebased: int
+    mocker: MockerFixture,
+    gitlab_api: Mock,
+    state: Mock,
+    limit: int,
+    expected_rebased: int,
 ) -> None:
     """Verify different limit values produce different rebase counts."""
-    mrs = [_make_mr(i) for i in range(1, 8)]
+    merge_requests = [_make_rebase_mr(i) for i in range(1, 8)]
 
-    _call_rebase(mocker, mrs, rebase_limit=limit)
+    _call_rebase(mocker, gitlab_api, state, merge_requests, rebase_limit=limit)
 
-    rebased_count = sum(mr.rebase.call_count for mr in mrs)
+    rebased_count = sum(mr.rebase.call_count for mr in merge_requests)
     assert rebased_count == expected_rebased, (
         f"limit={limit}: expected {expected_rebased} rebases, got {rebased_count}"
     )
 
 
-def test_rebase_failure_does_not_consume_budget(mocker: MockerFixture) -> None:
+def test_rebase_failure_does_not_consume_budget(
+    mocker: MockerFixture, gitlab_api: Mock, state: Mock
+) -> None:
     """A failed rebase doesn't consume a budget slot; subsequent MRs still get tried."""
-    mr_fail = _make_mr(1)
-    mr_fail.rebase.side_effect = gitlab.exceptions.GitlabMRRebaseError
-    mr_ok_a = _make_mr(2)
-    mr_ok_b = _make_mr(3)
-    mrs = [mr_fail, mr_ok_a, mr_ok_b]
+    merge_requests = [_make_rebase_mr(1), _make_rebase_mr(2), _make_rebase_mr(3)]
+    merge_requests[0].rebase.side_effect = GitlabMRRebaseError
 
-    _call_rebase(mocker, mrs, rebase_limit=2)
+    _call_rebase(mocker, gitlab_api, state, merge_requests, rebase_limit=2)
 
-    assert mr_fail.rebase.call_count == 1
-    assert mr_ok_a.rebase.call_count == 1
-    assert mr_ok_b.rebase.call_count == 1
+    assert merge_requests[0].rebase.call_count == 1
+    assert merge_requests[1].rebase.call_count == 1
+    assert merge_requests[2].rebase.call_count == 1
 
 
-def test_rebase_over_committed_clamps_to_zero(mocker: MockerFixture) -> None:
+def test_rebase_over_committed_clamps_to_zero(
+    mocker: MockerFixture, gitlab_api: Mock, state: Mock
+) -> None:
     """When already_active > limit, remaining_budget clamps to 0."""
-    mrs = [
-        _make_mr(1, is_rebased=True, pipeline_status="running"),
-        _make_mr(2, is_rebased=True, pipeline_status="running"),
-        _make_mr(3, is_rebased=True, pipeline_status="pending"),
-        _make_mr(4),
-        _make_mr(5),
-    ]
+    running_pipeline = create_autospec(ProjectMergeRequestPipeline, status="running")
+    pending_pipeline = create_autospec(ProjectMergeRequestPipeline, status="pending")
+    merge_requests = [_make_rebase_mr(i) for i in range(1, 6)]
 
-    _call_rebase(mocker, mrs, rebase_limit=2)
+    _call_rebase(
+        mocker,
+        gitlab_api,
+        state,
+        merge_requests,
+        rebase_limit=2,
+        rebased_iids={1, 2, 3},
+        pipelines={1: [running_pipeline], 2: [running_pipeline], 3: [pending_pipeline]},
+    )
 
-    assert mrs[3].rebase.call_count == 0
-    assert mrs[4].rebase.call_count == 0
+    assert merge_requests[3].rebase.call_count == 0
+    assert merge_requests[4].rebase.call_count == 0
 
 
 def test_rebase_mr_without_pipelines_not_counted_active(
-    mocker: MockerFixture,
+    mocker: MockerFixture, gitlab_api: Mock, state: Mock
 ) -> None:
     """A rebased MR with no pipelines doesn't count toward already_active."""
-    mr_rebased_no_pipeline = _make_mr(1, is_rebased=True)
-    mr_needs_a = _make_mr(2)
-    mr_needs_b = _make_mr(3)
-    mrs = [mr_rebased_no_pipeline, mr_needs_a, mr_needs_b]
+    merge_requests = [_make_rebase_mr(1), _make_rebase_mr(2), _make_rebase_mr(3)]
 
-    _call_rebase(mocker, mrs, rebase_limit=2)
+    _call_rebase(
+        mocker,
+        gitlab_api,
+        state,
+        merge_requests,
+        rebase_limit=2,
+        rebased_iids={1},
+    )
 
-    assert mr_rebased_no_pipeline.rebase.call_count == 0
-    assert mr_needs_a.rebase.call_count == 1
-    assert mr_needs_b.rebase.call_count == 1
+    assert merge_requests[0].rebase.call_count == 0
+    assert merge_requests[1].rebase.call_count == 1
+    assert merge_requests[2].rebase.call_count == 1
+
+
+def test_rebase_limit_independent_per_repo(mocker: MockerFixture, state: Mock) -> None:
+    """rebase_limit applies independently per repo.
+
+    Simulate 3 repos with varying states, each processed via a separate
+    rebase_merge_requests call (mirroring how run() iterates repos).
+    With limit=2 each repo should get its own budget of 2.
+
+    Repo A (project_id=10): 1 active pipeline + 3 need rebase -> 1 rebased
+    Repo B (project_id=20): 0 active pipelines + 4 need rebase -> 2 rebased
+    Repo C (project_id=30): 2 active pipelines + 2 need rebase -> 0 rebased
+    """
+    running_pipeline = create_autospec(ProjectMergeRequestPipeline, status="running")
+    pending_pipeline = create_autospec(ProjectMergeRequestPipeline, status="pending")
+
+    repo_a_merge_requests = [_make_rebase_mr(i, project_id=10) for i in range(1, 5)]
+    repo_b_merge_requests = [_make_rebase_mr(i, project_id=20) for i in range(5, 9)]
+    repo_c_merge_requests = [_make_rebase_mr(i, project_id=30) for i in range(9, 13)]
+
+    repo_configs: list[tuple[list[Mock], set[int], dict[int, list]]] = [
+        (repo_a_merge_requests, {1}, {1: [running_pipeline]}),
+        (repo_b_merge_requests, set(), {}),
+        (
+            repo_c_merge_requests,
+            {9, 10},
+            {9: [running_pipeline], 10: [pending_pipeline]},
+        ),
+    ]
+    for merge_requests, rebased_iids, pipelines in repo_configs:
+        mocked_gl = create_autospec(GitLabApi)
+        mocked_gl.project = create_autospec(Project)
+        mocked_gl.project.name = "test-project"
+        _call_rebase(
+            mocker,
+            mocked_gl,
+            state,
+            merge_requests,
+            rebase_limit=2,
+            rebased_iids=rebased_iids,
+            pipelines=pipelines,
+        )
+
+    # Repo A: 1 active eats 1 slot -> 1 rebase
+    assert repo_a_merge_requests[0].rebase.call_count == 0  # already rebased
+    assert repo_a_merge_requests[1].rebase.call_count == 1
+    assert repo_a_merge_requests[2].rebase.call_count == 0
+    assert repo_a_merge_requests[3].rebase.call_count == 0
+
+    # Repo B: 0 active -> full budget of 2
+    assert repo_b_merge_requests[0].rebase.call_count == 1
+    assert repo_b_merge_requests[1].rebase.call_count == 1
+    assert repo_b_merge_requests[2].rebase.call_count == 0
+    assert repo_b_merge_requests[3].rebase.call_count == 0
+
+    # Repo C: 2 active exhaust budget -> 0 rebases
+    assert repo_c_merge_requests[0].rebase.call_count == 0
+    assert repo_c_merge_requests[1].rebase.call_count == 0
+    assert repo_c_merge_requests[2].rebase.call_count == 0
+    assert repo_c_merge_requests[3].rebase.call_count == 0

--- a/reconcile/utils/unleash/__init__.py
+++ b/reconcile/utils/unleash/__init__.py
@@ -2,10 +2,12 @@ from .client import (
     get_feature_toggle_default,
     get_feature_toggle_state,
     get_feature_toggles,
+    get_feature_variant,
 )
 
 __all__ = [
     "get_feature_toggle_default",
     "get_feature_toggle_state",
     "get_feature_toggles",
+    "get_feature_variant",
 ]

--- a/reconcile/utils/unleash/client.py
+++ b/reconcile/utils/unleash/client.py
@@ -114,6 +114,28 @@ def get_feature_toggle_state(
     )
 
 
+def get_feature_variant(
+    feature_name: str, context: dict | None = None, default_variant: str = ""
+) -> str:
+    """Return the variant payload value for a feature toggle.
+
+    If Unleash is unavailable or the toggle has no variant configured,
+    returns *default_variant*.
+    """
+    api_url = os.environ.get("UNLEASH_API_URL")
+    client_access_token = os.environ.get("UNLEASH_CLIENT_ACCESS_TOKEN")
+    if not (api_url and client_access_token):
+        return default_variant
+
+    c = _get_unleash_api_client(api_url, client_access_token)
+    variant = c.get_variant(feature_name, context=context or {})
+    if variant and variant.get("enabled"):
+        payload = variant.get("payload", {})
+        if payload:
+            return payload.get("value", default_variant)
+    return default_variant
+
+
 def get_feature_toggles(api_url: str, client_access_token: str) -> Mapping[str, str]:
     c = _get_unleash_api_client(api_url, client_access_token)
 


### PR DESCRIPTION
[APPSRE-13993](https://redhat.atlassian.net/jira/software/c/projects/APPSRE/boards/11510?assignee=712020%3Ae95cb166-7599-4e03-aa29-3d40baa2bfce&selectedIssue=APPSRE-13993&useStoredSettings=true): Redefine rebase limit as per-repo pipeline concurrency cap

Problem:
`limit` resets every reconcile run (~1-2 min cycles), causing massive rebase churn — 2,142 "rebase limit reached" events in a 6h 52m window — with most triggered pipelines wasted.

Change:
`limit` now means "at most N MRs with active/successful pipelines at any time." Before rebasing, count MRs that already have running/pending/success pipelines and only rebase up to limit - already_active.

Backward compatible: when 0 MRs have active pipelines, behavior is identical to the old per-run counter.

Files:
reconcile/gitlab_housekeeping.py — split rebase_merge_requests() into a classification pass and a rebase pass
reconcile/test/test_gitlab_housekeeping.py — 12 tests covering budget calculation, edge cases, and backward compatibility


Validation
pytest: 31 passed
ruff lint: all checks passed
ruff format: clean
mypy: no issues

Assisted by Claude

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Selectable rebase strategies (top-k, active-cap, old-burst) via feature-variant; default remains old-burst. Strategy is resolved once per run.
  * Exposed feature-variant helper and Unleash client helper with safe fallback when env/config is missing.

* **Bug Fixes**
  * Rebase concurrency now correctly accounts for active/in-flight pipelines; timed-out pipelines can be canceled and running pipelines block retries. Failed rebases don’t consume budget.

* **Tests**
  * Comprehensive tests for strategies, budgeting, error handling, per-repo limits, dry-run behavior, and feature-variant mapping.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->