### PR TITLE
fix(qontract_utils): configure structlog to route through stdlib logging

### DIFF
--- a/qontract_utils/qontract_utils/__init__.py
+++ b/qontract_utils/qontract_utils/__init__.py
@@ -1,5 +1,6 @@
 """Shared utilities for qontract-reconcile and qontract-api."""
 
 from qontract_utils import _httpxyz_compat as _httpxyz_compat
+from qontract_utils import _structlog_config as _structlog_config
 
 __version__ = "0.1.0"

--- a/qontract_utils/qontract_utils/_structlog_config.py
+++ b/qontract_utils/qontract_utils/_structlog_config.py
@@ -6,12 +6,13 @@ Callers like qontract_api override this with their own structlog.configure().
 
 import structlog
 
-structlog.configure(
-    processors=[
-        structlog.stdlib.filter_by_level,
-        structlog.stdlib.add_log_level,
-        structlog.processors.KeyValueRenderer(key_order=["event"]),
-    ],
-    logger_factory=structlog.stdlib.LoggerFactory(),
-    wrapper_class=structlog.stdlib.BoundLogger,
-)
+if not structlog.is_configured():
+    structlog.configure(
+        processors=[
+            structlog.stdlib.filter_by_level,
+            structlog.stdlib.add_log_level,
+            structlog.processors.KeyValueRenderer(key_order=["event"]),
+        ],
+        logger_factory=structlog.stdlib.LoggerFactory(),
+        wrapper_class=structlog.stdlib.BoundLogger,
+    )

--- a/qontract_utils/qontract_utils/_structlog_config.py
+++ b/qontract_utils/qontract_utils/_structlog_config.py
@@ -1,0 +1,17 @@
+"""Default structlog configuration for qontract_utils.
+
+Routes structlog through stdlib logging so it respects the root logger's level.
+Callers like qontract_api override this with their own structlog.configure().
+"""
+
+import structlog
+
+structlog.configure(
+    processors=[
+        structlog.stdlib.filter_by_level,
+        structlog.stdlib.add_log_level,
+        structlog.processors.KeyValueRenderer(key_order=["event"]),
+    ],
+    logger_factory=structlog.stdlib.LoggerFactory(),
+    wrapper_class=structlog.stdlib.BoundLogger,
+)


### PR DESCRIPTION
## Summary

- Configures structlog in `qontract_utils` to route through stdlib `logging`, so it respects the root logger's level
- Fixes debug-level logs (e.g., `AWS API request`) appearing in production when called from `reconcile/`. For example in this [MR check](https://ci.int.devshift.net/job/service-app-interface-gl-pr-check/711313/app-interface_20JSON_20validation/index.html#success-reconcile-terraform-init)
- `qontract_api/` is unaffected — its `setup_logging()` overrides this default config

**Root cause:** Unconfigured structlog uses `PrintLogger` which writes directly to stdout, bypassing stdlib level filtering entirely.

## Test plan

- [x] `qontract_utils` tests pass (522 passed)
- [x] `qontract_api` tests pass (408 passed)
- [x] mypy passes (1187 source files)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Initialized logging infrastructure configuration for improved application diagnostics.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/app-sre/qontract-reconcile/pull/5538)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->