### PR TITLE
qontract-api: do not send logs to glitchtip

### DIFF
--- a/qontract_api/qontract_api/logger.py
+++ b/qontract_api/qontract_api/logger.py
@@ -117,8 +117,8 @@ def setup_logging(
             # see https://docs.sentry.io/platforms/python/data-management/data-collected/ for more info
             # Sensitive headers are automatically filtered by Sentry.
             send_default_pii=True,
-            # Enable logs to be sent to Sentry
-            enable_logs=True,
+            # Don't send logs to Sentry
+            enable_logs=False,
             ignore_errors=[ConnectionError],
             integrations=[
                 LoggingIntegration(event_level=sentry_event_level),

--- a/qontract_api/tests/test_logger.py
+++ b/qontract_api/tests/test_logger.py
@@ -356,7 +356,7 @@ def test_sentry_init_called_when_dsn_provided() -> None:
 
         assert call_args.kwargs["dsn"] == "https://example@sentry.io/123"
         assert call_args.kwargs["send_default_pii"] is True
-        assert call_args.kwargs["enable_logs"] is True
+        assert call_args.kwargs["enable_logs"] is False
         assert call_args.kwargs["ignore_errors"] == [ConnectionError]
 
         root_logger.handlers.clear()


### PR DESCRIPTION
All our logs are on AWS cloudwatch. No need to send them to Glitchtip

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Logs will no longer be sent to the error tracking service.

* **Tests**
  * Updated logging integration tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->