### PR TITLE
fix(quay-mirror): fail integration when skopeo copy errors occur

### DIFF
--- a/reconcile/gcp_image_mirror.py
+++ b/reconcile/gcp_image_mirror.py
@@ -61,6 +61,7 @@ class QuayMirror:
         self.session.close()
 
     def run(self) -> None:
+        errors: list[Exception] = []
         gql_result = gql_gcp_repos.query(query_func=self.gqlapi.query)
         processed_repos = self.process_repos_to_sync(gql_result)
         sync_tasks = self.process_sync_tasks(processed_repos)
@@ -79,6 +80,10 @@ class QuayMirror:
                 )
             except SkopeoCmdError as details:
                 logging.error("[%s]", details)
+                errors.append(details)
+
+        if errors:
+            raise ExceptionGroup("skopeo copy failures", errors)
 
     # processes the GQL repos to come up with a list of items that need to be synced
     def process_repos_to_sync(

--- a/reconcile/quay_mirror.py
+++ b/reconcile/quay_mirror.py
@@ -126,8 +126,8 @@ class QuayMirror:
     def __exit__(self, exc_type: Any, exc_value: Any, traceback: Any) -> None:
         self.session.close()
 
-    def run(self) -> bool:
-        error = False
+    def run(self) -> None:
+        errors: list[Exception] = []
         sync_tasks = self.process_sync_tasks()
         for org, data in sync_tasks.items():
             for item in data:
@@ -140,12 +140,13 @@ class QuayMirror:
                     )
                 except SkopeoCmdError as details:
                     _LOG.error("skopeo command error message: '%s'", details)
-                    error = True
+                    errors.append(details)
 
         if self.is_compare_tags and not self.dry_run:
             record_timestamp(self.control_file_path)
 
-        return error
+        if errors:
+            raise ExceptionGroup("skopeo copy failures", errors)
 
     @classmethod
     def process_repos_query(
@@ -402,9 +403,7 @@ def run(
         repository_urls,
         exclude_repository_urls,
     ) as quay_mirror:
-        error = quay_mirror.run()
-    if error:
-        sys.exit(ExitCodes.ERROR)
+        quay_mirror.run()
 
 
 def early_exit_desired_state(*args: Any, **kwargs: Any) -> dict[str, Any]:

--- a/reconcile/quay_mirror.py
+++ b/reconcile/quay_mirror.py
@@ -126,7 +126,8 @@ class QuayMirror:
     def __exit__(self, exc_type: Any, exc_value: Any, traceback: Any) -> None:
         self.session.close()
 
-    def run(self) -> None:
+    def run(self) -> bool:
+        error = False
         sync_tasks = self.process_sync_tasks()
         for org, data in sync_tasks.items():
             for item in data:
@@ -139,9 +140,12 @@ class QuayMirror:
                     )
                 except SkopeoCmdError as details:
                     _LOG.error("skopeo command error message: '%s'", details)
+                    error = True
 
         if self.is_compare_tags and not self.dry_run:
             record_timestamp(self.control_file_path)
+
+        return error
 
     @classmethod
     def process_repos_query(
@@ -398,7 +402,9 @@ def run(
         repository_urls,
         exclude_repository_urls,
     ) as quay_mirror:
-        quay_mirror.run()
+        error = quay_mirror.run()
+    if error:
+        sys.exit(ExitCodes.ERROR)
 
 
 def early_exit_desired_state(*args: Any, **kwargs: Any) -> dict[str, Any]:

--- a/reconcile/quay_mirror_org.py
+++ b/reconcile/quay_mirror_org.py
@@ -74,6 +74,7 @@ class QuayMirrorOrg:
         self.quay_api_store.cleanup()
 
     def run(self) -> None:
+        errors: list[Exception] = []
         sync_tasks = self.process_sync_tasks()
         for org, data in sync_tasks.items():
             for item in data:
@@ -86,9 +87,13 @@ class QuayMirrorOrg:
                     )
                 except SkopeoCmdError as details:
                     _LOG.error("skopeo command error message: '%s'", details)
+                    errors.append(details)
 
         if self.is_compare_tags and not self.dry_run:
             record_timestamp(self.control_file_path)
