### PR TITLE
perf(jinja2): add thread-safe caching for vault, s3, github, and quer…

### DIFF
--- a/reconcile/openshift_resources_base.py
+++ b/reconcile/openshift_resources_base.py
@@ -1,4 +1,5 @@
 import base64
+import functools
 import hashlib
 import itertools
 import json
@@ -45,6 +46,7 @@ from reconcile.utils.defer import defer
 from reconcile.utils.exceptions import FetchResourceError
 from reconcile.utils.jinja2.utils import (
     FetchSecretError,
+    Jinja2TemplateCache,
     process_extracurlyjinja2_template,
     process_jinja2_template,
 )
@@ -513,6 +515,7 @@ def fetch_openshift_resource(
     parent: Mapping[str, Any],
     settings: Mapping | None = None,
     skip_validation: bool = False,
+    cache: Jinja2TemplateCache | None = None,
 ) -> OR:
     provider = resource["provider"]
     if provider == "resource":
@@ -553,9 +556,9 @@ def fetch_openshift_resource(
         tt = resource["type"]
         tt = "jinja2" if tt is None else tt
         if tt == "jinja2":
-            tfunc = process_jinja2_template
+            tfunc = functools.partial(process_jinja2_template, cache=cache)
         elif tt == "extracurlyjinja2":
-            tfunc = process_extracurlyjinja2_template
+            tfunc = functools.partial(process_extracurlyjinja2_template, cache=cache)
         else:
             raise UnknownTemplateTypeError(tt)
         try:
@@ -629,9 +632,9 @@ def fetch_openshift_resource(
             tfunc = None
             tv = None
         elif tt == "resource-template-jinja2":
-            tfunc = process_jinja2_template
+            tfunc = functools.partial(process_jinja2_template, cache=cache)
         elif tt == "resource-template-extracurlyjinja2":
-            tfunc = process_extracurlyjinja2_template
+            tfunc = functools.partial(process_extracurlyjinja2_template, cache=cache)
         else:
             raise UnknownTemplateTypeError(tt)
         try:
@@ -706,9 +709,10 @@ def fetch_desired_state(
     parent: Mapping[str, Any],
     privileged: bool,
     settings: Mapping[str, Any] | None = None,
+    cache: Jinja2TemplateCache | None = None,
 ) -> None:
     try:
-        openshift_resource = fetch_openshift_resource(resource, parent, settings)
+        openshift_resource = fetch_openshift_resource(resource, parent, settings, cache=cache)
     except (
         FetchResourceError,
         FetchSecretError,
@@ -757,6 +761,7 @@ def fetch_states(
     spec: ob.StateSpec,
     ri: ResourceInventory,
     settings: Mapping[str, Any] | None = None,
+    cache: Jinja2TemplateCache | None = None,
 ) -> None:
     try:
         if isinstance(spec, ob.CurrentStateSpec):
@@ -778,6 +783,7 @@ def fetch_states(
                 spec.parent,
                 spec.privileged,
                 settings,
+                cache=cache,
             )
 
     except StatusCodeError as e:
@@ -792,6 +798,7 @@ def fetch_data(
     use_jump_host: bool,
     init_api_resources: bool = False,
     overrides: Iterable[str] | None = None,
+    cache: Jinja2TemplateCache | None = None,
 ) -> tuple[OC_Map, ResourceInventory]:
     ri = ResourceInventory()
     settings = queries.get_app_interface_settings()
@@ -812,7 +819,7 @@ def fetch_data(
         override_managed_types=overrides,
         cluster_scope_resource_validation=True,
     )
-    threaded.run(fetch_states, state_specs, thread_pool_size, ri=ri, settings=settings)
+    threaded.run(fetch_states, state_specs, thread_pool_size, ri=ri, settings=settings, cache=cache)
 
     return oc_map, ri
 
@@ -953,6 +960,7 @@ def run(
         use_jump_host,
         init_api_resources=init_api_resources,
         overrides=overrides,
+        cache=Jinja2TemplateCache(),
     )
     if defer:
         defer(oc_map.cleanup)
@@ -1241,7 +1249,7 @@ def early_exit_monkey_patch() -> Generator:
     ) as mocks:
         # mock lookup_secret
         mocks["lookup_secret"].side_effect = (
-            lambda path, key, version=None, tvars=None, allow_not_found=False, settings=None, secret_reader=None: (
+            lambda path, key, version=None, tvars=None, allow_not_found=False, settings=None, secret_reader=None, cache=None: (
                 f"vault({path}, {key}, {version}"
             )
         )
@@ -1251,7 +1259,7 @@ def early_exit_monkey_patch() -> Generator:
 
         # mock lookup_github_file_content
         mocks["lookup_github_file_content"].side_effect = (
-            lambda repo, path, ref, tvars=None, settings=None, secret_reader=None: (
+            lambda repo, path, ref, tvars=None, settings=None, secret_reader=None, cache=None: (
                 f"github({repo}, {path}, {ref})"
             )
         )
@@ -1267,7 +1275,7 @@ def early_exit_monkey_patch() -> Generator:
 
         # mock lookup_s3_object
         mocks["lookup_s3_object"].side_effect = (
-            lambda account_name, bucket_name, path, region_name=None: (
+            lambda account_name, bucket_name, path, region_name=None, cache=None: (
                 f"lookup_s3_object({account_name}, {bucket_name}, {path}, {region_name})"
             )
         )
@@ -1277,7 +1285,7 @@ def early_exit_monkey_patch() -> Generator:
 
         # mock list_s3_objects
         mocks["list_s3_objects"].side_effect = (
-            lambda account_name, bucket_name, path, region_name=None: (
+            lambda account_name, bucket_name, path, region_name=None, cache=None: (
                 f"list_s3_objects({account_name}, {bucket_name}, {path}, {region_name})"
             )
         )

--- a/reconcile/openshift_resources_base.py
+++ b/reconcile/openshift_resources_base.py
@@ -708,8 +708,8 @@ def fetch_desired_state(
     resource: Mapping[str, Any],
     parent: Mapping[str, Any],
     privileged: bool,
+    cache: Jinja2TemplateCache,
     settings: Mapping[str, Any] | None = None,
-    cache: Jinja2TemplateCache | None = None,
 ) -> None:
     try:
         openshift_resource = fetch_openshift_resource(
@@ -762,8 +762,8 @@ def fetch_desired_state(
 def fetch_states(
     spec: ob.StateSpec,
     ri: ResourceInventory,
+    cache: Jinja2TemplateCache,
     settings: Mapping[str, Any] | None = None,
-    cache: Jinja2TemplateCache | None = None,
 ) -> None:
     try:
         if isinstance(spec, ob.CurrentStateSpec):
@@ -784,8 +784,8 @@ def fetch_states(
                 spec.resource,
                 spec.parent,
                 spec.privileged,
-                settings,
                 cache=cache,
+                settings=settings,
             )
 
     except StatusCodeError as e:
@@ -798,9 +798,9 @@ def fetch_data(
     thread_pool_size: int,
     internal: bool | None,
     use_jump_host: bool,
+    cache: Jinja2TemplateCache,
     init_api_resources: bool = False,
     overrides: Iterable[str] | None = None,
-    cache: Jinja2TemplateCache | None = None,
 ) -> tuple[OC_Map, ResourceInventory]:
     ri = ResourceInventory()
     settings = queries.get_app_interface_settings()

--- a/reconcile/openshift_resources_base.py
+++ b/reconcile/openshift_resources_base.py
@@ -712,7 +712,9 @@ def fetch_desired_state(
     cache: Jinja2TemplateCache | None = None,
 ) -> None:
     try:
-        openshift_resource = fetch_openshift_resource(resource, parent, settings, cache=cache)
+        openshift_resource = fetch_openshift_resource(
+            resource, parent, settings, cache=cache
+        )
     except (
         FetchResourceError,
         FetchSecretError,
@@ -819,7 +821,14 @@ def fetch_data(
         override_managed_types=overrides,
         cluster_scope_resource_validation=True,
     )
-    threaded.run(fetch_states, state_specs, thread_pool_size, ri=ri, settings=settings, cache=cache)
+    threaded.run(
+        fetch_states,
+        state_specs,
+        thread_pool_size,
+        ri=ri,
+        settings=settings,
+        cache=cache,
+    )
 
     return oc_map, ri
 

--- a/reconcile/test/test_openshift_resources_base.py
+++ b/reconcile/test/test_openshift_resources_base.py
@@ -235,7 +235,7 @@ def test_fetch_states(
     ri = ResourceInventory()
     ri.initialize_resource_type("cs1", "ns1", "Template")
     current_state_spec.oc.get_items = lambda kind, **kwargs: [tmpl1]  # type: ignore[method-assign]
-    orb.fetch_states(ri=ri, spec=current_state_spec)
+    orb.fetch_states(ri=ri, spec=current_state_spec, cache=orb.Jinja2TemplateCache())
     _, _, _, resource = next(iter(ri))
     assert len(resource["current"]) == 1
     assert "tmpl1" in resource["current"]
@@ -246,7 +246,7 @@ def test_fetch_states_unknown_kind(current_state_spec: CurrentStateSpec) -> None
     current_state_spec.kind = "UnknownKind"
     ri = ResourceInventory()
     ri.initialize_resource_type("cs1", "ns1", "UnknownKind")
-    orb.fetch_states(ri=ri, spec=current_state_spec)
+    orb.fetch_states(ri=ri, spec=current_state_spec, cache=orb.Jinja2TemplateCache())
     _, _, _, resource = next(iter(ri))
     assert len(resource["current"]) == 0
 
@@ -257,7 +257,7 @@ def test_fetch_states_oc_error(current_state_spec: CurrentStateSpec) -> None:
     )
     ri = ResourceInventory()
     ri.initialize_resource_type("cs1", "ns1", "Template")
-    orb.fetch_states(ri=ri, spec=current_state_spec)
+    orb.fetch_states(ri=ri, spec=current_state_spec, cache=orb.Jinja2TemplateCache())
     assert ri.has_error_registered("cs1")
     _, _, _, resource = next(iter(ri))
     assert len(resource["current"]) == 0

--- a/reconcile/utils/jinja2/utils.py
+++ b/reconcile/utils/jinja2/utils.py
@@ -217,7 +217,11 @@ def lookup_graphql_query_results(
     **kwargs: dict[str, Any],
 ) -> list[Any]:
     cache = cache or Jinja2TemplateCache()
-    cache_key = (query, json.dumps(kwargs, sort_keys=True))
+    try:
+        kwargs_key = json.dumps(kwargs, sort_keys=True)
+    except TypeError:
+        kwargs_key = str(sorted((k, repr(v)) for k, v in kwargs.items()))
+    cache_key = (query, kwargs_key)
 
     def _fetch() -> list[Any]:
         gqlapi = gql.get_api()

--- a/reconcile/utils/jinja2/utils.py
+++ b/reconcile/utils/jinja2/utils.py
@@ -2,7 +2,7 @@ import datetime
 import json
 import os
 import threading
-from collections.abc import Mapping
+from collections.abc import Callable, Mapping
 from functools import cache
 from typing import Any, Self
 
@@ -112,34 +112,68 @@ def init_github() -> Github:
     return Github(token, base_url=GH_BASE_URL)
 
 
-def _get_or_create_lock(
-    locks: dict[Any, threading.Lock],
-    meta_lock: threading.Lock,
-    key: Any,
-) -> threading.Lock:
-    with meta_lock:
-        if key not in locks:
-            locks[key] = threading.Lock()
-        return locks[key]
+_MISSING: Any = object()
 
 
-_github_cache: dict[tuple[str, str, str], str] = {}
-_github_locks: dict[tuple[str, str, str], threading.Lock] = {}
-_github_locks_lock: threading.Lock = threading.Lock()
+class Jinja2TemplateCache:
+    """Scoped cache for Jinja2 template external lookups (vault, github, s3, query).
+
+    Create one instance per integration run and pass it to process_jinja2_template
+    so all template renderings within a run share cached results. A fresh instance
+    per run prevents stale data across loop iterations in run_integration.py.
+    """
+
+    GITHUB = "github"
+    QUERY = "query"
+    S3 = "s3"
+    S3_LS = "s3_ls"
+    VAULT = "vault"
+
+    _NAMESPACES = (GITHUB, QUERY, S3, S3_LS, VAULT)
+
+    def __init__(self) -> None:
+        self._stores: dict[str, dict[Any, Any]] = {ns: {} for ns in self._NAMESPACES}
+        self._locks: dict[str, dict[Any, threading.Lock]] = {
+            ns: {} for ns in self._NAMESPACES
+        }
+        self._meta_locks: dict[str, threading.Lock] = {
+            ns: threading.Lock() for ns in self._NAMESPACES
+        }
+
+    def _lock_for(self, namespace: str, key: Any) -> threading.Lock:
+        meta = self._meta_locks[namespace]
+        locks = self._locks[namespace]
+        with meta:
+            if key not in locks:
+                locks[key] = threading.Lock()
+            return locks[key]
+
+    def get(self, namespace: str, key: Any) -> Any:
+        return self._stores[namespace].get(key, _MISSING)
+
+    def set(self, namespace: str, key: Any, value: Any) -> None:
+        self._stores[namespace][key] = value
+
+    def get_or_set(self, namespace: str, key: Any, compute: Callable[[], Any]) -> Any:
+        with self._lock_for(namespace, key):
+            if key not in self._stores[namespace]:
+                self._stores[namespace][key] = compute()
+        return self._stores[namespace][key]
 
 
-def _fetch_github_file_content(repo: str, path: str, ref: str) -> str:
-    cache_key = (repo, path, ref)
-    with _get_or_create_lock(_github_locks, _github_locks_lock, cache_key):
-        if cache_key not in _github_cache:
-            gh = init_github()
-            content = GithubRepositoryApi.get_raw_file(
-                repo=gh.get_repo(repo),
-                path=path,
-                ref=ref,
-            )
-            _github_cache[cache_key] = content.decode("utf-8")
-    return _github_cache[cache_key]
+def _fetch_github_file_content(
+    repo: str, path: str, ref: str, cache: Jinja2TemplateCache
+) -> str:
+    def _fetch() -> str:
+        gh = init_github()
+        content = GithubRepositoryApi.get_raw_file(
+            repo=gh.get_repo(repo),
+            path=path,
+            ref=ref,
+        )
+        return content.decode("utf-8")
+
+    return cache.get_or_set(Jinja2TemplateCache.GITHUB, (repo, path, ref), _fetch)
 
 
 def lookup_github_file_content(
@@ -149,40 +183,37 @@ def lookup_github_file_content(
     tvars: dict[str, Any] | None = None,
     settings: Mapping[str, Any] | None = None,
     secret_reader: SecretReaderBase | None = None,
+    cache: Jinja2TemplateCache | None = None,
 ) -> str:
+    cache = cache or Jinja2TemplateCache()
     if tvars is not None:
         repo = process_jinja2_template(
-            body=repo, vars=tvars, settings=settings, secret_reader=secret_reader
+            body=repo, vars=tvars, settings=settings, secret_reader=secret_reader, cache=cache
         )
         path = process_jinja2_template(
-            body=path, vars=tvars, settings=settings, secret_reader=secret_reader
+            body=path, vars=tvars, settings=settings, secret_reader=secret_reader, cache=cache
         )
         ref = process_jinja2_template(
-            body=ref, vars=tvars, settings=settings, secret_reader=secret_reader
+            body=ref, vars=tvars, settings=settings, secret_reader=secret_reader, cache=cache
         )
-    return _fetch_github_file_content(repo, path, ref)
+    return _fetch_github_file_content(repo, path, ref, cache)
 
 
-_query_cache: dict[tuple[str, str], list[Any]] = {}
-_query_locks: dict[tuple[str, str], threading.Lock] = {}
-_query_locks_lock: threading.Lock = threading.Lock()
-
-
-def lookup_graphql_query_results(query: str, **kwargs: dict[str, Any]) -> list[Any]:
+def lookup_graphql_query_results(
+    query: str,
+    cache: Jinja2TemplateCache | None = None,
+    **kwargs: dict[str, Any],
+) -> list[Any]:
+    cache = cache or Jinja2TemplateCache()
     cache_key = (query, json.dumps(kwargs, sort_keys=True))
-    with _get_or_create_lock(_query_locks, _query_locks_lock, cache_key):
-        if cache_key not in _query_cache:
-            gqlapi = gql.get_api()
-            resource = gqlapi.get_resource(query)["content"]
-            rendered_resource = jinja2.Template(resource).render(**kwargs)
-            results = next(iter(gqlapi.query(rendered_resource).values()))
-            _query_cache[cache_key] = results
-    return _query_cache[cache_key]
 
+    def _fetch() -> list[Any]:
+        gqlapi = gql.get_api()
+        resource = gqlapi.get_resource(query)["content"]
+        rendered_resource = jinja2.Template(resource).render(**kwargs)
+        return next(iter(gqlapi.query(rendered_resource).values()))
 
-_s3_cache: dict[tuple[str, str, str, str | None], str] = {}
-_s3_locks: dict[tuple[str, str, str, str | None], threading.Lock] = {}
-_s3_locks_lock: threading.Lock = threading.Lock()
+    return cache.get_or_set(Jinja2TemplateCache.QUERY, cache_key, _fetch)
 
 
 def lookup_s3_object(
@@ -190,27 +221,25 @@ def lookup_s3_object(
     bucket_name: str,
     path: str,
     region_name: str | None = None,
+    cache: Jinja2TemplateCache | None = None,
 ) -> str:
+    cache = cache or Jinja2TemplateCache()
     cache_key = (account_name, bucket_name, path, region_name)
-    with _get_or_create_lock(_s3_locks, _s3_locks_lock, cache_key):
-        if cache_key not in _s3_cache:
-            settings = queries.get_app_interface_settings()
-            accounts = queries.get_aws_accounts(name=account_name)
-            if not accounts:
-                raise Exception(f"aws account not found: {account_name}")
-            with AWSApi(1, accounts, settings=settings, init_users=False) as aws_api:
-                _s3_cache[cache_key] = aws_api.get_s3_object_content(
-                    account_name,
-                    bucket_name,
-                    path,
-                    region_name=region_name,
-                )
-    return _s3_cache[cache_key]
 
+    def _fetch() -> str:
+        settings = queries.get_app_interface_settings()
+        accounts = queries.get_aws_accounts(name=account_name)
+        if not accounts:
+            raise Exception(f"aws account not found: {account_name}")
+        with AWSApi(1, accounts, settings=settings, init_users=False) as aws_api:
+            return aws_api.get_s3_object_content(
+                account_name,
+                bucket_name,
+                path,
+                region_name=region_name,
+            )
 
-_s3_ls_cache: dict[tuple[str, str, str, str | None], list[str]] = {}
-_s3_ls_locks: dict[tuple[str, str, str, str | None], threading.Lock] = {}
-_s3_ls_locks_lock: threading.Lock = threading.Lock()
+    return cache.get_or_set(Jinja2TemplateCache.S3, cache_key, _fetch)
 
 
 def list_s3_objects(
@@ -218,30 +247,25 @@ def list_s3_objects(
     bucket_name: str,
     path: str,
     region_name: str | None = None,
+    cache: Jinja2TemplateCache | None = None,
 ) -> list[str]:
+    cache = cache or Jinja2TemplateCache()
     cache_key = (account_name, bucket_name, path, region_name)
-    with _get_or_create_lock(_s3_ls_locks, _s3_ls_locks_lock, cache_key):
-        if cache_key not in _s3_ls_cache:
-            settings = queries.get_app_interface_settings()
-            accounts = queries.get_aws_accounts(name=account_name)
-            if not accounts:
-                raise Exception(f"aws account not found: {account_name}")
-            with AWSApi(1, accounts, settings=settings, init_users=False) as aws_api:
-                _s3_ls_cache[cache_key] = aws_api.list_s3_objects(
-                    account_name,
-                    bucket_name,
-                    path,
-                    region_name=region_name,
-                )
-    return _s3_ls_cache[cache_key]
 
+    def _fetch() -> list[str]:
+        settings = queries.get_app_interface_settings()
+        accounts = queries.get_aws_accounts(name=account_name)
+        if not accounts:
+            raise Exception(f"aws account not found: {account_name}")
+        with AWSApi(1, accounts, settings=settings, init_users=False) as aws_api:
+            return aws_api.list_s3_objects(
+                account_name,
+                bucket_name,
+                path,
+                region_name=region_name,
+            )
 
-# Caches all keys for a (path, version) in one read_all call.
-# None sentinel means the path was not found; used to avoid re-fetching on cache hit.
-# Keys within the same path are resolved locally without additional API calls.
-_vault_path_cache: dict[tuple[str, str | None], dict[str, str] | None] = {}
-_vault_path_locks: dict[tuple[str, str | None], threading.Lock] = {}
-_vault_locks_lock: threading.Lock = threading.Lock()
+    return cache.get_or_set(Jinja2TemplateCache.S3_LS, cache_key, _fetch)
 
 
 @retry()
@@ -261,17 +285,19 @@ def lookup_secret(
     allow_not_found: bool = False,
     settings: Mapping[str, Any] | None = None,
     secret_reader: SecretReaderBase | None = None,
+    cache: Jinja2TemplateCache | None = None,
 ) -> str | None:
+    cache = cache or Jinja2TemplateCache()
     if tvars is not None:
         path = process_jinja2_template(
-            body=path, vars=tvars, settings=settings, secret_reader=secret_reader
+            body=path, vars=tvars, settings=settings, secret_reader=secret_reader, cache=cache
         )
         key = process_jinja2_template(
-            body=key, vars=tvars, settings=settings, secret_reader=secret_reader
+            body=key, vars=tvars, settings=settings, secret_reader=secret_reader, cache=cache
         )
         if version and not isinstance(version, int):
             version = process_jinja2_template(
-                body=version, vars=tvars, settings=settings, secret_reader=secret_reader
+                body=version, vars=tvars, settings=settings, secret_reader=secret_reader, cache=cache
             )
     if not secret_reader:
         secret_reader = SecretReader(settings)
@@ -280,16 +306,18 @@ def lookup_secret(
     if version is not None and str(version).upper() == "LATEST":
         version = None
     cache_key = (path, str(version) if version is not None else None)
-    with _get_or_create_lock(_vault_path_locks, _vault_locks_lock, cache_key):
-        if cache_key not in _vault_path_cache:
-            try:
-                fetched = _vault_read_all(secret_reader, path, version)
-                _vault_path_cache[cache_key] = fetched
-            except SecretNotFoundError:
-                _vault_path_cache[cache_key] = None
-            except Exception as e:
-                raise FetchSecretError(e) from e
-    secret_data = _vault_path_cache[cache_key]
+
+    sr = secret_reader
+
+    def _fetch() -> dict[str, str] | None:
+        try:
+            return _vault_read_all(sr, path, version)
+        except SecretNotFoundError:
+            return None
+        except Exception as e:
+            raise FetchSecretError(e) from e
+
+    secret_data = cache.get_or_set(Jinja2TemplateCache.VAULT, cache_key, _fetch)
     if secret_data is None:
         if allow_not_found:
             return None
@@ -308,7 +336,9 @@ def process_jinja2_template(
     settings: Mapping[str, Any] | None = None,
     secret_reader: SecretReaderBase | None = None,
     template_render_options: TemplateRenderOptions | None = None,
+    cache: Jinja2TemplateCache | None = None,
 ) -> Any:
+    cache = cache or Jinja2TemplateCache()
     if vars is None:
         vars = {}
     vars.update({
@@ -320,6 +350,7 @@ def process_jinja2_template(
             allow_not_found=allow_not_found,
             settings=settings,
             secret_reader=secret_reader,
+            cache=cache,
         ),
         "github": lambda u, p, r, v=None: lookup_github_file_content(
             repo=u,
@@ -328,14 +359,15 @@ def process_jinja2_template(
             tvars=vars,
             settings=settings,
             secret_reader=secret_reader,
+            cache=cache,
         ),
         "urlescape": lambda u, s="/", e=None: urlescape(string=u, safe=s, encoding=e),
         "urlunescape": lambda u, e=None: urlunescape(string=u, encoding=e),
         "hash_list": hash_list,
-        "query": lookup_graphql_query_results,
+        "query": lambda q, **kw: lookup_graphql_query_results(q, cache=cache, **kw),
         "url": url_makes_sense,
-        "s3": lookup_s3_object,
-        "s3_ls": list_s3_objects,
+        "s3": lambda a, b, p, r=None: lookup_s3_object(a, b, p, r, cache=cache),
+        "s3_ls": lambda a, b, p, r=None: list_s3_objects(a, b, p, r, cache=cache),
         "flatten_dict": flatten,
         "yesterday": lambda: (utc_now() - datetime.timedelta(1)).strftime("%Y-%m-%d"),
         "sloth_alerts": generate_sloth_rules,
@@ -358,6 +390,7 @@ def process_extracurlyjinja2_template(
     settings: Mapping[str, Any] | None = None,
     secret_reader: SecretReaderBase | None = None,
     template_render_options: TemplateRenderOptions | None = None,
+    cache: Jinja2TemplateCache | None = None,
 ) -> Any:
     if vars is None:
         vars = {}
@@ -368,6 +401,7 @@ def process_extracurlyjinja2_template(
         settings=settings,
         secret_reader=secret_reader,
         template_render_options=template_render_options,
+        cache=cache,
     )
 
 

--- a/reconcile/utils/jinja2/utils.py
+++ b/reconcile/utils/jinja2/utils.py
@@ -214,7 +214,7 @@ def lookup_github_file_content(
 def lookup_graphql_query_results(
     query: str,
     cache: Jinja2TemplateCache | None = None,
-    **kwargs: dict[str, Any],
+    **kwargs: Any,
 ) -> list[Any]:
     cache = cache or Jinja2TemplateCache()
     try:

--- a/reconcile/utils/jinja2/utils.py
+++ b/reconcile/utils/jinja2/utils.py
@@ -1,5 +1,7 @@
 import datetime
+import json
 import os
+import threading
 from collections.abc import Mapping
 from functools import cache
 from typing import Any, Self
@@ -37,7 +39,6 @@ from reconcile.utils.secret_reader import (
     SecretReaderBase,
 )
 from reconcile.utils.sloth import generate_sloth_rules
-from reconcile.utils.vault import SecretFieldNotFoundError
 
 
 class Jinja2TemplateError(Exception):
@@ -111,6 +112,36 @@ def init_github() -> Github:
     return Github(token, base_url=GH_BASE_URL)
 
 
+def _get_or_create_lock(
+    locks: dict[Any, threading.Lock],
+    meta_lock: threading.Lock,
+    key: Any,
+) -> threading.Lock:
+    with meta_lock:
+        if key not in locks:
+            locks[key] = threading.Lock()
+        return locks[key]
+
+
+_github_cache: dict[tuple[str, str, str], str] = {}
+_github_locks: dict[tuple[str, str, str], threading.Lock] = {}
+_github_locks_lock: threading.Lock = threading.Lock()
+
+
+def _fetch_github_file_content(repo: str, path: str, ref: str) -> str:
+    cache_key = (repo, path, ref)
+    with _get_or_create_lock(_github_locks, _github_locks_lock, cache_key):
+        if cache_key not in _github_cache:
+            gh = init_github()
+            content = GithubRepositoryApi.get_raw_file(
+                repo=gh.get_repo(repo),
+                path=path,
+                ref=ref,
+            )
+            _github_cache[cache_key] = content.decode("utf-8")
+    return _github_cache[cache_key]
+
+
 def lookup_github_file_content(
     repo: str,
     path: str,
@@ -129,22 +160,29 @@ def lookup_github_file_content(
         ref = process_jinja2_template(
             body=ref, vars=tvars, settings=settings, secret_reader=secret_reader
         )
+    return _fetch_github_file_content(repo, path, ref)
 
-    gh = init_github()
-    content = GithubRepositoryApi.get_raw_file(
-        repo=gh.get_repo(repo),
-        path=path,
-        ref=ref,
-    )
-    return content.decode("utf-8")
+
+_query_cache: dict[tuple[str, str], list[Any]] = {}
+_query_locks: dict[tuple[str, str], threading.Lock] = {}
+_query_locks_lock: threading.Lock = threading.Lock()
 
 
 def lookup_graphql_query_results(query: str, **kwargs: dict[str, Any]) -> list[Any]:
-    gqlapi = gql.get_api()
-    resource = gqlapi.get_resource(query)["content"]
-    rendered_resource = jinja2.Template(resource).render(**kwargs)
-    results = next(iter(gqlapi.query(rendered_resource).values()))
-    return results
+    cache_key = (query, json.dumps(kwargs, sort_keys=True))
+    with _get_or_create_lock(_query_locks, _query_locks_lock, cache_key):
+        if cache_key not in _query_cache:
+            gqlapi = gql.get_api()
+            resource = gqlapi.get_resource(query)["content"]
+            rendered_resource = jinja2.Template(resource).render(**kwargs)
+            results = next(iter(gqlapi.query(rendered_resource).values()))
+            _query_cache[cache_key] = results
+    return _query_cache[cache_key]
+
+
+_s3_cache: dict[tuple[str, str, str, str | None], str] = {}
+_s3_locks: dict[tuple[str, str, str, str | None], threading.Lock] = {}
+_s3_locks_lock: threading.Lock = threading.Lock()
 
 
 def lookup_s3_object(
@@ -153,18 +191,26 @@ def lookup_s3_object(
     path: str,
     region_name: str | None = None,
 ) -> str:
-    settings = queries.get_app_interface_settings()
-    accounts = queries.get_aws_accounts(name=account_name)
-    if not accounts:
-        raise Exception(f"aws account not found: {account_name}")
+    cache_key = (account_name, bucket_name, path, region_name)
+    with _get_or_create_lock(_s3_locks, _s3_locks_lock, cache_key):
+        if cache_key not in _s3_cache:
+            settings = queries.get_app_interface_settings()
+            accounts = queries.get_aws_accounts(name=account_name)
+            if not accounts:
+                raise Exception(f"aws account not found: {account_name}")
+            with AWSApi(1, accounts, settings=settings, init_users=False) as aws_api:
+                _s3_cache[cache_key] = aws_api.get_s3_object_content(
+                    account_name,
+                    bucket_name,
+                    path,
+                    region_name=region_name,
+                )
+    return _s3_cache[cache_key]
 
-    with AWSApi(1, accounts, settings=settings, init_users=False) as aws_api:
-        return aws_api.get_s3_object_content(
-            account_name,
-            bucket_name,
-            path,
-            region_name=region_name,
-        )
+
+_s3_ls_cache: dict[tuple[str, str, str, str | None], list[str]] = {}
+_s3_ls_locks: dict[tuple[str, str, str, str | None], threading.Lock] = {}
+_s3_ls_locks_lock: threading.Lock = threading.Lock()
 
 
 def list_s3_objects(
@@ -173,21 +219,40 @@ def list_s3_objects(
     path: str,
     region_name: str | None = None,
 ) -> list[str]:
-    settings = queries.get_app_interface_settings()
-    accounts = queries.get_aws_accounts(name=account_name)
-    if not accounts:
-        raise Exception(f"aws account not found: {account_name}")
+    cache_key = (account_name, bucket_name, path, region_name)
+    with _get_or_create_lock(_s3_ls_locks, _s3_ls_locks_lock, cache_key):
+        if cache_key not in _s3_ls_cache:
+            settings = queries.get_app_interface_settings()
+            accounts = queries.get_aws_accounts(name=account_name)
+            if not accounts:
+                raise Exception(f"aws account not found: {account_name}")
+            with AWSApi(1, accounts, settings=settings, init_users=False) as aws_api:
+                _s3_ls_cache[cache_key] = aws_api.list_s3_objects(
+                    account_name,
+                    bucket_name,
+                    path,
+                    region_name=region_name,
+                )
+    return _s3_ls_cache[cache_key]
 
-    with AWSApi(1, accounts, settings=settings, init_users=False) as aws_api:
-        return aws_api.list_s3_objects(
-            account_name,
-            bucket_name,
-            path,
-            region_name=region_name,
-        )
+
+# Caches all keys for a (path, version) in one read_all call.
+# None sentinel means the path was not found; used to avoid re-fetching on cache hit.
+# Keys within the same path are resolved locally without additional API calls.
+_vault_path_cache: dict[tuple[str, str | None], dict[str, str] | None] = {}
+_vault_path_locks: dict[tuple[str, str | None], threading.Lock] = {}
+_vault_locks_lock: threading.Lock = threading.Lock()
 
 
 @retry()
+def _vault_read_all(
+    secret_reader: SecretReaderBase,
+    path: str,
+    version: str | None,
+) -> dict[str, str]:
+    return secret_reader.read_all({"path": path, "field": "", "version": version})
+
+
 def lookup_secret(
     path: str,
     key: str,
@@ -208,17 +273,32 @@ def lookup_secret(
             version = process_jinja2_template(
                 body=version, vars=tvars, settings=settings, secret_reader=secret_reader
             )
-    secret = {"path": path, "field": key, "version": version}
-    try:
-        if not secret_reader:
-            secret_reader = SecretReader(settings)
-        return secret_reader.read(secret)
-    except (SecretNotFoundError, SecretFieldNotFoundError) as e:
+    if not secret_reader:
+        secret_reader = SecretReader(settings)
+    # Normalize "LATEST" to None — both mean "current version" in Vault KV v2,
+    # sharing a single cache entry avoids a redundant Vault read.
+    if version is not None and str(version).upper() == "LATEST":
+        version = None
+    cache_key = (path, str(version) if version is not None else None)
+    with _get_or_create_lock(_vault_path_locks, _vault_locks_lock, cache_key):
+        if cache_key not in _vault_path_cache:
+            try:
+                fetched = _vault_read_all(secret_reader, path, version)
+                _vault_path_cache[cache_key] = fetched
+            except SecretNotFoundError:
+                _vault_path_cache[cache_key] = None
+            except Exception as e:
+                raise FetchSecretError(e) from e
+    secret_data = _vault_path_cache[cache_key]
+    if secret_data is None:
         if allow_not_found:
             return None
-        raise FetchSecretError(e) from None
-    except Exception as e:
-        raise FetchSecretError(e) from e
+        raise FetchSecretError(f"secret not found: {path}")
+    if key not in secret_data:
+        if allow_not_found:
+            return None
+        raise FetchSecretError(f"secret field not found: {path}/{key}")
+    return secret_data[key]
 
 
 def process_jinja2_template(

--- a/reconcile/utils/jinja2/utils.py
+++ b/reconcile/utils/jinja2/utils.py
@@ -112,9 +112,6 @@ def init_github() -> Github:
     return Github(token, base_url=GH_BASE_URL)
 
 
-_MISSING: Any = object()
-
-
 class Jinja2TemplateCache:
     """Scoped cache for Jinja2 template external lookups (vault, github, s3, query).
 
@@ -147,12 +144,6 @@ class Jinja2TemplateCache:
             if key not in locks:
                 locks[key] = threading.Lock()
             return locks[key]
-
-    def get(self, namespace: str, key: Any) -> Any:
-        return self._stores[namespace].get(key, _MISSING)
-
-    def set(self, namespace: str, key: Any, value: Any) -> None:
-        self._stores[namespace][key] = value
 
     def get_or_set(self, namespace: str, key: Any, compute: Callable[[], Any]) -> Any:
         with self._lock_for(namespace, key):

--- a/reconcile/utils/jinja2/utils.py
+++ b/reconcile/utils/jinja2/utils.py
@@ -188,13 +188,25 @@ def lookup_github_file_content(
     cache = cache or Jinja2TemplateCache()
     if tvars is not None:
         repo = process_jinja2_template(
-            body=repo, vars=tvars, settings=settings, secret_reader=secret_reader, cache=cache
+            body=repo,
+            vars=tvars,
+            settings=settings,
+            secret_reader=secret_reader,
+            cache=cache,
         )
         path = process_jinja2_template(
-            body=path, vars=tvars, settings=settings, secret_reader=secret_reader, cache=cache
+            body=path,
+            vars=tvars,
+            settings=settings,
+            secret_reader=secret_reader,
+            cache=cache,
         )
         ref = process_jinja2_template(
-            body=ref, vars=tvars, settings=settings, secret_reader=secret_reader, cache=cache
+            body=ref,
+            vars=tvars,
+            settings=settings,
+            secret_reader=secret_reader,
+            cache=cache,
         )
     return _fetch_github_file_content(repo, path, ref, cache)
 
@@ -290,14 +302,26 @@ def lookup_secret(
     cache = cache or Jinja2TemplateCache()
     if tvars is not None:
         path = process_jinja2_template(
-            body=path, vars=tvars, settings=settings, secret_reader=secret_reader, cache=cache
+            body=path,
+            vars=tvars,
+            settings=settings,
+            secret_reader=secret_reader,
+            cache=cache,
         )
         key = process_jinja2_template(
-            body=key, vars=tvars, settings=settings, secret_reader=secret_reader, cache=cache
+            body=key,
+            vars=tvars,
+            settings=settings,
+            secret_reader=secret_reader,
+            cache=cache,
         )
         if version and not isinstance(version, int):
             version = process_jinja2_template(
-                body=version, vars=tvars, settings=settings, secret_reader=secret_reader, cache=cache
+                body=version,
+                vars=tvars,
+                settings=settings,
+                secret_reader=secret_reader,
+                cache=cache,
             )
     if not secret_reader:
         secret_reader = SecretReader(settings)


### PR DESCRIPTION
…y template functions

Cache vault reads at path level using read_all, deduplicate github/s3/query fetches within a run, and serialize concurrent fetches of the same key with per-entry locks to avoid thundering-herd duplicate API calls.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance Improvements**
  * Added per-run template caching to speed resource templating and reduce redundant external lookups (secrets, files, queries, S3), improving runtime.
* **Behavioral Improvements**
  * More consistent templating across resource types (including Prometheus rules) for more reliable rendered outputs.
* **Tests**
  * Test harness updated to remain compatible with the new caching behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->