### PR TITLE
introduce ERv2 support for vpc-endpoint-service and vpc-endpoint providers

### DIFF
--- a/reconcile/external_resources/aws.py
+++ b/reconcile/external_resources/aws.py
@@ -333,6 +333,32 @@ class AWSMskFactory(AWSDefaultResourceFactory):
         }
 
 
+class AWSVpcEndpointServiceFactory(AWSDefaultResourceFactory):
+    def _build_arn(self, uid: str, terraform_username: str) -> str:
+        return f"arn:aws:iam::{uid}:user/{terraform_username}"
+
+    def resolve(
+        self,
+        spec: ExternalResourceSpec,
+        module_conf: ExternalResourceModuleConfiguration,
+    ) -> dict[str, Any]:
+        rvr = ResourceValueResolver(spec=spec, identifier_as_value=True)
+        data = rvr.resolve()
+
+        cluster_arns = [
+            self._build_arn(
+                c["spec"]["account"]["uid"],
+                c["spec"]["account"]["terraformUsername"],
+            )
+            for c in data.pop("allowed_consumer_clusters", []) or []
+            if c.get("spec", {}).get("account")
+        ]
+        explicit_arns = data.pop("allowed_principal_arns", []) or []
+        data["allowed_principal_arns"] = cluster_arns + explicit_arns
+
+        return data
+
+
 class AWSMskConnectFactory(AWSResourceFactory):
     def __init__(
         self,

--- a/reconcile/external_resources/aws.py
+++ b/reconcile/external_resources/aws.py
@@ -359,6 +359,26 @@ class AWSVpcEndpointServiceFactory(AWSDefaultResourceFactory):
         return data
 
 
+class AWSVpcEndpointFactory(AWSDefaultResourceFactory):
+    def resolve(
+        self,
+        spec: ExternalResourceSpec,
+        module_conf: ExternalResourceModuleConfiguration,
+    ) -> dict[str, Any]:
+        rvr = ResourceValueResolver(spec=spec, identifier_as_value=True)
+        data = rvr.resolve()
+
+        vpc = data.pop("vpc")
+        data["vpc_id"] = vpc["vpc_id"]
+        data["subnet_ids"] = [
+            s["id"] for s in vpc.get("subnets", []) if s.get("privacy") == "private"
+        ]
+        if region := vpc.get("region"):
+            data["region"] = region
+
+        return data
+
+
 class AWSMskConnectFactory(AWSResourceFactory):
     def __init__(
         self,

--- a/reconcile/external_resources/factories.py
+++ b/reconcile/external_resources/factories.py
@@ -11,6 +11,7 @@ from reconcile.external_resources.aws import (
     AWSMskFactory,
     AWSRdsFactory,
     AWSResourceFactory,
+    AWSVpcEndpointServiceFactory,
 )
 from reconcile.external_resources.cloudflare import (
     CloudflareDefaultResourceFactory,
@@ -110,6 +111,9 @@ def setup_aws_resource_factories(
             "msk": AWSMskFactory(er_inventory, secret_reader),
             "msk-connect": AWSMskConnectFactory(
                 er_inventory, secret_reader, vault_secrets_path
+            ),
+            "vpc-endpoint-service": AWSVpcEndpointServiceFactory(
+                er_inventory, secret_reader
             ),
         },
         default_factory=AWSDefaultResourceFactory(er_inventory, secret_reader),

--- a/reconcile/external_resources/factories.py
+++ b/reconcile/external_resources/factories.py
@@ -11,6 +11,7 @@ from reconcile.external_resources.aws import (
     AWSMskFactory,
     AWSRdsFactory,
     AWSResourceFactory,
+    AWSVpcEndpointFactory,
     AWSVpcEndpointServiceFactory,
 )
 from reconcile.external_resources.cloudflare import (
@@ -112,6 +113,7 @@ def setup_aws_resource_factories(
             "msk-connect": AWSMskConnectFactory(
                 er_inventory, secret_reader, vault_secrets_path
             ),
+            "vpc-endpoint": AWSVpcEndpointFactory(er_inventory, secret_reader),
             "vpc-endpoint-service": AWSVpcEndpointServiceFactory(
                 er_inventory, secret_reader
             ),

--- a/reconcile/external_resources/model.py
+++ b/reconcile/external_resources/model.py
@@ -26,6 +26,7 @@ from reconcile.gql_definitions.external_resources.external_resources_namespaces 
     NamespaceTerraformResourceRDSProxyV1,
     NamespaceTerraformResourceRDSV1,
     NamespaceTerraformResourceVpcEndpointServiceV1,
+    NamespaceTerraformResourceVpcEndpointV1,
     NamespaceV1,
 )
 from reconcile.gql_definitions.external_resources.external_resources_settings import (
@@ -110,6 +111,7 @@ SUPPORTED_RESOURCE_TYPES = (
     | NamespaceTerraformResourceCloudflareZoneV1
     | NamespaceTerraformResourceCloudflareAccountV1
     | NamespaceTerraformResourceVpcEndpointServiceV1
+    | NamespaceTerraformResourceVpcEndpointV1
 )
 
 

--- a/reconcile/external_resources/model.py
+++ b/reconcile/external_resources/model.py
@@ -25,6 +25,7 @@ from reconcile.gql_definitions.external_resources.external_resources_namespaces 
     NamespaceTerraformResourceMskV1,
     NamespaceTerraformResourceRDSProxyV1,
     NamespaceTerraformResourceRDSV1,
+    NamespaceTerraformResourceVpcEndpointServiceV1,
     NamespaceV1,
 )
 from reconcile.gql_definitions.external_resources.external_resources_settings import (
@@ -108,6 +109,7 @@ SUPPORTED_RESOURCE_TYPES = (
     | NamespaceTerraformResourceRDSProxyV1
     | NamespaceTerraformResourceCloudflareZoneV1
     | NamespaceTerraformResourceCloudflareAccountV1
+    | NamespaceTerraformResourceVpcEndpointServiceV1
 )
 
 

--- a/reconcile/gql_definitions/external_resources/external_resources_namespaces.gql
+++ b/reconcile/gql_definitions/external_resources/external_resources_namespaces.gql
@@ -501,6 +501,31 @@ query ExternalResourcesNamespaces {
               ...ExternalResourcesModuleOverrides
             }
           }
+          ... on NamespaceTerraformResourceVpcEndpointService_v1 {
+            region
+            identifier
+            openshift_service_name
+            allowed_consumer_clusters {
+              name
+              spec {
+                ... on ClusterSpecROSA_v1 {
+                  account {
+                    uid
+                    terraformUsername
+                  }
+                }
+              }
+            }
+            allowed_principal_arns
+            output_resource_name
+            annotations
+            tags
+            managed_by_erv2
+            delete
+            module_overrides {
+              ...ExternalResourcesModuleOverrides
+            }
+          }
         }
       }
       ... on NamespaceTerraformProviderResourceCloudflare_v1 {

--- a/reconcile/gql_definitions/external_resources/external_resources_namespaces.gql
+++ b/reconcile/gql_definitions/external_resources/external_resources_namespaces.gql
@@ -501,6 +501,26 @@ query ExternalResourcesNamespaces {
               ...ExternalResourcesModuleOverrides
             }
           }
+          ... on NamespaceTerraformResourceVpcEndpoint_v1 {
+            identifier
+            endpoint_service_name
+            vpc {
+              vpc_id
+              region
+              subnets {
+                id
+                privacy
+              }
+            }
+            output_resource_name
+            annotations
+            tags
+            managed_by_erv2
+            delete
+            module_overrides {
+              ...ExternalResourcesModuleOverrides
+            }
+          }
           ... on NamespaceTerraformResourceVpcEndpointService_v1 {
             region
             identifier

--- a/reconcile/gql_definitions/external_resources/external_resources_namespaces.py
+++ b/reconcile/gql_definitions/external_resources/external_resources_namespaces.py
@@ -583,6 +583,31 @@ query ExternalResourcesNamespaces {
               ...ExternalResourcesModuleOverrides
             }
           }
+          ... on NamespaceTerraformResourceVpcEndpointService_v1 {
+            region
+            identifier
+            openshift_service_name
+            allowed_consumer_clusters {
+              name
+              spec {
+                ... on ClusterSpecROSA_v1 {
+                  account {
+                    uid
+                    terraformUsername
+                  }
+                }
+              }
+            }
+            allowed_principal_arns
+            output_resource_name
+            annotations
+            tags
+            managed_by_erv2
+            delete
+            module_overrides {
+              ...ExternalResourcesModuleOverrides
+            }
+          }
         }
       }
       ... on NamespaceTerraformProviderResourceCloudflare_v1 {
@@ -1227,9 +1252,41 @@ class NamespaceTerraformResourceMskConnectV1(NamespaceTerraformResourceAWSV1):
     module_overrides: Optional[ExternalResourcesModuleOverrides] = Field(..., alias="module_overrides")
 
 
+class ClusterSpecV1(ConfiguredBaseModel):
+    ...
+
+
+class ClusterSpecROSAV1_AWSAccountV1(ConfiguredBaseModel):
+    uid: str = Field(..., alias="uid")
+    terraform_username: Optional[str] = Field(..., alias="terraformUsername")
+
+
+class ClusterSpecROSAV1(ClusterSpecV1):
+    account: Optional[ClusterSpecROSAV1_AWSAccountV1] = Field(..., alias="account")
+
+
+class NamespaceTerraformResourceVpcEndpointServiceV1_ClusterV1(ConfiguredBaseModel):
+    name: str = Field(..., alias="name")
+    spec: Optional[Union[ClusterSpecROSAV1, ClusterSpecV1]] = Field(..., alias="spec")
+
+
+class NamespaceTerraformResourceVpcEndpointServiceV1(NamespaceTerraformResourceAWSV1):
+    region: Optional[str] = Field(..., alias="region")
+    identifier: str = Field(..., alias="identifier")
+    openshift_service_name: str = Field(..., alias="openshift_service_name")
+    allowed_consumer_clusters: Optional[list[NamespaceTerraformResourceVpcEndpointServiceV1_ClusterV1]] = Field(..., alias="allowed_consumer_clusters")
+    allowed_principal_arns: Optional[list[str]] = Field(..., alias="allowed_principal_arns")
+    output_resource_name: Optional[str] = Field(..., alias="output_resource_name")
+    annotations: Optional[str] = Field(..., alias="annotations")
+    tags: Optional[str] = Field(..., alias="tags")
+    managed_by_erv2: Optional[bool] = Field(..., alias="managed_by_erv2")
+    delete: Optional[bool] = Field(..., alias="delete")
+    module_overrides: Optional[ExternalResourcesModuleOverrides] = Field(..., alias="module_overrides")
+
+
 class NamespaceTerraformProviderResourceAWSV1(NamespaceExternalResourceV1):
     provisioner: AWSAccountV1 = Field(..., alias="provisioner")
-    resources: list[Union[NamespaceTerraformResourceRDSV1, NamespaceTerraformResourceRosaAuthenticatorV1, NamespaceTerraformResourceALBV1, NamespaceTerraformResourceS3V1, NamespaceTerraformResourceElastiCacheV1, NamespaceTerraformResourceCloudWatchV1, NamespaceTerraformResourceASGV1, NamespaceTerraformResourceMskConnectV1, NamespaceTerraformResourceRDSProxyV1, NamespaceTerraformResourceRoleV1, NamespaceTerraformResourceKMSV1, NamespaceTerraformResourceMskV1, NamespaceTerraformResourceSNSTopicV1, NamespaceTerraformResourceServiceAccountV1, NamespaceTerraformResourceS3SQSV1, NamespaceTerraformResourceKinesisV1, NamespaceTerraformResourceRosaAuthenticatorVPCEV1, NamespaceTerraformResourceS3CloudFrontV1, NamespaceTerraformResourceElasticSearchV1, NamespaceTerraformResourceACMV1, NamespaceTerraformResourceRoute53ZoneV1, NamespaceTerraformResourceSQSV1, NamespaceTerraformResourceDynamoDBV1, NamespaceTerraformResourceECRV1, NamespaceTerraformResourceS3CloudFrontPublicKeyV1, NamespaceTerraformResourceSecretsManagerV1, NamespaceTerraformResourceSecretsManagerServiceAccountV1, NamespaceTerraformResourceAWSV1]] = Field(..., alias="resources")
+    resources: list[Union[NamespaceTerraformResourceRDSV1, NamespaceTerraformResourceRosaAuthenticatorV1, NamespaceTerraformResourceALBV1, NamespaceTerraformResourceS3V1, NamespaceTerraformResourceElastiCacheV1, NamespaceTerraformResourceCloudWatchV1, NamespaceTerraformResourceASGV1, NamespaceTerraformResourceMskConnectV1, NamespaceTerraformResourceVpcEndpointServiceV1, NamespaceTerraformResourceRDSProxyV1, NamespaceTerraformResourceRoleV1, NamespaceTerraformResourceKMSV1, NamespaceTerraformResourceMskV1, NamespaceTerraformResourceSNSTopicV1, NamespaceTerraformResourceServiceAccountV1, NamespaceTerraformResourceS3SQSV1, NamespaceTerraformResourceKinesisV1, NamespaceTerraformResourceRosaAuthenticatorVPCEV1, NamespaceTerraformResourceS3CloudFrontV1, NamespaceTerraformResourceElasticSearchV1, NamespaceTerraformResourceACMV1, NamespaceTerraformResourceRoute53ZoneV1, NamespaceTerraformResourceSQSV1, NamespaceTerraformResourceDynamoDBV1, NamespaceTerraformResourceECRV1, NamespaceTerraformResourceS3CloudFrontPublicKeyV1, NamespaceTerraformResourceSecretsManagerV1, NamespaceTerraformResourceSecretsManagerServiceAccountV1, NamespaceTerraformResourceAWSV1]] = Field(..., alias="resources")
 
 
 class CloudflareAccountV1(ConfiguredBaseModel):
@@ -1278,7 +1335,7 @@ class AppV1(ConfiguredBaseModel):
     cost_center: Optional[str] = Field(..., alias="costCenter")
 
 
-class ClusterSpecV1(ConfiguredBaseModel):
+class NamespaceV1_ClusterV1_ClusterSpecV1(ConfiguredBaseModel):
     region: str = Field(..., alias="region")
 
 
@@ -1293,7 +1350,7 @@ class NamespaceV1_ClusterV1(ConfiguredBaseModel):
     jump_host: Optional[CommonJumphostFields] = Field(..., alias="jumpHost")
     automation_token: Optional[VaultSecret] = Field(..., alias="automationToken")
     cluster_admin_automation_token: Optional[VaultSecret] = Field(..., alias="clusterAdminAutomationToken")
-    spec: Optional[ClusterSpecV1] = Field(..., alias="spec")
+    spec: Optional[NamespaceV1_ClusterV1_ClusterSpecV1] = Field(..., alias="spec")
     internal: Optional[bool] = Field(..., alias="internal")
     disable: Optional[DisableClusterAutomationsV1] = Field(..., alias="disable")
 

--- a/reconcile/gql_definitions/external_resources/external_resources_namespaces.py
+++ b/reconcile/gql_definitions/external_resources/external_resources_namespaces.py
@@ -583,6 +583,26 @@ query ExternalResourcesNamespaces {
               ...ExternalResourcesModuleOverrides
             }
           }
