### PR TITLE
feat(aws_api_typed): implement hooks framework for all AWS API clients

### DIFF
--- a/qontract_utils/qontract_utils/aws_api_typed/_hooks.py
+++ b/qontract_utils/qontract_utils/aws_api_typed/_hooks.py
@@ -1,0 +1,74 @@
+"""Shared hooks infrastructure for AWS API typed clients."""
+
+from __future__ import annotations
+
+import contextvars
+import time
+from dataclasses import dataclass
+
+import structlog
+from prometheus_client import Counter, Histogram
+
+from qontract_utils.hooks import Hooks
+from qontract_utils.metrics import DEFAULT_BUCKETS_EXTERNAL_API
+
+logger = structlog.get_logger(__name__)
+
+aws_request = Counter(
+    "qontract_reconcile_external_api_aws_requests_total",
+    "Total number of AWS API requests",
+    ["method", "service"],
+)
+
+aws_request_duration = Histogram(
+    "qontract_reconcile_external_api_aws_request_duration_seconds",
+    "AWS API request duration in seconds",
+    ["method", "service"],
+    buckets=DEFAULT_BUCKETS_EXTERNAL_API,
+)
+
+_latency_tracker: contextvars.ContextVar[tuple[float, ...]] = contextvars.ContextVar(
+    f"{__name__}.latency_tracker", default=()
+)
+
+
+@dataclass(frozen=True)
+class AWSApiCallContext:
+    """Context information passed to API call hooks."""
+
+    method: str
+    service: str
+
+
+def _metrics_hook(context: AWSApiCallContext) -> None:
+    """Built-in Prometheus metrics hook."""
+    aws_request.labels(context.method, context.service).inc()
+
+
+def _latency_start_hook(_context: AWSApiCallContext) -> None:
+    """Built-in hook to start latency measurement."""
+    _latency_tracker.set((*_latency_tracker.get(), time.perf_counter()))
+
+
+def _latency_end_hook(context: AWSApiCallContext) -> None:
+    """Built-in hook to record latency measurement."""
+    stack = _latency_tracker.get()
+    start_time = stack[-1]
+    _latency_tracker.set(stack[:-1])
+    duration = time.perf_counter() - start_time
+    aws_request_duration.labels(context.method, context.service).observe(duration)
+
+
+def _request_log_hook(context: AWSApiCallContext) -> None:
+    """Built-in hook for logging API requests."""
+    logger.debug(
+        "AWS API request",
+        method=context.method,
+        service=context.service,
+    )
+
+
+AWS_DEFAULT_HOOKS = Hooks(
+    pre_hooks=[_metrics_hook, _request_log_hook, _latency_start_hook],
+    post_hooks=[_latency_end_hook],
+)

--- a/qontract_utils/qontract_utils/aws_api_typed/account.py
+++ b/qontract_utils/qontract_utils/aws_api_typed/account.py
@@ -6,6 +6,9 @@ from typing import TYPE_CHECKING
 
 from pydantic import BaseModel
 
+from qontract_utils.aws_api_typed._hooks import AWS_DEFAULT_HOOKS, AWSApiCallContext
+from qontract_utils.hooks import Hooks, invoke_with_hooks, with_hooks
+
 if TYPE_CHECKING:
     from mypy_boto3_account import AccountClient
     from mypy_boto3_account.type_defs import AlternateContactTypeDef
@@ -27,10 +30,16 @@ class Region(BaseModel):
 log = logging.getLogger(__name__)
 
 
+@with_hooks(hooks=AWS_DEFAULT_HOOKS)
 class AWSApiAccount:
-    def __init__(self, client: AccountClient) -> None:
+    _hooks: Hooks
+
+    def __init__(self, client: AccountClient, hooks: Hooks | None = None) -> None:  # noqa: ARG002
         self.client = client
 
+    @invoke_with_hooks(
+        lambda: AWSApiCallContext(method="set_security_contact", service="account")
+    )
     def set_security_contact(
         self, name: str, title: str, email: str, phone_number: str
     ) -> None:
@@ -56,6 +65,9 @@ class AWSApiAccount:
             ):
                 raise
 
+    @invoke_with_hooks(
+        lambda: AWSApiCallContext(method="get_security_contact", service="account")
+    )
     def get_security_contact(self) -> AlternateContactTypeDef | None:
         """Get the security contact for the account."""
         try:
@@ -66,6 +78,9 @@ class AWSApiAccount:
             log.warning("Security contact not set.")
             return None
 
+    @invoke_with_hooks(
+        lambda: AWSApiCallContext(method="list_regions", service="account")
+    )
     def list_regions(self) -> list[Region]:
         """List all regions in the account."""
         regions = []
@@ -84,10 +99,16 @@ class AWSApiAccount:
                 regions.append(Region(name=region["RegionName"], status=status))
         return regions
 
+    @invoke_with_hooks(
+        lambda: AWSApiCallContext(method="enable_region", service="account")
+    )
     def enable_region(self, region: str) -> None:
         """Enable a region in the account."""
         self.client.enable_region(RegionName=region)
 
+    @invoke_with_hooks(
+        lambda: AWSApiCallContext(method="disable_region", service="account")
+    )
     def disable_region(self, region: str) -> None:
         """Disable a region in the account."""
         self.client.disable_region(RegionName=region)

--- a/qontract_utils/qontract_utils/aws_api_typed/cloudformation.py
+++ b/qontract_utils/qontract_utils/aws_api_typed/cloudformation.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+from qontract_utils.aws_api_typed._hooks import AWS_DEFAULT_HOOKS, AWSApiCallContext
+from qontract_utils.hooks import Hooks, invoke_with_hooks, with_hooks
 from qontract_utils.json_utils import json_dumps
 
 if TYPE_CHECKING:
@@ -13,10 +15,20 @@ if TYPE_CHECKING:
     )
 
 
+@with_hooks(hooks=AWS_DEFAULT_HOOKS)
 class AWSApiCloudFormation:
-    def __init__(self, client: CloudFormationClient) -> None:
+    _hooks: Hooks
+
+    def __init__(
+        self,
+        client: CloudFormationClient,
+        hooks: Hooks | None = None,  # noqa: ARG002
+    ) -> None:
         self.client = client
 
