### PR TITLE
external-resources: drop deprecated tf_state_dynamodb_table setting

### DIFF
--- a/reconcile/external_resources/factories.py
+++ b/reconcile/external_resources/factories.py
@@ -94,7 +94,6 @@ class TerraformModuleProvisionDataFactory(ModuleProvisionDataFactory):
         return TerraformModuleProvisionData(
             tf_state_bucket=self.settings.tf_state_bucket,
             tf_state_region=self.settings.tf_state_region,
-            tf_state_dynamodb_table=self.settings.tf_state_dynamodb_table,
             tf_state_key=key.state_path + "/terraform.tfstate",
         )
 

--- a/reconcile/external_resources/model.py
+++ b/reconcile/external_resources/model.py
@@ -423,7 +423,6 @@ class TerraformModuleProvisionData(ModuleProvisionData):
 
     tf_state_bucket: str
     tf_state_region: str
-    tf_state_dynamodb_table: str
     tf_state_key: str
 
 

--- a/reconcile/gql_definitions/external_resources/external_resources_settings.gql
+++ b/reconcile/gql_definitions/external_resources/external_resources_settings.gql
@@ -15,7 +15,6 @@ query ExternalResourcesSettings {
     }
     tf_state_bucket
     tf_state_region
-    tf_state_dynamodb_table
     vault_secrets_path
     outputs_secret_image
     outputs_secret_version

--- a/reconcile/gql_definitions/external_resources/external_resources_settings.py
+++ b/reconcile/gql_definitions/external_resources/external_resources_settings.py
@@ -47,7 +47,6 @@ query ExternalResourcesSettings {
     }
     tf_state_bucket
     tf_state_region
-    tf_state_dynamodb_table
     vault_secrets_path
     outputs_secret_image
     outputs_secret_version
@@ -86,7 +85,6 @@ class ExternalResourcesSettingsV1(ConfiguredBaseModel):
     workers_namespace: NamespaceV1 = Field(..., alias="workers_namespace")
     tf_state_bucket: Optional[str] = Field(..., alias="tf_state_bucket")
     tf_state_region: Optional[str] = Field(..., alias="tf_state_region")
-    tf_state_dynamodb_table: Optional[str] = Field(..., alias="tf_state_dynamodb_table")
     vault_secrets_path: str = Field(..., alias="vault_secrets_path")
     outputs_secret_image: str = Field(..., alias="outputs_secret_image")
     outputs_secret_version: str = Field(..., alias="outputs_secret_version")

--- a/reconcile/gql_definitions/introspection.json
+++ b/reconcile/gql_definitions/introspection.json
@@ -50744,18 +50744,6 @@
                             "deprecationReason": null
                         },
                         {
-                            "name": "tf_state_dynamodb_table",
-                            "description": null,
-                            "args": [],
-                            "type": {
-                                "kind": "SCALAR",
-                                "name": "String",
-                                "ofType": null
-                            },
-                            "isDeprecated": false,
-                            "deprecationReason": null
-                        },
-                        {
                             "name": "tf_state_region",
                             "description": null,
                             "args": [],

--- a/reconcile/test/external_resources/conftest.py
+++ b/reconcile/test/external_resources/conftest.py
@@ -39,7 +39,6 @@ def settings() -> ExternalResourcesSettingsV1:
     return ExternalResourcesSettingsV1(
         tf_state_bucket="bucket",
         tf_state_region="us-east-1",
-        tf_state_dynamodb_table="dynamodb_table",
         state_dynamodb_account=AWSAccountV1(name="app-int-example-01"),
         state_dynamodb_table="state_dynamo_table",
         state_dynamodb_region="us-east-1",

--- a/reconcile/test/external_resources/test_aws_external_resource_factory.py
+++ b/reconcile/test/external_resources/test_aws_external_resource_factory.py
@@ -101,7 +101,6 @@ def test_create_external_resource(
             module_provision_data=TerraformModuleProvisionData(
                 tf_state_bucket=settings.tf_state_bucket,
                 tf_state_region=settings.tf_state_region,
-                tf_state_dynamodb_table=settings.tf_state_dynamodb_table,
                 tf_state_key="aws/test/rds/test-rds/terraform.tfstate",
             ),
         ),

--- a/reconcile/test/external_resources/test_aws_msk_connect_factory.py
+++ b/reconcile/test/external_resources/test_aws_msk_connect_factory.py
@@ -108,7 +108,6 @@ def _make_provision(identifier: str) -> ExternalResourceProvision:
         module_provision_data=TerraformModuleProvisionData(
             tf_state_bucket="bucket",
             tf_state_region="us-east-1",
-            tf_state_dynamodb_table="table",
             tf_state_key=f"aws/test/msk-connect/{identifier}/terraform.tfstate",
         ),
     )

--- a/reconcile/test/external_resources/test_cloudflare_factory.py
+++ b/reconcile/test/external_resources/test_cloudflare_factory.py
@@ -141,7 +141,6 @@ def test_create_cloudflare_external_resource(
             module_provision_data=TerraformModuleProvisionData(
                 tf_state_bucket=settings.tf_state_bucket,
                 tf_state_region=settings.tf_state_region,
-                tf_state_dynamodb_table=settings.tf_state_dynamodb_table,
                 tf_state_key="cloudflare/test-cf-account/zone/test-zone/terraform.tfstate",
             ),
         ),

--- a/reconcile/test/external_resources/test_er_models.py
+++ b/reconcile/test/external_resources/test_er_models.py
@@ -211,7 +211,6 @@ def test_er_external_resource_export(
             "module_provision_data": {
                 "tf_state_bucket": "tf_state_bucket",
                 "tf_state_region": "tf_state_region",
-                "tf_state_dynamodb_table": "tf_state_dynamodb_table",
                 "tf_state_key": "aws/test/rds/test-rds/terraform.tfstate",
             },
         },
@@ -242,7 +241,6 @@ def test_er_external_resource_export(
     "identifier": "test-rds",
     "module_provision_data": {
       "tf_state_bucket": "tf_state_bucket",
-      "tf_state_dynamodb_table": "tf_state_dynamodb_table",
       "tf_state_key": "aws/test/rds/test-rds/terraform.tfstate",
       "tf_state_region": "tf_state_region"
     },


### PR DESCRIPTION
Remove the unused and deprecated `tf_state_dynamodb_table` ERv2 settings. See also https://github.com/app-sre/external-resources-io/pull/413

Depends on:
* https://github.com/app-sre/er-aws-elasticache/pull/592
* https://github.com/app-sre/er-aws-msk-connect/pull/24
* https://github.com/app-sre/er-aws-msk/pull/585
* https://github.com/app-sre/er-aws-kms/pull/193
* https://github.com/app-sre/er-aws-rds/pull/481
* https://github.com/app-sre/er-aws-rds-proxy/pull/151
* https://github.com/app-sre/er-aws-cloudwatch/pull/74

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated Terraform backend state storage configuration for external resources to use S3 bucket and region-based storage instead of DynamoDB table-based storage.

* **Tests**
  * Updated test cases to align with the revised Terraform state storage configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->