### PR TITLE
fix(slack-usergroups): use workspace user IDs for Enterprise Grid users

### DIFF
--- a/qontract_api/qontract_api/slack/slack_workspace_client.py
+++ b/qontract_api/qontract_api/slack/slack_workspace_client.py
@@ -291,9 +291,15 @@ class SlackWorkspaceClient:
         channel_name_by_id = {
             channel.id: channel.name for channel in self.get_channels().values()
         }
-        org_username_by_id = {
-            user.id: user.org_username for user in self.get_users().values()
-        }
+        # Build lookup covering both workspace IDs (U...) and enterprise IDs (W...).
+        # usergroups_list returns workspace-level U... IDs in ug.users, but user.id
+        # returns the enterprise W... ID for Enterprise Grid users. Without both keys,
+        # Enterprise Grid users are silently dropped from current state every reconcile.
+        org_username_by_id: dict[str, str] = {}
+        for user in self.get_users().values():
+            org_username_by_id[user.pk] = user.org_username
+            if user.enterprise_user:
+                org_username_by_id[user.enterprise_user.id] = user.org_username
 
         return [
             SlackUsergroup(

--- a/qontract_api/tests/slack/test_slack_workspace_client.py
+++ b/qontract_api/tests/slack/test_slack_workspace_client.py
@@ -8,8 +8,10 @@ from qontract_utils.slack_api import (
     ChatPostMessageResponse,
     SlackApiError,
     SlackChannel,
+    SlackEnterpriseUser,
     SlackUser,
     SlackUsergroup,
+    SlackUsergroupPrefs,
     SlackUserProfile,
 )
 
@@ -692,3 +694,47 @@ def test_chat_post_message_propagates_slack_api_error(
         )
 
     assert exc_info.value.response["error"] == "channel_not_found"
+
+
+def test_get_slack_usergroups_enterprise_grid_user_resolved(
+    client: SlackWorkspaceClient,
+    mock_cache: MagicMock,
+) -> None:
+    """Enterprise Grid users must appear in current state.
+
+    usergroups_list returns workspace U... IDs in ug.users, but user.id returns
+    the enterprise W... ID when enterprise_user is set. Without a dual-keyed lookup,
+    Enterprise Grid users are silently dropped from current state every reconcile cycle,
+    causing an infinite loop where the same users appear in users_to_add on every run.
+    """
+    enterprise_user = SlackEnterpriseUser(id="W_ENTERPRISE")
+    user = SlackUser(
+        id="U_WORKSPACE",
+        name="testuser",
+        deleted=False,
+        profile=SlackUserProfile(email="testuser@example.com"),
+        enterprise_user=enterprise_user,
+    )
+    # usergroups_list returns workspace-level U... IDs
+    ug = SlackUsergroup(
+        id="UG1",
+        handle="oncall",
+        users=["U_WORKSPACE"],
+        prefs=SlackUsergroupPrefs(channels=[]),
+    )
+
+    def get_obj_side_effect(cache_key: str, *_args: Any, **_kwargs: Any) -> Any:
+        if "usergroups" in cache_key:
+            return CachedUsergroups(items=[ug])
+        if "users" in cache_key:
+            return CachedUsers(items=[user])
+        if "channels" in cache_key:
+            return CachedChannels(items=[])
+        return None
+
+    mock_cache.get_obj.side_effect = get_obj_side_effect
+
+    result = client.get_slack_usergroups(["oncall"])
+
+    assert len(result) == 1
+    assert result[0].config.users == ["testuser"]


### PR DESCRIPTION
SlackUser.id returns the enterprise W... ID when enterprise_user is set,
but usergroups_list returns workspace-level U... IDs in ug.users. This
caused Enterprise Grid users to be silently dropped from the current state
on every reconcile cycle, making them always appear in users_to_add and
causing an infinite loop (observed: bhthakur, jbanerje, faldana).

Fix: build a dual-keyed lookup (both U... and W... → org_username) in
get_slack_usergroups so Enterprise Grid users are correctly resolved from
Slack usergroup membership.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Slack Enterprise Grid user handling in usergroup management by enhancing user identification across workspace and enterprise grid contexts, ensuring users remain properly associated with usergroups

* **Tests**
  * Added test coverage for Enterprise Grid user resolution in usergroup retrieval and configuration
  * Added test coverage validating Enterprise Grid user identification when syncing usergroup membership to Slack

<!-- end of auto-generated comment: release notes by coderabbit.ai -->