+
+        if errors:
+            raise ExceptionGroup("skopeo copy failures", errors)
 
     def process_org_mirrors(self) -> dict[OrgKey, list[dict[str, Any]]]:
         """It collects the list of repositories in the upstream org from an API

--- a/reconcile/test/test_gcp_image_mirror.py
+++ b/reconcile/test/test_gcp_image_mirror.py
@@ -142,7 +142,7 @@ def gcp_mirror_instance(
 def test_run_succeeds_with_no_errors(
     gcp_mirror_instance: tuple[QuayMirror, MagicMock], mocker: MockerFixture
 ) -> None:
-    qm, _ = gcp_mirror_instance
+    qm, mock_skopeo = gcp_mirror_instance
     tasks = [
         SyncTask(
             source_url="docker.io/foo:1",
@@ -152,7 +152,14 @@ def test_run_succeeds_with_no_errors(
     ]
     mocker.patch.object(qm, "process_sync_tasks", return_value=tasks)
 
-    qm.run()  # should not raise
+    qm.run()
+
+    mock_skopeo.copy.assert_called_once_with(
+        src_image="docker.io/foo:1",
+        src_creds=None,
+        dst_image=f"gcr.io/{TEST_PROJECT_NAME}/foo:1",
+        dest_creds="user:token",
+    )
 
 
 def test_run_raises_exception_group_on_skopeo_error(

--- a/reconcile/test/test_gcp_image_mirror.py
+++ b/reconcile/test/test_gcp_image_mirror.py
@@ -1,3 +1,4 @@
+from collections.abc import Generator
 from unittest.mock import MagicMock, create_autospec
 
 import pytest
@@ -126,52 +127,56 @@ def test_process_repos_to_sync(
         )
 
 
-class TestRunErrorHandling:
-    def test_run_succeeds_with_no_errors(
-        self, setup_mocks: None, mocker: MockerFixture
-    ) -> None:
-        with QuayMirror() as qm:
-            mock_skopeo: MagicMock = MagicMock()
-            qm.skopeo_cli = mock_skopeo
-            qm.push_creds = {f"gcr_{TEST_PROJECT_NAME}": "user:token"}
-            tasks = [
-                SyncTask(
-                    source_url="docker.io/foo:1",
-                    dest_url=f"gcr.io/{TEST_PROJECT_NAME}/foo:1",
-                    org_name=TEST_PROJECT_NAME,
-                ),
-            ]
-            mocker.patch.object(qm, "process_sync_tasks", return_value=tasks)
-            mocker.patch("reconcile.gcp_image_mirror.gql_gcp_repos")
+@pytest.fixture()
+def gcp_mirror_instance(
+    setup_mocks: None, mocker: MockerFixture
+) -> Generator[tuple[QuayMirror, MagicMock], None, None]:
+    mocker.patch("reconcile.gcp_image_mirror.gql_gcp_repos")
+    with QuayMirror() as qm:
+        mock_skopeo: MagicMock = MagicMock()
+        qm.skopeo_cli = mock_skopeo
+        qm.push_creds = {f"gcr_{TEST_PROJECT_NAME}": "user:token"}
+        yield qm, mock_skopeo
 
-            qm.run()
 
-    def test_run_raises_exception_group_on_skopeo_error(
-        self, setup_mocks: None, mocker: MockerFixture
-    ) -> None:
-        with QuayMirror() as qm:
-            mock_skopeo: MagicMock = MagicMock()
-            qm.skopeo_cli = mock_skopeo
-            qm.push_creds = {f"gcr_{TEST_PROJECT_NAME}": "user:token"}
-            tasks = [
-                SyncTask(
-                    source_url="docker.io/foo:1",
-                    dest_url=f"gcr.io/{TEST_PROJECT_NAME}/foo:1",
-                    org_name=TEST_PROJECT_NAME,
-                ),
-                SyncTask(
-                    source_url="docker.io/foo:2",
-                    dest_url=f"gcr.io/{TEST_PROJECT_NAME}/foo:2",
-                    org_name=TEST_PROJECT_NAME,
-                ),
-            ]
-            mocker.patch.object(qm, "process_sync_tasks", return_value=tasks)
-            mocker.patch("reconcile.gcp_image_mirror.gql_gcp_repos")
-            mock_skopeo.copy.side_effect = [SkopeoCmdError("exit code: 1"), None]
+def test_run_succeeds_with_no_errors(
+    gcp_mirror_instance: tuple[QuayMirror, MagicMock], mocker: MockerFixture
+) -> None:
+    qm, _ = gcp_mirror_instance
+    tasks = [
+        SyncTask(
+            source_url="docker.io/foo:1",
+            dest_url=f"gcr.io/{TEST_PROJECT_NAME}/foo:1",
+            org_name=TEST_PROJECT_NAME,
+        ),
+    ]
+    mocker.patch.object(qm, "process_sync_tasks", return_value=tasks)
 
-            with pytest.raises(ExceptionGroup) as exc_info:
-                qm.run()
+    qm.run()  # should not raise
 
-            assert mock_skopeo.copy.call_count == 2
-            assert len(exc_info.value.exceptions) == 1
-            assert isinstance(exc_info.value.exceptions[0], SkopeoCmdError)
+
+def test_run_raises_exception_group_on_skopeo_error(
+    gcp_mirror_instance: tuple[QuayMirror, MagicMock], mocker: MockerFixture
+) -> None:
+    qm, mock_skopeo = gcp_mirror_instance
+    tasks = [
+        SyncTask(
+            source_url="docker.io/foo:1",
+            dest_url=f"gcr.io/{TEST_PROJECT_NAME}/foo:1",
+            org_name=TEST_PROJECT_NAME,
+        ),
+        SyncTask(
+            source_url="docker.io/foo:2",
+            dest_url=f"gcr.io/{TEST_PROJECT_NAME}/foo:2",
+            org_name=TEST_PROJECT_NAME,
+        ),
+    ]
+    mocker.patch.object(qm, "process_sync_tasks", return_value=tasks)
+    mock_skopeo.copy.side_effect = [SkopeoCmdError("exit code: 1"), None]
+
+    with pytest.raises(ExceptionGroup) as exc_info:
+        qm.run()
+
+    assert mock_skopeo.copy.call_count == 2
+    assert len(exc_info.value.exceptions) == 1
+    assert isinstance(exc_info.value.exceptions[0], SkopeoCmdError)

--- a/reconcile/test/test_gcp_image_mirror.py
+++ b/reconcile/test/test_gcp_image_mirror.py
@@ -1,9 +1,10 @@
-from unittest.mock import create_autospec
+from unittest.mock import MagicMock, create_autospec
 
 import pytest
 from pytest_mock import MockerFixture, MockFixture
+from sretoolbox.container.skopeo import SkopeoCmdError
 
-from reconcile.gcp_image_mirror import ImageSyncItem, QuayMirror
+from reconcile.gcp_image_mirror import ImageSyncItem, QuayMirror, SyncTask
 from reconcile.gql_definitions.fragments.container_image_mirror import (
     ContainerImageMirror,
 )
@@ -123,3 +124,54 @@ def test_process_repos_to_sync(
             gcp_image_mirror.process_repos_to_sync(repo_query_gql)
             == expected_sync_results
         )
+
+
+class TestRunErrorHandling:
+    def test_run_succeeds_with_no_errors(
+        self, setup_mocks: None, mocker: MockerFixture
+    ) -> None:
+        with QuayMirror() as qm:
+            mock_skopeo: MagicMock = MagicMock()
+            qm.skopeo_cli = mock_skopeo
+            qm.push_creds = {f"gcr_{TEST_PROJECT_NAME}": "user:token"}
+            tasks = [
+                SyncTask(
+                    source_url="docker.io/foo:1",
+                    dest_url=f"gcr.io/{TEST_PROJECT_NAME}/foo:1",
+                    org_name=TEST_PROJECT_NAME,
+                ),
+            ]
+            mocker.patch.object(qm, "process_sync_tasks", return_value=tasks)
+            mocker.patch("reconcile.gcp_image_mirror.gql_gcp_repos")
+
+            qm.run()
+
+    def test_run_raises_exception_group_on_skopeo_error(
+        self, setup_mocks: None, mocker: MockerFixture
+    ) -> None:
+        with QuayMirror() as qm:
+            mock_skopeo: MagicMock = MagicMock()
+            qm.skopeo_cli = mock_skopeo
+            qm.push_creds = {f"gcr_{TEST_PROJECT_NAME}": "user:token"}
+            tasks = [
+                SyncTask(
+                    source_url="docker.io/foo:1",
+                    dest_url=f"gcr.io/{TEST_PROJECT_NAME}/foo:1",
+                    org_name=TEST_PROJECT_NAME,
+                ),
+                SyncTask(
+                    source_url="docker.io/foo:2",
+                    dest_url=f"gcr.io/{TEST_PROJECT_NAME}/foo:2",
+                    org_name=TEST_PROJECT_NAME,
+                ),
+            ]
+            mocker.patch.object(qm, "process_sync_tasks", return_value=tasks)
+            mocker.patch("reconcile.gcp_image_mirror.gql_gcp_repos")
+            mock_skopeo.copy.side_effect = [SkopeoCmdError("exit code: 1"), None]
+
+            with pytest.raises(ExceptionGroup) as exc_info:
+                qm.run()
+
+            assert mock_skopeo.copy.call_count == 2
+            assert len(exc_info.value.exceptions) == 1
+            assert isinstance(exc_info.value.exceptions[0], SkopeoCmdError)

--- a/reconcile/test/test_quay_mirror.py
+++ b/reconcile/test/test_quay_mirror.py
@@ -204,57 +204,57 @@ def test_quay_mirror_session(mocker: MockerFixture) -> None:
     mocked_request.Session.return_value.close.assert_called_once_with()
 
 
-@patch("reconcile.utils.gql.get_api", autospec=True)
-@patch("reconcile.queries.get_app_interface_settings", return_value={})
-class TestRunErrorHandling:
-    def _make_mirror(
-        self, mock_gql: Mock, mock_settings: Mock
-    ) -> tuple[QuayMirror, MagicMock]:
-        qm = QuayMirror(dry_run=True, compare_tags=False)
-        mock_skopeo: MagicMock = MagicMock()
-        qm.skopeo_cli = mock_skopeo
-        qm.push_creds = {}
-        return qm, mock_skopeo
+@pytest.fixture()
+def quay_mirror_instance(mocker: MockerFixture) -> tuple[QuayMirror, MagicMock]:
+    mocker.patch("reconcile.utils.gql.get_api", autospec=True)
+    mocker.patch("reconcile.queries.get_app_interface_settings", return_value={})
+    qm = QuayMirror(dry_run=True, compare_tags=False)
+    mock_skopeo: MagicMock = MagicMock()
+    qm.skopeo_cli = mock_skopeo
+    qm.push_creds = {}
+    return qm, mock_skopeo
 
-    def test_run_succeeds_with_no_errors(
-        self, mock_gql: Mock, mock_settings: Mock, mocker: MockerFixture
-    ) -> None:
-        qm, _ = self._make_mirror(mock_gql, mock_settings)
-        org = OrgKey(instance="quay.io", org_name="test-org")
-        task = {
+
+def test_run_succeeds_with_no_errors(
+    quay_mirror_instance: tuple[QuayMirror, MagicMock], mocker: MockerFixture
+) -> None:
+    qm, _ = quay_mirror_instance
+    org = OrgKey(instance="quay.io", org_name="test-org")
+    task = {
+        "mirror_url": "docker.io/foo:1",
+        "mirror_creds": None,
+        "image_url": "quay.io/test-org/foo:1",
+    }
+    mocker.patch.object(qm, "process_sync_tasks", return_value={org: [task]})
+    qm.push_creds[org] = "user:token"
+
+    qm.run()  # should not raise
+
+
+def test_run_raises_exception_group_on_skopeo_error(
+    quay_mirror_instance: tuple[QuayMirror, MagicMock], mocker: MockerFixture
+) -> None:
+    qm, mock_skopeo = quay_mirror_instance
+    org = OrgKey(instance="quay.io", org_name="test-org")
+    tasks = [
+        {
             "mirror_url": "docker.io/foo:1",
             "mirror_creds": None,
             "image_url": "quay.io/test-org/foo:1",
-        }
-        mocker.patch.object(qm, "process_sync_tasks", return_value={org: [task]})
-        qm.push_creds[org] = "user:token"
+        },
+        {
+            "mirror_url": "docker.io/foo:2",
+            "mirror_creds": None,
+            "image_url": "quay.io/test-org/foo:2",
+        },
+    ]
+    mocker.patch.object(qm, "process_sync_tasks", return_value={org: tasks})
+    qm.push_creds[org] = "user:token"
+    mock_skopeo.copy.side_effect = [SkopeoCmdError("exit code: 1"), None]
 
-        qm.run()  # should not raise
+    with pytest.raises(ExceptionGroup) as exc_info:
+        qm.run()
 
-    def test_run_raises_exception_group_on_skopeo_error(
-        self, mock_gql: Mock, mock_settings: Mock, mocker: MockerFixture
-    ) -> None:
-        qm, mock_skopeo = self._make_mirror(mock_gql, mock_settings)
-        org = OrgKey(instance="quay.io", org_name="test-org")
-        tasks = [
-            {
-                "mirror_url": "docker.io/foo:1",
-                "mirror_creds": None,
-                "image_url": "quay.io/test-org/foo:1",
-            },
-            {
-                "mirror_url": "docker.io/foo:2",
-                "mirror_creds": None,
-                "image_url": "quay.io/test-org/foo:2",
-            },
-        ]
-        mocker.patch.object(qm, "process_sync_tasks", return_value={org: tasks})
-        qm.push_creds[org] = "user:token"
-        mock_skopeo.copy.side_effect = [SkopeoCmdError("exit code: 1"), None]
-
-        with pytest.raises(ExceptionGroup) as exc_info:
-            qm.run()
-
-        assert mock_skopeo.copy.call_count == 2
-        assert len(exc_info.value.exceptions) == 1
-        assert isinstance(exc_info.value.exceptions[0], SkopeoCmdError)
+    assert mock_skopeo.copy.call_count == 2
+    assert len(exc_info.value.exceptions) == 1
+    assert isinstance(exc_info.value.exceptions[0], SkopeoCmdError)

--- a/reconcile/test/test_quay_mirror.py
+++ b/reconcile/test/test_quay_mirror.py
@@ -3,17 +3,20 @@ from __future__ import annotations
 import os
 import tempfile
 from typing import TYPE_CHECKING
-from unittest.mock import create_autospec, patch
+from unittest.mock import MagicMock, create_autospec, patch
 
 import pytest
 import requests
+from sretoolbox.container.skopeo import SkopeoCmdError
 
 from reconcile.quay_mirror import (
     CONTROL_FILE_NAME,
     OrgKey,
     QuayMirror,
     queries,
+    run,
 )
+from reconcile.status import ExitCodes
 from reconcile.utils.quay_mirror import sync_tag
 
 from .fixtures import Fixtures
@@ -201,3 +204,75 @@ def test_quay_mirror_session(mocker: MockerFixture) -> None:
         assert quay_mirror.session == mocked_request.Session.return_value
 
     mocked_request.Session.return_value.close.assert_called_once_with()
+
+
+@patch("reconcile.utils.gql.get_api", autospec=True)
+@patch("reconcile.queries.get_app_interface_settings", return_value={})
+class TestRunErrorHandling:
+    def _make_mirror(self, mock_gql: Mock, mock_settings: Mock) -> tuple[QuayMirror, MagicMock]:
+        qm = QuayMirror(dry_run=True, compare_tags=False)
+        mock_skopeo: MagicMock = MagicMock()
+        qm.skopeo_cli = mock_skopeo
+        qm.push_creds = {}
+        return qm, mock_skopeo
+
+    def test_run_returns_false_on_success(
+        self, mock_gql: Mock, mock_settings: Mock, mocker: MockerFixture
+    ) -> None:
+        qm, _ = self._make_mirror(mock_gql, mock_settings)
+        org = OrgKey(instance="quay.io", org_name="test-org")
+        task = {"mirror_url": "docker.io/foo:1", "mirror_creds": None, "image_url": "quay.io/test-org/foo:1"}
+        mocker.patch.object(qm, "process_sync_tasks", return_value={org: [task]})
+        qm.push_creds[org] = "user:token"
+
+        assert qm.run() is False
+
+    def test_run_returns_true_on_skopeo_error(
+        self, mock_gql: Mock, mock_settings: Mock, mocker: MockerFixture
+    ) -> None:
+        qm, mock_skopeo = self._make_mirror(mock_gql, mock_settings)
+        org = OrgKey(instance="quay.io", org_name="test-org")
+        tasks = [
+            {"mirror_url": "docker.io/foo:1", "mirror_creds": None, "image_url": "quay.io/test-org/foo:1"},
+            {"mirror_url": "docker.io/foo:2", "mirror_creds": None, "image_url": "quay.io/test-org/foo:2"},
+        ]
+        mocker.patch.object(qm, "process_sync_tasks", return_value={org: tasks})
+        qm.push_creds[org] = "user:token"
+        mock_skopeo.copy.side_effect = [SkopeoCmdError("exit code: 1"), None]
+
+        assert qm.run() is True
+        assert mock_skopeo.copy.call_count == 2
+
+    def test_module_run_exits_on_error(
+        self, mock_gql: Mock, mock_settings: Mock, mocker: MockerFixture
+    ) -> None:
+        mocker.patch("reconcile.quay_mirror.requests")
+        mocker.patch.object(QuayMirror, "run", return_value=True)
+        mocker.patch.object(QuayMirror, "_get_push_creds", return_value={})
+
+        with pytest.raises(SystemExit) as exc_info:
+            run(
+                dry_run=True,
+                control_file_dir=None,
+                compare_tags=False,
+                compare_tags_interval=86400,
+                repository_urls=None,
+                exclude_repository_urls=None,
+            )
+        assert exc_info.value.code == ExitCodes.ERROR
+
+    def test_module_run_no_exit_on_success(
+        self, mock_gql: Mock, mock_settings: Mock, mocker: MockerFixture
+    ) -> None:
+        mocker.patch("reconcile.quay_mirror.requests")
+        mocker.patch.object(QuayMirror, "run", return_value=False)
+        mocker.patch.object(QuayMirror, "_get_push_creds", return_value={})
+
+        run(
+            dry_run=True,
+            control_file_dir=None,
+            compare_tags=False,
+            compare_tags_interval=86400,
+            repository_urls=None,
+            exclude_repository_urls=None,
+        )

--- a/reconcile/test/test_quay_mirror.py
+++ b/reconcile/test/test_quay_mirror.py
@@ -14,9 +14,7 @@ from reconcile.quay_mirror import (
     OrgKey,
     QuayMirror,
     queries,
-    run,
 )
-from reconcile.status import ExitCodes
 from reconcile.utils.quay_mirror import sync_tag
 
 from .fixtures import Fixtures
@@ -209,70 +207,54 @@ def test_quay_mirror_session(mocker: MockerFixture) -> None:
 @patch("reconcile.utils.gql.get_api", autospec=True)
 @patch("reconcile.queries.get_app_interface_settings", return_value={})
 class TestRunErrorHandling:
-    def _make_mirror(self, mock_gql: Mock, mock_settings: Mock) -> tuple[QuayMirror, MagicMock]:
+    def _make_mirror(
+        self, mock_gql: Mock, mock_settings: Mock
+    ) -> tuple[QuayMirror, MagicMock]:
         qm = QuayMirror(dry_run=True, compare_tags=False)
         mock_skopeo: MagicMock = MagicMock()
         qm.skopeo_cli = mock_skopeo
         qm.push_creds = {}
         return qm, mock_skopeo
 
-    def test_run_returns_false_on_success(
+    def test_run_succeeds_with_no_errors(
         self, mock_gql: Mock, mock_settings: Mock, mocker: MockerFixture
     ) -> None:
         qm, _ = self._make_mirror(mock_gql, mock_settings)
         org = OrgKey(instance="quay.io", org_name="test-org")
-        task = {"mirror_url": "docker.io/foo:1", "mirror_creds": None, "image_url": "quay.io/test-org/foo:1"}
+        task = {
+            "mirror_url": "docker.io/foo:1",
+            "mirror_creds": None,
+            "image_url": "quay.io/test-org/foo:1",
+        }
         mocker.patch.object(qm, "process_sync_tasks", return_value={org: [task]})
         qm.push_creds[org] = "user:token"
 
-        assert qm.run() is False
+        qm.run()  # should not raise
 
-    def test_run_returns_true_on_skopeo_error(
+    def test_run_raises_exception_group_on_skopeo_error(
         self, mock_gql: Mock, mock_settings: Mock, mocker: MockerFixture
     ) -> None:
         qm, mock_skopeo = self._make_mirror(mock_gql, mock_settings)
         org = OrgKey(instance="quay.io", org_name="test-org")
         tasks = [
-            {"mirror_url": "docker.io/foo:1", "mirror_creds": None, "image_url": "quay.io/test-org/foo:1"},
-            {"mirror_url": "docker.io/foo:2", "mirror_creds": None, "image_url": "quay.io/test-org/foo:2"},
+            {
+                "mirror_url": "docker.io/foo:1",
+                "mirror_creds": None,
+                "image_url": "quay.io/test-org/foo:1",
+            },
+            {
+                "mirror_url": "docker.io/foo:2",
+                "mirror_creds": None,
+                "image_url": "quay.io/test-org/foo:2",
+            },
         ]
         mocker.patch.object(qm, "process_sync_tasks", return_value={org: tasks})
         qm.push_creds[org] = "user:token"
         mock_skopeo.copy.side_effect = [SkopeoCmdError("exit code: 1"), None]
 
-        assert qm.run() is True
+        with pytest.raises(ExceptionGroup) as exc_info:
+            qm.run()
+
         assert mock_skopeo.copy.call_count == 2
-
-    def test_module_run_exits_on_error(
-        self, mock_gql: Mock, mock_settings: Mock, mocker: MockerFixture
-    ) -> None:
-        mocker.patch("reconcile.quay_mirror.requests")
-        mocker.patch.object(QuayMirror, "run", return_value=True)
-        mocker.patch.object(QuayMirror, "_get_push_creds", return_value={})
-
-        with pytest.raises(SystemExit) as exc_info:
-            run(
-                dry_run=True,
-                control_file_dir=None,
-                compare_tags=False,
-                compare_tags_interval=86400,
-                repository_urls=None,
-                exclude_repository_urls=None,
-            )
-        assert exc_info.value.code == ExitCodes.ERROR
-
-    def test_module_run_no_exit_on_success(
-        self, mock_gql: Mock, mock_settings: Mock, mocker: MockerFixture
-    ) -> None:
-        mocker.patch("reconcile.quay_mirror.requests")
-        mocker.patch.object(QuayMirror, "run", return_value=False)
-        mocker.patch.object(QuayMirror, "_get_push_creds", return_value={})
-
-        run(
-            dry_run=True,
-            control_file_dir=None,
-            compare_tags=False,
-            compare_tags_interval=86400,
-            repository_urls=None,
-            exclude_repository_urls=None,
-        )
+        assert len(exc_info.value.exceptions) == 1
+        assert isinstance(exc_info.value.exceptions[0], SkopeoCmdError)

--- a/reconcile/test/test_quay_mirror_org.py
+++ b/reconcile/test/test_quay_mirror_org.py
@@ -117,10 +117,12 @@ def test_run_succeeds_with_no_errors(
     quay_mirror_org_instance: tuple[QuayMirrorOrg, MagicMock],
     mocker: MockerFixture,
 ) -> None:
-    qm, _ = quay_mirror_org_instance
+    qm, mock_skopeo = quay_mirror_org_instance
     mocker.patch.object(qm, "process_sync_tasks", return_value={})
 
     qm.run()
+
+    mock_skopeo.copy.assert_not_called()
 
 
 def test_run_raises_exception_group_on_skopeo_error(

--- a/reconcile/test/test_quay_mirror_org.py
+++ b/reconcile/test/test_quay_mirror_org.py
@@ -103,53 +103,51 @@ def test_quay_mirror_org_session(mocker: MockerFixture) -> None:
     mocked_request.Session.return_value.close.assert_called_once_with()
 
 
-@patch("reconcile.quay_base.get_quay_api_store", return_value={})
-@patch("reconcile.quay_mirror_org.requests")
-class TestRunErrorHandling:
-    def _make_mirror(self) -> tuple[QuayMirrorOrg, MagicMock]:
-        qm = QuayMirrorOrg(dry_run=True, compare_tags=False)
-        mock_skopeo: MagicMock = MagicMock()
-        qm.skopeo_cli = mock_skopeo
-        return qm, mock_skopeo
+@pytest.fixture()
+def quay_mirror_org_instance(mocker: MockerFixture) -> tuple[QuayMirrorOrg, MagicMock]:
+    mocker.patch("reconcile.quay_base.get_quay_api_store", return_value={})
+    mocker.patch("reconcile.quay_mirror_org.requests")
+    qm = QuayMirrorOrg(dry_run=True, compare_tags=False)
+    mock_skopeo: MagicMock = MagicMock()
+    qm.skopeo_cli = mock_skopeo
+    return qm, mock_skopeo
 
-    def test_run_succeeds_with_no_errors(
-        self,
-        mock_requests: Mock,
-        mock_quay_api_store: Mock,
-        mocker: MockerFixture,
-    ) -> None:
-        qm, _ = self._make_mirror()
-        mocker.patch.object(qm, "process_sync_tasks", return_value={})
 
+def test_run_succeeds_with_no_errors(
+    quay_mirror_org_instance: tuple[QuayMirrorOrg, MagicMock],
+    mocker: MockerFixture,
+) -> None:
+    qm, _ = quay_mirror_org_instance
+    mocker.patch.object(qm, "process_sync_tasks", return_value={})
+
+    qm.run()
+
+
+def test_run_raises_exception_group_on_skopeo_error(
+    quay_mirror_org_instance: tuple[QuayMirrorOrg, MagicMock],
+    mocker: MockerFixture,
+) -> None:
+    qm, mock_skopeo = quay_mirror_org_instance
+    org_key = ("quay.io", "test-org")
+    tasks = [
+        {
+            "mirror_url": "docker.io/foo:1",
+            "mirror_creds": None,
+            "image_url": "quay.io/test-org/foo:1",
+        },
+        {
+            "mirror_url": "docker.io/foo:2",
+            "mirror_creds": None,
+            "image_url": "quay.io/test-org/foo:2",
+        },
+    ]
+    mocker.patch.object(qm, "process_sync_tasks", return_value={org_key: tasks})
+    mocker.patch.object(qm, "get_push_creds", return_value="user:token")
+    mock_skopeo.copy.side_effect = [SkopeoCmdError("exit code: 1"), None]
+
+    with pytest.raises(ExceptionGroup) as exc_info:
         qm.run()
 
-    def test_run_raises_exception_group_on_skopeo_error(
-        self,
-        mock_requests: Mock,
-        mock_quay_api_store: Mock,
-        mocker: MockerFixture,
-    ) -> None:
-        qm, mock_skopeo = self._make_mirror()
-        org_key = ("quay.io", "test-org")
-        tasks = [
-            {
-                "mirror_url": "docker.io/foo:1",
-                "mirror_creds": None,
-                "image_url": "quay.io/test-org/foo:1",
-            },
-            {
-                "mirror_url": "docker.io/foo:2",
-                "mirror_creds": None,
-                "image_url": "quay.io/test-org/foo:2",
-            },
-        ]
-        mocker.patch.object(qm, "process_sync_tasks", return_value={org_key: tasks})
-        mocker.patch.object(qm, "get_push_creds", return_value="user:token")
-        mock_skopeo.copy.side_effect = [SkopeoCmdError("exit code: 1"), None]
-
-        with pytest.raises(ExceptionGroup) as exc_info:
-            qm.run()
-
-        assert mock_skopeo.copy.call_count == 2
-        assert len(exc_info.value.exceptions) == 1
-        assert isinstance(exc_info.value.exceptions[0], SkopeoCmdError)
+    assert mock_skopeo.copy.call_count == 2
+    assert len(exc_info.value.exceptions) == 1
+    assert isinstance(exc_info.value.exceptions[0], SkopeoCmdError)

--- a/reconcile/test/test_quay_mirror_org.py
+++ b/reconcile/test/test_quay_mirror_org.py
@@ -3,9 +3,10 @@ from __future__ import annotations
 import os
 import tempfile
 from typing import TYPE_CHECKING
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
+from sretoolbox.container.skopeo import SkopeoCmdError
 
 from reconcile.quay_mirror_org import (
     CONTROL_FILE_NAME,
@@ -100,3 +101,55 @@ def test_quay_mirror_org_session(mocker: MockerFixture) -> None:
         assert quay_mirror_org.session == mocked_request.Session.return_value
 
     mocked_request.Session.return_value.close.assert_called_once_with()
+
+
+@patch("reconcile.quay_base.get_quay_api_store", return_value={})
+@patch("reconcile.quay_mirror_org.requests")
+class TestRunErrorHandling:
+    def _make_mirror(self) -> tuple[QuayMirrorOrg, MagicMock]:
+        qm = QuayMirrorOrg(dry_run=True, compare_tags=False)
+        mock_skopeo: MagicMock = MagicMock()
+        qm.skopeo_cli = mock_skopeo
+        return qm, mock_skopeo
+
+    def test_run_succeeds_with_no_errors(
+        self,
+        mock_requests: Mock,
+        mock_quay_api_store: Mock,
+        mocker: MockerFixture,
+    ) -> None:
+        qm, _ = self._make_mirror()
+        mocker.patch.object(qm, "process_sync_tasks", return_value={})
+
+        qm.run()
+
+    def test_run_raises_exception_group_on_skopeo_error(
+        self,
+        mock_requests: Mock,
+        mock_quay_api_store: Mock,
+        mocker: MockerFixture,
+    ) -> None:
+        qm, mock_skopeo = self._make_mirror()
+        org_key = ("quay.io", "test-org")
+        tasks = [
+            {
+                "mirror_url": "docker.io/foo:1",
+                "mirror_creds": None,
+                "image_url": "quay.io/test-org/foo:1",
+            },
+            {
+                "mirror_url": "docker.io/foo:2",
+                "mirror_creds": None,
+                "image_url": "quay.io/test-org/foo:2",
+            },
+        ]
+        mocker.patch.object(qm, "process_sync_tasks", return_value={org_key: tasks})
+        mocker.patch.object(qm, "get_push_creds", return_value="user:token")
+        mock_skopeo.copy.side_effect = [SkopeoCmdError("exit code: 1"), None]
+
+        with pytest.raises(ExceptionGroup) as exc_info:
+            qm.run()
+
+        assert mock_skopeo.copy.call_count == 2
+        assert len(exc_info.value.exceptions) == 1
+        assert isinstance(exc_info.value.exceptions[0], SkopeoCmdError)


### PR DESCRIPTION
Previously, SkopeoCmdError exceptions were swallowed and logged, causing the integration to exit 0 even when image copies failed. Now QuayMirror.run() tracks errors and returns a bool; the module-level run() exits with ExitCodes.ERROR if any copy failed, while still attempting all remaining tasks.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Mirror runs now collect individual image copy failures and fail at the end of a run, reporting all copy errors together instead of silently continuing.

* **Tests**
  * Added unit tests covering successful mirror runs and runs that raise an aggregated copy-error when some copy attempts fail (including multi-task scenarios).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->