### PR TITLE
feat(change-log-tracking): write size-limited minimized-bundle-diffs.json

### DIFF
--- a/reconcile/change_owners/change_log_tracking.py
+++ b/reconcile/change_owners/change_log_tracking.py
@@ -1,7 +1,6 @@
 import logging
 from collections import defaultdict
 from collections.abc import Callable
-from datetime import UTC, datetime, timedelta
 
 from gitlab.v4.objects import (
     ProjectCommit,
@@ -63,7 +62,6 @@ class ChangeLogIntegrationParams(PydanticRunParams):
     gitlab_project_id: str
     process_existing: bool = False
     commit: str | None = None
-    lookback_days: int = 31
 
 
 class ChangeLogIntegration(QontractReconcileIntegration[ChangeLogIntegrationParams]):
@@ -142,10 +140,6 @@ class ChangeLogIntegration(QontractReconcileIntegration[ChangeLogIntegrationPara
 
             logging.info(f"Processing commit {commit}")
             gl_commit = gl.project.commits.get(commit)
-            if self.params.process_existing:
-                cutoff = datetime.now(UTC) - timedelta(days=self.params.lookback_days)
-                if datetime.fromisoformat(gl_commit.committed_date) < cutoff:
-                    continue
             change_log_item = ChangeLogItem(
                 commit=commit,
                 merged_at=gl_commit.committed_date,

--- a/reconcile/change_owners/change_log_tracking.py
+++ b/reconcile/change_owners/change_log_tracking.py
@@ -1,3 +1,4 @@
+import json
 import logging
 from collections import defaultdict
 from collections.abc import Callable
@@ -34,6 +35,8 @@ from reconcile.utils.state import init_state
 
 QONTRACT_INTEGRATION = "change-log-tracking"
 BUNDLE_DIFFS_OBJ = "bundle-diffs.json"
+MINIMIZED_BUNDLE_DIFFS_OBJ = "minimized-bundle-diffs.json"
+MINIMIZED_BUNDLE_DIFFS_SIZE_LIMIT_BYTES = 990 * 1024
 DEFAULT_MERGE_COMMIT_PREFIX = "Merge branch '"
 
 
@@ -241,3 +244,17 @@ class ChangeLogIntegration(QontractReconcileIntegration[ChangeLogIntegrationPara
         )
         if not dry_run:
             integration_state.add(BUNDLE_DIFFS_OBJ, change_log.model_dump(), force=True)
+            minimized_items = list(change_log.items)
+            while (
+                minimized_items
+                and len(
+                    json.dumps(ChangeLog(items=minimized_items).model_dump()).encode()
+                )
+                >= MINIMIZED_BUNDLE_DIFFS_SIZE_LIMIT_BYTES
+            ):
+                minimized_items.pop()
+            integration_state.add(
+                MINIMIZED_BUNDLE_DIFFS_OBJ,
+                ChangeLog(items=minimized_items).model_dump(),
+                force=True,
+            )

--- a/reconcile/change_owners/change_log_tracking.py
+++ b/reconcile/change_owners/change_log_tracking.py
@@ -37,7 +37,6 @@ QONTRACT_INTEGRATION = "change-log-tracking"
 BUNDLE_DIFFS_OBJ = "bundle-diffs.json"
 PROCESSED_COMMITS_OBJ = "processed-commits.json"
 DEFAULT_MERGE_COMMIT_PREFIX = "Merge branch '"
-MAX_CHANGE_LOG_ITEMS = 3000
 
 
 class ChangeLogItem(BaseModel):
@@ -256,10 +255,9 @@ class ChangeLogIntegration(QontractReconcileIntegration[ChangeLogIntegrationPara
         logging.info(f"apps: {change_log.apps}")
         logging.info(f"change_types: {change_log.change_types}")
 
-        sorted_items = sorted(change_log.items, key=lambda i: i.merged_at, reverse=True)
-        for overflow_item in sorted_items[MAX_CHANGE_LOG_ITEMS:]:
-            processed_commits[overflow_item.commit] = overflow_item.merged_at
-        change_log.items = sorted_items[:MAX_CHANGE_LOG_ITEMS]
+        change_log.items = sorted(
+            change_log.items, key=lambda i: i.merged_at, reverse=True
+        )
         if not dry_run:
             integration_state.add(BUNDLE_DIFFS_OBJ, change_log.model_dump(), force=True)
             integration_state.add(PROCESSED_COMMITS_OBJ, processed_commits, force=True)

--- a/reconcile/change_owners/change_log_tracking.py
+++ b/reconcile/change_owners/change_log_tracking.py
@@ -35,7 +35,6 @@ from reconcile.utils.state import init_state
 
 QONTRACT_INTEGRATION = "change-log-tracking"
 BUNDLE_DIFFS_OBJ = "bundle-diffs.json"
-PROCESSED_COMMITS_OBJ = "processed-commits.json"
 DEFAULT_MERGE_COMMIT_PREFIX = "Merge branch '"
 
 
@@ -123,16 +122,9 @@ class ChangeLogIntegration(QontractReconcileIntegration[ChangeLogIntegrationPara
             defer(diff_state.cleanup)
             defer(gl.cleanup)
 
-        existing_change_log = ChangeLog()
-        # commit sha -> committed_date for commits older than lookback_days;
-        # lets normal runs skip stale commits without a GitLab API call.
-        # ignored when --process-existing rebuilds state from scratch.
-        processed_commits: dict[str, str] = {}
         if not self.params.process_existing:
             existing_change_log = ChangeLog(**integration_state.get(BUNDLE_DIFFS_OBJ))
-            processed_commits = integration_state.get(PROCESSED_COMMITS_OBJ, {})
 
-        cutoff = datetime.now(UTC) - timedelta(days=self.params.lookback_days)
         change_log = ChangeLog()
         for item in diff_state.ls():
             key = item.lstrip("/")
@@ -147,18 +139,13 @@ class ChangeLogIntegration(QontractReconcileIntegration[ChangeLogIntegrationPara
                     logging.debug(f"Found existing commit {commit}")
                     change_log.items.append(existing_change_log_item)
                     continue
-                if commit in processed_commits:
-                    if datetime.fromisoformat(processed_commits[commit]) < cutoff:
-                        logging.debug(f"Skipping already processed commit {commit}")
-                        continue
-                    # lookback_days was increased — commit is now within window, re-process
-                    del processed_commits[commit]
 
             logging.info(f"Processing commit {commit}")
             gl_commit = gl.project.commits.get(commit)
-            if datetime.fromisoformat(gl_commit.committed_date) < cutoff:
-                processed_commits[commit] = gl_commit.committed_date
-                continue
+            if self.params.process_existing:
+                cutoff = datetime.now(UTC) - timedelta(days=self.params.lookback_days)
+                if datetime.fromisoformat(gl_commit.committed_date) < cutoff:
+                    continue
             change_log_item = ChangeLogItem(
                 commit=commit,
                 merged_at=gl_commit.committed_date,
@@ -260,4 +247,3 @@ class ChangeLogIntegration(QontractReconcileIntegration[ChangeLogIntegrationPara
         )
         if not dry_run:
             integration_state.add(BUNDLE_DIFFS_OBJ, change_log.model_dump(), force=True)
-            integration_state.add(PROCESSED_COMMITS_OBJ, processed_commits, force=True)

--- a/reconcile/change_owners/change_log_tracking.py
+++ b/reconcile/change_owners/change_log_tracking.py
@@ -252,7 +252,9 @@ class ChangeLogIntegration(QontractReconcileIntegration[ChangeLogIntegrationPara
                 )
                 >= MINIMIZED_BUNDLE_DIFFS_SIZE_LIMIT_BYTES
             ):
-                minimized_items.pop()
+                # drop 5 at a time to reduce re-serializations; losing a few
+                # extra entries out of ~3500 is negligible
+                del minimized_items[-5:]
             integration_state.add(
                 MINIMIZED_BUNDLE_DIFFS_OBJ,
                 ChangeLog(items=minimized_items).model_dump(),

--- a/reconcile/test/change_owners/test_change_log_tracking.py
+++ b/reconcile/test/change_owners/test_change_log_tracking.py
@@ -1,5 +1,4 @@
 from collections.abc import Callable
-from datetime import UTC, datetime
 from typing import Any
 from unittest.mock import create_autospec
 
@@ -24,11 +23,7 @@ from reconcile.gql_definitions.common.apps import AppV1
 from reconcile.utils.gql import GqlApi
 
 APP_PATH = "/services/a/app.yml"
-FIXED_NOW = datetime(2024, 3, 1, 0, 0, 0, tzinfo=UTC)
-MERGED_AT = (
-    "2024-02-15T00:00:00+00:00"  # 14 days before FIXED_NOW, within 30-day window
-)
-MERGED_AT_OLD = "2024-01-01T00:00:00+00:00"  # 60 days before FIXED_NOW, outside window
+MERGED_AT = "2024-01-01T00:00:00Z"
 COMMIT_SHA = "commit_sha"
 
 
@@ -39,7 +34,6 @@ def setup_mocks(
     apps: list[AppV1],
     datafiles: dict[str, Any],
     commit_message: str,
-    committed_date: str = MERGED_AT,
 ) -> dict[str, Any]:
     data = gql_class_factory(ChangeTypesQueryData, {})
     mocked_gql_api = gql_api_builder(data.model_dump(by_alias=True))
@@ -77,15 +71,11 @@ def setup_mocks(
     project.commits = create_autospec(ProjectCommitManager)
     commit = create_autospec(
         ProjectCommit,
-        committed_date=committed_date,
+        committed_date=MERGED_AT,
         message=commit_message,
     )
     project.commits.get.return_value = commit
     mocked_gl.project = project
-
-    mock_datetime = mocker.patch("reconcile.change_owners.change_log_tracking.datetime")
-    mock_datetime.now.return_value = FIXED_NOW
-    mock_datetime.fromisoformat = datetime.fromisoformat
 
     return {
         "state": mocked_state,
@@ -152,36 +142,5 @@ def test_change_log_tracking_with_deleted_app(
     mocks["state"].add.assert_called_once_with(
         "bundle-diffs.json",
         expected_change_log.model_dump(),
-        force=True,
-    )
-
-
-def test_change_log_tracking_filters_old_commits(
-    mocker: MockerFixture,
-    gql_api_builder: Callable[..., GqlApi],
-    gql_class_factory: Callable[..., ChangeTypesQueryData],
-) -> None:
-    mocks = setup_mocks(
-        mocker,
-        gql_api_builder,
-        gql_class_factory,
-        apps=[],
-        datafiles={},
-        commit_message="some change",
-        committed_date=MERGED_AT_OLD,
-    )
-    integration = ChangeLogIntegration(
-        ChangeLogIntegrationParams(
-            gitlab_project_id="test",
-            process_existing=True,
-            commit=None,
-        )
-    )
-
-    integration.run(dry_run=False)
-
-    mocks["state"].add.assert_called_once_with(
-        "bundle-diffs.json",
-        ChangeLog().model_dump(),
         force=True,
     )

--- a/reconcile/test/change_owners/test_change_log_tracking.py
+++ b/reconcile/test/change_owners/test_change_log_tracking.py
@@ -1,6 +1,6 @@
 from collections.abc import Callable
 from typing import Any
-from unittest.mock import create_autospec
+from unittest.mock import call, create_autospec
 
 import pytest
 from gitlab.v4.objects import (
@@ -11,6 +11,8 @@ from gitlab.v4.objects import (
 from pytest_mock import MockerFixture
 
 from reconcile.change_owners.change_log_tracking import (
+    BUNDLE_DIFFS_OBJ,
+    MINIMIZED_BUNDLE_DIFFS_OBJ,
     ChangeLog,
     ChangeLogIntegration,
     ChangeLogIntegrationParams,
@@ -139,8 +141,7 @@ def test_change_log_tracking_with_deleted_app(
 
     integration.run(dry_run=False)
 
-    mocks["state"].add.assert_called_once_with(
-        "bundle-diffs.json",
-        expected_change_log.model_dump(),
-        force=True,
-    )
+    mocks["state"].add.assert_has_calls([
+        call(BUNDLE_DIFFS_OBJ, expected_change_log.model_dump(), force=True),
+        call(MINIMIZED_BUNDLE_DIFFS_OBJ, expected_change_log.model_dump(), force=True),
+    ])

--- a/reconcile/test/change_owners/test_change_log_tracking.py
+++ b/reconcile/test/change_owners/test_change_log_tracking.py
@@ -12,8 +12,6 @@ from gitlab.v4.objects import (
 from pytest_mock import MockerFixture
 
 from reconcile.change_owners.change_log_tracking import (
-    BUNDLE_DIFFS_OBJ,
-    PROCESSED_COMMITS_OBJ,
     ChangeLog,
     ChangeLogIntegration,
     ChangeLogIntegrationParams,
@@ -151,8 +149,10 @@ def test_change_log_tracking_with_deleted_app(
 
     integration.run(dry_run=False)
 
-    mocks["state"].add.assert_any_call(
-        BUNDLE_DIFFS_OBJ, expected_change_log.model_dump(), force=True
+    mocks["state"].add.assert_called_once_with(
+        "bundle-diffs.json",
+        expected_change_log.model_dump(),
+        force=True,
     )
 
 
@@ -180,84 +180,8 @@ def test_change_log_tracking_filters_old_commits(
 
     integration.run(dry_run=False)
 
-    mocks["state"].add.assert_any_call(
-        BUNDLE_DIFFS_OBJ, ChangeLog().model_dump(), force=True
-    )
-    mocks["state"].add.assert_any_call(
-        PROCESSED_COMMITS_OBJ, {COMMIT_SHA: MERGED_AT_OLD}, force=True
-    )
-
-
-def test_change_log_tracking_adds_old_commit_to_processed_map(
-    mocker: MockerFixture,
-    gql_api_builder: Callable[..., GqlApi],
-    gql_class_factory: Callable[..., ChangeTypesQueryData],
-) -> None:
-    """Old commit not yet in the processed map: fetches from GitLab, filters it, records it."""
-    mocks = setup_mocks(
-        mocker,
-        gql_api_builder,
-        gql_class_factory,
-        apps=[],
-        datafiles={},
-        commit_message="some change",
-        committed_date=MERGED_AT_OLD,
-    )
-    mocks["state"].get.side_effect = lambda key, default=None: {
-        BUNDLE_DIFFS_OBJ: {"items": []},
-        PROCESSED_COMMITS_OBJ: {},
-    }.get(key, default)
-
-    integration = ChangeLogIntegration(
-        ChangeLogIntegrationParams(
-            gitlab_project_id="test",
-            process_existing=False,
-            commit=None,
-        )
-    )
-
-    integration.run(dry_run=False)
-
-    mocks["gl"].project.commits.get.assert_called_once_with(COMMIT_SHA)
-    mocks["state"].add.assert_any_call(
-        BUNDLE_DIFFS_OBJ, ChangeLog().model_dump(), force=True
-    )
-    mocks["state"].add.assert_any_call(
-        PROCESSED_COMMITS_OBJ, {COMMIT_SHA: MERGED_AT_OLD}, force=True
-    )
-
-
-def test_change_log_tracking_skips_processed_commits_without_api_call(
-    mocker: MockerFixture,
-    gql_api_builder: Callable[..., GqlApi],
-    gql_class_factory: Callable[..., ChangeTypesQueryData],
-) -> None:
-    """Old commit already in the processed map: skipped without a GitLab API call."""
-    mocks = setup_mocks(
-        mocker,
-        gql_api_builder,
-        gql_class_factory,
-        apps=[],
-        datafiles={},
-        commit_message="some change",
-        committed_date=MERGED_AT_OLD,
-    )
-    mocks["state"].get.side_effect = lambda key, default=None: {
-        BUNDLE_DIFFS_OBJ: {"items": []},
-        PROCESSED_COMMITS_OBJ: {COMMIT_SHA: MERGED_AT_OLD},
-    }.get(key, default)
-
-    integration = ChangeLogIntegration(
-        ChangeLogIntegrationParams(
-            gitlab_project_id="test",
-            process_existing=False,
-            commit=None,
-        )
-    )
-
-    integration.run(dry_run=False)
-
-    mocks["gl"].project.commits.get.assert_not_called()
-    mocks["state"].add.assert_any_call(
-        PROCESSED_COMMITS_OBJ, {COMMIT_SHA: MERGED_AT_OLD}, force=True
+    mocks["state"].add.assert_called_once_with(
+        "bundle-diffs.json",
+        ChangeLog().model_dump(),
+        force=True,
     )


### PR DESCRIPTION
## Summary

- Reverts yesterday's change-log-tracking fixes (#5504, #5505, #5507) which hit a ConfigMap size limit
- Introduces `minimized-bundle-diffs.json` written alongside `bundle-diffs.json`, guaranteed to be under 990KB by dropping oldest entries until the size constraint is met

## Test plan

- [ ] Existing unit tests updated and passing
- [ ] Verify `minimized-bundle-diffs.json` is written to state after a dry-run=false run
- [ ] Verify content is identical to `bundle-diffs.json` when under 990KB
- [ ] Verify oldest entries are trimmed when over 990KB

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Removed time-based commit reprocessing from change log tracking
  * Simplified change log generation and item handling
  * Updated change log persistence and storage mechanism
  * Implemented automatic size optimization for stored change logs

<!-- end of auto-generated comment: release notes by coderabbit.ai -->