+          ... on NamespaceTerraformResourceVpcEndpoint_v1 {
+            identifier
+            endpoint_service_name
+            vpc {
+              vpc_id
+              region
+              subnets {
+                id
+                privacy
+              }
+            }
+            output_resource_name
+            annotations
+            tags
+            managed_by_erv2
+            delete
+            module_overrides {
+              ...ExternalResourcesModuleOverrides
+            }
+          }
           ... on NamespaceTerraformResourceVpcEndpointService_v1 {
             region
             identifier
@@ -1252,6 +1272,29 @@ class NamespaceTerraformResourceMskConnectV1(NamespaceTerraformResourceAWSV1):
     module_overrides: Optional[ExternalResourcesModuleOverrides] = Field(..., alias="module_overrides")
 
 
+class AWSSubnetV1(ConfiguredBaseModel):
+    q_id: str = Field(..., alias="id")
+    privacy: Optional[str] = Field(..., alias="privacy")
+
+
+class NamespaceTerraformResourceVpcEndpointV1_AWSVPCV1(ConfiguredBaseModel):
+    vpc_id: str = Field(..., alias="vpc_id")
+    region: str = Field(..., alias="region")
+    subnets: Optional[list[AWSSubnetV1]] = Field(..., alias="subnets")
+
+
+class NamespaceTerraformResourceVpcEndpointV1(NamespaceTerraformResourceAWSV1):
+    identifier: str = Field(..., alias="identifier")
+    endpoint_service_name: str = Field(..., alias="endpoint_service_name")
+    vpc: NamespaceTerraformResourceVpcEndpointV1_AWSVPCV1 = Field(..., alias="vpc")
+    output_resource_name: Optional[str] = Field(..., alias="output_resource_name")
+    annotations: Optional[str] = Field(..., alias="annotations")
+    tags: Optional[str] = Field(..., alias="tags")
+    managed_by_erv2: Optional[bool] = Field(..., alias="managed_by_erv2")
+    delete: Optional[bool] = Field(..., alias="delete")
+    module_overrides: Optional[ExternalResourcesModuleOverrides] = Field(..., alias="module_overrides")
+
+
 class ClusterSpecV1(ConfiguredBaseModel):
     ...
 
@@ -1286,7 +1329,7 @@ class NamespaceTerraformResourceVpcEndpointServiceV1(NamespaceTerraformResourceA
 
 class NamespaceTerraformProviderResourceAWSV1(NamespaceExternalResourceV1):
     provisioner: AWSAccountV1 = Field(..., alias="provisioner")
-    resources: list[Union[NamespaceTerraformResourceRDSV1, NamespaceTerraformResourceRosaAuthenticatorV1, NamespaceTerraformResourceALBV1, NamespaceTerraformResourceS3V1, NamespaceTerraformResourceElastiCacheV1, NamespaceTerraformResourceCloudWatchV1, NamespaceTerraformResourceASGV1, NamespaceTerraformResourceMskConnectV1, NamespaceTerraformResourceVpcEndpointServiceV1, NamespaceTerraformResourceRDSProxyV1, NamespaceTerraformResourceRoleV1, NamespaceTerraformResourceKMSV1, NamespaceTerraformResourceMskV1, NamespaceTerraformResourceSNSTopicV1, NamespaceTerraformResourceServiceAccountV1, NamespaceTerraformResourceS3SQSV1, NamespaceTerraformResourceKinesisV1, NamespaceTerraformResourceRosaAuthenticatorVPCEV1, NamespaceTerraformResourceS3CloudFrontV1, NamespaceTerraformResourceElasticSearchV1, NamespaceTerraformResourceACMV1, NamespaceTerraformResourceRoute53ZoneV1, NamespaceTerraformResourceSQSV1, NamespaceTerraformResourceDynamoDBV1, NamespaceTerraformResourceECRV1, NamespaceTerraformResourceS3CloudFrontPublicKeyV1, NamespaceTerraformResourceSecretsManagerV1, NamespaceTerraformResourceSecretsManagerServiceAccountV1, NamespaceTerraformResourceAWSV1]] = Field(..., alias="resources")
+    resources: list[Union[NamespaceTerraformResourceRDSV1, NamespaceTerraformResourceRosaAuthenticatorV1, NamespaceTerraformResourceALBV1, NamespaceTerraformResourceS3V1, NamespaceTerraformResourceElastiCacheV1, NamespaceTerraformResourceCloudWatchV1, NamespaceTerraformResourceASGV1, NamespaceTerraformResourceMskConnectV1, NamespaceTerraformResourceVpcEndpointServiceV1, NamespaceTerraformResourceRDSProxyV1, NamespaceTerraformResourceRoleV1, NamespaceTerraformResourceKMSV1, NamespaceTerraformResourceMskV1, NamespaceTerraformResourceSNSTopicV1, NamespaceTerraformResourceVpcEndpointV1, NamespaceTerraformResourceServiceAccountV1, NamespaceTerraformResourceS3SQSV1, NamespaceTerraformResourceKinesisV1, NamespaceTerraformResourceRosaAuthenticatorVPCEV1, NamespaceTerraformResourceS3CloudFrontV1, NamespaceTerraformResourceElasticSearchV1, NamespaceTerraformResourceACMV1, NamespaceTerraformResourceRoute53ZoneV1, NamespaceTerraformResourceSQSV1, NamespaceTerraformResourceDynamoDBV1, NamespaceTerraformResourceECRV1, NamespaceTerraformResourceS3CloudFrontPublicKeyV1, NamespaceTerraformResourceSecretsManagerV1, NamespaceTerraformResourceSecretsManagerServiceAccountV1, NamespaceTerraformResourceAWSV1]] = Field(..., alias="resources")
 
 
 class CloudflareAccountV1(ConfiguredBaseModel):

--- a/reconcile/gql_definitions/introspection.json
+++ b/reconcile/gql_definitions/introspection.json
@@ -18874,6 +18874,16 @@
                         },
                         {
                             "kind": "OBJECT",
+                            "name": "NamespaceTerraformResourceVpcEndpointService_v1",
+                            "ofType": null
+                        },
+                        {
+                            "kind": "OBJECT",
+                            "name": "NamespaceTerraformResourceVpcEndpoint_v1",
+                            "ofType": null
+                        },
+                        {
+                            "kind": "OBJECT",
                             "name": "NamespaceTerraformResourceRDS_v1",
                             "ofType": null
                         },
@@ -21210,6 +21220,372 @@
                                     "name": "String",
                                     "ofType": null
                                 }
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "managed_by_erv2",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "SCALAR",
+                                "name": "Boolean",
+                                "ofType": null
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "delete",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "SCALAR",
+                                "name": "Boolean",
+                                "ofType": null
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "module_overrides",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "OBJECT",
+                                "name": "ExternalResourcesModuleOverrides_v1",
+                                "ofType": null
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "tags",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "SCALAR",
+                                "name": "JSON",
+                                "ofType": null
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        }
+                    ],
+                    "inputFields": null,
+                    "interfaces": [
+                        {
+                            "kind": "INTERFACE",
+                            "name": "NamespaceTerraformResourceAWS_v1",
+                            "ofType": null
+                        }
+                    ],
+                    "enumValues": null,
+                    "possibleTypes": null
+                },
+                {
+                    "kind": "OBJECT",
+                    "name": "NamespaceTerraformResourceVpcEndpointService_v1",
+                    "description": null,
+                    "fields": [
+                        {
+                            "name": "provider",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "NON_NULL",
+                                "name": null,
+                                "ofType": {
+                                    "kind": "SCALAR",
+                                    "name": "String",
+                                    "ofType": null
+                                }
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "region",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "SCALAR",
+                                "name": "String",
+                                "ofType": null
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "identifier",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "NON_NULL",
+                                "name": null,
+                                "ofType": {
+                                    "kind": "SCALAR",
+                                    "name": "String",
+                                    "ofType": null
+                                }
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "openshift_service_name",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "NON_NULL",
+                                "name": null,
+                                "ofType": {
+                                    "kind": "SCALAR",
+                                    "name": "String",
+                                    "ofType": null
+                                }
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "allowed_consumer_clusters",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "LIST",
+                                "name": null,
+                                "ofType": {
+                                    "kind": "NON_NULL",
+                                    "name": null,
+                                    "ofType": {
+                                        "kind": "OBJECT",
+                                        "name": "Cluster_v1",
+                                        "ofType": null
+                                    }
+                                }
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "allowed_principal_arns",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "LIST",
+                                "name": null,
+                                "ofType": {
+                                    "kind": "NON_NULL",
+                                    "name": null,
+                                    "ofType": {
+                                        "kind": "SCALAR",
+                                        "name": "String",
+                                        "ofType": null
+                                    }
+                                }
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "output_resource_name",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "SCALAR",
+                                "name": "String",
+                                "ofType": null
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "output_format",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "INTERFACE",
+                                "name": "NamespaceTerraformResourceOutputFormat_v1",
+                                "ofType": null
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "annotations",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "SCALAR",
+                                "name": "JSON",
+                                "ofType": null
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "managed_by_erv2",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "SCALAR",
+                                "name": "Boolean",
+                                "ofType": null
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "delete",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "SCALAR",
+                                "name": "Boolean",
+                                "ofType": null
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "module_overrides",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "OBJECT",
+                                "name": "ExternalResourcesModuleOverrides_v1",
+                                "ofType": null
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "tags",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "SCALAR",
+                                "name": "JSON",
+                                "ofType": null
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        }
+                    ],
+                    "inputFields": null,
+                    "interfaces": [
+                        {
+                            "kind": "INTERFACE",
+                            "name": "NamespaceTerraformResourceAWS_v1",
+                            "ofType": null
+                        }
+                    ],
+                    "enumValues": null,
+                    "possibleTypes": null
+                },
+                {
+                    "kind": "OBJECT",
+                    "name": "NamespaceTerraformResourceVpcEndpoint_v1",
+                    "description": null,
+                    "fields": [
+                        {
+                            "name": "provider",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "NON_NULL",
+                                "name": null,
+                                "ofType": {
+                                    "kind": "SCALAR",
+                                    "name": "String",
+                                    "ofType": null
+                                }
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "identifier",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "NON_NULL",
+                                "name": null,
+                                "ofType": {
+                                    "kind": "SCALAR",
+                                    "name": "String",
+                                    "ofType": null
+                                }
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "endpoint_service_name",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "NON_NULL",
+                                "name": null,
+                                "ofType": {
+                                    "kind": "SCALAR",
+                                    "name": "String",
+                                    "ofType": null
+                                }
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "vpc",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "NON_NULL",
+                                "name": null,
+                                "ofType": {
+                                    "kind": "OBJECT",
+                                    "name": "AWSVPC_v1",
+                                    "ofType": null
+                                }
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "output_resource_name",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "SCALAR",
+                                "name": "String",
+                                "ofType": null
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "output_format",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "INTERFACE",
+                                "name": "NamespaceTerraformResourceOutputFormat_v1",
+                                "ofType": null
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "annotations",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "SCALAR",
+                                "name": "JSON",
+                                "ofType": null
                             },
                             "isDeprecated": false,
                             "deprecationReason": null

--- a/reconcile/gql_definitions/terraform_resources/terraform_resources_namespaces.gql
+++ b/reconcile/gql_definitions/terraform_resources/terraform_resources_namespaces.gql
@@ -466,6 +466,10 @@ query TerraformResourcesNamespaces {
             annotations
             managed_by_erv2
           }
+          ... on NamespaceTerraformResourceVpcEndpointService_v1 {
+            identifier
+            managed_by_erv2
+          }
         }
       }
     }

