### PR TITLE
fix(github-org): require managedTeams and deprecate PermissionGithubOrg_v1

### DIFF
--- a/docs/integrations/github-owners.md
+++ b/docs/integrations/github-owners.md
@@ -31,8 +31,7 @@ The GitHub org's API token is looked up from the corresponding `githuborg_v1` en
 $schema: /access/role-1.yml
 name: my-team-admins
 permissions:
-  - $schema: /access/permission-github-org-team-1.yml
-    service: github-org-team
+  - service: github-org-team
     org: my-github-org
     team: my-team
     role: owner
@@ -246,8 +245,7 @@ Roles with GitHub org owner permissions are defined using `PermissionGithubOrgTe
 $schema: /access/role-1.yml
 name: my-admins
 permissions:
-  - $schema: /access/permission-github-org-team-1.yml
-    service: github-org-team
+  - service: github-org-team
     org: my-github-org   # must match githuborg_v1 name
     team: my-team
     role: owner

--- a/docs/integrations/github-owners.md
+++ b/docs/integrations/github-owners.md
@@ -4,7 +4,7 @@
 
 ## Description
 
-The `github-owners` integration ensures that GitHub organization admin (owner) membership reflects the desired state declared in App-Interface. It reads roles with `github-org` or `github-org-team` owner permissions and adds any missing users or bots to the corresponding GitHub organizations. Owner removal is intentionally not supported — removing org admins requires explicit manual review.
+The `github-owners` integration ensures that GitHub organization admin (owner) membership reflects the desired state declared in App-Interface. It reads roles with `github-org-team` owner permissions and adds any missing users or bots to the corresponding GitHub organizations. Owner removal is intentionally not supported — removing org admins requires explicit manual review.
 
 ## Features
 
@@ -19,7 +19,7 @@ The `github-owners` integration ensures that GitHub organization admin (owner) m
 
 Desired state is derived from `roles_v1` in App-Interface. A user or bot becomes a desired owner of a GitHub org when:
 
-1. They are a member of a role that has a `PermissionGithubOrg_v1` or `PermissionGithubOrgTeam_v1` permission with `role: owner`
+1. They are a member of a role that has a `PermissionGithubOrgTeam_v1` permission with `role: owner`
 2. The role is not expired (no `expirationDate`, or `expirationDate` is in the future)
 3. The user has a `github_username` set on their profile
 
@@ -31,9 +31,10 @@ The GitHub org's API token is looked up from the corresponding `githuborg_v1` en
 $schema: /access/role-1.yml
 name: my-team-admins
 permissions:
-  - $schema: /access/permission-github-org-1.yml
-    service: github-org
+  - $schema: /access/permission-github-org-team-1.yml
+    service: github-org-team
     org: my-github-org
+    team: my-team
     role: owner
 users:
   - $ref: /teams/my-team/users/alice.yml
@@ -238,16 +239,17 @@ Authorization: Bearer <JWT_TOKEN>
 
 **App-Interface Schema:**
 
-Roles with GitHub org owner permissions are defined using `PermissionGithubOrg_v1` or `PermissionGithubOrgTeam_v1`:
+Roles with GitHub org owner permissions are defined using `PermissionGithubOrgTeam_v1`:
 
 ```yaml
 # Role granting GitHub org ownership
 $schema: /access/role-1.yml
 name: my-admins
 permissions:
-  - $schema: /access/permission-github-org-1.yml
-    service: github-org
+  - $schema: /access/permission-github-org-team-1.yml
+    service: github-org-team
     org: my-github-org   # must match githuborg_v1 name
+    team: my-team
     role: owner
 users:
   - $ref: /teams/.../users/alice.yml

