### PR TITLE
fix(endpoint-monitoring): fully qualify Probe managed type with API group

### DIFF
--- a/reconcile/closedbox_endpoint_monitoring_base.py
+++ b/reconcile/closedbox_endpoint_monitoring_base.py
@@ -151,7 +151,7 @@ def run_for_provider(
             use_jump_host=use_jump_host,
             integration=integration,
             integration_version=integration_version,
-            override_managed_types=["Probe"],
+            override_managed_types=["Probe.monitoring.coreos.com"],
         )
         if defer:
             defer(oc_map.cleanup)


### PR DESCRIPTION
## Summary

- `closedbox_endpoint_monitoring_base.py` passed the unqualified kind `"Probe"` as `override_managed_types`, causing an `AmbiguousResourceTypeError` on clusters where multiple CRDs share that short name (e.g. `appsres09ue1/openshift-customer-monitoring`)
- Fixed by qualifying it as `Probe.monitoring.coreos.com`, consistent with how `ServiceMonitor.monitoring.coreos.com` and `PodMonitor.monitoring.coreos.com` are referenced elsewhere

## Test plan

- [ ] Dry-run `blackbox-exporter-endpoint-monitoring` against `appsres09ue1` — error should be gone

🤖 Generated with [Claude Code](https://claude.com/claude-code)