+    @invoke_with_hooks(
+        lambda: AWSApiCallContext(method="create_stack", service="cloudformation")
+    )
     def create_stack(
         self,
         stack_name: str,
@@ -60,6 +72,9 @@ class AWSApiCloudFormation:
         self.client.get_waiter("stack_create_complete").wait(StackName=stack_name)
         return response["StackId"]
 
+    @invoke_with_hooks(
+        lambda: AWSApiCallContext(method="update_stack", service="cloudformation")
+    )
     def update_stack(
         self,
         stack_name: str,
@@ -92,6 +107,9 @@ class AWSApiCloudFormation:
         self.client.get_waiter("stack_update_complete").wait(StackName=stack_name)
         return response["StackId"]
 
+    @invoke_with_hooks(
+        lambda: AWSApiCallContext(method="get_stack", service="cloudformation")
+    )
     def get_stack(self, stack_name: str) -> StackTypeDef | None:
         """Retrieve information about a CloudFormation stack by its name.
 
@@ -112,6 +130,9 @@ class AWSApiCloudFormation:
                 return None
             raise
 
+    @invoke_with_hooks(
+        lambda: AWSApiCallContext(method="get_template_body", service="cloudformation")
+    )
     def get_template_body(self, stack_name: str) -> str:
         """
         Retrieve the CloudFormation template body for a specified stack.

--- a/qontract_utils/qontract_utils/aws_api_typed/dynamodb.py
+++ b/qontract_utils/qontract_utils/aws_api_typed/dynamodb.py
@@ -2,12 +2,18 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+from qontract_utils.aws_api_typed._hooks import AWS_DEFAULT_HOOKS
+from qontract_utils.hooks import Hooks, with_hooks
+
 if TYPE_CHECKING:
     from mypy_boto3_dynamodb import DynamoDBClient
 
 
+@with_hooks(hooks=AWS_DEFAULT_HOOKS)
 class AWSApiDynamoDB:
-    def __init__(self, client: DynamoDBClient) -> None:
+    _hooks: Hooks
+
+    def __init__(self, client: DynamoDBClient, hooks: Hooks | None = None) -> None:  # noqa: ARG002
         self.client = client
 
     @property

--- a/qontract_utils/qontract_utils/aws_api_typed/iam.py
+++ b/qontract_utils/qontract_utils/aws_api_typed/iam.py
@@ -5,6 +5,9 @@ from typing import TYPE_CHECKING
 import botocore
 from pydantic import BaseModel, Field
 
+from qontract_utils.aws_api_typed._hooks import AWS_DEFAULT_HOOKS, AWSApiCallContext
+from qontract_utils.hooks import Hooks, invoke_with_hooks, with_hooks
+
 if TYPE_CHECKING:
     from mypy_boto3_iam import IAMClient
 
@@ -25,10 +28,16 @@ class AWSEntityAlreadyExistsError(Exception):
     """Raised when the user already exists in IAM."""
 
 
+@with_hooks(hooks=AWS_DEFAULT_HOOKS)
 class AWSApiIam:
-    def __init__(self, client: IAMClient) -> None:
+    _hooks: Hooks
+
+    def __init__(self, client: IAMClient, hooks: Hooks | None = None) -> None:  # noqa: ARG002
         self.client = client
 
+    @invoke_with_hooks(
+        lambda: AWSApiCallContext(method="create_access_key", service="iam")
+    )
     def create_access_key(self, user_name: str) -> AWSAccessKey:
         """Create an access key for a given user."""
         credentials = self.client.create_access_key(
@@ -36,6 +45,7 @@ class AWSApiIam:
         )
         return AWSAccessKey(**credentials["AccessKey"])
 
+    @invoke_with_hooks(lambda: AWSApiCallContext(method="create_user", service="iam"))
     def create_user(self, user_name: str) -> AWSUser:
         """Create a new IAM user."""
         try:
@@ -48,6 +58,9 @@ class AWSApiIam:
                 ) from e
             raise
 
+    @invoke_with_hooks(
+        lambda: AWSApiCallContext(method="attach_user_policy", service="iam")
+    )
     def attach_user_policy(self, user_name: str, policy_arn: str) -> None:
         """Attach a policy to a user."""
         self.client.attach_user_policy(
@@ -55,10 +68,16 @@ class AWSApiIam:
             PolicyArn=policy_arn,
         )
 
+    @invoke_with_hooks(
+        lambda: AWSApiCallContext(method="get_account_alias", service="iam")
+    )
     def get_account_alias(self) -> str:
         """Get the account alias."""
         return self.client.list_account_aliases()["AccountAliases"][0]
 
+    @invoke_with_hooks(
+        lambda: AWSApiCallContext(method="set_account_alias", service="iam")
+    )
     def set_account_alias(self, account_alias: str) -> None:
         """Set the account alias."""
         try:

--- a/qontract_utils/qontract_utils/aws_api_typed/logs.py
+++ b/qontract_utils/qontract_utils/aws_api_typed/logs.py
@@ -2,6 +2,9 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+from qontract_utils.aws_api_typed._hooks import AWS_DEFAULT_HOOKS, AWSApiCallContext
+from qontract_utils.hooks import Hooks, invoke_with_hooks, with_hooks
+
 if TYPE_CHECKING:
     from collections.abc import Iterable, Iterator
 
@@ -9,18 +12,34 @@ if TYPE_CHECKING:
     from mypy_boto3_logs.type_defs import LogGroupTypeDef
 
 
+@with_hooks(hooks=AWS_DEFAULT_HOOKS)
 class AWSApiLogs:
-    def __init__(self, client: CloudWatchLogsClient) -> None:
+    _hooks: Hooks
+
+    def __init__(
+        self,
+        client: CloudWatchLogsClient,
+        hooks: Hooks | None = None,  # noqa: ARG002
+    ) -> None:
         self.client = client
 
+    @invoke_with_hooks(
+        lambda: AWSApiCallContext(method="get_log_groups", service="logs")
+    )
     def get_log_groups(self) -> Iterator[LogGroupTypeDef]:
         paginator = self.client.get_paginator("describe_log_groups")
         for page in paginator.paginate():
             yield from page["logGroups"]
 
+    @invoke_with_hooks(
+        lambda: AWSApiCallContext(method="delete_log_group", service="logs")
+    )
     def delete_log_group(self, log_group_name: str) -> None:
         self.client.delete_log_group(logGroupName=log_group_name)
 
+    @invoke_with_hooks(
+        lambda: AWSApiCallContext(method="put_retention_policy", service="logs")
+    )
     def put_retention_policy(
         self,
         log_group_name: str,
@@ -31,12 +50,14 @@ class AWSApiLogs:
             retentionInDays=retention_in_days,
         )
 
+    @invoke_with_hooks(lambda: AWSApiCallContext(method="get_tags", service="logs"))
     def get_tags(self, arn: str) -> dict[str, str]:
         tags = self.client.list_tags_for_resource(
             resourceArn=self._normalize_log_group_arn(arn),
         )
         return tags.get("tags") or {}
 
+    @invoke_with_hooks(lambda: AWSApiCallContext(method="set_tags", service="logs"))
     def set_tags(
         self,
         arn: str,
@@ -47,6 +68,7 @@ class AWSApiLogs:
             tags=tags,
         )
 
+    @invoke_with_hooks(lambda: AWSApiCallContext(method="delete_tags", service="logs"))
     def delete_tags(
         self,
         arn: str,

--- a/qontract_utils/qontract_utils/aws_api_typed/logs.py
+++ b/qontract_utils/qontract_utils/aws_api_typed/logs.py
@@ -92,4 +92,4 @@ class AWSApiLogs:
         Returns:
             The normalized ARN without the trailing ":*".
         """
-        return arn.rstrip(":*")
+        return arn.removesuffix(":*")

--- a/qontract_utils/qontract_utils/aws_api_typed/organization.py
+++ b/qontract_utils/qontract_utils/aws_api_typed/organization.py
@@ -5,6 +5,9 @@ from typing import TYPE_CHECKING
 
 from pydantic import BaseModel, Field
 
+from qontract_utils.aws_api_typed._hooks import AWS_DEFAULT_HOOKS, AWSApiCallContext
+from qontract_utils.hooks import Hooks, invoke_with_hooks, with_hooks
+
 if TYPE_CHECKING:
     from collections.abc import Iterable, Mapping
 
@@ -74,8 +77,11 @@ class AWSAccountNotFoundError(Exception):
     """Exception raised when the account cannot be found in the specified OU."""
 
 
+@with_hooks(hooks=AWS_DEFAULT_HOOKS)
 class AWSApiOrganizations:
-    def __init__(self, client: OrganizationsClient) -> None:
+    _hooks: Hooks
+
+    def __init__(self, client: OrganizationsClient, hooks: Hooks | None = None) -> None:  # noqa: ARG002
         self.client = client
         self.get_organizational_units_tree = functools.lru_cache(maxsize=None)(
             self._get_organizational_units_tree
@@ -96,6 +102,9 @@ class AWSApiOrganizations:
                 self.get_organizational_units_tree(root=ou)
         return root
 
+    @invoke_with_hooks(
+        lambda: AWSApiCallContext(method="create_account", service="organizations")
+    )
     def create_account(
         self, email: str, name: str, *, access_to_billing: bool = True
     ) -> AWSAccountStatus:
@@ -112,6 +121,11 @@ class AWSApiOrganizations:
             )
         return status
 
+    @invoke_with_hooks(
+        lambda: AWSApiCallContext(
+            method="describe_create_account_status", service="organizations"
+        )
+    )
     def describe_create_account_status(
         self, create_account_request_id: str
     ) -> AWSAccountStatus:
@@ -121,6 +135,9 @@ class AWSApiOrganizations:
         )
         return AWSAccountStatus(**resp["CreateAccountStatus"])
 
+    @invoke_with_hooks(
+        lambda: AWSApiCallContext(method="get_ou", service="organizations")
+    )
     def get_ou(self, uid: str) -> str:
         """Return the organizational unit ID of an account."""
         resp = self.client.list_parents(ChildId=uid)
@@ -129,6 +146,9 @@ class AWSApiOrganizations:
                 return p["Id"]
         raise AWSAccountNotFoundError(f"Account {uid} not found!")
 
+    @invoke_with_hooks(
+        lambda: AWSApiCallContext(method="move_account", service="organizations")
+    )
     def move_account(self, uid: str, destination_parent_id: str) -> None:
         """Move an account to a different organizational unit."""
         source_parent_id = self.get_ou(uid=uid)
@@ -140,11 +160,17 @@ class AWSApiOrganizations:
             DestinationParentId=destination_parent_id,
         )
 
+    @invoke_with_hooks(
+        lambda: AWSApiCallContext(method="describe_account", service="organizations")
+    )
     def describe_account(self, uid: str) -> AWSAccount:
         """Return the status of an account."""
         resp = self.client.describe_account(AccountId=uid)
         return AWSAccount(**resp["Account"])
 
+    @invoke_with_hooks(
+        lambda: AWSApiCallContext(method="tag_resource", service="organizations")
+    )
     def tag_resource(self, resource_id: str, tags: Mapping[str, str]) -> None:
         """Tag a resource."""
         self.client.tag_resource(
@@ -152,6 +178,9 @@ class AWSApiOrganizations:
             Tags=[{"Key": k, "Value": v} for k, v in tags.items()],
         )
 
+    @invoke_with_hooks(
+        lambda: AWSApiCallContext(method="untag_resource", service="organizations")
+    )
     def untag_resource(self, resource_id: str, tag_keys: Iterable[str]) -> None:
         """Untag a resource."""
         self.client.untag_resource(ResourceId=resource_id, TagKeys=list(tag_keys))

--- a/qontract_utils/qontract_utils/aws_api_typed/s3.py
+++ b/qontract_utils/qontract_utils/aws_api_typed/s3.py
@@ -2,14 +2,21 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+from qontract_utils.aws_api_typed._hooks import AWS_DEFAULT_HOOKS, AWSApiCallContext
+from qontract_utils.hooks import Hooks, invoke_with_hooks, with_hooks
+
 if TYPE_CHECKING:
     from mypy_boto3_s3 import S3Client
 
 
+@with_hooks(hooks=AWS_DEFAULT_HOOKS)
 class AWSApiS3:
-    def __init__(self, client: S3Client) -> None:
+    _hooks: Hooks
+
+    def __init__(self, client: S3Client, hooks: Hooks | None = None) -> None:  # noqa: ARG002
         self.client = client
 
+    @invoke_with_hooks(lambda: AWSApiCallContext(method="create_bucket", service="s3"))
     def create_bucket(self, name: str, region: str) -> str:
         """Create an S3 bucket without any ACLs therefore the creator will be the owner and returns the ARN."""
         bucket_kwargs = {}

--- a/qontract_utils/qontract_utils/aws_api_typed/service_quotas.py
+++ b/qontract_utils/qontract_utils/aws_api_typed/service_quotas.py
@@ -4,6 +4,9 @@ from typing import TYPE_CHECKING
 
 from pydantic import BaseModel, Field
 
+from qontract_utils.aws_api_typed._hooks import AWS_DEFAULT_HOOKS, AWSApiCallContext
+from qontract_utils.hooks import Hooks, invoke_with_hooks, with_hooks
+
 if TYPE_CHECKING:
     from mypy_boto3_service_quotas import ServiceQuotasClient
     from mypy_boto3_service_quotas.literals import RequestStatusType
@@ -42,10 +45,18 @@ class AWSResourceAlreadyExistsError(Exception):
     """Raised when quota increase request already exists."""
 
 
+@with_hooks(hooks=AWS_DEFAULT_HOOKS)
 class AWSApiServiceQuotas:
-    def __init__(self, client: ServiceQuotasClient) -> None:
+    _hooks: Hooks
+
+    def __init__(self, client: ServiceQuotasClient, hooks: Hooks | None = None) -> None:  # noqa: ARG002
         self.client = client
 
+    @invoke_with_hooks(
+        lambda: AWSApiCallContext(
+            method="get_requested_service_quota_change", service="service-quotas"
+        )
+    )
     def get_requested_service_quota_change(
         self, request_id: str
     ) -> AWSRequestedServiceQuotaChange:
@@ -53,6 +64,11 @@ class AWSApiServiceQuotas:
         req = self.client.get_requested_service_quota_change(RequestId=request_id)
         return AWSRequestedServiceQuotaChange(**req["RequestedQuota"])
 
+    @invoke_with_hooks(
+        lambda: AWSApiCallContext(
+            method="request_service_quota_change", service="service-quotas"
+        )
+    )
     def request_service_quota_change(
         self, service_code: str, quota_code: str, desired_value: float
     ) -> AWSRequestedServiceQuotaChange:
@@ -69,6 +85,9 @@ class AWSApiServiceQuotas:
                 f"Service quota increase request {service_code=}, {quota_code=} already exists."
             ) from None
 
+    @invoke_with_hooks(
+        lambda: AWSApiCallContext(method="get_service_quota", service="service-quotas")
+    )
     def get_service_quota(self, service_code: str, quota_code: str) -> AWSQuota:
         """Return the current value of the service quota."""
         try:

--- a/qontract_utils/qontract_utils/aws_api_typed/sts.py
+++ b/qontract_utils/qontract_utils/aws_api_typed/sts.py
@@ -5,6 +5,9 @@ from typing import TYPE_CHECKING
 
 from pydantic import BaseModel, Field
 
+from qontract_utils.aws_api_typed._hooks import AWS_DEFAULT_HOOKS, AWSApiCallContext
+from qontract_utils.hooks import Hooks, invoke_with_hooks, with_hooks
+
 if TYPE_CHECKING:
     from mypy_boto3_sts import STSClient
 
@@ -16,10 +19,14 @@ class AWSCredentials(BaseModel):
     expiration: datetime = Field(..., alias="Expiration")
 
 
+@with_hooks(hooks=AWS_DEFAULT_HOOKS)
 class AWSApiSts:
-    def __init__(self, client: STSClient) -> None:
+    _hooks: Hooks
+
+    def __init__(self, client: STSClient, hooks: Hooks | None = None) -> None:  # noqa: ARG002
         self.client = client
 
+    @invoke_with_hooks(lambda: AWSApiCallContext(method="assume_role", service="sts"))
     def assume_role(self, account_id: str, role: str) -> AWSCredentials:
         """Assume a role and return temporary credentials."""
         assumed_role_object = self.client.assume_role(
@@ -28,6 +35,9 @@ class AWSApiSts:
         )
         return AWSCredentials(**assumed_role_object["Credentials"])
 
+    @invoke_with_hooks(
+        lambda: AWSApiCallContext(method="get_session_token", service="sts")
+    )
     def get_session_token(self, duration_seconds: int = 900) -> AWSCredentials:
         """Return temporary credentials."""
         assumed_role_object = self.client.get_session_token(

--- a/qontract_utils/qontract_utils/aws_api_typed/support.py
+++ b/qontract_utils/qontract_utils/aws_api_typed/support.py
@@ -5,6 +5,9 @@ from typing import TYPE_CHECKING, Literal
 
 from pydantic import BaseModel, Field
 
+from qontract_utils.aws_api_typed._hooks import AWS_DEFAULT_HOOKS, AWSApiCallContext
+from qontract_utils.hooks import Hooks, invoke_with_hooks, with_hooks
+
 if TYPE_CHECKING:
     from mypy_boto3_support import SupportClient
 
@@ -31,10 +34,16 @@ SEVERITY_LEVEL_SUPPORT_PLANS = [
 ]
 
 
+@with_hooks(hooks=AWS_DEFAULT_HOOKS)
 class AWSApiSupport:
-    def __init__(self, client: SupportClient) -> None:
+    _hooks: Hooks
+
+    def __init__(self, client: SupportClient, hooks: Hooks | None = None) -> None:  # noqa: ARG002
         self.client = client
 
+    @invoke_with_hooks(
+        lambda: AWSApiCallContext(method="create_case", service="support")
+    )
     def create_case(
         self,
         subject: str,
@@ -57,11 +66,17 @@ class AWSApiSupport:
         )
         return case["caseId"]
 
+    @invoke_with_hooks(
+        lambda: AWSApiCallContext(method="describe_case", service="support")
+    )
     def describe_case(self, case_id: str) -> AWSCase:
         """Return the status of a support case."""
         case = self.client.describe_cases(caseIdList=[case_id])["cases"][0]
         return AWSCase(**case)
 
+    @invoke_with_hooks(
+        lambda: AWSApiCallContext(method="get_support_level", service="support")
+    )
     def get_support_level(self) -> SupportPlan:
         """Return the support level of the account."""
         try:

--- a/qontract_utils/qontract_utils/hooks.py
+++ b/qontract_utils/qontract_utils/hooks.py
@@ -504,7 +504,7 @@ class InvokeWithHooksMethod:
 
             try:
                 yield from self.func(*prepend_args, *args, **kwargs)
-            except:
+            except Exception:
                 for hook in hooks.error_hooks:
                     hook(*hook_args)
                 raise
@@ -561,8 +561,7 @@ class InvokeWithHooksMethod:
 
                         # Execute method - no yield, just return!
                         return self.func(*prepend_args, *args, **kwargs)
-            except:
-                # Error hooks
+            except Exception:
                 for hook in hooks.error_hooks:
                     hook(*hook_args)
                 raise

--- a/qontract_utils/qontract_utils/hooks.py
+++ b/qontract_utils/qontract_utils/hooks.py
@@ -470,17 +470,58 @@ class InvokeWithHooksMethod:
         callable_name: str,
         prepend_args: tuple[Any, ...] = (),
     ) -> Callable[..., Any]:
-        """Create wrapper function with hooks and retry support.
+        """Create wrapper function with hooks and retry support."""
+        if inspect.isgeneratorfunction(self.func):
+            return self._create_generator_wrapper(hooks, instance, prepend_args)
+        return self._create_sync_wrapper(hooks, instance, callable_name, prepend_args)
 
-        Args:
-            hooks: Hook configuration to use
-            instance: Instance for context factory (None for standalone functions)
-            callable_name: Name for stamina logging
-            prepend_args: Arguments to prepend to function call (e.g., instance for methods)
+    def _create_generator_wrapper(
+        self,
+        hooks: Hooks,
+        instance: Any | None,
+        prepend_args: tuple[Any, ...] = (),
+    ) -> Callable[..., Any]:
+        """Create wrapper for generator functions.
 
-        Returns:
-            Wrapper function that executes hooks and retries
+        Uses yield from so pre/post/error hooks fire around actual iteration,
+        not around generator object creation. No retry support — stamina's
+        retry_context cannot wrap yield boundaries.
         """
+
+        @functools.wraps(self.func)
+        def wrapper(*args: Any, **kwargs: Any) -> Any:
+            if self.context_factory is not None:
+                context = _build_context_from_args(
+                    self.context_factory, instance, self.func, args, kwargs
+                )
+            else:
+                context = None
+
+            hook_args = (context,) if context is not None else ()
+
+            for hook in hooks.pre_hooks:
+                hook(*hook_args)
+
+            try:
+                yield from self.func(*prepend_args, *args, **kwargs)
+            except:
+                for hook in hooks.error_hooks:
+                    hook(*hook_args)
+                raise
+            finally:
+                for hook in hooks.post_hooks:
+                    hook(*hook_args)
+
+        return wrapper
+
+    def _create_sync_wrapper(
+        self,
+        hooks: Hooks,
+        instance: Any | None,
+        callable_name: str,
+        prepend_args: tuple[Any, ...] = (),
+    ) -> Callable[..., Any]:
+        """Create wrapper for regular (non-generator) functions."""
 
         @functools.wraps(self.func)
         def wrapper(*args: Any, **kwargs: Any) -> Any:

--- a/qontract_utils/qontract_utils/hooks.py
+++ b/qontract_utils/qontract_utils/hooks.py
@@ -472,6 +472,14 @@ class InvokeWithHooksMethod:
     ) -> Callable[..., Any]:
         """Create wrapper function with hooks and retry support."""
         if inspect.isgeneratorfunction(self.func):
+            effective_retry = self.retry_config or hooks.retry_config
+            if effective_retry is not None and effective_retry is not NO_RETRY_CONFIG:
+                msg = (
+                    f"Retry is not supported for generator method "
+                    f"{callable_name!r}. Remove retry_config or refactor the "
+                    "method to return a materialized result."
+                )
+                raise ValueError(msg)
             return self._create_generator_wrapper(hooks, instance, prepend_args)
         return self._create_sync_wrapper(hooks, instance, callable_name, prepend_args)
 

--- a/qontract_utils/tests/aws_api_typed/test_aws_api_typed_account.py
+++ b/qontract_utils/tests/aws_api_typed/test_aws_api_typed_account.py
@@ -4,7 +4,9 @@ import botocore
 import pytest
 from mypy_boto3_account import AccountClient
 from pytest_mock import MockerFixture
+from qontract_utils.aws_api_typed._hooks import AWSApiCallContext
 from qontract_utils.aws_api_typed.account import AWSApiAccount, OptStatus, Region
+from qontract_utils.hooks import Hooks
 
 
 @pytest.fixture
@@ -189,3 +191,12 @@ def test_aws_api_typed_account_disable_region(
 ) -> None:
     aws_api_account.disable_region("region")
     account_client.disable_region.assert_called_once_with(RegionName="region")
+
+
+def test_hooks_fire_on_method_call(account_client: MagicMock) -> None:
+    contexts: list[AWSApiCallContext] = []
+    api = AWSApiAccount(client=account_client, hooks=Hooks(pre_hooks=[contexts.append]))
+    api.enable_region("us-east-1")
+    assert len(contexts) == 1
+    assert contexts[0].method == "enable_region"
+    assert contexts[0].service == "account"

--- a/qontract_utils/tests/aws_api_typed/test_aws_api_typed_cloudformation.py
+++ b/qontract_utils/tests/aws_api_typed/test_aws_api_typed_cloudformation.py
@@ -8,7 +8,9 @@ from mypy_boto3_cloudformation import (
     StackUpdateCompleteWaiter,
 )
 from mypy_boto3_cloudformation.waiter import ChangeSetCreateCompleteWaiter
+from qontract_utils.aws_api_typed._hooks import AWSApiCallContext
 from qontract_utils.aws_api_typed.cloudformation import AWSApiCloudFormation
+from qontract_utils.hooks import Hooks
 
 
 @pytest.fixture
@@ -199,3 +201,17 @@ def test_get_template_body_with_json(
     mock_cloudformation_client.get_template.assert_called_once_with(
         StackName="test-stack"
     )
+
+
+def test_hooks_fire_on_method_call(mock_cloudformation_client: MagicMock) -> None:
+    contexts: list[AWSApiCallContext] = []
+    api = AWSApiCloudFormation(
+        client=mock_cloudformation_client, hooks=Hooks(pre_hooks=[contexts.append])
+    )
+    mock_cloudformation_client.get_template.return_value = {
+        "TemplateBody": "Resources: {}"
+    }
+    api.get_template_body("stack")
+    assert len(contexts) == 1
+    assert contexts[0].method == "get_template_body"
+    assert contexts[0].service == "cloudformation"

--- a/qontract_utils/tests/aws_api_typed/test_aws_api_typed_dynamodb.py
+++ b/qontract_utils/tests/aws_api_typed/test_aws_api_typed_dynamodb.py
@@ -4,6 +4,7 @@ from typing import TYPE_CHECKING
 
 import pytest
 from qontract_utils.aws_api_typed.dynamodb import AWSApiDynamoDB
+from qontract_utils.hooks import Hooks
 
 if TYPE_CHECKING:
     from mypy_boto3_dynamodb import DynamoDBClient
@@ -24,3 +25,8 @@ def test_aws_api_typed_dynamodb_boto3_client_returns_client(
     aws_api_dynamodb: AWSApiDynamoDB, dynamodb_client: DynamoDBClient
 ) -> None:
     assert isinstance(aws_api_dynamodb.boto3_client, type(dynamodb_client))
+
+
+def test_hooks_accepted_in_constructor(dynamodb_client: DynamoDBClient) -> None:
+    api = AWSApiDynamoDB(client=dynamodb_client, hooks=Hooks())
+    assert api.client == dynamodb_client

--- a/qontract_utils/tests/aws_api_typed/test_aws_api_typed_iam.py
+++ b/qontract_utils/tests/aws_api_typed/test_aws_api_typed_iam.py
@@ -5,7 +5,9 @@ import pytest
 from mypy_boto3_iam import IAMClient
 from mypy_boto3_iam.type_defs import ListAccountAliasesResponseTypeDef
 from pytest_mock import MockerFixture
+from qontract_utils.aws_api_typed._hooks import AWSApiCallContext
 from qontract_utils.aws_api_typed.iam import AWSApiIam
+from qontract_utils.hooks import Hooks
 
 
 @pytest.fixture
@@ -153,3 +155,15 @@ def test_aws_api_typed_iam_get_account_alias(
 ) -> None:
     iam_client.list_account_aliases.return_value = {"AccountAliases": ["account_alias"]}
     assert aws_api_iam.get_account_alias() == "account_alias"
+
+
+def test_hooks_fire_on_method_call(iam_client: MagicMock) -> None:
+    contexts: list[AWSApiCallContext] = []
+    api = AWSApiIam(client=iam_client, hooks=Hooks(pre_hooks=[contexts.append]))
+    iam_client.create_access_key.return_value = {
+        "AccessKey": {"AccessKeyId": "id", "SecretAccessKey": "secret"}
+    }
+    api.create_access_key("user")
+    assert len(contexts) == 1
+    assert contexts[0].method == "create_access_key"
+    assert contexts[0].service == "iam"

--- a/qontract_utils/tests/aws_api_typed/test_aws_api_typed_logs.py
+++ b/qontract_utils/tests/aws_api_typed/test_aws_api_typed_logs.py
@@ -3,7 +3,9 @@ from unittest.mock import MagicMock, create_autospec
 import pytest
 from botocore.exceptions import ClientError
 from mypy_boto3_logs import CloudWatchLogsClient, DescribeLogGroupsPaginator
+from qontract_utils.aws_api_typed._hooks import AWSApiCallContext
 from qontract_utils.aws_api_typed.logs import AWSApiLogs
+from qontract_utils.hooks import Hooks
 
 
 @pytest.fixture
@@ -168,3 +170,13 @@ def test_delete_tags(
         resourceArn=expected_arn,
         tagKeys=tags,
     )
+
+
+def test_hooks_fire_on_method_call(mock_logs_client: MagicMock) -> None:
+    contexts: list[AWSApiCallContext] = []
+    api = AWSApiLogs(client=mock_logs_client, hooks=Hooks(pre_hooks=[contexts.append]))
+    mock_logs_client.delete_log_group.return_value = None
+    api.delete_log_group("my-log-group")
+    assert len(contexts) == 1
+    assert contexts[0].method == "delete_log_group"
+    assert contexts[0].service == "logs"

--- a/qontract_utils/tests/aws_api_typed/test_aws_api_typed_organization.py
+++ b/qontract_utils/tests/aws_api_typed/test_aws_api_typed_organization.py
@@ -4,11 +4,13 @@ from typing import TYPE_CHECKING
 from unittest.mock import MagicMock
 
 import pytest
+from qontract_utils.aws_api_typed._hooks import AWSApiCallContext
 from qontract_utils.aws_api_typed.organization import (
     AWSAccountCreationError,
     AWSAccountNotFoundError,
     AWSApiOrganizations,
 )
+from qontract_utils.hooks import Hooks
 
 if TYPE_CHECKING:
     from mypy_boto3_organizations import OrganizationsClient
@@ -206,3 +208,24 @@ def test_aws_api_typed_organizations_untag_resource(
     organization_client.untag_resource.assert_called_once_with(
         ResourceId="resource_id", TagKeys=["key"]
     )
+
+
+def test_hooks_fire_on_method_call(
+    organization_client: MagicMock,
+) -> None:
+    contexts: list[AWSApiCallContext] = []
+    api = AWSApiOrganizations(
+        client=organization_client, hooks=Hooks(pre_hooks=[contexts.append])
+    )
+    organization_client.describe_account.return_value = {
+        "Account": {
+            "Name": "name",
+            "Id": "id",
+            "Email": "email",
+            "Status": "ACTIVE",
+        }
+    }
+    api.describe_account("id")
+    assert len(contexts) == 1
+    assert contexts[0].method == "describe_account"
+    assert contexts[0].service == "organizations"

--- a/qontract_utils/tests/aws_api_typed/test_aws_api_typed_s3.py
+++ b/qontract_utils/tests/aws_api_typed/test_aws_api_typed_s3.py
@@ -3,7 +3,9 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 import pytest
+from qontract_utils.aws_api_typed._hooks import AWSApiCallContext
 from qontract_utils.aws_api_typed.s3 import AWSApiS3
+from qontract_utils.hooks import Hooks
 
 if TYPE_CHECKING:
     from unittest.mock import MagicMock
@@ -42,3 +44,12 @@ def test_aws_api_typed_iam_create_bucket_other_region(
     s3_client.create_bucket.assert_called_once_with(
         Bucket="bucket", CreateBucketConfiguration={"LocationConstraint": "us-east-2"}
     )
+
+
+def test_hooks_fire_on_method_call(s3_client: MagicMock) -> None:
+    contexts: list[AWSApiCallContext] = []
+    api = AWSApiS3(client=s3_client, hooks=Hooks(pre_hooks=[contexts.append]))
+    api.create_bucket("bucket", "us-east-1")
+    assert len(contexts) == 1
+    assert contexts[0].method == "create_bucket"
+    assert contexts[0].service == "s3"

--- a/qontract_utils/tests/aws_api_typed/test_aws_api_typed_service_quotas.py
+++ b/qontract_utils/tests/aws_api_typed/test_aws_api_typed_service_quotas.py
@@ -3,7 +3,9 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 import pytest
+from qontract_utils.aws_api_typed._hooks import AWSApiCallContext
 from qontract_utils.aws_api_typed.service_quotas import AWSApiServiceQuotas
+from qontract_utils.hooks import Hooks
 
 if TYPE_CHECKING:
     from unittest.mock import MagicMock
@@ -86,3 +88,23 @@ def test_aws_api_typed_service_quotas_get_service_quota(
     assert quota.quota_code == "quota_code"
     assert quota.quota_name == "quota_name"
     assert quota.value == 100.0
+
+
+def test_hooks_fire_on_method_call(service_quotas_client: MagicMock) -> None:
+    contexts: list[AWSApiCallContext] = []
+    api = AWSApiServiceQuotas(
+        client=service_quotas_client, hooks=Hooks(pre_hooks=[contexts.append])
+    )
+    service_quotas_client.get_service_quota.return_value = {
+        "Quota": {
+            "ServiceCode": "sc",
+            "ServiceName": "sn",
+            "QuotaCode": "qc",
+            "QuotaName": "qn",
+            "Value": 1.0,
+        }
+    }
+    api.get_service_quota("sc", "qc")
+    assert len(contexts) == 1
+    assert contexts[0].method == "get_service_quota"
+    assert contexts[0].service == "service-quotas"

--- a/qontract_utils/tests/aws_api_typed/test_aws_api_typed_sts.py
+++ b/qontract_utils/tests/aws_api_typed/test_aws_api_typed_sts.py
@@ -4,7 +4,9 @@ from datetime import UTC, datetime
 from typing import TYPE_CHECKING
 
 import pytest
+from qontract_utils.aws_api_typed._hooks import AWSApiCallContext
 from qontract_utils.aws_api_typed.sts import AWSApiSts
+from qontract_utils.hooks import Hooks
 
 if TYPE_CHECKING:
     from unittest.mock import MagicMock
@@ -59,3 +61,21 @@ def test_aws_api_typed_sts_get_session_token(
     assert credentials.secret_access_key == "secret_access_key"
     assert credentials.session_token == "session_token"
     assert credentials.expiration == now
+
+
+def test_hooks_fire_on_method_call(sts_client: MagicMock) -> None:
+    contexts: list[AWSApiCallContext] = []
+    api = AWSApiSts(client=sts_client, hooks=Hooks(pre_hooks=[contexts.append]))
+    now = datetime.now(tz=UTC)
+    sts_client.assume_role.return_value = {
+        "Credentials": {
+            "AccessKeyId": "id",
+            "SecretAccessKey": "secret",
+            "SessionToken": "token",
+            "Expiration": now,
+        }
+    }
+    api.assume_role("123456", "role")
+    assert len(contexts) == 1
+    assert contexts[0].method == "assume_role"
+    assert contexts[0].service == "sts"

--- a/qontract_utils/tests/aws_api_typed/test_aws_api_typed_support.py
+++ b/qontract_utils/tests/aws_api_typed/test_aws_api_typed_support.py
@@ -3,7 +3,9 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 import pytest
+from qontract_utils.aws_api_typed._hooks import AWSApiCallContext
 from qontract_utils.aws_api_typed.support import AWSApiSupport, SupportPlan
+from qontract_utils.hooks import Hooks
 
 if TYPE_CHECKING:
     from unittest.mock import MagicMock
@@ -107,3 +109,15 @@ def test_aws_api_typed_support_get_support_level(
     }
 
     assert aws_api_support.get_support_level() == expected_support_level
+
+
+def test_hooks_fire_on_method_call(support_client: MagicMock) -> None:
+    contexts: list[AWSApiCallContext] = []
+    api = AWSApiSupport(client=support_client, hooks=Hooks(pre_hooks=[contexts.append]))
+    support_client.describe_cases.return_value = {
+        "cases": [{"caseId": "id", "subject": "s", "status": "open"}]
+    }
+    api.describe_case("id")
+    assert len(contexts) == 1
+    assert contexts[0].method == "describe_case"
+    assert contexts[0].service == "support"

--- a/qontract_utils/tests/aws_api_typed/test_aws_hooks.py
+++ b/qontract_utils/tests/aws_api_typed/test_aws_hooks.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+import time
+from unittest.mock import patch
+
+from qontract_utils.aws_api_typed import _hooks  # noqa: PLC2701
+from qontract_utils.aws_api_typed._hooks import AWSApiCallContext  # noqa: PLC2701
+
+
+def test_context_creation() -> None:
+    ctx = AWSApiCallContext(method="assume_role", service="sts")
+    assert ctx.method == "assume_role"
+    assert ctx.service == "sts"
+
+
+def test_metrics_hook_increments_counter() -> None:
+    ctx = AWSApiCallContext(method="create_account", service="organizations")
+    before = _hooks.aws_request.labels("create_account", "organizations")._value.get()
+    _hooks._metrics_hook(ctx)
+    after = _hooks.aws_request.labels("create_account", "organizations")._value.get()
+    assert after == before + 1
+
+
+def test_latency_tracking() -> None:
+    ctx = AWSApiCallContext(method="assume_role", service="sts")
+    _hooks._latency_start_hook(ctx)
+    assert len(_hooks._latency_tracker.get()) == 1
+    _hooks._latency_end_hook(ctx)
+    assert len(_hooks._latency_tracker.get()) == 0
+
+
+def test_latency_nested_calls() -> None:
+    ctx_outer = AWSApiCallContext(method="move_account", service="organizations")
+    ctx_inner = AWSApiCallContext(method="get_ou", service="organizations")
+    _hooks._latency_start_hook(ctx_outer)
+    _hooks._latency_start_hook(ctx_inner)
+    assert len(_hooks._latency_tracker.get()) == 2
+    _hooks._latency_end_hook(ctx_inner)
+    assert len(_hooks._latency_tracker.get()) == 1
+    _hooks._latency_end_hook(ctx_outer)
+    assert len(_hooks._latency_tracker.get()) == 0
+
+
+def test_latency_end_hook_observes_duration() -> None:
+    ctx = AWSApiCallContext(method="test_duration", service="sts")
+    _hooks._latency_start_hook(ctx)
+    with patch.object(time, "perf_counter", return_value=time.perf_counter() + 0.5):
+        _hooks._latency_end_hook(ctx)
+    assert _hooks.aws_request_duration.labels("test_duration", "sts")._sum.get() > 0
+
+
+def test_request_log_hook() -> None:
+    ctx = AWSApiCallContext(method="describe_account", service="organizations")
+    _hooks._request_log_hook(ctx)
+
+
+def test_default_hooks_structure() -> None:
+    hooks = _hooks.AWS_DEFAULT_HOOKS
+    assert len(hooks.pre_hooks) == 3
+    assert len(hooks.post_hooks) == 1
+    assert hooks.retry_config is None
+    assert _hooks._metrics_hook in hooks.pre_hooks
+    assert _hooks._request_log_hook in hooks.pre_hooks
+    assert _hooks._latency_start_hook in hooks.pre_hooks
+    assert _hooks._latency_end_hook in hooks.post_hooks

--- a/qontract_utils/tests/hooks/test_generator.py
+++ b/qontract_utils/tests/hooks/test_generator.py
@@ -1,0 +1,206 @@
+"""Tests for @invoke_with_hooks on generator functions.
+
+Covers generator-specific behavior: hooks fire around actual iteration,
+not around generator object creation.
+"""
+
+from collections.abc import Generator, Iterator
+from dataclasses import dataclass
+from typing import Any
+
+import pytest
+from qontract_utils.hooks import NO_RETRY_CONFIG, Hooks, invoke_with_hooks, with_hooks
+
+
+def test_generator_yields_correct_values() -> None:
+    class TestApi:
+        def __init__(self) -> None:
+            self._hooks = Hooks(retry_config=NO_RETRY_CONFIG)
+
+        @invoke_with_hooks()
+        def items(self) -> Iterator[int]:
+            yield from [1, 2, 3]
+
+    assert list(TestApi().items()) == [1, 2, 3]
+
+
+def test_generator_pre_hooks_fire_on_iteration() -> None:
+    """Pre-hooks must fire when iteration starts, not when the generator object is created."""
+    execution_order: list[str] = []
+
+    def pre_hook() -> None:
+        execution_order.append("pre")
+
+    class TestApi:
+        def __init__(self) -> None:
+            self._hooks = Hooks(pre_hooks=[pre_hook], retry_config=NO_RETRY_CONFIG)
+
+        @invoke_with_hooks()
+        def items(self) -> Iterator[int]:
+            execution_order.append("yield")
+            yield 1
+
+    api = TestApi()
+    gen = api.items()
+    assert execution_order == []
+    next(gen)
+    assert execution_order == ["pre", "yield"]
+
+
+def test_generator_post_hooks_fire_after_exhaustion() -> None:
+    execution_order: list[str] = []
+
+    def post_hook() -> None:
+        execution_order.append("post")
+
+    class TestApi:
+        def __init__(self) -> None:
+            self._hooks = Hooks(post_hooks=[post_hook], retry_config=NO_RETRY_CONFIG)
+
+        @invoke_with_hooks()
+        def items(self) -> Iterator[int]:
+            yield 1
+            execution_order.append("after_yield")
+
+    api = TestApi()
+    result = list(api.items())
+    assert result == [1]
+    assert execution_order == ["after_yield", "post"]
+
+
+def test_generator_post_hooks_fire_on_close() -> None:
+    """Post-hooks fire even if generator is closed before exhaustion."""
+    execution_order: list[str] = []
+
+    def post_hook() -> None:
+        execution_order.append("post")
+
+    class TestApi:
+        def __init__(self) -> None:
+            self._hooks = Hooks(post_hooks=[post_hook], retry_config=NO_RETRY_CONFIG)
+
+        @invoke_with_hooks()
+        def items(self) -> Generator[int, None, None]:
+            yield 1
+            yield 2
+            yield 3
+
+    api = TestApi()
+    gen = api.items()
+    next(gen)
+    gen.close()
+    assert "post" in execution_order
+
+
+def test_generator_error_hooks_fire_on_exception() -> None:
+    execution_order: list[str] = []
+
+    def error_hook() -> None:
+        execution_order.append("error")
+
+    def post_hook() -> None:
+        execution_order.append("post")
+
+    class TestApi:
+        def __init__(self) -> None:
+            self._hooks = Hooks(
+                error_hooks=[error_hook],
+                post_hooks=[post_hook],
+                retry_config=NO_RETRY_CONFIG,
+            )
+
+        @invoke_with_hooks()
+        def items(self) -> Iterator[int]:
+            yield 1
+            raise ValueError("boom")
+
+    api = TestApi()
+    gen = api.items()
+    next(gen)
+    with pytest.raises(ValueError, match="boom"):
+        next(gen)
+    assert execution_order == ["error", "post"]
+
+
+def test_generator_context_passed_to_hooks() -> None:
+    @dataclass(frozen=True)
+    class Ctx:
+        method: str
+
+    contexts: list[Any] = []
+
+    def pre_hook(ctx: Ctx) -> None:
+        contexts.append(("pre", ctx))
+
+    def post_hook(ctx: Ctx) -> None:
+        contexts.append(("post", ctx))
+
+    class TestApi:
+        def __init__(self) -> None:
+            self._hooks = Hooks(
+                pre_hooks=[pre_hook],
+                post_hooks=[post_hook],
+                retry_config=NO_RETRY_CONFIG,
+            )
+
+        @invoke_with_hooks(lambda: Ctx(method="items"))
+        def items(self) -> Iterator[int]:
+            yield 1
+
+    list(TestApi().items())
+    assert len(contexts) == 2
+    assert contexts[0] == ("pre", Ctx(method="items"))
+    assert contexts[1] == ("post", Ctx(method="items"))
+
+
+def test_generator_with_hooks_decorator() -> None:
+    """Works with @with_hooks class decorator."""
+    contexts: list[Any] = []
+
+    def user_hook(ctx: Any) -> None:
+        contexts.append(ctx)
+
+    @dataclass(frozen=True)
+    class Ctx:
+        method: str
+
+    default_hooks = Hooks(retry_config=NO_RETRY_CONFIG)
+
+    @with_hooks(hooks=default_hooks)
+    class TestApi:
+        _hooks: Hooks
+
+        def __init__(self, hooks: Hooks | None = None) -> None:
+            pass
+
+        @invoke_with_hooks(lambda: Ctx(method="items"))
+        def items(self) -> Iterator[int]:
+            yield from [10, 20]
+
+    api = TestApi(hooks=Hooks(pre_hooks=[user_hook]))
+    assert list(api.items()) == [10, 20]
+    assert len(contexts) == 1
+    assert contexts[0].method == "items"
+
+
+def test_generator_hook_execution_order() -> None:
+    execution_order: list[str] = []
+
+    class TestApi:
+        def __init__(self) -> None:
+            self._hooks = Hooks(
+                pre_hooks=[lambda: execution_order.append("pre")],
+                post_hooks=[lambda: execution_order.append("post")],
+                retry_config=NO_RETRY_CONFIG,
+            )
+
+        @invoke_with_hooks()
+        def items(self) -> Iterator[str]:
+            execution_order.append("yield_1")
+            yield "a"
+            execution_order.append("yield_2")
+            yield "b"
+
+    result = list(TestApi().items())
+    assert result == ["a", "b"]
+    assert execution_order == ["pre", "yield_1", "yield_2", "post"]

--- a/qontract_utils/tests/hooks/test_generator.py
+++ b/qontract_utils/tests/hooks/test_generator.py
@@ -69,15 +69,16 @@ def test_generator_post_hooks_fire_after_exhaustion() -> None:
 
 
 def test_generator_post_hooks_fire_on_close() -> None:
-    """Post-hooks fire even if generator is closed before exhaustion."""
+    """Post-hooks fire on close, error-hooks must not (GeneratorExit is not an Exception)."""
     execution_order: list[str] = []
-
-    def post_hook() -> None:
-        execution_order.append("post")
 
     class TestApi:
         def __init__(self) -> None:
-            self._hooks = Hooks(post_hooks=[post_hook], retry_config=NO_RETRY_CONFIG)
+            self._hooks = Hooks(
+                post_hooks=[lambda: execution_order.append("post")],
+                error_hooks=[lambda: execution_order.append("error")],
+                retry_config=NO_RETRY_CONFIG,
+            )
 
         @invoke_with_hooks()
         def items(self) -> Generator[int, None, None]:
@@ -90,6 +91,7 @@ def test_generator_post_hooks_fire_on_close() -> None:
     next(gen)
     gen.close()
     assert "post" in execution_order
+    assert "error" not in execution_order
 
 
 def test_generator_error_hooks_fire_on_exception() -> None:

--- a/qontract_utils/tests/hooks/test_generator.py
+++ b/qontract_utils/tests/hooks/test_generator.py
@@ -206,3 +206,22 @@ def test_generator_hook_execution_order() -> None:
     result = list(TestApi().items())
     assert result == ["a", "b"]
     assert execution_order == ["pre", "yield_1", "yield_2", "post"]
+
+
+def test_generator_rejects_retry_config() -> None:
+    """Generator methods must reject retry_config at decoration time."""
+    from qontract_utils.hooks import RetryConfig
+
+    with pytest.raises(ValueError, match="Retry is not supported for generator method"):
+
+        class TestApi:
+            def __init__(self) -> None:
+                self._hooks = Hooks(
+                    retry_config=RetryConfig(on=Exception, attempts=3),
+                )
+
+            @invoke_with_hooks()
+            def items(self) -> Iterator[int]:
+                yield 1
+
+        TestApi().items()


### PR DESCRIPTION
## Summary

- Add shared hooks infrastructure (`_hooks.py`) with `AWSApiCallContext`, Prometheus metrics (`aws_requests_total`, `aws_request_duration_seconds`), and latency tracking for all AWS API typed clients
- Apply `@with_hooks` / `@invoke_with_hooks` decorators to all 10 AWS API clients: account, cloudformation, dynamodb, iam, logs, organization, s3, service_quotas, sts, support
- Add hook-wiring tests for each client and unit tests for the shared hooks module

## Why

Enables observability (Prometheus metrics, structured logging, latency tracking) for AWS API calls. Critical for the `aws_account_manager` migration where parallel Celery tasks can cause AWS API throttling (APPSRE-13864).

## Design decisions

- **Shared `_hooks.py`** — avoids duplicating ~70 lines of boilerplate across 10 clients
- **No hooks-level retry** — boto3 already has `DEFAULT_CONFIG` with `retries={"mode": "standard", "total_max_attempts": 10}`, adding hooks retry would cause double-retry storms
- **`_get_organizational_units_tree` not hooked** — private, recursive, wrapped with `lru_cache`; hooking would fire metrics per OU in the tree
- **`lambda:` without `self`** — context factories don't need instance access since context only contains static method/service names

## Test plan

- [x] All 520 qontract_utils tests pass
- [x] mypy strict passes
- [x] ruff passes
- [x] Hook-wiring test per client verifies context is passed correctly
- [x] Shared hooks tests cover metrics increment, latency tracking (incl. nested), and `AWS_DEFAULT_HOOKS` structure

JIRA: [APPSRE-13864](https://redhat.atlassian.net/browse/APPSRE-13864)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Global AWS observability: Prometheus request counters, per-request latency tracking, and structured request logging.
  * Hook-enabled AWS clients: standardized pre/post hooks applied across many AWS service wrappers; clients now accept hooks; CloudWatch Logs tag management and Support-case describe exposed.

* **Refactor**
  * Hook invocation extended to support generator-style operations with correct pre/post/error ordering and retry restrictions for generators.

* **Tests**
  * Broad test coverage for hook firing, metrics, latency (including nested calls), generator semantics, and per-client hook wiring.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->