### PR TITLE
feat(oum): support authenticated LDAP/FreeIPA for group member resolution

### DIFF
--- a/qontract_utils/qontract_utils/ldap_api/__init__.py
+++ b/qontract_utils/qontract_utils/ldap_api/__init__.py
@@ -1,12 +1,12 @@
 """LDAP API client for FreeIPA with hook system."""
 
 from qontract_utils.ldap_api.api import LdapApi, LdapApiCallContext, LdapApiError
-from qontract_utils.ldap_api.models import LdapGroupMembers, LdapUser
+from qontract_utils.ldap_api.models import LdapGroup, LdapUser
 
 __all__ = [
     "LdapApi",
     "LdapApiCallContext",
     "LdapApiError",
-    "LdapGroupMembers",
+    "LdapGroup",
     "LdapUser",
 ]

--- a/qontract_utils/qontract_utils/ldap_api/api.py
+++ b/qontract_utils/qontract_utils/ldap_api/api.py
@@ -3,6 +3,7 @@
 import contextvars
 import time
 import types
+from collections import defaultdict
 from collections.abc import Iterable
 from dataclasses import dataclass
 from typing import Self
@@ -20,10 +21,11 @@ from ldap3.core.exceptions import (
     LDAPSocketSendError,
 )
 from ldap3.utils.conv import escape_filter_chars
+from ldap3.utils.dn import parse_dn
 from prometheus_client import Counter, Histogram
 
 from qontract_utils.hooks import Hooks, RetryConfig, invoke_with_hooks, with_hooks
-from qontract_utils.ldap_api.models import LdapUser
+from qontract_utils.ldap_api.models import LdapGroup, LdapUser
 from qontract_utils.metrics import DEFAULT_BUCKETS_EXTERNAL_API
 
 logger = structlog.get_logger(__name__)
@@ -149,7 +151,7 @@ class LdapApi:
         bind_dn: str | None = None,
         bind_password: str | None = None,
         *,
-        start_tls: bool = False,
+        start_tls: bool = True,
         timeout: int = _DEFAULT_TIMEOUT,
         hooks: Hooks | None = None,  # noqa: ARG002 - Handled by @with_hooks decorator
     ) -> None:
@@ -178,6 +180,15 @@ class LdapApi:
     ) -> None:
         self._connection.unbind()
 