--- a/reconcile/gql_definitions/terraform_resources/terraform_resources_namespaces.gql
+++ b/reconcile/gql_definitions/terraform_resources/terraform_resources_namespaces.gql
@@ -470,6 +470,10 @@ query TerraformResourcesNamespaces {
             identifier
             managed_by_erv2
           }
+          ... on NamespaceTerraformResourceVpcEndpoint_v1 {
+            identifier
+            managed_by_erv2
+          }
         }
       }
     }

--- a/reconcile/gql_definitions/terraform_resources/terraform_resources_namespaces.py
+++ b/reconcile/gql_definitions/terraform_resources/terraform_resources_namespaces.py
@@ -523,6 +523,10 @@ query TerraformResourcesNamespaces {
             annotations
             managed_by_erv2
           }
+          ... on NamespaceTerraformResourceVpcEndpointService_v1 {
+            identifier
+            managed_by_erv2
+          }
         }
       }
     }
@@ -1121,8 +1125,13 @@ class NamespaceTerraformResourceMskConnectV1(NamespaceTerraformResourceAWSV1):
     managed_by_erv2: Optional[bool] = Field(..., alias="managed_by_erv2")
 
 
+class NamespaceTerraformResourceVpcEndpointServiceV1(NamespaceTerraformResourceAWSV1):
+    identifier: str = Field(..., alias="identifier")
+    managed_by_erv2: Optional[bool] = Field(..., alias="managed_by_erv2")
+
+
 class NamespaceTerraformProviderResourceAWSV1(NamespaceExternalResourceV1):