--- a/reconcile/github_org.py
+++ b/reconcile/github_org.py
@@ -53,11 +53,8 @@ ROLES_QUERY = """
       github_username
     }
     permissions {
-      service
-      ...on PermissionGithubOrg_v1 {
-        org
-      }
       ...on PermissionGithubOrgTeam_v1 {
+        service
         org
         team
       }
@@ -144,8 +141,8 @@ def get_org_and_teams(
 
 
 @retry()
-def get_members(unit: Organization | Team) -> list[str]:
-    return [member.login for member in unit.get_members()]
+def get_members(team: Team) -> list[str]:
+    return [member.login for member in team.get_members()]
 
 
 class GHApiStore:
@@ -178,24 +175,17 @@ def fetch_current_state(gh_api_store: GHApiStore) -> AggregatedList:
     state = AggregatedList()
 
     for org_name in gh_api_store.orgs():
+        managed_teams = gh_api_store.managed_teams(org_name)
+        if not managed_teams:
+            continue
+
         g = gh_api_store.github(org_name)
         raw_gh_api = gh_api_store.raw_github_api(org_name)
-        managed_teams = gh_api_store.managed_teams(org_name)
-        # if 'managedTeams' is not specified
-        # we manage all teams
-        is_managed = managed_teams is None or len(managed_teams) == 0
-
         org, teams = get_org_and_teams(g, org_name)
-
-        org_members = None
-        if is_managed:
-            org_members = get_members(org)
-            org_members.extend(raw_gh_api.org_invitations(org_name))
-            org_members = [m.lower() for m in org_members]
 
         all_team_members = []
         for team in teams:
-            if not is_managed and team.name not in (managed_teams or []):
+            if team.name not in managed_teams:
                 continue
 
             members = get_members(team)
@@ -209,13 +199,9 @@ def fetch_current_state(gh_api_store: GHApiStore) -> AggregatedList:
             )
         all_team_members = list(set(all_team_members))
 
-        members = org_members or all_team_members
         state.add(
-            {
-                "service": "github-org",
-                "org": org_name,
-            },
-            members,
+            {"service": "github-org", "org": org_name},
+            all_team_members,
         )
 
     return state
@@ -229,7 +215,7 @@ def fetch_desired_state(infer_clusters: bool = True) -> AggregatedList:
     for role in roles:
         permissions = list(
             filter(
-                lambda p: p.get("service") in {"github-org", "github-org-team"},
+                lambda p: p.get("service") == "github-org-team",
                 role["permissions"],
             )
         )
@@ -244,17 +230,14 @@ def fetch_desired_state(infer_clusters: bool = True) -> AggregatedList:
         members = [m.lower() for m in user_members + bot_members]
 
         for permission in permissions:
-            if permission["service"] == "github-org":
-                state.add(permission, members)
-            elif permission["service"] == "github-org-team":
-                state.add(permission, members)
-                state.add(
-                    {
-                        "service": "github-org",
-                        "org": permission["org"],
-                    },
-                    members,
-                )
+            state.add(permission, members)
+            state.add(
+                {
+                    "service": "github-org",
+                    "org": permission["org"],
+                },
+                members,
+            )
 
     if not infer_clusters:
         return state
@@ -343,11 +326,6 @@ class RunnerAction:
                     logging.info([label, member, org, team])
                     gh_user = g.get_user(member)
                     gh_team.remove_membership(gh_user)
-
-                # members = gh_team.get_members()
-                # if len(list(members)) == 0:
-                #     logging.info(["del_team", org, team])
-                #     gh_team.delete()
 
         return action
 

--- a/reconcile/github_owners_api.py
+++ b/reconcile/github_owners_api.py
@@ -45,7 +45,6 @@ from reconcile.gql_definitions.common.github_orgs import GithubOrgV1
 from reconcile.gql_definitions.common.github_orgs import query as github_orgs_query
 from reconcile.gql_definitions.github_owners_api.roles import (
     PermissionGithubOrgTeamV1,
-    PermissionGithubOrgV1,
     RoleV1,
 )
 from reconcile.gql_definitions.github_owners_api.roles import query as roles_query
@@ -70,7 +69,7 @@ class GithubOwnersIntegration(
     """Manage GitHub organization owner membership via qontract-api.
 
     This integration:
