### PR TITLE
chore(deps): upgrade dependencies

### DIFF
--- a/dockerfiles/Dockerfile
+++ b/dockerfiles/Dockerfile
@@ -2,7 +2,7 @@
 # STAGE 1 - build-image
 ###############################################################################
 FROM quay.io/redhat-services-prod/app-sre-tenant/container-images-master/qontract-reconcile-builder-master:1.5.1-1@sha256:b376ee1b22f804ee7a13a5f6e0cf2fe67e897827c2be6d73fd5b89bfbe1931e1 AS build-image
-COPY --from=ghcr.io/astral-sh/uv:0.11.7@sha256:240fb85ab0f263ef12f492d8476aa3a2e4e1e333f7d67fbdd923d00a506a516a /uv /bin/uv
+COPY --from=ghcr.io/astral-sh/uv:0.11.13@sha256:841c8e6fe30a8b07b4478d12d0c608cba6de66102d29d65d1cc423af86051563 /uv /bin/uv
 
 WORKDIR /work
 
@@ -29,7 +29,7 @@ RUN UV_DYNAMIC_VERSIONING_BYPASS="0.0.0" uv sync --frozen --no-group dev
 # STAGE 2 - dev-image
 ###############################################################################
 FROM quay.io/redhat-services-prod/app-sre-tenant/container-images-master/qontract-reconcile-base-master:1.5.2-1@sha256:feb8c631c26c0d9ad1ec24903baf0afc20028bd98b0826625ca5389e8ffc6676 AS dev-image
-COPY --from=ghcr.io/astral-sh/uv:0.11.7@sha256:240fb85ab0f263ef12f492d8476aa3a2e4e1e333f7d67fbdd923d00a506a516a /uv /bin/uv
+COPY --from=ghcr.io/astral-sh/uv:0.11.13@sha256:841c8e6fe30a8b07b4478d12d0c608cba6de66102d29d65d1cc423af86051563 /uv /bin/uv
 
 ENV \
     # use venv from ubi image
@@ -85,7 +85,7 @@ CMD ["run-integration"]
 # STAGE 4 - unittest image
 ###############################################################################
 FROM prod-image-pre-test AS test-image