-    resources: list[Union[NamespaceTerraformResourceRDSV1, NamespaceTerraformResourceALBV1, NamespaceTerraformResourceRosaAuthenticatorV1, NamespaceTerraformResourceRoleV1, NamespaceTerraformResourceS3V1, NamespaceTerraformResourceASGV1, NamespaceTerraformResourceRDSProxyV1, NamespaceTerraformResourceElastiCacheV1, NamespaceTerraformResourceSNSTopicV1, NamespaceTerraformResourceCloudWatchV1, NamespaceTerraformResourceServiceAccountV1, NamespaceTerraformResourceS3CloudFrontV1, NamespaceTerraformResourceS3SQSV1, NamespaceTerraformResourceKMSV1, NamespaceTerraformResourceKinesisV1, NamespaceTerraformResourceRosaAuthenticatorVPCEV1, NamespaceTerraformResourceMskV1, NamespaceTerraformResourceElasticSearchV1, NamespaceTerraformResourceACMV1, NamespaceTerraformResourceSecretsManagerV1, NamespaceTerraformResourceRoute53ZoneV1, NamespaceTerraformResourceMskConnectV1, NamespaceTerraformResourceSQSV1, NamespaceTerraformResourceDynamoDBV1, NamespaceTerraformResourceECRV1, NamespaceTerraformResourceS3CloudFrontPublicKeyV1, NamespaceTerraformResourceSecretsManagerServiceAccountV1, NamespaceTerraformResourceAWSV1]] = Field(..., alias="resources")
+    resources: list[Union[NamespaceTerraformResourceRDSV1, NamespaceTerraformResourceALBV1, NamespaceTerraformResourceRosaAuthenticatorV1, NamespaceTerraformResourceRoleV1, NamespaceTerraformResourceS3V1, NamespaceTerraformResourceASGV1, NamespaceTerraformResourceRDSProxyV1, NamespaceTerraformResourceElastiCacheV1, NamespaceTerraformResourceSNSTopicV1, NamespaceTerraformResourceCloudWatchV1, NamespaceTerraformResourceServiceAccountV1, NamespaceTerraformResourceS3CloudFrontV1, NamespaceTerraformResourceS3SQSV1, NamespaceTerraformResourceKMSV1, NamespaceTerraformResourceKinesisV1, NamespaceTerraformResourceRosaAuthenticatorVPCEV1, NamespaceTerraformResourceMskV1, NamespaceTerraformResourceElasticSearchV1, NamespaceTerraformResourceACMV1, NamespaceTerraformResourceSecretsManagerV1, NamespaceTerraformResourceRoute53ZoneV1, NamespaceTerraformResourceMskConnectV1, NamespaceTerraformResourceSQSV1, NamespaceTerraformResourceDynamoDBV1, NamespaceTerraformResourceECRV1, NamespaceTerraformResourceS3CloudFrontPublicKeyV1, NamespaceTerraformResourceSecretsManagerServiceAccountV1, NamespaceTerraformResourceVpcEndpointServiceV1, NamespaceTerraformResourceAWSV1]] = Field(..., alias="resources")
 
 
 class EnvironmentV1(ConfiguredBaseModel):

