### PR TITLE
fix(endpoint-monitoring): use kind_and_group for resource inventory key

### DIFF
--- a/reconcile/closedbox_endpoint_monitoring_base.py
+++ b/reconcile/closedbox_endpoint_monitoring_base.py
@@ -119,7 +119,7 @@ def fill_desired_state(
         ri.add_desired(
             cluster=provider.namespace["cluster"]["name"],
             namespace=provider.namespace["name"],
-            resource_type=probe.kind,
+            resource_type=probe.kind_and_group,
             name=probe.name,
             value=probe,
         )

--- a/reconcile/test/test_closedbox_endpoint_monitoring.py
+++ b/reconcile/test/test_closedbox_endpoint_monitoring.py
@@ -168,7 +168,7 @@ def test_blackbox_exporter_filling_desired_state(mocker: MockerFixture) -> None:
     add_desired_mock.assert_called_with(
         cluster="app-sre-stage-01",
         namespace="openshift-customer-monitoring",
-        resource_type="Probe",
+        resource_type="Probe.monitoring.coreos.com",
         name="blackbox-exporter-http-2xx",
         value=ANY,
     )
@@ -189,7 +189,7 @@ def test_signalfx_filling_desired_state(mocker: MockerFixture) -> None:
     add_desired_mock.assert_called_with(
         cluster="app-sre-stage-01",
         namespace="openshift-customer-monitoring",
-        resource_type="Probe",
+        resource_type="Probe.monitoring.coreos.com",
         name="signalfx-exporter-http-2xx",
         value=ANY,
     )


### PR DESCRIPTION
fill_desired_state was keying the resource inventory with probe.kind ("Probe") while fetch_current_state initialized it with the fully-qualified type ("Probe.monitoring.coreos.com"), causing a KeyError at reconcile time.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved OpenShift resource identification and classification during reconciliation to enhance inventory tracking and resource matching accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->