+    @staticmethod
+    def _check_ldap_response(status: dict) -> None:
+        """Check LDAP response status and raise LdapApiError on failure."""
+        if (error_code := status.get("result", 99999)) != 0:
+            error_desc = status.get("description", "unknown error")
+            raise LdapApiError(
+                f"LDAP operation failed (error {error_code}: {error_desc})"
+            )
+
     @invoke_with_hooks(
         lambda: LdapApiCallContext(method="get_users"),
         retry_config=_LDAP_RETRY_CONFIG,
@@ -200,11 +211,45 @@ class LdapApi:
         _, status, results, _ = self._connection.search(
             self.base_dn, f"(&(objectclass=person)(|{user_filter}))", attributes=["uid"]
         )
-
-        # status["result"] is 0 on success, non-zero on failure (e.g., server down, timeout, etc.)
-        # and should exists according to RFC 4511 search result format. If missing, treat as unknown error.
-        if (error_code := status.get("result", 99999)) != 0:
-            error_desc = status.get("description", "unknown error")
-            raise LdapApiError(f"LDAP search failed (error {error_code}: {error_desc})")
+        self._check_ldap_response(status)
 
         return [LdapUser(username=r["attributes"]["uid"][0]) for r in results]
+
+    @invoke_with_hooks(
+        lambda: LdapApiCallContext(method="get_group_members"),
+        retry_config=_LDAP_RETRY_CONFIG,
+    )
+    def get_group_members(self, groups_dns: Iterable[str]) -> list[LdapGroup]:
+        """Get members of the specified LDAP groups.
+
+        Attention: groups_dns must be full DNs (e.g., "cn=group1,ou=groups,dc=example,dc=com") as returned by the LDAP "memberOf" attribute.
+        """
+        if not groups_dns:
+            return []
+
+        group_filter = (
+            f"(|{''.join([f'(memberOf={dn})' for dn in sorted(groups_dns)])})"
+        )
+
+        _, status, users, _ = self._connection.search(
+            self.base_dn,
+            group_filter,
+            attributes=["uid", "memberOf"],
+        )
+
+        self._check_ldap_response(status)
+
+        groups_and_members: dict[str, set[str]] = defaultdict(set[str])
+        for u in users:
+            uid = u["attributes"]["uid"][0]
+            for group in set(u["attributes"]["memberOf"]).intersection(groups_dns):
+                groups_and_members[group].add(uid)
+
+        return [
+            LdapGroup(
+                cn=parse_dn(dn)[0][1],
+                dn=dn,
+                members=frozenset(LdapUser(username=uid) for uid in members),
+            )
+            for dn, members in groups_and_members.items()
+        ]

--- a/qontract_utils/qontract_utils/ldap_api/api.py
+++ b/qontract_utils/qontract_utils/ldap_api/api.py
@@ -227,9 +227,7 @@ class LdapApi:
         if not groups_dns:
             return []
 
-        group_filter = (
-            f"(|{''.join([f'(memberOf={dn})' for dn in sorted(groups_dns)])})"
-        )
+        group_filter = f"(|{''.join([f'(memberOf={escape_filter_chars(dn)})' for dn in sorted(groups_dns)])})"
 
         _, status, users, _ = self._connection.search(
             self.base_dn,

--- a/qontract_utils/qontract_utils/ldap_api/api.py
+++ b/qontract_utils/qontract_utils/ldap_api/api.py
@@ -4,7 +4,7 @@ import contextvars
 import time
 import types
 from collections import defaultdict
-from collections.abc import Iterable
+from collections.abc import Collection, Iterable
 from dataclasses import dataclass
 from typing import Self
 
@@ -31,6 +31,7 @@ from qontract_utils.metrics import DEFAULT_BUCKETS_EXTERNAL_API
 logger = structlog.get_logger(__name__)
 
 _DEFAULT_TIMEOUT = 30
+_UNKNOWN_LDAP_ERROR = 99999
 
 # Prometheus metrics
 ldap_request = Counter(
@@ -116,6 +117,16 @@ _LDAP_RETRY_CONFIG = RetryConfig(
 )
 
 
+def _get_cn_from_dn(dn: str) -> str:
+    """Extract CN value from a DN string."""
+    rdn = parse_dn(dn)[0]
+    if rdn[0].lower() != "cn":
+        raise LdapApiError(
+            f"Expected CN as first RDN component, got {rdn[0]!r} in {dn!r}"
+        )
+    return rdn[1]
+
+
 @with_hooks(
     hooks=Hooks(
         pre_hooks=[_metrics_hook, _request_log_hook, _latency_start_hook],
@@ -183,7 +194,7 @@ class LdapApi:
     @staticmethod
     def _check_ldap_response(status: dict) -> None:
         """Check LDAP response status and raise LdapApiError on failure."""
-        if (error_code := status.get("result", 99999)) != 0:
+        if (error_code := status.get("result", _UNKNOWN_LDAP_ERROR)) != 0:
             error_desc = status.get("description", "unknown error")
             raise LdapApiError(
                 f"LDAP operation failed (error {error_code}: {error_desc})"
@@ -219,7 +230,7 @@ class LdapApi:
         lambda: LdapApiCallContext(method="get_group_members"),
         retry_config=_LDAP_RETRY_CONFIG,
     )
-    def get_group_members(self, groups_dns: Iterable[str]) -> list[LdapGroup]:
+    def get_group_members(self, groups_dns: Collection[str]) -> list[LdapGroup]:
         """Get members of the specified LDAP groups.
 
         Attention: groups_dns must be full DNs (e.g., "cn=group1,ou=groups,dc=example,dc=com") as returned by the LDAP "memberOf" attribute.
@@ -245,7 +256,7 @@ class LdapApi:
 
         return [
             LdapGroup(
-                cn=parse_dn(dn)[0][1],
+                cn=_get_cn_from_dn(dn),
                 dn=dn,
                 members=frozenset(LdapUser(username=uid) for uid in members),
             )

--- a/qontract_utils/qontract_utils/ldap_api/models.py
+++ b/qontract_utils/qontract_utils/ldap_api/models.py
@@ -13,13 +13,14 @@ class LdapUser(BaseModel, frozen=True):
     username: str
 
 
-class LdapGroupMembers(BaseModel, frozen=True):
-    """Members of an LDAP group returned by get_group_members.
+class LdapGroup(BaseModel, frozen=True):
+    """An LDAP group returned by get_group_members.
 
     Attributes:
         dn: Full distinguished name of the group
-        members: Set of member usernames (uid attribute values)
+        members: Set of member LDAP users
     """
 
+    cn: str
     dn: str
-    members: frozenset[str]
+    members: frozenset[LdapUser]

--- a/qontract_utils/tests/ldap_api/test_ldap_api.py
+++ b/qontract_utils/tests/ldap_api/test_ldap_api.py
@@ -8,7 +8,7 @@ import pytest
 from pydantic import ValidationError
 from qontract_utils.hooks import Hooks
 from qontract_utils.ldap_api.api import LdapApi, LdapApiCallContext, LdapApiError
-from qontract_utils.ldap_api.models import LdapGroupMembers, LdapUser
+from qontract_utils.ldap_api.models import LdapGroup, LdapUser
 
 
 @pytest.fixture
@@ -126,12 +126,12 @@ def test_ldap_api_context_manager_start_tls(mock_ldap3: MagicMock) -> None:
     )
 
 
-def test_ldap_api_context_manager_no_start_tls_by_default(
+def test_ldap_api_context_manager_start_tls_by_default(
     mock_ldap3: MagicMock, ldap_api: LdapApi
 ) -> None:
-    """Test __enter__ does NOT call start_tls() by default."""
+    """Test __enter__ calls start_tls() by default."""
     with ldap_api:
-        mock_ldap3.connection.start_tls.assert_not_called()
+        mock_ldap3.connection.start_tls.assert_called_once()
 
 
 # --- get_users ---
@@ -226,7 +226,7 @@ def test_get_users_search_failure_raises_error(
         None,
     )
 
-    with ldap_api, pytest.raises(LdapApiError, match="LDAP search failed"):
+    with ldap_api, pytest.raises(LdapApiError, match="LDAP operation failed"):
         ldap_api.get_users(["alice"])
 
 
@@ -283,13 +283,16 @@ def test_ldap_user_model_frozen() -> None:
         user.username = "bob"  # type: ignore[misc]
 
 
-def test_ldap_group_members_model_frozen() -> None:
-    """Test LdapGroupMembers is immutable."""
-    group = LdapGroupMembers(
-        dn="cn=admins,dc=example,dc=com", members=frozenset({"alice"})
+def test_ldap_group_model_frozen() -> None:
+    """Test LdapGroup is immutable."""
+    group = LdapGroup(
+        cn="admins",
+        dn="cn=admins,dc=example,dc=com",
+        members=frozenset({LdapUser(username="alice")}),
     )
+    assert group.cn == "admins"
     assert group.dn == "cn=admins,dc=example,dc=com"
-    assert group.members == frozenset({"alice"})
+    assert group.members == frozenset({LdapUser(username="alice")})
     with pytest.raises(ValidationError, match="frozen"):
         group.dn = "other"  # type: ignore[misc]
 
@@ -330,7 +333,7 @@ def test_get_users_does_not_retry_on_logical_error(
         None,
     )
 
-    with ldap_api, pytest.raises(LdapApiError, match="LDAP search failed"):
+    with ldap_api, pytest.raises(LdapApiError, match="LDAP operation failed"):
         ldap_api.get_users(["alice"])
 
     # Should have been called only once (no retry)
@@ -377,3 +380,172 @@ def test_ldap_api_call_context_immutable() -> None:
     context = LdapApiCallContext(method="get_users")
     with pytest.raises(AttributeError):
         context.method = "other"  # type: ignore[misc]
+
+
+# --- get_group_members ---
+
+
+def test_get_group_members_returns_groups_with_members(
+    mock_ldap3: MagicMock, ldap_api: LdapApi
+) -> None:
+    """Test get_group_members returns LdapGroup models with CN, DN, and members."""
+    group1_dn = "cn=admins,ou=groups,dc=example,dc=com"
+    group2_dn = "cn=devs,ou=groups,dc=example,dc=com"
+    mock_ldap3.connection.search.return_value = (
+        True,
+        {"result": 0, "description": "success"},
+        [
+            {"attributes": {"uid": ["alice"], "memberOf": [group1_dn, group2_dn]}},
+            {"attributes": {"uid": ["bob"], "memberOf": [group1_dn]}},
+        ],
+        None,
+    )
+
+    with ldap_api:
+        result = ldap_api.get_group_members([group1_dn, group2_dn])
+
+    groups_by_cn = {g.cn: g for g in result}
+    assert set(groups_by_cn) == {"admins", "devs"}
+    assert groups_by_cn["admins"].dn == group1_dn
+    assert {u.username for u in groups_by_cn["admins"].members} == {"alice", "bob"}
+    assert groups_by_cn["devs"].dn == group2_dn
+    assert {u.username for u in groups_by_cn["devs"].members} == {"alice"}
+
+
+def test_get_group_members_empty_input(
+    mock_ldap3: MagicMock, ldap_api: LdapApi
+) -> None:
+    """Test get_group_members with empty input returns empty list."""
+    with ldap_api:
+        result = ldap_api.get_group_members([])
+
+    assert result == []
+    mock_ldap3.connection.search.assert_not_called()
+
+
+def test_get_group_members_builds_correct_filter(
+    mock_ldap3: MagicMock, ldap_api: LdapApi
+) -> None:
+    """Test get_group_members constructs the correct LDAP filter."""
+    group_dn = "cn=admins,ou=groups,dc=example,dc=com"
+    mock_ldap3.connection.search.return_value = (
+        True,
+        {"result": 0, "description": "success"},
+        [],
+        None,
+    )
+
+    with ldap_api:
+        ldap_api.get_group_members([group_dn])
+
+    call_args = mock_ldap3.connection.search.call_args
+    assert call_args[0][0] == "dc=example,dc=com"
+    filter_str = call_args[0][1]
+    assert f"(memberOf={group_dn})" in filter_str
+
+
+def test_get_group_members_search_failure_raises_error(
+    mock_ldap3: MagicMock, ldap_api: LdapApi
+) -> None:
+    """Test get_group_members raises LdapApiError on search failure."""
+    mock_ldap3.connection.search.return_value = (
+        False,
+        {"result": 53, "description": "Server Unwilling to Perform"},
+        [],
+        None,
+    )
+
+    with ldap_api, pytest.raises(LdapApiError, match="LDAP operation failed"):
+        ldap_api.get_group_members(["cn=admins,ou=groups,dc=example,dc=com"])
+
+
+def test_get_group_members_ignores_unrelated_memberships(
+    mock_ldap3: MagicMock, ldap_api: LdapApi
+) -> None:
+    """Test get_group_members only includes requested groups, not all memberOf values."""
+    requested_dn = "cn=admins,ou=groups,dc=example,dc=com"
+    other_dn = "cn=other,ou=groups,dc=example,dc=com"
+    mock_ldap3.connection.search.return_value = (
+        True,
+        {"result": 0, "description": "success"},
+        [
+            {"attributes": {"uid": ["alice"], "memberOf": [requested_dn, other_dn]}},
+        ],
+        None,
+    )
+
+    with ldap_api:
+        result = ldap_api.get_group_members([requested_dn])
+
+    assert len(result) == 1
+    assert result[0].cn == "admins"
+    assert result[0].dn == requested_dn
+
+
+def test_get_group_members_calls_hooks(
+    mock_ldap3: MagicMock, ldap_api: LdapApi
+) -> None:
+    """Test get_group_members triggers hooks with correct context."""
+    pre_hook = MagicMock()
+    ldap_api._hooks = Hooks(pre_hooks=[pre_hook])
+    mock_ldap3.connection.search.return_value = (
+        True,
+        {"result": 0, "description": "success"},
+        [],
+        None,
+    )
+
+    with ldap_api:
+        ldap_api.get_group_members(["cn=admins,ou=groups,dc=example,dc=com"])
+
+    pre_hook.assert_called_once()
+    context = pre_hook.call_args[0][0]
+    assert isinstance(context, LdapApiCallContext)
+    assert context.method == "get_group_members"
+
+
+def test_get_group_members_retries_on_transient_error(
+    mock_ldap3: MagicMock, ldap_api: LdapApi, enable_retry: None
+) -> None:
+    """Test get_group_members retries on transient network errors."""
+    from ldap3.core.exceptions import LDAPCommunicationError
+
+    group_dn = "cn=admins,ou=groups,dc=example,dc=com"
+    mock_ldap3.connection.search.side_effect = [
+        LDAPCommunicationError("connection reset"),
+        (
+            True,
+            {"result": 0, "description": "success"},
+            [{"attributes": {"uid": ["alice"], "memberOf": [group_dn]}}],
+            None,
+        ),
+    ]
+
+    with ldap_api:
+        result = ldap_api.get_group_members([group_dn])
+
+    assert len(result) == 1
+    assert result[0].cn == "admins"
+    assert mock_ldap3.connection.search.call_count == 2
+
+
+def test_get_group_members_members_are_ldap_user_models(
+    mock_ldap3: MagicMock, ldap_api: LdapApi
+) -> None:
+    """Test get_group_members returns LdapUser instances as members."""
+    group_dn = "cn=team,ou=groups,dc=example,dc=com"
+    mock_ldap3.connection.search.return_value = (
+        True,
+        {"result": 0, "description": "success"},
+        [
+            {"attributes": {"uid": ["alice"], "memberOf": [group_dn]}},
+        ],
+        None,
+    )
+
+    with ldap_api:
+        result = ldap_api.get_group_members([group_dn])
+
+    member = next(iter(result[0].members))
+    assert isinstance(member, LdapUser)
+    assert member.username == "alice"

--- a/qontract_utils/tests/ldap_api/test_ldap_api.py
+++ b/qontract_utils/tests/ldap_api/test_ldap_api.py
@@ -549,3 +549,24 @@ def test_get_group_members_members_are_ldap_user_models(
     member = next(iter(result[0].members))
     assert isinstance(member, LdapUser)
     assert member.username == "alice"
+
+
+def test_get_group_members_escapes_special_characters(
+    mock_ldap3: MagicMock, ldap_api: LdapApi
+) -> None:
+    """Test get_group_members escapes LDAP filter special characters in DNs."""
+    mock_ldap3.connection.search.return_value = (
+        True,
+        {"result": 0, "description": "success"},
+        [],
+        None,
+    )
+
+    dn_with_parens = "cn=group(test),ou=groups,dc=example,dc=com"
+    with ldap_api:
+        ldap_api.get_group_members([dn_with_parens])
+
+    filter_str = mock_ldap3.connection.search.call_args[0][1]
+    assert f"(memberOf={dn_with_parens})" not in filter_str
+    assert "\\28" in filter_str  # ( -> \28
+    assert "\\29" in filter_str  # ) -> \29

--- a/reconcile/oum/providers.py
+++ b/reconcile/oum/providers.py
@@ -60,8 +60,12 @@ def init_ldap_group_member_provider(group_base_dn: str) -> LdapGroupMemberProvid
     bind_password = None
     if settings.credentials:
         ldap_credentials = secret_reader.read_all_secret(settings.credentials)
-        bind_dn = ldap_credentials.get("bind_dn")
-        bind_password = ldap_credentials.get("bind_password")
+        if "bind_dn" not in ldap_credentials or "bind_password" not in ldap_credentials:
+            raise ValueError(
+                "LDAP credentials must contain 'bind_dn' and 'bind_password'"
+            )
+        bind_dn = ldap_credentials["bind_dn"]
+        bind_password = ldap_credentials["bind_password"]
     return LdapGroupMemberProvider(
         LdapApi(
             server_url=settings.server_url,

--- a/reconcile/oum/providers.py
+++ b/reconcile/oum/providers.py
@@ -3,8 +3,13 @@ from abc import (
     abstractmethod,
 )
 
+from qontract_utils.ldap_api import LdapApi
+
+from reconcile.typed_queries.app_interface_vault_settings import (
+    get_app_interface_vault_settings,
+)
 from reconcile.typed_queries.ldap_settings import get_ldap_settings
-from reconcile.utils.ldap_client import LdapClient
+from reconcile.utils.secret_reader import create_secret_reader
 
 
 class GroupMemberProvider(ABC):
@@ -24,20 +29,18 @@ class LdapGroupMemberProvider(GroupMemberProvider):
     Resolve group members using the LDAP groups.
     """
 
-    def __init__(self, ldap_client: LdapClient, group_base_dn: str):
+    def __init__(self, ldap_client: LdapApi, group_base_dn: str) -> None:
         self.ldap_client = ldap_client
         self.group_base_dn = group_base_dn
 
     def resolve_groups(self, group_ids: set[str]) -> dict[str, set[str]]:
-        group_dn_mapping = {f"cn={cn},{self.group_base_dn}": cn for cn in group_ids}
-        if len(group_ids) == 0:
+        if not group_ids:
             return {}
         with self.ldap_client as lc:
-            groups_members_by_dn = lc.get_group_members(set(group_dn_mapping.keys()))
-        return {
-            group_dn_mapping[dn]: members
-            for dn, members in groups_members_by_dn.items()
-        }
+            groups = lc.get_group_members({
+                f"cn={cn},{self.group_base_dn}" for cn in group_ids
+            })
+        return {group.cn: {user.username for user in group.members} for group in groups}
 
 
 def init_ldap_group_member_provider(group_base_dn: str) -> LdapGroupMemberProvider:
@@ -51,12 +54,20 @@ def init_ldap_group_member_provider(group_base_dn: str) -> LdapGroupMemberProvid
     """
 
     settings = get_ldap_settings()
+    vault_settings = get_app_interface_vault_settings()
+    secret_reader = create_secret_reader(use_vault=vault_settings.vault)
+    bind_dn = None
+    bind_password = None
+    if settings.credentials:
+        ldap_credentials = secret_reader.read_all_secret(settings.credentials)
+        bind_dn = ldap_credentials.get("bind_dn")
+        bind_password = ldap_credentials.get("bind_password")
     return LdapGroupMemberProvider(
-        LdapClient.from_params(
+        LdapApi(
             server_url=settings.server_url,
-            user=None,
-            password=None,
             base_dn=settings.base_dn,
+            bind_dn=bind_dn,
+            bind_password=bind_password,
         ),
         group_base_dn,
     )

--- a/reconcile/test/ocm/oum/test_oum_providers.py
+++ b/reconcile/test/ocm/oum/test_oum_providers.py
@@ -1,23 +1,39 @@
 import pytest
 from pytest_mock import MockerFixture
 
+from qontract_utils.ldap_api import LdapApi
+from qontract_utils.ldap_api.models import LdapGroup, LdapUser
+
 from reconcile.oum.providers import LdapGroupMemberProvider
-from reconcile.utils.ldap_client import LdapClient
 
 
 @pytest.fixture
-def mock_ldap_client(mocker: MockerFixture) -> LdapClient:
-    lc = mocker.Mock(spec=LdapClient, autospec=True)
-    lc.return_value.get_group_members.return_value = {
-        "cn=group1,dc=example,dc=com": {"user1", "user2"},
-        "cn=group2,dc=example,dc=com": {"user3", "user4"},
-    }
+def mock_ldap_client(mocker: MockerFixture) -> LdapApi:
+    lc = mocker.Mock(spec=LdapApi, autospec=True)
+    lc.return_value.get_group_members.return_value = [
+        LdapGroup(
+            cn="group1",
+            dn="cn=group1,dc=example,dc=com",
+            members=frozenset({
+                LdapUser(username="user1"),
+                LdapUser(username="user2"),
+            }),
+        ),
+        LdapGroup(
+            cn="group2",
+            dn="cn=group2,dc=example,dc=com",
+            members=frozenset({
+                LdapUser(username="user3"),
+                LdapUser(username="user4"),
+            }),
+        ),
+    ]
     lc.__enter__ = lc
     lc.__exit__ = mocker.Mock(return_value=None)
     return lc
 
 
-def test_ldap_group_member_provider(mock_ldap_client: LdapClient) -> None:
+def test_ldap_group_member_provider(mock_ldap_client: LdapApi) -> None:
     provider = LdapGroupMemberProvider(mock_ldap_client, "dc=example,dc=com")
     groups = provider.resolve_groups({"group1", "group2"})
     assert "group1" in groups
@@ -26,7 +42,7 @@ def test_ldap_group_member_provider(mock_ldap_client: LdapClient) -> None:
     assert groups["group2"] == {"user3", "user4"}
 
 
-def test_ldap_group_member_provider_empty_list(mock_ldap_client: LdapClient) -> None:
+def test_ldap_group_member_provider_empty_list(mock_ldap_client: LdapApi) -> None:
     provider = LdapGroupMemberProvider(mock_ldap_client, "dc=example,dc=com")
     groups = provider.resolve_groups(set())
     assert groups == {}

--- a/reconcile/test/ocm/oum/test_oum_providers.py
+++ b/reconcile/test/ocm/oum/test_oum_providers.py
@@ -1,6 +1,5 @@
 import pytest
 from pytest_mock import MockerFixture
-
 from qontract_utils.ldap_api import LdapApi
 from qontract_utils.ldap_api.models import LdapGroup, LdapUser
 


### PR DESCRIPTION
Extend qontract_utils/ldap_api with get_group_members to query group
memberships via authenticated FreeIPA binds. Redesign LdapGroup model
with typed members and CN extraction. Update OUM providers to use the
new API.


Ticket: [APPSRE-13659](https://redhat.atlassian.net/browse/APPSRE-13659)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added group-member retrieval returning groups with canonical name and member user objects.

* **Bug Fixes**
  * Centralized LDAP response validation and standardized LDAP error messages.
  * Ignores unrelated memberships and properly escapes DNs in searches.

* **Chores**
  * STARTTLS enabled by default for LDAP connections; provider wiring updated to use the new API.

* **Tests**
  * Updated and expanded tests for group-member retrieval, DN handling, errors, retries and TLS.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->