### PR TITLE
qontract-api: remove worker health check

### DIFF
--- a/qontract_api/qontract_api/health.py
+++ b/qontract_api/qontract_api/health.py
@@ -60,22 +60,6 @@ def check_cache_health(cache: CacheBackend | None) -> HealthStatus:
         return HealthStatus(status="unhealthy", message=f"Cache check failed: {e}")
 
 
-def check_worker_health() -> HealthStatus:
-    """Check background worker health.
-
-    Returns:
-        HealthStatus with
-          current cache health
-    """
-    # avoid circular imports
-    from qontract_api.tasks.health import health_check  # noqa: PLC0415
-
-    try:
-        return health_check.delay().wait(timeout=5)
-    except Exception as e:  # noqa: BLE001
-        return HealthStatus(status="unhealthy", message=f"Worker check failed: {e}")
-
-
 def get_health_status(cache: CacheOptionalDep) -> HealthResponse:
     """Get overall health status including all components.
 
@@ -89,7 +73,6 @@ def get_health_status(cache: CacheOptionalDep) -> HealthResponse:
 
     # Check cache
     components["cache"] = check_cache_health(cache)
-    components["worker"] = check_worker_health()
 
     # Determine overall status
     component_statuses = [c.status for c in components.values()]

--- a/qontract_api/tests/test_health.py
+++ b/qontract_api/tests/test_health.py
@@ -1,11 +1,8 @@
 """Tests for health check endpoints."""
 
 from http import HTTPStatus
-from unittest.mock import MagicMock, patch
 
 from fastapi.testclient import TestClient
-
-from qontract_api.health import HealthStatus
 
 
 def test_root_endpoint(client: TestClient) -> None:
@@ -22,18 +19,8 @@ def test_liveness_probe(client: TestClient) -> None:
     assert data["status"] == "healthy"
 
 
-@patch("qontract_api.tasks.health.health_check")
-def test_readiness_probe_without_cache(
-    mock_health_check: MagicMock, client: TestClient
-) -> None:
+def test_readiness_probe_without_cache(client: TestClient) -> None:
     """Test readiness probe fails when cache is not initialized."""
-    # Mock worker health check to succeed
-    mock_result = MagicMock()
-    mock_result.wait.return_value = HealthStatus(
-        status="healthy", message="Celery worker is operational"
-    )
-    mock_health_check.delay.return_value = mock_result
-
     response = client.get("/health/ready")
     assert response.status_code == HTTPStatus.OK
     data = response.json()
@@ -43,21 +30,10 @@ def test_readiness_probe_without_cache(
     assert "cache" in data["components"]
 
 
-@patch("qontract_api.tasks.health.health_check")
-def test_readiness_probe_with_cache(
-    mock_health_check: MagicMock, client_with_cache: TestClient
-) -> None:
+def test_readiness_probe_with_cache(client_with_cache: TestClient) -> None:
     """Test readiness probe succeeds when cache is healthy."""
-    # Mock worker health check to succeed
-    mock_result = MagicMock()
-    mock_result.wait.return_value = HealthStatus(
-        status="healthy", message="Celery worker is operational"
-    )
-    mock_health_check.delay.return_value = mock_result
-
     response = client_with_cache.get("/health/ready")
     assert response.status_code == HTTPStatus.OK
     data = response.json()
     assert data["status"] == "healthy"
     assert data["components"]["cache"]["status"] == "healthy"
-    assert data["components"]["worker"]["status"] == "healthy"


### PR DESCRIPTION
Follows #5519

The `qontract-api` server depends on the Redis cache but not on the healthiness of the `qontract-api-workers`. In case of worker issues, all API pods would go in an unhealthy state, and `contract-api` at all isn't working anymore :( 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Changes**
  * Health endpoint no longer reports a separate worker component; overall system health is now based solely on the cache component, so worker failures are no longer reflected.

* **Tests**
  * Readiness tests updated to validate health responses using only the cache component status.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->