### PR TITLE
fix(qontract-api): increase readinessProbe timeout to prevent false failures

### DIFF
--- a/openshift/qontract-api.yaml
+++ b/openshift/qontract-api.yaml
@@ -123,7 +123,7 @@ objects:
                   path: /health/ready
                   port: ${{QAPI_APP_PORT}}
                 periodSeconds: 60
-                timeoutSeconds: 5
+                timeoutSeconds: 10
               livenessProbe:
                 httpGet:
                   path: /health/live


### PR DESCRIPTION
## Summary

The qontract-api pod is experiencing **131 readiness probe failures in the last hour** with the error:

```
Readiness probe failed: Get "http://10.130.6.151:8080/health/ready": context deadline exceeded (Client.Timeout exceeded while awaiting headers)
```

The current `timeoutSeconds: 5` is too short — the `/health/ready` endpoint occasionally takes longer than 5 seconds to respond under load, causing the probe to fail and the pod to be marked as not ready.

## Changes

- Increase `timeoutSeconds` from `5` to `10` for the readiness probe in `openshift/qontract-api.yaml`

## Test plan

- [ ] Verify the template renders correctly
- [ ] Monitor readiness probe failures after deployment — expect significant reduction