-    1. Queries App-Interface for roles with github-org/github-org-team owner permissions
+    1. Queries App-Interface for roles with github-org-team owner permissions
     2. Filters expired roles
     3. Queries App-Interface for GitHub org configs (to get API tokens)
     4. Compiles the desired owner state per org
@@ -103,7 +102,7 @@ class GithubOwnersIntegration(
     ) -> list[GithubOrgDesiredState]:
         """Compile the desired owner state from roles and org configs.
 
-        Groups all github-org and github-org-team owner permissions by org,
+        Groups all github-org-team owner permissions by org,
         collects all users and bots with those permissions, and matches them
         to the org's GitHub API token.
 
@@ -120,9 +119,7 @@ class GithubOwnersIntegration(
 
         for role in roles:
             for permission in role.permissions or []:
-                if not isinstance(
-                    permission, (PermissionGithubOrgV1, PermissionGithubOrgTeamV1)
-                ):
+                if not isinstance(permission, PermissionGithubOrgTeamV1):
                     continue
                 if permission.role != "owner":
                     continue

--- a/reconcile/gql_definitions/github_owners_api/roles.gql
+++ b/reconcile/gql_definitions/github_owners_api/roles.gql
@@ -9,12 +9,8 @@ query GithubOwnersApiRoles {
       github_username
     }
     permissions {
-      service
-      ... on PermissionGithubOrg_v1 {
-        org
-        role
-      }
       ... on PermissionGithubOrgTeam_v1 {
+        service
         org
         role
       }

--- a/reconcile/gql_definitions/github_owners_api/roles.py
+++ b/reconcile/gql_definitions/github_owners_api/roles.py
@@ -29,12 +29,8 @@ query GithubOwnersApiRoles {
       github_username
     }
     permissions {
-      service
-      ... on PermissionGithubOrg_v1 {
-        org
-        role
-      }
       ... on PermissionGithubOrgTeam_v1 {
+        service
         org
         role
       }
@@ -60,15 +56,11 @@ class BotV1(ConfiguredBaseModel):
 
 
 class PermissionV1(ConfiguredBaseModel):
-    service: str = Field(..., alias="service")
-
-
-class PermissionGithubOrgV1(PermissionV1):
-    org: str = Field(..., alias="org")
-    role: Optional[str] = Field(..., alias="role")
+    ...
 
 
 class PermissionGithubOrgTeamV1(PermissionV1):
+    service: str = Field(..., alias="service")
     org: str = Field(..., alias="org")
     role: Optional[str] = Field(..., alias="role")
 
@@ -77,7 +69,7 @@ class RoleV1(ConfiguredBaseModel):
     name: str = Field(..., alias="name")
     users: list[UserV1] = Field(..., alias="users")
     bots: list[BotV1] = Field(..., alias="bots")
-    permissions: Optional[list[Union[PermissionGithubOrgV1, PermissionGithubOrgTeamV1, PermissionV1]]] = Field(..., alias="permissions")
+    permissions: Optional[list[Union[PermissionGithubOrgTeamV1, PermissionV1]]] = Field(..., alias="permissions")
     expiration_date: Optional[str] = Field(..., alias="expirationDate")
 
 

--- a/reconcile/gql_definitions/introspection.json
+++ b/reconcile/gql_definitions/introspection.json
@@ -857,11 +857,6 @@
                         },
                         {
                             "kind": "OBJECT",
-                            "name": "PermissionGithubOrg_v1",
-                            "ofType": null
-                        },
-                        {
-                            "kind": "OBJECT",
                             "name": "PermissionGithubOrgTeam_v1",
                             "ofType": null
                         },
@@ -34154,293 +34149,6 @@
                 },
                 {
                     "kind": "OBJECT",
-                    "name": "PermissionGithubOrg_v1",
-                    "description": null,
-                    "fields": [
-                        {
-                            "name": "schema",
-                            "description": null,
-                            "args": [],
-                            "type": {
-                                "kind": "NON_NULL",
-                                "name": null,
-                                "ofType": {
-                                    "kind": "SCALAR",
-                                    "name": "String",
-                                    "ofType": null
-                                }
-                            },
-                            "isDeprecated": false,
-                            "deprecationReason": null
-                        },
-                        {
-                            "name": "path",
-                            "description": null,
-                            "args": [],
-                            "type": {
-                                "kind": "NON_NULL",
-                                "name": null,
-                                "ofType": {
-                                    "kind": "SCALAR",
-                                    "name": "String",
-                                    "ofType": null
-                                }
-                            },
-                            "isDeprecated": false,
-                            "deprecationReason": null
-                        },
-                        {
-                            "name": "labels",
-                            "description": null,
-                            "args": [],
-                            "type": {
-                                "kind": "SCALAR",
-                                "name": "JSON",
-                                "ofType": null
-                            },
-                            "isDeprecated": false,
-                            "deprecationReason": null
-                        },
-                        {
-                            "name": "name",
-                            "description": null,
-                            "args": [],
-                            "type": {
-                                "kind": "NON_NULL",
-                                "name": null,
-                                "ofType": {
-                                    "kind": "SCALAR",
-                                    "name": "String",
-                                    "ofType": null
-                                }
-                            },
-                            "isDeprecated": false,
-                            "deprecationReason": null
-                        },
-                        {
-                            "name": "description",
-                            "description": null,
-                            "args": [],
-                            "type": {
-                                "kind": "NON_NULL",
-                                "name": null,
-                                "ofType": {
-                                    "kind": "SCALAR",
-                                    "name": "String",
-                                    "ofType": null
-                                }
-                            },
-                            "isDeprecated": false,
-                            "deprecationReason": null
-                        },
-                        {
-                            "name": "service",
-                            "description": null,
-                            "args": [],
-                            "type": {
-                                "kind": "NON_NULL",
-                                "name": null,
-                                "ofType": {
-                                    "kind": "SCALAR",
-                                    "name": "String",
-                                    "ofType": null
-                                }
-                            },
-                            "isDeprecated": false,
-                            "deprecationReason": null
-                        },
-                        {
-                            "name": "org",
-                            "description": null,
-                            "args": [],
-                            "type": {
-                                "kind": "NON_NULL",
-                                "name": null,
-                                "ofType": {
-                                    "kind": "SCALAR",
-                                    "name": "String",
-                                    "ofType": null
-                                }
-                            },
-                            "isDeprecated": false,
-                            "deprecationReason": null
-                        },
-                        {
-                            "name": "role",
-                            "description": null,
-                            "args": [],
-                            "type": {
-                                "kind": "SCALAR",
-                                "name": "String",
-                                "ofType": null
-                            },
-                            "isDeprecated": false,
-                            "deprecationReason": null
-                        }
-                    ],
-                    "inputFields": null,
-                    "interfaces": [
-                        {
-                            "kind": "INTERFACE",
-                            "name": "Permission_v1",
-                            "ofType": null
-                        },
-                        {
-                            "kind": "INTERFACE",
-                            "name": "DatafileObject_v1",
-                            "ofType": null
-                        }
-                    ],
-                    "enumValues": null,
-                    "possibleTypes": null
-                },
-                {
-                    "kind": "INTERFACE",
-                    "name": "Permission_v1",
-                    "description": null,
-                    "fields": [
-                        {
-                            "name": "schema",
-                            "description": null,
-                            "args": [],
-                            "type": {
-                                "kind": "NON_NULL",
-                                "name": null,
-                                "ofType": {
-                                    "kind": "SCALAR",
-                                    "name": "String",
-                                    "ofType": null
-                                }
-                            },
-                            "isDeprecated": false,
-                            "deprecationReason": null
-                        },
-                        {
-                            "name": "path",
-                            "description": null,
-                            "args": [],
-                            "type": {
-                                "kind": "NON_NULL",
-                                "name": null,
-                                "ofType": {
-                                    "kind": "SCALAR",
-                                    "name": "String",
-                                    "ofType": null
-                                }
-                            },
-                            "isDeprecated": false,
-                            "deprecationReason": null
-                        },
-                        {
-                            "name": "labels",
-                            "description": null,
-                            "args": [],
-                            "type": {
-                                "kind": "SCALAR",
-                                "name": "JSON",
-                                "ofType": null
-                            },
-                            "isDeprecated": false,
-                            "deprecationReason": null
-                        },
-                        {
-                            "name": "name",
-                            "description": null,
-                            "args": [],
-                            "type": {
-                                "kind": "NON_NULL",
-                                "name": null,
-                                "ofType": {
-                                    "kind": "SCALAR",
-                                    "name": "String",
-                                    "ofType": null
-                                }
-                            },
-                            "isDeprecated": false,
-                            "deprecationReason": null
-                        },
-                        {
-                            "name": "description",
-                            "description": null,
-                            "args": [],
-                            "type": {
-                                "kind": "NON_NULL",
-                                "name": null,
-                                "ofType": {
-                                    "kind": "SCALAR",
-                                    "name": "String",
-                                    "ofType": null
-                                }
-                            },
-                            "isDeprecated": false,
-                            "deprecationReason": null
-                        },
-                        {
-                            "name": "service",
-                            "description": null,
-                            "args": [],
-                            "type": {
-                                "kind": "NON_NULL",
-                                "name": null,
-                                "ofType": {
-                                    "kind": "SCALAR",
-                                    "name": "String",
-                                    "ofType": null
-                                }
-                            },
-                            "isDeprecated": false,
-                            "deprecationReason": null
-                        }
-                    ],
-                    "inputFields": null,
-                    "interfaces": [
-                        {
-                            "kind": "INTERFACE",
-                            "name": "DatafileObject_v1",
-                            "ofType": null
-                        }
-                    ],
-                    "enumValues": null,
-                    "possibleTypes": [
-                        {
-                            "kind": "OBJECT",
-                            "name": "PermissionGithubOrg_v1",
-                            "ofType": null
-                        },
-                        {
-                            "kind": "OBJECT",
-                            "name": "PermissionGithubOrgTeam_v1",
-                            "ofType": null
-                        },
-                        {
-                            "kind": "OBJECT",
-                            "name": "PermissionJenkinsRole_v1",
-                            "ofType": null
-                        },
-                        {
-                            "kind": "OBJECT",
-                            "name": "PermissionGitlabGroupMembership_v1",
-                            "ofType": null
-                        },
-                        {
-                            "kind": "OBJECT",
-                            "name": "PermissionSlackUsergroup_v1",
-                            "ofType": null
-                        },
-                        {
-                            "kind": "OBJECT",
-                            "name": "PermissionQuayOrgTeam_v1",
-                            "ofType": null
-                        },
-                        {
-                            "kind": "OBJECT",
-                            "name": "PermissionAutomatedActions_v1",
-                            "ofType": null
-                        }
-                    ]
-                },
-                {
-                    "kind": "OBJECT",
                     "name": "PermissionGithubOrgTeam_v1",
                     "description": null,
                     "fields": [
@@ -34596,6 +34304,146 @@
                     ],
                     "enumValues": null,
                     "possibleTypes": null
+                },
+                {
+                    "kind": "INTERFACE",
+                    "name": "Permission_v1",
+                    "description": null,
+                    "fields": [
+                        {
+                            "name": "schema",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "NON_NULL",
+                                "name": null,
+                                "ofType": {
+                                    "kind": "SCALAR",
+                                    "name": "String",
+                                    "ofType": null
+                                }
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "path",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "NON_NULL",
+                                "name": null,
+                                "ofType": {
+                                    "kind": "SCALAR",
+                                    "name": "String",
+                                    "ofType": null
+                                }
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "labels",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "SCALAR",
+                                "name": "JSON",
+                                "ofType": null
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "name",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "NON_NULL",
+                                "name": null,
+                                "ofType": {
+                                    "kind": "SCALAR",
+                                    "name": "String",
+                                    "ofType": null
+                                }
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "description",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "NON_NULL",
+                                "name": null,
+                                "ofType": {
+                                    "kind": "SCALAR",
+                                    "name": "String",
+                                    "ofType": null
+                                }
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "service",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "NON_NULL",
+                                "name": null,
+                                "ofType": {
+                                    "kind": "SCALAR",
+                                    "name": "String",
+                                    "ofType": null
+                                }
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        }
+                    ],
+                    "inputFields": null,
+                    "interfaces": [
+                        {
+                            "kind": "INTERFACE",
+                            "name": "DatafileObject_v1",
+                            "ofType": null
+                        }
+                    ],
+                    "enumValues": null,
+                    "possibleTypes": [
+                        {
+                            "kind": "OBJECT",
+                            "name": "PermissionGithubOrgTeam_v1",
+                            "ofType": null
+                        },
+                        {
+                            "kind": "OBJECT",
+                            "name": "PermissionJenkinsRole_v1",
+                            "ofType": null
+                        },
+                        {
+                            "kind": "OBJECT",
+                            "name": "PermissionGitlabGroupMembership_v1",
+                            "ofType": null
+                        },
+                        {
+                            "kind": "OBJECT",
+                            "name": "PermissionSlackUsergroup_v1",
+                            "ofType": null
+                        },
+                        {
+                            "kind": "OBJECT",
+                            "name": "PermissionQuayOrgTeam_v1",
+                            "ofType": null
+                        },
+                        {
+                            "kind": "OBJECT",
+                            "name": "PermissionAutomatedActions_v1",
+                            "ofType": null
+                        }
+                    ]
                 },
                 {
                     "kind": "OBJECT",

--- a/reconcile/test/fixtures/github_org/config.toml
+++ b/reconcile/test/fixtures/github_org/config.toml
@@ -4,5 +4,6 @@ server = "http://localhost:4000/graphql"
 [github]
 [github.org_a]
 token = "token_org_a"
+managed_teams = ["team1"]
 # [github.org_b]
 # token = "token_org_b"

--- a/reconcile/test/fixtures/github_org/current_state_simple.yml
+++ b/reconcile/test/fixtures/github_org/current_state_simple.yml
@@ -13,7 +13,6 @@ gh_api:
 state:
 - items:
   - user1
-  - user2
   params:
     org: org_a
     service: github-org

--- a/reconcile/test/fixtures/github_org/desired_state_simple.yml
+++ b/reconcile/test/fixtures/github_org/desired_state_simple.yml
@@ -7,8 +7,6 @@ gql_response:
     expirationDate: null
     permissions:
     - org: org_a
-      service: github-org
-    - org: org_a
       team: team1
       service: github-org-team
 

--- a/reconcile/test/test_github_org.py
+++ b/reconcile/test/test_github_org.py
@@ -3,7 +3,7 @@ from typing import Any
 from unittest.mock import patch
 
 from github import NamedUser
-from github.Organization import Organization
+from github.Team import Team
 from pytest_mock import MockerFixture
 
 from reconcile import github_org
@@ -19,10 +19,6 @@ fxt = Fixtures("github_org")
 
 
 class RawGithubApiMock:
-    @staticmethod
-    def org_invitations(org_name: str) -> list:
-        return []
-
     @staticmethod
     def team_invitations(org_id: str, team_id: str) -> list:
         return []
@@ -60,9 +56,6 @@ class GithubMock:
             @property
             def name(self) -> str:
                 return self.spec_team["name"]
-
-        def get_members(self) -> Iterable[dict]:
-            return map(AttrDict, self.spec_org["members"])
 
         def get_teams(self) -> Iterable[GithubTeamMock]:
             return map(self.GithubTeamMock, self.spec_org["teams"])
@@ -135,16 +128,35 @@ class TestGithubOrg:
     def test_get_members(self, mocker: MockerFixture) -> None:
         member_a = mocker.create_autospec(NamedUser, login="a")
         member_b = mocker.create_autospec(NamedUser, login="b")
-        org = mocker.create_autospec(Organization)
-        org.get_members.return_value = [member_a, member_b]
+        team = mocker.create_autospec(Team)
+        team.get_members.return_value = [member_a, member_b]
 
-        assert github_org.get_members(org) == ["a", "b"]
+        assert github_org.get_members(team) == ["a", "b"]
 
     def test_get_org_teams(self, mocker: MockerFixture) -> None:
-        org = mocker.create_autospec(Organization)
+        org = mocker.create_autospec(github_org.Organization)
         org.get_teams.return_value = ["teams"]
         gh = mocker.create_autospec(github_org.Github)
         gh.get_organization.return_value = org
 
         _, teams = github_org.get_org_and_teams(gh, "org")
         assert teams == ["teams"]
+
+    def test_fetch_current_state_skips_org_without_managed_teams(self) -> None:
+        with (
+            patch("reconcile.github_org.RawGithubApi") as m_rga,
+            patch("reconcile.github_org.Github") as m_gh,
+        ):
+            m_gh.return_value = GithubMock({})
+            m_rga.return_value = RawGithubApiMock()
+
+            # Temporarily clear managed_teams for org_a
+            orig = config.get_config()["github"]["org_a"].get("managed_teams")
+            config.get_config()["github"]["org_a"]["managed_teams"] = None
+
+            gh_api_store = github_org.GHApiStore(config.get_config())
+            current_state = github_org.fetch_current_state(gh_api_store).dump()
+
+            config.get_config()["github"]["org_a"]["managed_teams"] = orig
+
+        assert current_state == []

--- a/reconcile/test/test_github_owners_api.py
+++ b/reconcile/test/test_github_owners_api.py
@@ -24,7 +24,6 @@ from reconcile.gql_definitions.fragments.vault_secret import VaultSecret
 from reconcile.gql_definitions.github_owners_api.roles import (
     BotV1,
     PermissionGithubOrgTeamV1,
-    PermissionGithubOrgV1,
     PermissionV1,
     RoleV1,
     UserV1,
@@ -74,10 +73,6 @@ def make_role(
     )
 
 
-def make_github_org_permission(org: str, role: str = "owner") -> PermissionGithubOrgV1:
-    return PermissionGithubOrgV1(service="github-org", org=org, role=role)
-
-
 def make_github_org_team_permission(
     org: str, role: str = "owner"
 ) -> PermissionGithubOrgTeamV1:
@@ -95,7 +90,7 @@ class TestCompileDesiredState:
         roles = [
             make_role(
                 users=["Alice"],
-                permissions=[make_github_org_permission("my-org")],
+                permissions=[make_github_org_team_permission("my-org")],
             )
         ]
         github_orgs = {"my-org": make_github_org("my-org")}
@@ -111,7 +106,7 @@ class TestCompileDesiredState:
         roles = [
             make_role(
                 users=["Charlie", "Alice", "BOB"],
-                permissions=[make_github_org_permission("my-org")],
+                permissions=[make_github_org_team_permission("my-org")],
             )
         ]
         github_orgs = {"my-org": make_github_org("my-org")}
@@ -126,7 +121,7 @@ class TestCompileDesiredState:
             make_role(
                 users=["alice"],
                 bots=["bot-user"],
-                permissions=[make_github_org_permission("my-org")],
+                permissions=[make_github_org_team_permission("my-org")],
             )
         ]
         github_orgs = {"my-org": make_github_org("my-org")}
@@ -140,7 +135,7 @@ class TestCompileDesiredState:
         integration = make_integration()
         role = make_role(
             users=["alice"],
-            permissions=[make_github_org_permission("my-org")],
+            permissions=[make_github_org_team_permission("my-org")],
         )
         # Add a bot with no github_username
         role.bots.append(BotV1(github_username=None))
@@ -169,7 +164,7 @@ class TestCompileDesiredState:
         roles = [
             make_role(
                 users=["alice"],
-                permissions=[make_github_org_permission("my-org", role="member")],
+                permissions=[make_github_org_team_permission("my-org", role="member")],
             )
         ]
         github_orgs = {"my-org": make_github_org("my-org")}
@@ -183,7 +178,7 @@ class TestCompileDesiredState:
         roles = [
             make_role(
                 users=["alice"],
-                permissions=[PermissionV1(service="openshift-rolebinding")],
+                permissions=[PermissionV1()],
             )
         ]
         github_orgs = {"my-org": make_github_org("my-org")}
@@ -198,8 +193,8 @@ class TestCompileDesiredState:
             make_role(
                 users=["alice"],
                 permissions=[
-                    make_github_org_permission("org-a"),
-                    make_github_org_permission("org-b"),
+                    make_github_org_team_permission("org-a"),
+                    make_github_org_team_permission("org-b"),
                 ],
             )
         ]
@@ -222,7 +217,7 @@ class TestCompileDesiredState:
         roles = [
             make_role(
                 users=["alice"],
-                permissions=[make_github_org_permission("unknown-org")],
+                permissions=[make_github_org_team_permission("unknown-org")],
             )
         ]
 
@@ -236,7 +231,7 @@ class TestCompileDesiredState:
         roles = [
             make_role(
                 users=["alice"],
-                permissions=[make_github_org_permission("my-org")],
+                permissions=[make_github_org_team_permission("my-org")],
             )
         ]
         github_orgs = {
@@ -256,12 +251,12 @@ class TestCompileDesiredState:
             make_role(
                 name="role-a",
                 users=["alice"],
-                permissions=[make_github_org_permission("my-org")],
+                permissions=[make_github_org_team_permission("my-org")],
             ),
             make_role(
                 name="role-b",
                 users=["bob"],
-                permissions=[make_github_org_permission("my-org")],
+                permissions=[make_github_org_team_permission("my-org")],
             ),
         ]
         github_orgs = {"my-org": make_github_org("my-org")}
@@ -277,8 +272,8 @@ class TestCompileDesiredState:
             make_role(
                 users=["alice"],
                 permissions=[
-                    make_github_org_permission("org-a"),
-                    make_github_org_permission("org-b"),
+                    make_github_org_team_permission("org-a"),
+                    make_github_org_team_permission("org-b"),
                 ],
             )
         ]

--- a/reconcile/utils/raw_github_api.py
+++ b/reconcile/utils/raw_github_api.py
@@ -67,15 +67,6 @@ class RawGithubApi:
 
         return result
 
-    def org_invitations(self, org: str) -> list[str]:
-        invitations = self.query(f"/orgs/{org}/invitations")
-
-        return [
-            login
-            for login in (invitation.get("login") for invitation in invitations)
-            if login is not None
-        ]
-
     def team_invitations(self, org_id: str | int, team_id: str | int) -> list[str]:
         invitations = self.query(f"/organizations/{org_id}/team/{team_id}/invitations")
 


### PR DESCRIPTION
## Summary

- Require `managedTeams` to be explicitly configured; orgs without it are skipped entirely
- Derive org membership from managed team members only (fixes 422 errors from enterprise teams)
- Remove `PermissionGithubOrg_v1` from all GQL queries and code — all data migrated to `PermissionGithubOrgTeam_v1`
- Clean up dead code: `org_invitations`, org-level `get_members`, enterprise team filter

## Test plan

- [x] `pytest reconcile/test/test_github_org.py` — 5 tests pass
- [x] `pytest reconcile/test/test_github_owners_api.py` — 21 tests pass
- [ ] Verify in staging with dry-run before applying

JIRA: https://redhat.atlassian.net/browse/APPSRE-14122

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified guidance: owner membership is now documented as derived solely from team-level owner permissions.

* **Refactor**
  * Owner resolution and current-state aggregation now use configured team memberships (and team invitations) rather than org-wide members.
  * Orgs without configured managed teams are skipped during current-state collection.

* **Tests**
  * Test fixtures and suites updated to reflect team-level behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->