### PR TITLE
refactor: use status_url from reconcile task for polling

### DIFF
--- a/reconcile/github_owners_api.py
+++ b/reconcile/github_owners_api.py
@@ -28,9 +28,7 @@ from qontract_api_client.api.integrations.github_owners import (
 from qontract_api_client.api.integrations.github_owners import (
     asyncio as reconcile_github_owners,
 )
-from qontract_api_client.api.integrations.github_owners_task_status import (
-    asyncio as github_owners_task_status,
-)
+from qontract_api_client.models import GithubOwnersTaskResult
 from qontract_api_client.models.github_org_desired_state import (
     GithubOrgDesiredState,
 )
@@ -202,10 +200,9 @@ class GithubOwnersIntegration(
             return
 
         # Wait for task completion and log actions
-        task_result = await github_owners_task_status(
-            client=self.qontract_api_client, task_id=task.id, timeout=300
+        task_result = await self.poll_task_status(
+            status_url=task.status_url, result_type=GithubOwnersTaskResult
         )
-
         if task_result.status == TaskStatus.PENDING:
             raise IntegrationError(
                 "github-owners-api: task did not complete within the timeout period"

--- a/reconcile/glitchtip_api/integration.py
+++ b/reconcile/glitchtip_api/integration.py
@@ -9,9 +9,7 @@ from collections.abc import Callable
 from qontract_api_client.api.integrations.glitchtip import (
     asyncio as reconcile_glitchtip,
 )
-from qontract_api_client.api.integrations.glitchtip_task_status import (
-    asyncio as glitchtip_task_status,
-)
+from qontract_api_client.models import GlitchtipTaskResult
 from qontract_api_client.models.gi_instance import GIInstance
 from qontract_api_client.models.gi_organization import GIOrganization
 from qontract_api_client.models.gi_project import GIProject
@@ -249,10 +247,9 @@ class GlitchtipApiIntegration(
             # and change events will be automatically published via the events framework.
             return
 
-        task_result = await glitchtip_task_status(
-            client=self.qontract_api_client, task_id=task.id, timeout=300
+        task_result = await self.poll_task_status(
+            status_url=task.status_url, result_type=GlitchtipTaskResult
         )
-
         if task_result.status == TaskStatus.PENDING:
             logging.error("Glitchtip task did not complete within the timeout period")
             sys.exit(1)

--- a/reconcile/glitchtip_project_alerts_api/integration.py
+++ b/reconcile/glitchtip_project_alerts_api/integration.py
@@ -14,7 +14,7 @@ from qontract_api_client.api.integrations.glitchtip_project_alerts import (
     asyncio as reconcile_glitchtip_project_alerts,
 )
 from qontract_api_client.api.integrations.glitchtip_project_alerts_task_status import (
-    asyncio as glitchtip_project_alerts_task_status,
+    GlitchtipProjectAlertsTaskResult,
 )
 from qontract_api_client.models.glitchtip_instance import GlitchtipInstance
 from qontract_api_client.models.glitchtip_organization import GlitchtipOrganization
@@ -311,8 +311,8 @@ class GlitchtipProjectAlertsIntegration(
             # and change events will be automatically published via the events framework.
             return
 
-        task_result = await glitchtip_project_alerts_task_status(
-            client=self.qontract_api_client, task_id=task.id, timeout=300
+        task_result = await self.poll_task_status(
+            status_url=task.status_url, result_type=GlitchtipProjectAlertsTaskResult
         )
 
         if task_result.status == TaskStatus.PENDING:

--- a/reconcile/slack_usergroups_api.py
+++ b/reconcile/slack_usergroups_api.py
@@ -45,13 +45,11 @@ from qontract_api_client.api.integrations.slack_usergroups import (
 from qontract_api_client.api.integrations.slack_usergroups import (
     asyncio as reconcile_slack_usergroups,
 )
-from qontract_api_client.api.integrations.slack_usergroups_task_status import (
-    asyncio as slack_usergroups_task_status,
-)
 from qontract_api_client.models import (
     SlackUsergroupActionCreate,
     SlackUsergroupActionUpdateMetadata,
     SlackUsergroupActionUpdateUsers,
+    SlackUsergroupsTaskResult,
 )
 from qontract_api_client.models.secret import Secret
 from qontract_api_client.models.slack_usergroup import SlackUsergroup
@@ -668,8 +666,8 @@ class SlackUsergroupsIntegration(
             return
 
         # wait for task completion and get the action list
-        task_result = await slack_usergroups_task_status(
-            client=self.qontract_api_client, task_id=task.id, timeout=300
+        task_result = await self.poll_task_status(
+            status_url=task.status_url, result_type=SlackUsergroupsTaskResult
         )
         if task_result.status == TaskStatus.PENDING:
             logging.error("Task did not complete within the timeout period")

--- a/reconcile/test/test_github_owners_api.py
+++ b/reconcile/test/test_github_owners_api.py
@@ -441,9 +441,8 @@ class TestAsyncRun:
                 "reconcile.github_owners_api.reconcile_github_owners",
                 new=AsyncMock(return_value=task_response),
             ),
-            patch(
-                "reconcile.github_owners_api.github_owners_task_status",
-                new=AsyncMock(return_value=task_result),
+            patch.object(
+                integration, "poll_task_status", new=AsyncMock(return_value=task_result)
             ),
             patch.object(
                 type(integration),
@@ -481,9 +480,7 @@ class TestAsyncRun:
                 "reconcile.github_owners_api.reconcile_github_owners",
                 new=AsyncMock(return_value=task_response),
             ),
-            patch(
-                "reconcile.github_owners_api.github_owners_task_status"
-            ) as mock_status,
+            patch.object(integration, "poll_task_status") as mock_status,
             patch.object(
                 type(integration),
                 "qontract_api_client",
@@ -522,9 +519,8 @@ class TestAsyncRun:
                 "reconcile.github_owners_api.reconcile_github_owners",
                 new=AsyncMock(return_value=task_response),
             ),
-            patch(
-                "reconcile.github_owners_api.github_owners_task_status",
-                new=AsyncMock(return_value=task_result),
+            patch.object(
+                integration, "poll_task_status", new=AsyncMock(return_value=task_result)
             ),
             patch.object(
                 type(integration),
@@ -564,9 +560,8 @@ class TestAsyncRun:
                 "reconcile.github_owners_api.reconcile_github_owners",
                 new=AsyncMock(return_value=task_response),
             ),
-            patch(
-                "reconcile.github_owners_api.github_owners_task_status",
-                new=AsyncMock(return_value=task_result),
+            patch.object(
+                integration, "poll_task_status", new=AsyncMock(return_value=task_result)
             ),
             patch.object(
                 type(integration),

--- a/reconcile/utils/runtime/integration.py
+++ b/reconcile/utils/runtime/integration.py
@@ -3,12 +3,13 @@ from abc import (
     ABC,
     abstractmethod,
 )
-from collections.abc import Callable
+from collections.abc import Callable, Mapping
 from dataclasses import dataclass
 from types import ModuleType
 from typing import (
     Any,
     Optional,
+    Protocol,
     Self,
     TypeVar,
 )
@@ -240,6 +241,13 @@ class QontractReconcileIntegration[RunParamsTypeVar: RunParams](ABC):
         )
 
 
+class FromDict(Protocol):
+    """Protocol for generated API client models with from_dict classmethod."""
+
+    @classmethod
+    def from_dict(cls, src_dict: Mapping[str, Any]) -> Self: ...
+
+
 class QontractReconcileApiIntegration[RunParamsTypeVar: RunParams](ABC):
     """
     The base class for all integrations using the Qontract API.
@@ -255,7 +263,8 @@ class QontractReconcileApiIntegration[RunParamsTypeVar: RunParams](ABC):
 
     @staticmethod
     async def _raise_on_4xx_5xx(response: httpxyz.Response) -> None:
-        response.raise_for_status()
+        if response.status_code != 409:
+            response.raise_for_status()
 
     @property
     def qontract_api_client(self) -> AuthenticatedClient:
@@ -299,6 +308,25 @@ class QontractReconcileApiIntegration[RunParamsTypeVar: RunParams](ABC):
             vault_settings = get_app_interface_vault_settings()
             self._secret_reader = create_secret_reader(use_vault=vault_settings.vault)
         return self._secret_reader
+
+    async def poll_task_status[T: FromDict](
+        self,
+        status_url: str,
+        result_type: type[T],
+        *,
+        timeout: int = 300,
+    ) -> T:
+        """Follow a status_url to poll task completion.
+
+        Uses the status_url returned by POST endpoints to retrieve task results
+        without requiring the caller to know about task IDs or URL construction.
+        """
+        response = await self.qontract_api_client.get_async_httpx_client().request(
+            method="get",
+            url=status_url,
+            params={"timeout": timeout},
+        )
+        return result_type.from_dict(response.json())
 
     @abstractmethod
     async def async_run(self, dry_run: bool) -> None:


### PR DESCRIPTION
Add `poll_task_status()` to `QontractReconcileApiIntegration` base class
that follows the `status_url` returned by POST endpoints. This removes
duplicated task-status polling logic from individual integrations and
eliminates the need for integration-specific `task_status` API imports.


Ticket: [APPSRE-13862](https://redhat.atlassian.net/browse/APPSRE-13862)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Standardized status-URL-based task polling across multiple integrations and added a generic typed polling helper.

* **Bug Fixes**
  * Adjusted HTTP error handling to skip raising on 409 responses to reduce unnecessary failures.

* **Tests**
  * Updated tests to mock the new instance-level polling flow.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/app-sre/qontract-reconcile/pull/5548)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->