--- a/reconcile/gql_definitions/terraform_resources/terraform_resources_namespaces.py
+++ b/reconcile/gql_definitions/terraform_resources/terraform_resources_namespaces.py
@@ -527,6 +527,10 @@ query TerraformResourcesNamespaces {
             identifier
             managed_by_erv2
           }
+          ... on NamespaceTerraformResourceVpcEndpoint_v1 {
+            identifier
+            managed_by_erv2
+          }
         }
       }
     }
@@ -1130,8 +1134,13 @@ class NamespaceTerraformResourceVpcEndpointServiceV1(NamespaceTerraformResourceA
     managed_by_erv2: Optional[bool] = Field(..., alias="managed_by_erv2")
 
 
+class NamespaceTerraformResourceVpcEndpointV1(NamespaceTerraformResourceAWSV1):
+    identifier: str = Field(..., alias="identifier")
+    managed_by_erv2: Optional[bool] = Field(..., alias="managed_by_erv2")
+
+
 class NamespaceTerraformProviderResourceAWSV1(NamespaceExternalResourceV1):
-    resources: list[Union[NamespaceTerraformResourceRDSV1, NamespaceTerraformResourceALBV1, NamespaceTerraformResourceRosaAuthenticatorV1, NamespaceTerraformResourceRoleV1, NamespaceTerraformResourceS3V1, NamespaceTerraformResourceASGV1, NamespaceTerraformResourceRDSProxyV1, NamespaceTerraformResourceElastiCacheV1, NamespaceTerraformResourceSNSTopicV1, NamespaceTerraformResourceCloudWatchV1, NamespaceTerraformResourceServiceAccountV1, NamespaceTerraformResourceS3CloudFrontV1, NamespaceTerraformResourceS3SQSV1, NamespaceTerraformResourceKMSV1, NamespaceTerraformResourceKinesisV1, NamespaceTerraformResourceRosaAuthenticatorVPCEV1, NamespaceTerraformResourceMskV1, NamespaceTerraformResourceElasticSearchV1, NamespaceTerraformResourceACMV1, NamespaceTerraformResourceSecretsManagerV1, NamespaceTerraformResourceRoute53ZoneV1, NamespaceTerraformResourceMskConnectV1, NamespaceTerraformResourceSQSV1, NamespaceTerraformResourceDynamoDBV1, NamespaceTerraformResourceECRV1, NamespaceTerraformResourceS3CloudFrontPublicKeyV1, NamespaceTerraformResourceSecretsManagerServiceAccountV1, NamespaceTerraformResourceVpcEndpointServiceV1, NamespaceTerraformResourceAWSV1]] = Field(..., alias="resources")
+    resources: list[Union[NamespaceTerraformResourceRDSV1, NamespaceTerraformResourceALBV1, NamespaceTerraformResourceRosaAuthenticatorV1, NamespaceTerraformResourceRoleV1, NamespaceTerraformResourceS3V1, NamespaceTerraformResourceASGV1, NamespaceTerraformResourceRDSProxyV1, NamespaceTerraformResourceElastiCacheV1, NamespaceTerraformResourceSNSTopicV1, NamespaceTerraformResourceCloudWatchV1, NamespaceTerraformResourceServiceAccountV1, NamespaceTerraformResourceS3CloudFrontV1, NamespaceTerraformResourceS3SQSV1, NamespaceTerraformResourceKMSV1, NamespaceTerraformResourceKinesisV1, NamespaceTerraformResourceRosaAuthenticatorVPCEV1, NamespaceTerraformResourceMskV1, NamespaceTerraformResourceElasticSearchV1, NamespaceTerraformResourceACMV1, NamespaceTerraformResourceSecretsManagerV1, NamespaceTerraformResourceRoute53ZoneV1, NamespaceTerraformResourceMskConnectV1, NamespaceTerraformResourceSQSV1, NamespaceTerraformResourceDynamoDBV1, NamespaceTerraformResourceECRV1, NamespaceTerraformResourceS3CloudFrontPublicKeyV1, NamespaceTerraformResourceSecretsManagerServiceAccountV1, NamespaceTerraformResourceVpcEndpointServiceV1, NamespaceTerraformResourceVpcEndpointV1, NamespaceTerraformResourceAWSV1]] = Field(..., alias="resources")
 
 
 class EnvironmentV1(ConfiguredBaseModel):

--- a/reconcile/test/external_resources/test_aws_vpc_endpoint_factory.py
+++ b/reconcile/test/external_resources/test_aws_vpc_endpoint_factory.py
@@ -1,0 +1,122 @@
+from unittest.mock import Mock
+
+import pytest
+
+from reconcile.external_resources.aws import AWSVpcEndpointFactory
+from reconcile.external_resources.model import ExternalResourceModuleConfiguration
+from reconcile.utils.external_resource_spec import ExternalResourceSpec
+
+
+@pytest.fixture
+def module_conf() -> ExternalResourceModuleConfiguration:
+    return ExternalResourceModuleConfiguration(
+        image="stable-image",
+        version="1.0.0",
+        outputs_secret_image="path/to/er-output-secret-image",
+        outputs_secret_version="er-output-secret-version",
+        reconcile_timeout_minutes=60,
+        reconcile_drift_interval_minutes=60,
+    )
+
+
+def _make_spec(vpc: dict) -> ExternalResourceSpec:
+    return ExternalResourceSpec(
+        provision_provider="aws",
+        provisioner={"name": "test", "resources_default_region": "us-east-1"},
+        resource={
+            "identifier": "myservice-endpoint",
+            "provider": "vpc-endpoint",
+            "endpoint_service_name": "com.amazonaws.vpce.us-east-1.vpce-svc-0123456789abcdef0",
+            "vpc": vpc,
+        },
+        namespace={
+            "cluster": {"name": "test_cluster"},
+            "name": "test_namespace",
+            "environment": {"name": "test_env"},
+            "app": {"name": "test_app"},
+        },
+    )
+
+
+def test_resolve_flattens_vpc(module_conf: ExternalResourceModuleConfiguration) -> None:
+    spec = _make_spec({
+        "vpc_id": "vpc-0123456789abcdef0",
+        "region": "us-east-1",
+        "subnets": [
+            {"id": "subnet-aaaa", "privacy": "private"},
+            {"id": "subnet-bbbb", "privacy": "private"},
+            {"id": "subnet-cccc", "privacy": "public"},
+        ],
+    })
+    factory = AWSVpcEndpointFactory(Mock(), Mock())
+
+    data = factory.resolve(spec, module_conf)
+
+    assert data["vpc_id"] == "vpc-0123456789abcdef0"
+    assert data["region"] == "us-east-1"
+    assert data["subnet_ids"] == ["subnet-aaaa", "subnet-bbbb"]
+    assert "vpc" not in data
+
+
+def test_resolve_private_subnets_only(
+    module_conf: ExternalResourceModuleConfiguration,
+) -> None:
+    spec = _make_spec({
+        "vpc_id": "vpc-abc",
+        "subnets": [
+            {"id": "subnet-pub1", "privacy": "public"},
+            {"id": "subnet-priv1", "privacy": "private"},
+            {"id": "subnet-noprivacy"},
+        ],
+    })
+    factory = AWSVpcEndpointFactory(Mock(), Mock())
+
+    data = factory.resolve(spec, module_conf)
+
+    assert data["subnet_ids"] == ["subnet-priv1"]
+
+
+def test_resolve_no_region_in_vpc(
+    module_conf: ExternalResourceModuleConfiguration,
+) -> None:
+    spec = _make_spec({
+        "vpc_id": "vpc-abc",
+        "subnets": [],
+    })
+    factory = AWSVpcEndpointFactory(Mock(), Mock())
+
+    data = factory.resolve(spec, module_conf)
+
+    assert "region" not in data
+
+
+def test_resolve_empty_subnets(
+    module_conf: ExternalResourceModuleConfiguration,
+) -> None:
+    spec = _make_spec({
+        "vpc_id": "vpc-abc",
+        "region": "us-east-1",
+        "subnets": [],
+    })
+    factory = AWSVpcEndpointFactory(Mock(), Mock())
+
+    data = factory.resolve(spec, module_conf)
+
+    assert data["subnet_ids"] == []
+
+
+def test_resolve_passes_through_endpoint_service_name(
+    module_conf: ExternalResourceModuleConfiguration,
+) -> None:
+    spec = _make_spec({
+        "vpc_id": "vpc-abc",
+        "subnets": [],
+    })
+    factory = AWSVpcEndpointFactory(Mock(), Mock())
+
+    data = factory.resolve(spec, module_conf)
+
+    assert (
+        data["endpoint_service_name"]
+        == "com.amazonaws.vpce.us-east-1.vpce-svc-0123456789abcdef0"
+    )

--- a/reconcile/test/external_resources/test_aws_vpc_endpoint_service_factory.py
+++ b/reconcile/test/external_resources/test_aws_vpc_endpoint_service_factory.py
@@ -1,0 +1,129 @@
+from unittest.mock import Mock
+
+import pytest
+
+from reconcile.external_resources.aws import AWSVpcEndpointServiceFactory
+from reconcile.external_resources.model import ExternalResourceModuleConfiguration
+from reconcile.utils.external_resource_spec import ExternalResourceSpec
+
+
+@pytest.fixture
+def module_conf() -> ExternalResourceModuleConfiguration:
+    return ExternalResourceModuleConfiguration(
+        image="stable-image",
+        version="1.0.0",
+        outputs_secret_image="path/to/er-output-secret-image",
+        outputs_secret_version="er-output-secret-version",
+        reconcile_timeout_minutes=60,
+        reconcile_drift_interval_minutes=60,
+    )
+
+
+def _make_spec(
+    allowed_consumer_clusters: list | None = None,
+    allowed_principal_arns: list | None = None,
+) -> ExternalResourceSpec:
+    resource: dict = {
+        "identifier": "vault-stage-vpce-service",
+        "provider": "vpc-endpoint-service",
+        "openshift_service_name": "vault",
+    }
+    if allowed_consumer_clusters is not None:
+        resource["allowed_consumer_clusters"] = allowed_consumer_clusters
+    if allowed_principal_arns is not None:
+        resource["allowed_principal_arns"] = allowed_principal_arns
+    return ExternalResourceSpec(
+        provision_provider="aws",
+        provisioner={"name": "test", "resources_default_region": "us-east-1"},
+        resource=resource,
+        namespace={
+            "cluster": {"name": "test_cluster"},
+            "name": "test_namespace",
+            "environment": {"name": "test_env"},
+            "app": {"name": "test_app"},
+        },
+    )
+
+
+def _cluster(uid: str, terraform_username: str) -> dict:
+    return {
+        "name": f"cluster-{uid}",
+        "spec": {"account": {"uid": uid, "terraformUsername": terraform_username}},
+    }
+
+
+def test_resolve_builds_arns_from_clusters(
+    module_conf: ExternalResourceModuleConfiguration,
+) -> None:
+    spec = _make_spec(
+        allowed_consumer_clusters=[
+            _cluster("111111111111", "cluster-a-terraform"),
+            _cluster("222222222222", "cluster-b-terraform"),
+        ]
+    )
+    factory = AWSVpcEndpointServiceFactory(Mock(), Mock())
+
+    data = factory.resolve(spec, module_conf)
+
+    assert data["allowed_principal_arns"] == [
+        "arn:aws:iam::111111111111:user/cluster-a-terraform",
+        "arn:aws:iam::222222222222:user/cluster-b-terraform",
+    ]
+    assert "allowed_consumer_clusters" not in data
+
+
+def test_resolve_passes_through_explicit_arns(
+    module_conf: ExternalResourceModuleConfiguration,
+) -> None:
+    spec = _make_spec(allowed_principal_arns=["arn:aws:iam::536697226309:root"])
+    factory = AWSVpcEndpointServiceFactory(Mock(), Mock())
+
+    data = factory.resolve(spec, module_conf)
+
+    assert data["allowed_principal_arns"] == ["arn:aws:iam::536697226309:root"]
+
+
+def test_resolve_merges_cluster_arns_and_explicit_arns(
+    module_conf: ExternalResourceModuleConfiguration,
+) -> None:
+    spec = _make_spec(
+        allowed_consumer_clusters=[_cluster("111111111111", "cluster-a-terraform")],
+        allowed_principal_arns=["arn:aws:iam::536697226309:root"],
+    )
+    factory = AWSVpcEndpointServiceFactory(Mock(), Mock())
+
+    data = factory.resolve(spec, module_conf)
+
+    assert data["allowed_principal_arns"] == [
+        "arn:aws:iam::111111111111:user/cluster-a-terraform",
+        "arn:aws:iam::536697226309:root",
+    ]
+
+
+def test_resolve_empty_when_no_arns_configured(
+    module_conf: ExternalResourceModuleConfiguration,
+) -> None:
+    spec = _make_spec()
+    factory = AWSVpcEndpointServiceFactory(Mock(), Mock())
+
+    data = factory.resolve(spec, module_conf)
+
+    assert data["allowed_principal_arns"] == []
+
+
+def test_resolve_skips_cluster_without_account(
+    module_conf: ExternalResourceModuleConfiguration,
+) -> None:
+    spec = _make_spec(
+        allowed_consumer_clusters=[
+            _cluster("111111111111", "cluster-a-terraform"),
+            {"name": "broken-cluster", "spec": {}},
+        ]
+    )
+    factory = AWSVpcEndpointServiceFactory(Mock(), Mock())
+
+    data = factory.resolve(spec, module_conf)
+
+    assert data["allowed_principal_arns"] == [
+        "arn:aws:iam::111111111111:user/cluster-a-terraform",
+    ]


### PR DESCRIPTION
Adds qontract-reconcile support for two new ERv2-managed resource types implementing AWS PrivateLink via [er-aws-vpc-endpoint-service](https://github.com/app-sre/er-aws-vpc-endpoint-service) (provider side) and [er-aws-vpc-endpoint](https://github.com/app-sre/er-aws-vpc-endpoint) (consumer side).

## Changes

- Added inline fragments and generated Pydantic models for two new resource types:

  - NamespaceTerraformResourceVpcEndpointService_v1
  - NamespaceTerraformResourceVpcEndpoint_v1 

## Dependencies

- https://github.com/app-sre/qontract-schemas/pull/994

## Related

- Module repos: [er-aws-vpc-endpoint-service](https://github.com/app-sre/er-aws-vpc-endpoint-service), [er-aws-vpc-endpoint](https://github.com/app-sre/er-aws-vpc-endpoint)
- [Design doc](https://github.com/openshift-online/platform-engineering-enhancements/blob/main/app-sre/design-docs/er-aws-privatelink.md)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Support for AWS VPC Endpoints and VPC Endpoint Services as managed external resources: exposed to inventory/API, selectable VPC/subnets, service consumer allowlisting, and recognized when marked managed_by_erv2; provider/region and output/module settings respected.
* **Tests**
  * Added unit tests covering spec resolution, private-subnet filtering, ARN construction and merging with explicit ARNs, and related edge cases.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/app-sre/qontract-reconcile/pull/5511?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->