-COPY --from=ghcr.io/astral-sh/uv:0.11.7@sha256:240fb85ab0f263ef12f492d8476aa3a2e4e1e333f7d67fbdd923d00a506a516a /uv /bin/uv
+COPY --from=ghcr.io/astral-sh/uv:0.11.13@sha256:841c8e6fe30a8b07b4478d12d0c608cba6de66102d29d65d1cc423af86051563 /uv /bin/uv
 
 ENV \
     # use venv from ubi image

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,7 @@ dependencies = [
     "pyOpenSSL~=23.0",
     "pypd>=1.1.0,<1.2.0",
     "python-gitlab==6.0.0",
-    "requests-oauthlib~=1.3",
+    "requests-oauthlib~=2.0",
     "requests~=2.32",
     "rich==14.3.1",
     "ruamel.yaml>=0.17.22,<0.18.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ dependencies = [
     "jsonpointer~=2.4",
     "kubernetes==32.0.1",
     "ldap3>=2.9.1,<2.10.0",
-    "networkx~=2.8",
+    "networkx~=3.6",
     "parse==1.18.0",
     "prometheus-client~=0.8",
     "psycopg2-binary~=2.9",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ dependencies = [
     "Click>=7.0,<9.0",
     "croniter>=1.0.15,<1.1.0",
     "dateparser~=1.1.7",
-    "deepdiff==8.6.1",
+    "deepdiff==9.0.0",
     "dnspython~=2.1",
     "dt==1.1.73",
     "filetype~=1.2.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,7 +64,7 @@ dependencies = [
     "toml>=0.10.0,<0.11.0",
     "UnleashClient~=5.11",
     "urllib3~=2.2",
-    "websocket-client<0.55.0,>=0.35",
+    "websocket-client~=1.9.0",
     "yamllint==1.34.0",
     "qontract-api-client",
     "qontract-utils",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,7 @@ dependencies = [
     "pydantic~=2.12.3",
     "PyGithub>=1.58,<1.59",
     "pyjwt~=2.7",
-    "pyOpenSSL~=23.0",
+    "pyOpenSSL~=26.2",
     "pypd>=1.1.0,<1.2.0",
     "python-gitlab==6.0.0",
     "requests-oauthlib~=2.0",

--- a/qontract_api/Dockerfile
+++ b/qontract_api/Dockerfile
@@ -37,7 +37,7 @@ WORKDIR ${APP_ROOT}/src
 # Builder image
 #
 FROM registry.access.redhat.com/ubi9/python-312-minimal@sha256:df1c6dcb266a265011595fa1f149b3add42b66d8ac0e7f4244d5b64ef04c7fe1 AS builder
-COPY --from=ghcr.io/astral-sh/uv:0.11.7@sha256:240fb85ab0f263ef12f492d8476aa3a2e4e1e333f7d67fbdd923d00a506a516a /uv /bin/uv
+COPY --from=ghcr.io/astral-sh/uv:0.11.13@sha256:841c8e6fe30a8b07b4478d12d0c608cba6de66102d29d65d1cc423af86051563 /uv /bin/uv
 
 ENV APP_ROOT=/opt/app-root
 ENV \
@@ -63,7 +63,7 @@ RUN cd qontract_api && uv sync --frozen --no-group dev
 # Test image
 #
 FROM base AS test
-COPY --from=ghcr.io/astral-sh/uv:0.11.7@sha256:240fb85ab0f263ef12f492d8476aa3a2e4e1e333f7d67fbdd923d00a506a516a /uv /bin/uv
+COPY --from=ghcr.io/astral-sh/uv:0.11.13@sha256:841c8e6fe30a8b07b4478d12d0c608cba6de66102d29d65d1cc423af86051563 /uv /bin/uv
 
 USER root
 # install dependencies
@@ -96,7 +96,7 @@ COPY --from=test $TESTFLAG $TESTFLAG
 # Dev image with debugpy
 #
 FROM prod AS debug
-COPY --from=ghcr.io/astral-sh/uv:0.11.7@sha256:240fb85ab0f263ef12f492d8476aa3a2e4e1e333f7d67fbdd923d00a506a516a /uv /bin/uv
+COPY --from=ghcr.io/astral-sh/uv:0.11.13@sha256:841c8e6fe30a8b07b4478d12d0c608cba6de66102d29d65d1cc423af86051563 /uv /bin/uv
 
 EXPOSE 5678
 RUN uv pip install debugpy watchdog

--- a/qontract_api/pyproject.toml
+++ b/qontract_api/pyproject.toml
@@ -7,7 +7,7 @@ license = { text = "Apache 2.0" }
 readme = "README.md"
 requires-python = ">=3.12"
 dependencies = [
-    "cachetools==6.2.2",
+    "cachetools==7.1.1",
     "celery==5.5.3",
     "cloudevents==1.12.0",
     "fastapi==0.121.1",
@@ -37,7 +37,7 @@ dev = [
     "pytest==9.0.2",
     "rich==14.3.1",
     "ruff==0.15.12",
-    "types-cachetools==6.2.0.20251022",
+    "types-cachetools==7.0.0.20260503",
     "types-hvac==2.4.0.20251115",
 ]
 

--- a/qontract_api/pyproject.toml
+++ b/qontract_api/pyproject.toml
@@ -9,7 +9,6 @@ requires-python = ">=3.12"
 dependencies = [
     "cachetools==7.1.1",
     "celery==5.5.3",
-    "cloudevents==1.12.0",
     "fastapi==0.121.1",
     "faststream[cli,redis,prometheus]==0.6.6",
     "prometheus-client==0.23.1",

--- a/qontract_api_client/Dockerfile
+++ b/qontract_api_client/Dockerfile
@@ -1,5 +1,5 @@
 FROM registry.access.redhat.com/ubi9/python-312-minimal@sha256:df1c6dcb266a265011595fa1f149b3add42b66d8ac0e7f4244d5b64ef04c7fe1 AS base
-COPY --from=ghcr.io/astral-sh/uv:0.11.7@sha256:240fb85ab0f263ef12f492d8476aa3a2e4e1e333f7d67fbdd923d00a506a516a /uv /bin/uv
+COPY --from=ghcr.io/astral-sh/uv:0.11.13@sha256:841c8e6fe30a8b07b4478d12d0c608cba6de66102d29d65d1cc423af86051563 /uv /bin/uv
 
 COPY LICENSE /licenses/
 

--- a/qontract_utils/Dockerfile
+++ b/qontract_utils/Dockerfile
@@ -1,5 +1,5 @@
 FROM registry.access.redhat.com/ubi9/python-312-minimal@sha256:df1c6dcb266a265011595fa1f149b3add42b66d8ac0e7f4244d5b64ef04c7fe1 AS base
-COPY --from=ghcr.io/astral-sh/uv:0.11.7@sha256:240fb85ab0f263ef12f492d8476aa3a2e4e1e333f7d67fbdd923d00a506a516a /uv /bin/uv
+COPY --from=ghcr.io/astral-sh/uv:0.11.13@sha256:841c8e6fe30a8b07b4478d12d0c608cba6de66102d29d65d1cc423af86051563 /uv /bin/uv
 
 COPY LICENSE /licenses/
 

--- a/qontract_utils/pyproject.toml
+++ b/qontract_utils/pyproject.toml
@@ -7,7 +7,7 @@ dependencies = [
     # keep in sync with boto3-stubs in dependency-groups.type
     "boto3==1.34.94",
     "botocore==1.34.94",
-    "cloudevents==1.12.0",
+    "cloudevents==2.0.0",
     "faststream[redis]==0.6.6",
     "httpxyz==0.31.2",
     "hvac==2.4.0",

--- a/qontract_utils/qontract_utils/events/_models.py
+++ b/qontract_utils/qontract_utils/events/_models.py
@@ -1,9 +1,23 @@
-from cloudevents.pydantic.v2.event import CloudEvent
+import uuid
+from datetime import UTC, datetime
+from typing import Any
+
+from pydantic import BaseModel, Field
 
 
-class Event(CloudEvent):
-    """Represents a CloudEvent with a flexible payload.
+class Event(BaseModel):
+    """CloudEvent v1.0 spec as a Pydantic model.
 
-    The payload can be any JSON-serializable data structure, allowing for
-    versatile event contents while adhering to the CloudEvents specification.
+    Replaces the removed cloudevents.pydantic integration (cloudevents SDK v2)
+    while keeping the same public API: keyword construction and attribute access.
     """
+
+    source: str
+    type: str
+    id: str = Field(default_factory=lambda: str(uuid.uuid4()))
+    specversion: str = "1.0"
+    time: datetime = Field(default_factory=lambda: datetime.now(UTC))
+    data: Any = None
+    datacontenttype: str | None = None
+    dataschema: str | None = None
+    subject: str | None = None

--- a/qontract_utils/tests/events/test_brokers.py
+++ b/qontract_utils/tests/events/test_brokers.py
@@ -32,6 +32,7 @@ def test_run_without_context_raises(broker: RedisBroker) -> None:
     coro = AsyncMock()()
     with pytest.raises(RuntimeError, match="Broker is not connected"):
         broker._run(coro)
+    coro.close()
 
 
 def test_enter_creates_loop_and_connects(
@@ -91,6 +92,7 @@ def test_run_with_closed_loop_raises(broker: RedisBroker) -> None:
     coro = AsyncMock()()
     with pytest.raises(RuntimeError, match="Broker is not connected"):
         broker._run(coro)
+    coro.close()
 
 
 def test_exit_closes_loop_even_on_stop_error(

--- a/qontract_utils/tests/events/test_brokers.py
+++ b/qontract_utils/tests/events/test_brokers.py
@@ -1,0 +1,120 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from qontract_utils.events import RedisBroker
+
+if TYPE_CHECKING:
+    from pytest_mock import MockerFixture
+
+
+@pytest.fixture
+def mock_fast_broker(mocker: MockerFixture) -> MagicMock:
+    mock = mocker.MagicMock()
+    mock.connect = AsyncMock()
+    mock.stop = AsyncMock()
+    mock.publish = AsyncMock(return_value=b"1234567890-0")
+    return mock
+
+
+@pytest.fixture
+def broker(mocker: MockerFixture, mock_fast_broker: MagicMock) -> RedisBroker:
+    mocker.patch(
+        "qontract_utils.events._brokers.FastRedisBroker",
+        return_value=mock_fast_broker,
+    )
+    return RedisBroker(url="redis://localhost:6379")
+
+
+def test_run_without_context_raises(broker: RedisBroker) -> None:
+    coro = AsyncMock()()
+    with pytest.raises(RuntimeError, match="Broker is not connected"):
+        broker._run(coro)
+
+
+def test_enter_creates_loop_and_connects(
+    broker: RedisBroker, mock_fast_broker: MagicMock
+) -> None:
+    with broker:
+        assert broker._loop is not None
+        assert not broker._loop.is_closed()
+        mock_fast_broker.connect.assert_awaited_once()
+
+
+def test_exit_stops_broker_and_closes_loop(
+    broker: RedisBroker, mock_fast_broker: MagicMock
+) -> None:
+    with broker:
+        loop = broker._loop
+
+    mock_fast_broker.stop.assert_awaited_once()
+    assert loop is not None
+    assert loop.is_closed()
+    assert broker._loop is None
+
+
+def test_publish(broker: RedisBroker, mock_fast_broker: MagicMock) -> None:
+    with broker:
+        result = broker.publish(
+            message="test-message",
+            stream="test-stream",
+            headers={"x-trace": "abc"},
+        )
+
+    mock_fast_broker.publish.assert_awaited_once_with(
+        "test-message",
+        stream="test-stream",
+        headers={"x-trace": "abc"},
+    )
+    assert result == b"1234567890-0"
+
+
+def test_publish_without_optional_params(
+    broker: RedisBroker, mock_fast_broker: MagicMock
+) -> None:
+    with broker:
+        broker.publish(message="msg")
+
+    mock_fast_broker.publish.assert_awaited_once_with(
+        "msg",
+        stream=None,
+        headers=None,
+    )
+
+
+def test_run_with_closed_loop_raises(broker: RedisBroker) -> None:
+    with broker:
+        pass
+
+    coro = AsyncMock()()
+    with pytest.raises(RuntimeError, match="Broker is not connected"):
+        broker._run(coro)
+
+
+def test_exit_closes_loop_even_on_stop_error(
+    broker: RedisBroker, mock_fast_broker: MagicMock
+) -> None:
+    mock_fast_broker.stop = AsyncMock(side_effect=RuntimeError("stop failed"))
+
+    with pytest.raises(RuntimeError, match="stop failed"), broker:
+        loop = broker._loop
+
+    assert loop is not None
+    assert loop.is_closed()
+    assert broker._loop is None
+
+
+def test_reentry_creates_new_loop(
+    broker: RedisBroker, mock_fast_broker: MagicMock
+) -> None:
+    with broker:
+        first_loop = broker._loop
+
+    with broker:
+        second_loop = broker._loop
+
+    assert first_loop is not second_loop
+    assert mock_fast_broker.connect.await_count == 2
+    assert mock_fast_broker.stop.await_count == 2

--- a/qontract_utils/tests/events/test_models.py
+++ b/qontract_utils/tests/events/test_models.py
@@ -1,0 +1,62 @@
+from cloudevents.pydantic.v2.event import CloudEvent
+from qontract_utils.events import Event
+
+
+def test_event_is_cloud_event_subclass() -> None:
+    assert issubclass(Event, CloudEvent)
+
+
+def test_event_creation() -> None:
+    event = Event(
+        source="test-source",
+        type="test.event.created",
+        data={"key": "value"},
+    )
+    assert event["source"] == "test-source"
+    assert event["type"] == "test.event.created"
+    assert event.data == {"key": "value"}
+
+
+def test_event_data_content_type() -> None:
+    event = Event(
+        source="test-source",
+        type="test.event",
+        data={"foo": "bar"},
+        datacontenttype="application/json",
+    )
+    assert event["datacontenttype"] == "application/json"
+
+
+def test_event_with_complex_data() -> None:
+    data = {
+        "users": [{"name": "Alice"}, {"name": "Bob"}],
+        "count": 2,
+        "nested": {"deep": True},
+    }
+    event = Event(
+        source="test-source",
+        type="test.event",
+        data=data,
+    )
+    assert event.data == data
+
+
+def test_event_with_none_data() -> None:
+    event = Event(
+        source="test-source",
+        type="test.event",
+    )
+    assert event.data is None
+
+
+def test_event_json_roundtrip() -> None:
+    event = Event(
+        source="test-source",
+        type="test.event",
+        data={"key": "value"},
+    )
+    json_str = event.model_dump_json()
+    restored = Event.model_validate_json(json_str)
+    assert restored["source"] == event["source"]
+    assert restored["type"] == event["type"]
+    assert restored.data == event.data

--- a/qontract_utils/tests/events/test_models.py
+++ b/qontract_utils/tests/events/test_models.py
@@ -1,9 +1,18 @@
-from cloudevents.pydantic.v2.event import CloudEvent
+from pydantic import BaseModel
 from qontract_utils.events import Event
 
 
-def test_event_is_cloud_event_subclass() -> None:
-    assert issubclass(Event, CloudEvent)
+def test_event_is_pydantic_model() -> None:
+    assert issubclass(Event, BaseModel)
+
+
+def test_event_defaults() -> None:
+    event = Event(source="s", type="t")
+    assert event.specversion == "1.0"
+    assert event.id
+    assert event.time is not None
+    assert event.data is None
+    assert event.datacontenttype is None
 
 
 def test_event_creation() -> None:
@@ -12,8 +21,8 @@ def test_event_creation() -> None:
         type="test.event.created",
         data={"key": "value"},
     )
-    assert event["source"] == "test-source"
-    assert event["type"] == "test.event.created"
+    assert event.source == "test-source"
+    assert event.type == "test.event.created"
     assert event.data == {"key": "value"}
 
 
@@ -24,7 +33,7 @@ def test_event_data_content_type() -> None:
         data={"foo": "bar"},
         datacontenttype="application/json",
     )
-    assert event["datacontenttype"] == "application/json"
+    assert event.datacontenttype == "application/json"
 
 
 def test_event_with_complex_data() -> None:
@@ -57,6 +66,6 @@ def test_event_json_roundtrip() -> None:
     )
     json_str = event.model_dump_json()
     restored = Event.model_validate_json(json_str)
-    assert restored["source"] == event["source"]
-    assert restored["type"] == event["type"]
+    assert restored.source == event.source
+    assert restored.type == event.type
     assert restored.data == event.data

--- a/reconcile/test/utils/test_utils_openssl.py
+++ b/reconcile/test/utils/test_utils_openssl.py
@@ -54,7 +54,7 @@ def test_get_certificate_common_name_invalid_pem() -> None:
     ("host", "expected"),
     [
         ("example.com", True),
-        ("sub.example.com", True),
+        ("sub.example.com", False),
         ("other.com", False),
         ("notexample.com", False),
     ],
@@ -70,7 +70,7 @@ def test_certificate_matches_host_exact(
     [
         ("foo.example.com", True),
         ("bar.example.com", True),
-        ("example.com", True),
+        ("example.com", False),
         ("foo.other.com", False),
         ("other.com", False),
     ],

--- a/reconcile/test/utils/test_utils_openssl.py
+++ b/reconcile/test/utils/test_utils_openssl.py
@@ -1,0 +1,81 @@
+import pytest
+from OpenSSL import crypto
+
+from reconcile.utils.openssl import (
+    certificate_matches_host,
+    get_certificate_common_name,
+)
+
+
+def _generate_cert(cn: str) -> bytes:
+    """Generate a self-signed PEM certificate with the given CN."""
+    key = crypto.PKey()
+    key.generate_key(crypto.TYPE_RSA, 2048)
+    cert = crypto.X509()
+    cert.get_subject().CN = cn
+    cert.set_serial_number(1)
+    cert.gmtime_adj_notBefore(0)
+    cert.gmtime_adj_notAfter(365 * 24 * 60 * 60)
+    cert.set_issuer(cert.get_subject())
+    cert.set_pubkey(key)
+    cert.sign(key, "sha256")
+    return crypto.dump_certificate(crypto.FILETYPE_PEM, cert)
+
+
+@pytest.fixture
+def exact_cert() -> bytes:
+    return _generate_cert("example.com")
+
+
+@pytest.fixture
+def wildcard_cert() -> bytes:
+    return _generate_cert("*.example.com")
+
+
+@pytest.mark.parametrize(
+    ("cn", "expected"),
+    [
+        ("example.com", "example.com"),
+        ("*.example.com", "*.example.com"),
+        ("sub.domain.example.com", "sub.domain.example.com"),
+    ],
+)
+def test_get_certificate_common_name(cn: str, expected: str) -> None:
+    cert = _generate_cert(cn)
+    assert get_certificate_common_name(cert) == expected
+
+
+def test_get_certificate_common_name_invalid_pem() -> None:
+    with pytest.raises(crypto.Error):
+        get_certificate_common_name(b"not-a-certificate")
+
+
+@pytest.mark.parametrize(
+    ("host", "expected"),
+    [
+        ("example.com", True),
+        ("sub.example.com", True),
+        ("other.com", False),
+        ("notexample.com", False),
+    ],
+)
+def test_certificate_matches_host_exact(
+    exact_cert: bytes, host: str, expected: bool
+) -> None:
+    assert certificate_matches_host(exact_cert, host) == expected
+
+
+@pytest.mark.parametrize(
+    ("host", "expected"),
+    [
+        ("foo.example.com", True),
+        ("bar.example.com", True),
+        ("example.com", True),
+        ("foo.other.com", False),
+        ("other.com", False),
+    ],
+)
+def test_certificate_matches_host_wildcard(
+    wildcard_cert: bytes, host: str, expected: bool
+) -> None:
+    assert certificate_matches_host(wildcard_cert, host) == expected

--- a/reconcile/utils/openssl.py
+++ b/reconcile/utils/openssl.py
@@ -2,8 +2,10 @@ from OpenSSL import crypto
 
 
 def certificate_matches_host(certificate: bytes, host: str) -> bool:
-    common_name = get_certificate_common_name(certificate)
-    return host.endswith(common_name.replace("*.", ""))
+    if cn := get_certificate_common_name(certificate):
+        domain = cn.replace("*.", "")
+        return host == domain or host.endswith(f".{domain}")
+    return False
 
 
 def get_certificate_common_name(certificate: bytes) -> str:

--- a/reconcile/utils/openssl.py
+++ b/reconcile/utils/openssl.py
@@ -2,10 +2,12 @@ from OpenSSL import crypto
 
 
 def certificate_matches_host(certificate: bytes, host: str) -> bool:
-    if cn := get_certificate_common_name(certificate):
-        domain = cn.replace("*.", "")
-        return host == domain or host.endswith(f".{domain}")
-    return False
+    if not (cn := get_certificate_common_name(certificate)):
+        return False
+    if cn.startswith("*."):
+        domain = cn.removeprefix("*.")
+        return host != domain and host.endswith(f".{domain}")
+    return host == cn
 
 
 def get_certificate_common_name(certificate: bytes) -> str:

--- a/uv.lock
+++ b/uv.lock
@@ -576,14 +576,14 @@ wheels = [
 
 [[package]]
 name = "deepdiff"
-version = "8.6.1"
+version = "9.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "orderly-set" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/19/76/36c9aab3d5c19a94091f7c6c6e784efca50d87b124bf026c36e94719f33c/deepdiff-8.6.1.tar.gz", hash = "sha256:ec56d7a769ca80891b5200ec7bd41eec300ced91ebcc7797b41eb2b3f3ff643a", size = 634054, upload-time = "2025-09-03T19:40:41.461Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/24/20/63dd34163ed07393968128dc8c7ab948c96e47c4ce76976ea533de64909d/deepdiff-9.0.0.tar.gz", hash = "sha256:4872005306237b5b50829803feff58a1dfd20b2b357a55de22e7ded65b2008a7", size = 151952, upload-time = "2026-03-30T05:52:23.769Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f7/e6/efe534ef0952b531b630780e19cabd416e2032697019d5295defc6ef9bd9/deepdiff-8.6.1-py3-none-any.whl", hash = "sha256:ee8708a7f7d37fb273a541fa24ad010ed484192cd0c4ffc0fa0ed5e2d4b9e78b", size = 91378, upload-time = "2025-09-03T19:40:39.679Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/c4/da7089cd7aa4ab554f56e18a7fb08dcfed8fd2ae91fa528f5b1be207a148/deepdiff-9.0.0-py3-none-any.whl", hash = "sha256:b1ae0dd86290d86a03de5fbee728fde43095c1472ae4974bdab23ab4656305bd", size = 170540, upload-time = "2026-03-30T05:52:22.008Z" },
 ]
 
 [[package]]
@@ -2175,7 +2175,7 @@ requires-dist = [
     { name = "click", specifier = ">=7.0,<9.0" },
     { name = "croniter", specifier = ">=1.0.15,<1.1.0" },
     { name = "dateparser", specifier = "~=1.1.7" },
-    { name = "deepdiff", specifier = "==8.6.1" },
+    { name = "deepdiff", specifier = "==9.0.0" },
     { name = "dnspython", specifier = "~=2.1" },
     { name = "dt", specifier = "==1.1.73" },
     { name = "filetype", specifier = "~=1.2.0" },

--- a/uv.lock
+++ b/uv.lock
@@ -2200,7 +2200,7 @@ requires-dist = [
     { name = "toml", specifier = ">=0.10.0,<0.11.0" },
     { name = "unleashclient", specifier = "~=5.11" },
     { name = "urllib3", specifier = "~=2.2" },
-    { name = "websocket-client", specifier = ">=0.35,<0.55.0" },
+    { name = "websocket-client", specifier = "~=1.9.0" },
     { name = "yamllint", specifier = "==1.34.0" },
 ]
 
@@ -3138,14 +3138,11 @@ wheels = [
 
 [[package]]
 name = "websocket-client"
-version = "0.54.0"
+version = "1.9.0"
 source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "six" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/35/d4/14e446a82bc9172d088ebd81c0b02c5ca8481bfeecb13c9ef07998f9249b/websocket_client-0.54.0.tar.gz", hash = "sha256:e51562c91ddb8148e791f0155fdb01325d99bb52c4cdbb291aee7a3563fd0849", size = 36413, upload-time = "2018-11-01T04:35:16.66Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/2c/41/aa4bf9664e4cda14c3b39865b12251e8e7d239f4cd0e3cc1b6c2ccde25c1/websocket_client-1.9.0.tar.gz", hash = "sha256:9e813624b6eb619999a97dc7958469217c3176312b3a16a4bd1bc7e08a46ec98", size = 70576, upload-time = "2025-10-07T21:16:36.495Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/26/2d/f749a5c82f6192d77ed061a38e02001afcba55fe8477336d26a950ab17ce/websocket_client-0.54.0-py2.py3-none-any.whl", hash = "sha256:8c8bf2d4f800c3ed952df206b18c28f7070d9e3dcbd6ca6291127574f57ee786", size = 200115, upload-time = "2018-11-01T04:35:20.98Z" },
+    { url = "https://files.pythonhosted.org/packages/34/db/b10e48aa8fff7407e67470363eac595018441cf32d5e1001567a7aeba5d2/websocket_client-1.9.0-py3-none-any.whl", hash = "sha256:af248a825037ef591efbf6ed20cc5faa03d3b47b9e5a2230a529eeee1c1fc3ef", size = 82616, upload-time = "2025-10-07T21:16:34.951Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -499,23 +499,41 @@ wheels = [
 
 [[package]]
 name = "cryptography"
-version = "41.0.7"
+version = "48.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cffi" },
+    { name = "cffi", marker = "platform_python_implementation != 'PyPy'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/ce/b3/13a12ea7edb068de0f62bac88a8ffd92cc2901881b391839851846b84a81/cryptography-41.0.7.tar.gz", hash = "sha256:13f93ce9bea8016c253b34afc6bd6a75993e5c40672ed5405a9c832f0d4a00bc", size = 630892, upload-time = "2023-11-28T00:49:41.784Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/9f/a9/db8f313fdcd85d767d4973515e1db101f9c71f95fced83233de224673757/cryptography-48.0.0.tar.gz", hash = "sha256:5c3932f4436d1cccb036cb0eaef46e6e2db91035166f1ad6505c3c9d5a635920", size = 832984, upload-time = "2026-05-04T22:59:38.133Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e4/73/5461318abd2fe426855a2f66775c063bbefd377729ece3c3ee048ddf19a5/cryptography-41.0.7-cp37-abi3-macosx_10_12_universal2.whl", hash = "sha256:3c78451b78313fa81607fa1b3f1ae0a5ddd8014c38a02d9db0616133987b9cdf", size = 5342676, upload-time = "2023-11-28T00:48:49.291Z" },
-    { url = "https://files.pythonhosted.org/packages/a9/76/d705397d076fcbf5671544eb72a70b5a5ac83462d23dbd2a365a3bf3692a/cryptography-41.0.7-cp37-abi3-macosx_10_12_x86_64.whl", hash = "sha256:928258ba5d6f8ae644e764d0f996d61a8777559f72dfeb2eea7e2fe0ad6e782d", size = 2850425, upload-time = "2023-11-28T00:49:29.113Z" },
-    { url = "https://files.pythonhosted.org/packages/68/bb/475658ea92653a894589e657d6cea9ae01354db73405d62126ac5e74e2f8/cryptography-41.0.7-cp37-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5a1b41bc97f1ad230a41657d9155113c7521953869ae57ac39ac7f1bb471469a", size = 4161547, upload-time = "2023-11-28T00:48:38.466Z" },
-    { url = "https://files.pythonhosted.org/packages/14/fd/dd5bd6ab0d12476ebca579cbfd48d31bd90fa28fa257b209df585dcf62a0/cryptography-41.0.7-cp37-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:841df4caa01008bad253bce2a6f7b47f86dc9f08df4b433c404def869f590a15", size = 4363688, upload-time = "2023-11-28T00:49:34.285Z" },
-    { url = "https://files.pythonhosted.org/packages/3e/81/ae2c51ea2b80d57d5756a12df67816230124faea0a762a7a6304fe3c819c/cryptography-41.0.7-cp37-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:5429ec739a29df2e29e15d082f1d9ad683701f0ec7709ca479b3ff2708dae65a", size = 4148846, upload-time = "2023-11-28T00:49:04.704Z" },
-    { url = "https://files.pythonhosted.org/packages/62/bd/69628ab50368b1beb900eb1de5c46f8137169b75b2458affe95f2f470501/cryptography-41.0.7-cp37-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:43f2552a2378b44869fe8827aa19e69512e3245a219104438692385b0ee119d1", size = 4372805, upload-time = "2023-11-28T00:48:44.452Z" },
-    { url = "https://files.pythonhosted.org/packages/b6/4a/1808333c5ea79cb6d51102036cbcf698704b1fc7a5ccd139957aeadd2311/cryptography-41.0.7-cp37-abi3-musllinux_1_1_aarch64.whl", hash = "sha256:af03b32695b24d85a75d40e1ba39ffe7db7ffcb099fe507b39fd41a565f1b157", size = 4255463, upload-time = "2023-11-28T00:48:32.06Z" },
-    { url = "https://files.pythonhosted.org/packages/c5/07/826d66b6b03c5bfde8b451bea22c41e68d60aafff0ffa02c5f0819844319/cryptography-41.0.7-cp37-abi3-musllinux_1_1_x86_64.whl", hash = "sha256:49f0805fc0b2ac8d4882dd52f4a3b935b210935d500b6b805f321addc8177406", size = 4441232, upload-time = "2023-11-28T00:49:20.186Z" },
-    { url = "https://files.pythonhosted.org/packages/f3/4f/11b739e95598db236013cc9efb4e3d02b51dd0861c85470c3fe42720ef5b/cryptography-41.0.7-cp37-abi3-win32.whl", hash = "sha256:f983596065a18a2183e7f79ab3fd4c475205b839e02cbc0efbbf9666c4b3083d", size = 2236277, upload-time = "2023-11-28T00:49:09.796Z" },
-    { url = "https://files.pythonhosted.org/packages/f6/23/b28f4a03650512efff13a8fcbb977bac178a765c5a887a6720bee13fa85b/cryptography-41.0.7-cp37-abi3-win_amd64.whl", hash = "sha256:90452ba79b8788fa380dfb587cca692976ef4e757b194b093d845e8d99f612f2", size = 2671839, upload-time = "2023-11-28T00:48:41.223Z" },
+    { url = "https://files.pythonhosted.org/packages/df/3d/01f6dd9190170a5a241e0e98c2d04be3664a9e6f5b9b872cde63aff1c3dd/cryptography-48.0.0-cp311-abi3-macosx_10_9_universal2.whl", hash = "sha256:0c558d2cdffd8f4bbb30fc7134c74d2ca9a476f830bb053074498fbc86f41ed6", size = 8001587, upload-time = "2026-05-04T22:57:36.803Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/6e/e90527eef33f309beb811cf7c982c3aeffcce8e3edb178baa4ca3ae4a6fa/cryptography-48.0.0-cp311-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:f5333311663ea94f75dd408665686aaf426563556bb5283554a3539177e03b8c", size = 4690433, upload-time = "2026-05-04T22:57:40.373Z" },
+    { url = "https://files.pythonhosted.org/packages/90/04/673510ed51ddff56575f306cf1617d80411ee76831ccd3097599140efdfe/cryptography-48.0.0-cp311-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:7995ef305d7165c3f11ae07f2517e5a4f1d5c18da1376a0a9ed496336b69e5f3", size = 4710620, upload-time = "2026-05-04T22:57:42.935Z" },
+    { url = "https://files.pythonhosted.org/packages/14/d5/e9c4ef932c8d800490c34d8bd589d64a31d5890e27ec9e9ad532be893294/cryptography-48.0.0-cp311-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:40ba1f85eaa6959837b1d51c9767e230e14612eea4ef110ee8854ada22da1bf5", size = 4696283, upload-time = "2026-05-04T22:57:45.294Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/29/174b9dfb60b12d59ecfc6cfa04bc88c21b42a54f01b8aae09bb6e51e4c7f/cryptography-48.0.0-cp311-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:369a6348999f94bbd53435c894377b20ab95f25a9065c283570e70150d8abc3c", size = 5296573, upload-time = "2026-05-04T22:57:47.933Z" },
+    { url = "https://files.pythonhosted.org/packages/95/38/0d29a6fd7d0d1373f0c0c88a04ba20e359b257753ac497564cd660fc1d55/cryptography-48.0.0-cp311-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:a0e692c683f4df67815a2d258b324e66f4738bd7a96a218c826dce4f4bd05d8f", size = 4743677, upload-time = "2026-05-04T22:57:50.067Z" },
+    { url = "https://files.pythonhosted.org/packages/30/be/eef653013d5c63b6a490529e0316f9ac14a37602965d4903efed1399f32b/cryptography-48.0.0-cp311-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:18349bbc56f4743c8b12dc32e2bccb2cf83ee8b69a3bba74ef8ae857e26b3d25", size = 4330808, upload-time = "2026-05-04T22:57:52.301Z" },
+    { url = "https://files.pythonhosted.org/packages/84/9e/500463e87abb7a0a0f9f256ec21123ecde0a7b5541a15e840ea54551fd81/cryptography-48.0.0-cp311-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:7e8eac43dfca5c4cccc6dad9a80504436fca53bb9bc3100a2386d730fbe6b602", size = 4695941, upload-time = "2026-05-04T22:57:54.603Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/dc/7303087450c2ec9e7fbb750e17c2abfbc658f23cbd0e54009509b7cc4091/cryptography-48.0.0-cp311-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:9ccdac7d40688ecb5a3b4a604b8a88c8002e3442d6c60aead1db2a89a041560c", size = 5252579, upload-time = "2026-05-04T22:57:57.207Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/c0/7101d3b7215edcdc90c45da544961fd8ed2d6448f77577460fa75a8443f7/cryptography-48.0.0-cp311-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:bd72e68b06bb1e96913f97dd4901119bc17f39d4586a5adf2d3e47bc2b9d58b5", size = 4743326, upload-time = "2026-05-04T22:57:59.535Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/d8/5b833bad13016f562ab9d063d68199a4bd121d18458e439515601d3357ec/cryptography-48.0.0-cp311-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:59baa2cb386c4f0b9905bd6eb4c2a79a69a128408fd31d32ca4d7102d4156321", size = 4826672, upload-time = "2026-05-04T22:58:01.996Z" },
+    { url = "https://files.pythonhosted.org/packages/98/e1/7074eb8bf3c135558c73fc2bcf0f5633f912e6fb87e868a55c454080ef09/cryptography-48.0.0-cp311-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:9249e3cd978541d665967ac2cb2787fd6a62bddf1e75b3e347a594d7dacf4f74", size = 4972574, upload-time = "2026-05-04T22:58:03.968Z" },
+    { url = "https://files.pythonhosted.org/packages/04/70/e5a1b41d325f797f39427aa44ef8baf0be500065ab6d8e10369d850d4a4f/cryptography-48.0.0-cp311-abi3-win32.whl", hash = "sha256:9c459db21422be75e2809370b829a87eb37f74cd785fc4aa9ea1e5f43b47cda4", size = 3294868, upload-time = "2026-05-04T22:58:06.467Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/ac/8ac51b4a5fc5932eb7ee5c517ba7dc8cd834f0048962b6b352f00f41ebf9/cryptography-48.0.0-cp311-abi3-win_amd64.whl", hash = "sha256:5b012212e08b8dd5edc78ef54da83dd9892fd9105323b3993eff6bea65dc21d7", size = 3817107, upload-time = "2026-05-04T22:58:08.845Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/63/61d4a4e1c6b6bab6ce1e213cd36a24c415d90e76d78c5eb8577c5541d2e8/cryptography-48.0.0-cp39-abi3-macosx_10_9_universal2.whl", hash = "sha256:58d00498e8933e4a194f3076aee1b4a97dfec1a6da444535755822fe5d8b0b86", size = 7983482, upload-time = "2026-05-04T22:58:43.769Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/ac/f5b5995b87770c693e2596559ffafe195b4033a57f14a82268a2842953f3/cryptography-48.0.0-cp39-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:614d0949f4790582d2cc25553abd09dd723025f0c0e7c67376a1d77196743d6e", size = 4683266, upload-time = "2026-05-04T22:58:46.064Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/c6/8b14f67e18338fbc4adb76f66c001f5c3610b3e2d1837f268f47a347dbbb/cryptography-48.0.0-cp39-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:7ce4bfae76319a532a2dc68f82cc32f5676ee792a983187dac07183690e5c66f", size = 4696228, upload-time = "2026-05-04T22:58:48.22Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/73/f808fbae9514bd91b47875b003f13e284c8c6bdfd904b7944e803937eec1/cryptography-48.0.0-cp39-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:2eb992bbd4661238c5a397594c83f5b4dc2bc5b848c365c8f991b6780efcc5c7", size = 4689097, upload-time = "2026-05-04T22:58:50.9Z" },
+    { url = "https://files.pythonhosted.org/packages/93/01/d86632d7d28db8ae83221995752eeb6639ffb374c2d22955648cf8d52797/cryptography-48.0.0-cp39-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:22a5cb272895dce158b2cacdfdc3debd299019659f42947dbdac6f32d68fe832", size = 5283582, upload-time = "2026-05-04T22:58:53.017Z" },
+    { url = "https://files.pythonhosted.org/packages/02/e1/50edc7a50334807cc4791fc4a0ce7468b4a1416d9138eab358bfc9a3d70b/cryptography-48.0.0-cp39-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:2b4d59804e8408e2fea7d1fbaf218e5ec984325221db76e6a241a9abd6cdd95c", size = 4730479, upload-time = "2026-05-04T22:58:55.611Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/af/99a582b1b1641ff5911ac559beb45097cf79efd4ead4657f578ef1af2d47/cryptography-48.0.0-cp39-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:984a20b0f62a26f48a3396c72e4bc34c66e356d356bf370053066b3b6d54634a", size = 4326481, upload-time = "2026-05-04T22:58:57.607Z" },
+    { url = "https://files.pythonhosted.org/packages/90/ee/89aa26a06ef0a7d7611788ffd571a7c50e368cc6a4d5eef8b4884e866edb/cryptography-48.0.0-cp39-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:5a5ed8fde7a1d09376ca0b40e68cd59c69fe23b1f9768bd5824f54681626032a", size = 4688713, upload-time = "2026-05-04T22:59:00.077Z" },
+    { url = "https://files.pythonhosted.org/packages/70/ba/bcb1b0bb7a33d4c7c0c4d4c7874b4a62ae4f56113a5f4baefa362dfb1f0f/cryptography-48.0.0-cp39-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:8cd666227ef7af430aa5914a9910e0ddd703e75f039cef0825cd0da71b6b711a", size = 5238165, upload-time = "2026-05-04T22:59:02.317Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/70/ca4003b1ce5ca3dc3186ada51908c8a9b9ff7d5cab83cc0d43ee14ec144f/cryptography-48.0.0-cp39-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:9071196d81abc88b3516ac8cdfad32e2b66dd4a5393a8e68a961e9161ddc6239", size = 4729947, upload-time = "2026-05-04T22:59:05.255Z" },
+    { url = "https://files.pythonhosted.org/packages/44/a0/4ec7cf774207905aef1a8d11c3750d5a1db805eb380ee4e16df317870128/cryptography-48.0.0-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:1e2d54c8be6152856a36f0882ab231e70f8ec7f14e93cf87db8a2ed056bf160c", size = 4822059, upload-time = "2026-05-04T22:59:07.802Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/75/a2e55f99c16fcac7b5d6c1eb19ad8e00799854d6be5ca845f9259eae1681/cryptography-48.0.0-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:a5da777e32ffed6f85a7b2b3f7c5cbc88c146bfcd0a1d7baf5fcc6c52ee35dd4", size = 4960575, upload-time = "2026-05-04T22:59:09.851Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/23/6e6f32143ab5d8b36ca848a502c4bcd477ae75b9e1677e3530d669062578/cryptography-48.0.0-cp39-abi3-win32.whl", hash = "sha256:77a2ccbbe917f6710e05ba9adaa25fb5075620bf3ea6fb751997875aff4ae4bd", size = 3279117, upload-time = "2026-05-04T22:59:12.019Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/9a/0fea98a70cf1749d41d738836f6349d97945f7c89433a259a6c2642eefeb/cryptography-48.0.0-cp39-abi3-win_amd64.whl", hash = "sha256:16cd65b9330583e4619939b3a3843eec1e6e789744bb01e7c7e2e62e33c239c8", size = 3792100, upload-time = "2026-05-04T22:59:14.884Z" },
 ]
 
 [[package]]
@@ -1739,14 +1757,15 @@ wheels = [
 
 [[package]]
 name = "pyopenssl"
-version = "23.3.0"
+version = "26.2.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "cryptography" },
+    { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/bf/a0/e667c3c43b65a188cc3041fa00c50655315b93be45182b2c94d185a2610e/pyOpenSSL-23.3.0.tar.gz", hash = "sha256:6b2cba5cc46e822750ec3e5a81ee12819850b11303630d575e98108a079c2b12", size = 183043, upload-time = "2023-10-26T03:06:53.373Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/1a/51/27a5ad5f939d08f690a326ef9582cda7140555180db71695f6fb747d6a36/pyopenssl-26.2.0.tar.gz", hash = "sha256:8c6fcecd1183a7fc897548dfe388b0cdb7f37e018200d8409cf33959dbe35387", size = 182195, upload-time = "2026-05-04T23:06:09.72Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/db/de/007b832ad7a95e6a73745609bbe123c407aa2c46bb0b8f765c8718294e7f/pyOpenSSL-23.3.0-py3-none-any.whl", hash = "sha256:6756834481d9ed5470f4a9393455154bc92fe7a64b7bc6ee2c804e78c52099b2", size = 58812, upload-time = "2023-10-26T03:06:51.836Z" },
+    { url = "https://files.pythonhosted.org/packages/73/b8/a0e2790ae249d6f38c9f66de7a211621a7ab2650217bcd04e1262f578a56/pyopenssl-26.2.0-py3-none-any.whl", hash = "sha256:4f9d971bc5298b8bc1fab282803da04bf000c755d4ad9d99b52de2569ca19a70", size = 55823, upload-time = "2026-05-04T23:06:08.395Z" },
 ]
 
 [[package]]
@@ -2179,7 +2198,7 @@ requires-dist = [
     { name = "pydantic", specifier = "~=2.12.3" },
     { name = "pygithub", specifier = ">=1.58,<1.59" },
     { name = "pyjwt", specifier = "~=2.7" },
-    { name = "pyopenssl", specifier = "~=23.0" },
+    { name = "pyopenssl", specifier = "~=26.2" },
     { name = "pypd", specifier = ">=1.1.0,<1.2.0" },
     { name = "python-gitlab", specifier = "==6.0.0" },
     { name = "qontract-api-client", editable = "qontract_api_client" },

--- a/uv.lock
+++ b/uv.lock
@@ -299,11 +299,11 @@ wheels = [
 
 [[package]]
 name = "cachetools"
-version = "6.2.2"
+version = "7.1.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/fb/44/ca1675be2a83aeee1886ab745b28cda92093066590233cc501890eb8417a/cachetools-6.2.2.tar.gz", hash = "sha256:8e6d266b25e539df852251cfd6f990b4bc3a141db73b939058d809ebd2590fc6", size = 31571, upload-time = "2025-11-13T17:42:51.465Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ff/e2/85f227594656000ff4d8adadae91a21f536d4a84c6c716a86bd6685874be/cachetools-7.1.1.tar.gz", hash = "sha256:27bdf856d68fd3c71c26c01b5edc312124ed427524d1ddb31aa2b7746fe20d4b", size = 40202, upload-time = "2026-05-03T20:00:29.391Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e6/46/eb6eca305c77a4489affe1c5d8f4cae82f285d9addd8de4ec084a7184221/cachetools-6.2.2-py3-none-any.whl", hash = "sha256:6c09c98183bf58560c97b2abfcedcbaf6a896a490f534b031b661d3723b45ace", size = 11503, upload-time = "2025-11-13T17:42:50.232Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/0f/f897abe4ea0a8c408ae65c8c83bffab4936ad65d6032d4fb4cd35bbdc3ee/cachetools-7.1.1-py3-none-any.whl", hash = "sha256:0335cd7a0952d2b22327441fb0628139e234c565559eeb91a8a4ac7551c5353d", size = 16775, upload-time = "2026-05-03T20:00:27.857Z" },
 ]
 
 [[package]]
@@ -1990,7 +1990,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "cachetools", specifier = "==6.2.2" },
+    { name = "cachetools", specifier = "==7.1.1" },
     { name = "celery", specifier = "==5.5.3" },
     { name = "cloudevents", specifier = "==1.12.0" },
     { name = "fastapi", specifier = "==0.121.1" },
@@ -2018,7 +2018,7 @@ dev = [
     { name = "pytest-mock", specifier = "==3.15.1" },
     { name = "rich", specifier = "==14.3.1" },
     { name = "ruff", specifier = "==0.15.12" },
-    { name = "types-cachetools", specifier = "==6.2.0.20251022" },
+    { name = "types-cachetools", specifier = "==7.0.0.20260503" },
     { name = "types-hvac", specifier = "==2.4.0.20251115" },
 ]
 
@@ -2768,11 +2768,11 @@ wheels = [
 
 [[package]]
 name = "types-cachetools"
-version = "6.2.0.20251022"
+version = "7.0.0.20260503"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/3b/a8/f9bcc7f1be63af43ef0170a773e2d88817bcc7c9d8769f2228c802826efe/types_cachetools-6.2.0.20251022.tar.gz", hash = "sha256:f1d3c736f0f741e89ec10f0e1b0138625023e21eb33603a930c149e0318c0cef", size = 9608, upload-time = "2025-10-22T03:03:58.16Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ec/57/5d3b8b3e66b002911ec1274e87f904eeee1d843c8713d95476c25c29cf31/types_cachetools-7.0.0.20260503.tar.gz", hash = "sha256:dfa4dcdf453f397dfc6d69fc0a57423ac1f248393f70aa56b5d05fac2df7a96c", size = 10033, upload-time = "2026-05-03T05:19:54.128Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/98/2d/8d821ed80f6c2c5b427f650bf4dc25b80676ed63d03388e4b637d2557107/types_cachetools-6.2.0.20251022-py3-none-any.whl", hash = "sha256:698eb17b8f16b661b90624708b6915f33dbac2d185db499ed57e4997e7962cad", size = 9341, upload-time = "2025-10-22T03:03:57.036Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/a8/84562723d9a3572e0851d82bdea6bed5a7dc033c6bd648f492c76b8c4ac8/types_cachetools-7.0.0.20260503-py3-none-any.whl", hash = "sha256:011b4fe0e85ef05c4a2471a4fda40254a78746b501cc1727359233872bb3a4e9", size = 9493, upload-time = "2026-05-03T05:19:53.124Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -433,14 +433,15 @@ wheels = [
 
 [[package]]
 name = "cloudevents"
-version = "1.12.0"
+version = "2.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "deprecation" },
+    { name = "python-dateutil" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/7a/aa/804bdb5f2f021fcc887eeabfa24bad0ffd4b150f60850ae88faa51d393a5/cloudevents-1.12.0.tar.gz", hash = "sha256:ebd5544ceb58c8378a0787b657a2ae895e929b80a82d6675cba63f0e8c5539e0", size = 34494, upload-time = "2025-06-02T18:58:45.104Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/71/ee/22614a29a1754e6abd979eebfb5f5ecc8ffb6e4e267f3879f017bc5d5531/cloudevents-2.0.0.tar.gz", hash = "sha256:3224851b2ac902b868ed4bc1aa10772ada8cdf85f180322b12968d90a1dceef2", size = 46940, upload-time = "2026-03-24T16:22:20.214Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/4c/b6/4e29b74bb40daa7580310a5ff0df5f121a08ce98340e01a960b668468aab/cloudevents-1.12.0-py3-none-any.whl", hash = "sha256:49196267f5f963d87ae156f93fc0fa32f4af69485f2c8e62e0db8b0b4b8b8921", size = 55762, upload-time = "2025-06-02T18:58:44.013Z" },
+    { url = "https://files.pythonhosted.org/packages/43/3a/4df9a7de0bbb30dc6c0f9f707602160ff269dd01a11127f237ef01232b13/cloudevents-2.0.0-py3-none-any.whl", hash = "sha256:babb257989a933b18312897c3bf3a7cc65e270831227822f2db10b50d1278546", size = 94592, upload-time = "2026-03-24T16:22:19.094Z" },
 ]
 
 [[package]]
@@ -1977,7 +1978,6 @@ source = { editable = "qontract_api" }
 dependencies = [
     { name = "cachetools" },
     { name = "celery" },
-    { name = "cloudevents" },
     { name = "fastapi" },
     { name = "faststream", extra = ["cli", "prometheus", "redis"] },
     { name = "prometheus-client" },
@@ -2011,7 +2011,6 @@ dev = [
 requires-dist = [
     { name = "cachetools", specifier = "==7.1.1" },
     { name = "celery", specifier = "==5.5.3" },
-    { name = "cloudevents", specifier = "==1.12.0" },
     { name = "fastapi", specifier = "==0.121.1" },
     { name = "faststream", extras = ["cli", "redis", "prometheus"], specifier = "==0.6.6" },
     { name = "prometheus-client", specifier = "==0.23.1" },
@@ -2301,7 +2300,7 @@ dev = [
 requires-dist = [
     { name = "boto3", specifier = "==1.34.94" },
     { name = "botocore", specifier = "==1.34.94" },
-    { name = "cloudevents", specifier = "==1.12.0" },
+    { name = "cloudevents", specifier = "==2.0.0" },
     { name = "faststream", extras = ["redis"], specifier = "==0.6.6" },
     { name = "httpxyz", specifier = "==0.31.2" },
     { name = "hvac", specifier = "==2.4.0" },

--- a/uv.lock
+++ b/uv.lock
@@ -2185,7 +2185,7 @@ requires-dist = [
     { name = "qontract-api-client", editable = "qontract_api_client" },
     { name = "qontract-utils", editable = "qontract_utils" },
     { name = "requests", specifier = "~=2.32" },
-    { name = "requests-oauthlib", specifier = "~=1.3" },
+    { name = "requests-oauthlib", specifier = "~=2.0" },
     { name = "rich", specifier = "==14.3.1" },
     { name = "ruamel-yaml", specifier = ">=0.17.22,<0.18.0" },
     { name = "semver", specifier = "~=3.0" },
@@ -2364,15 +2364,15 @@ wheels = [
 
 [[package]]
 name = "requests-oauthlib"
-version = "1.3.1"
+version = "2.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "oauthlib" },
     { name = "requests" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/95/52/531ef197b426646f26b53815a7d2a67cb7a331ef098bb276db26a68ac49f/requests-oauthlib-1.3.1.tar.gz", hash = "sha256:75beac4a47881eeb94d5ea5d6ad31ef88856affe2332b9aafb52c6452ccf0d7a", size = 52027, upload-time = "2022-01-29T18:52:24.037Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/42/f2/05f29bc3913aea15eb670be136045bf5c5bbf4b99ecb839da9b422bb2c85/requests-oauthlib-2.0.0.tar.gz", hash = "sha256:b3dffaebd884d8cd778494369603a9e7b58d29111bf6b41bdc2dcd87203af4e9", size = 55650, upload-time = "2024-03-22T20:32:29.939Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/6f/bb/5deac77a9af870143c684ab46a7934038a53eb4aa975bc0687ed6ca2c610/requests_oauthlib-1.3.1-py2.py3-none-any.whl", hash = "sha256:2577c501a2fb8d05a304c09d090d6e47c306fef15809d102b327cf8364bddab5", size = 23892, upload-time = "2022-01-29T18:52:22.279Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/5d/63d4ae3b9daea098d5d6f5da83984853c1bbacd5dc826764b249fe119d24/requests_oauthlib-2.0.0-py2.py3-none-any.whl", hash = "sha256:7dd8a5c40426b779b0868c404bdef9768deccf22749cde15852df527e6269b36", size = 24179, upload-time = "2024-03-22T20:32:28.055Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -1348,11 +1348,11 @@ wheels = [
 
 [[package]]
 name = "networkx"
-version = "2.8.8"
+version = "3.6.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/cd/16/c44e8550012735b8f21b3df7f39e8ba5a987fb764ac017ad5f3589735889/networkx-2.8.8.tar.gz", hash = "sha256:230d388117af870fce5647a3c52401fcf753e94720e6ea6b4197a5355648885e", size = 1960828, upload-time = "2022-11-01T20:31:52.02Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/6a/51/63fe664f3908c97be9d2e4f1158eb633317598cfa6e1fc14af5383f17512/networkx-3.6.1.tar.gz", hash = "sha256:26b7c357accc0c8cde558ad486283728b65b6a95d85ee1cd66bafab4c8168509", size = 2517025, upload-time = "2025-12-08T17:02:39.908Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/42/31/d2f89f1ae42718f8c8a9e440ebe38d7d5fe1e0d9eb9178ce779e365b3ab0/networkx-2.8.8-py3-none-any.whl", hash = "sha256:e435dfa75b1d7195c7b8378c3859f0445cd88c6b0375c181ed66823a9ceb7524", size = 2025192, upload-time = "2022-11-01T20:31:49.035Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/c9/b2622292ea83fbb4ec318f5b9ab867d0a28ab43c5717bb85b0a5f6b3b0a4/networkx-3.6.1-py3-none-any.whl", hash = "sha256:d47fbf302e7d9cbbb9e2555a0d267983d2aa476bac30e90dfbe5669bd57f3762", size = 2068504, upload-time = "2025-12-08T17:02:38.159Z" },
 ]
 
 [[package]]
@@ -2172,7 +2172,7 @@ requires-dist = [
     { name = "jsonpointer", specifier = "~=2.4" },
     { name = "kubernetes", specifier = "==32.0.1" },
     { name = "ldap3", specifier = ">=2.9.1,<2.10.0" },
-    { name = "networkx", specifier = "~=2.8" },
+    { name = "networkx", specifier = "~=3.6" },
     { name = "parse", specifier = "==1.18.0" },
     { name = "prometheus-client", specifier = "~=0.8" },
     { name = "psycopg2-binary", specifier = "~=2.9" },


### PR DESCRIPTION
## Summary

Upgrade multiple Python dependencies and add missing unit tests.

### Dependency upgrades

- **cloudevents** — upgraded to v2; replaced removed `cloudevents.pydantic` integration with a standalone Pydantic `Event` model in `qontract_utils/events`
- **pyopenssl** — upgraded to latest version; fixed domain-boundary check in `certificate_matches_host`
- **deepdiff** — upgraded to latest version
- **cachetools** — upgraded to latest version
- **websocket-client** — upgraded to latest version
- **requests-oauthlib** — upgraded to latest version
- **networkx** — upgraded to latest version
- **uv** — upgraded in Dockerfiles

### New unit tests

- **`reconcile/test/utils/test_utils_openssl.py`** — tests for `certificate_matches_host` including wildcard matching and domain-boundary validation
- **`qontract_utils/tests/events/test_models.py`** — tests for the `Event` model (creation, defaults, serialization roundtrip)
- **`qontract_utils/tests/events/test_brokers.py`** — tests for `RedisBroker` (context manager lifecycle, publish, error cleanup, re-entry)

## Test plan

- [x] `qontract_utils` event tests pass (`uv run pytest tests/events/`)
- [x] `qontract_api` event-related tests pass without changes
- [x] openssl unit tests pass
- [x] ruff + mypy clean

## Replaces

* #5267
* #5272
* #5275
* #5403
* #5447
* #5462
* #5478
* #5532

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved certificate hostname matching and updated runtime container binaries.

* **Chores**
  * Bumped multiple project dependencies for compatibility, security, and updated container tooling.

* **Refactor**
  * Reworked the event model implementation, introducing explicit CloudEvent-style fields and default id/time handling.

* **Tests**
  * Added unit tests for event models, event broker lifecycle/publishing, and OpenSSL certificate helpers.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/app-sre/qontract-reconcile/pull/5540)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->