### PR TITLE
feat: add DM notifications for slack-usergroups membership changes (APPSRE-14273)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -79,7 +79,7 @@ dev = [
     "pytest-cov==7.0.0",
     "pytest-httpserver==1.1.3",
     "pytest-mock==3.15.1",
-    "qenerate==0.9.1",
+    "qenerate==0.9.2",
     "responses==0.25.0",
     "ruff==0.15.12",
     "smtpdfix==0.5.3",

--- a/qontract_api/openapi.json
+++ b/qontract_api/openapi.json
@@ -2,12 +2,19 @@
   "components": {
     "schemas": {
       "ChatRequest": {
-        "description": "Request model for posting a Slack message.\n\nImmutable model with all fields required to send a chat message.\n\nAttributes:\n    workspace_name: Slack workspace name\n    channel: Channel name to post to\n    text: Message text\n    thread_ts: Optional thread timestamp for replies\n    icon_emoji: Emoji to use as the message icon\n    icon_url: URL to an image to use as the message icon\n    username: Bot username to display\n    secret: Secret reference for Slack bot token",
+        "description": "Request model for posting a Slack message or DM.\n\nExactly one of `channel` or `user` must be set:\n- `channel`: post to a Slack channel by name\n- `user`: send a DM to a user by org_username",
         "properties": {
           "channel": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "description": "Channel name to post to (e.g., 'sd-app-sre-reconcile')",
-            "title": "Channel",
-            "type": "string"
+            "title": "Channel"
           },
           "icon_emoji": {
             "anyOf": [
@@ -54,6 +61,18 @@
             "description": "Optional thread timestamp for replies",
             "title": "Thread Ts"
           },
+          "user": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "org_username to send a DM to (e.g., 'jsmith@redhat.com')",
+            "title": "User"
+          },
           "username": {
             "anyOf": [
               {
@@ -74,7 +93,6 @@
         },
         "required": [
           "workspace_name",
-          "channel",
           "text",
           "secret"
         ],
@@ -2103,6 +2121,48 @@
         "title": "LdapUsersCheckResponse",
         "type": "object"
       },
+      "NotificationAddUser": {
+        "description": "Notify users when they are added to the usergroup.",
+        "properties": {
+          "action": {
+            "const": "add-user",
+            "default": "add-user",
+            "title": "Action",
+            "type": "string"
+          },
+          "message": {
+            "description": "DM message to send to added users",
+            "title": "Message",
+            "type": "string"
+          }
+        },
+        "required": [
+          "message"
+        ],
+        "title": "NotificationAddUser",
+        "type": "object"
+      },
+      "NotificationRemoveUser": {
+        "description": "Notify users when they are removed from the usergroup.",
+        "properties": {
+          "action": {
+            "const": "remove-user",
+            "default": "remove-user",
+            "title": "Action",
+            "type": "string"
+          },
+          "message": {
+            "description": "DM message to send to removed users",
+            "title": "Message",
+            "type": "string"
+          }
+        },
+        "required": [
+          "message"
+        ],
+        "title": "NotificationRemoveUser",
+        "type": "object"
+      },
       "PagerDutyUser": {
         "description": "PagerDuty user representation.\n\nImmutable model representing a user from PagerDuty API.\n\nAttributes:\n    username: PagerDuty username (computed from email)",
         "properties": {
@@ -2330,6 +2390,28 @@
             "title": "Action Type",
             "type": "string"
           },
+          "notifications": {
+            "description": "Notification actions triggered on membership changes",
+            "items": {
+              "discriminator": {
+                "mapping": {
+                  "add-user": "#/components/schemas/NotificationAddUser",
+                  "remove-user": "#/components/schemas/NotificationRemoveUser"
+                },
+                "propertyName": "action"
+              },
+              "oneOf": [
+                {
+                  "$ref": "#/components/schemas/NotificationAddUser"
+                },
+                {
+                  "$ref": "#/components/schemas/NotificationRemoveUser"
+                }
+              ]
+            },
+            "title": "Notifications",
+            "type": "array"
+          },
           "usergroup": {
             "description": "Usergroup handle/name",
             "title": "Usergroup",
@@ -2392,6 +2474,28 @@
             "description": "Usergroup description",
             "title": "Description",
             "type": "string"
+          },
+          "notifications": {
+            "description": "Notification actions triggered on membership changes",
+            "items": {
+              "discriminator": {
+                "mapping": {
+                  "add-user": "#/components/schemas/NotificationAddUser",
+                  "remove-user": "#/components/schemas/NotificationRemoveUser"
+                },
+                "propertyName": "action"
+              },
+              "oneOf": [
+                {
+                  "$ref": "#/components/schemas/NotificationAddUser"
+                },
+                {
+                  "$ref": "#/components/schemas/NotificationRemoveUser"
+                }
+              ]
+            },
+            "title": "Notifications",
+            "type": "array"
           },
           "users": {
             "default": [],
@@ -2851,7 +2955,7 @@
     },
     "/api/v1/external/slack/chat": {
       "post": {
-        "description": "Post a message to a Slack channel.\n\nSends a chat message to the specified channel in the given workspace.\nSupports threaded replies via thread_ts.\n\nArgs:\n    request: Chat request with channel, text, and credentials\n\nReturns:\n    ChatResponse with ts, channel, and optional thread_ts\n\nRaises:\n    HTTPException:\n        - 502 Bad Gateway: If Slack API call fails",
+        "description": "Post a message to a Slack channel or send a DM to a user.\n\nExactly one of `channel` or `user` must be set in the request:\n- `channel`: post to a Slack channel by name\n- `user`: send a DM to a user by org_username\n\nArgs:\n    request: Chat request with channel/user, text, and credentials\n\nReturns:\n    ChatResponse with ts, channel, and optional thread_ts\n\nRaises:\n    HTTPException:\n        - 404 Not Found: Channel or user not found\n        - 502 Bad Gateway: If Slack API call fails",
         "operationId": "slack-chat-post-message",
         "requestBody": {
           "content": {

--- a/qontract_api/qontract_api/external/slack/router.py
+++ b/qontract_api/qontract_api/external/slack/router.py
@@ -1,10 +1,10 @@
 """FastAPI router for Slack external API endpoints.
 
-Provides a POST endpoint for sending chat messages via Slack.
+Provides a POST endpoint for sending chat messages or DMs via Slack.
 """
 
 from fastapi import APIRouter, HTTPException, status
-from qontract_utils.slack_api import SlackApiError
+from qontract_utils.slack_api import SlackApiError, UserNotFoundError
 
 from qontract_api.config import settings
 from qontract_api.dependencies import CacheDep, SecretManagerDep, UserDep
@@ -30,19 +30,21 @@ def post_chat(
     cache: CacheDep,
     secret_manager: SecretManagerDep,
 ) -> ChatResponse:
-    """Post a message to a Slack channel.
+    """Post a message to a Slack channel or send a DM to a user.
 
-    Sends a chat message to the specified channel in the given workspace.
-    Supports threaded replies via thread_ts.
+    Exactly one of `channel` or `user` must be set in the request:
+    - `channel`: post to a Slack channel by name
+    - `user`: send a DM to a user by org_username
 
     Args:
-        request: Chat request with channel, text, and credentials
+        request: Chat request with channel/user, text, and credentials
 
     Returns:
         ChatResponse with ts, channel, and optional thread_ts
 
     Raises:
         HTTPException:
+            - 404 Not Found: Channel or user not found
             - 502 Bad Gateway: If Slack API call fails
     """
     client = create_slack_workspace_client(
@@ -54,23 +56,31 @@ def post_chat(
     )
 
     try:
-        result = client.chat_post_message(
-            channel=request.channel,
-            text=request.text,
-            thread_ts=request.thread_ts,
-            icon_emoji=request.icon_emoji,
-            icon_url=request.icon_url,
-            username=request.username,
-        )
-    except ValueError as e:
+        if request.user:
+            result = client.send_dm(
+                org_username=request.user,
+                text=request.text,
+            )
+        else:
+            assert request.channel  # guaranteed by model_validator
+            result = client.chat_post_message(
+                channel=request.channel,
+                text=request.text,
+                thread_ts=request.thread_ts,
+                icon_emoji=request.icon_emoji,
+                icon_url=request.icon_url,
+                username=request.username,
+            )
+    except (ValueError, UserNotFoundError) as e:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
             detail=str(e),
         ) from e
     except SlackApiError as e:
+        target = request.user or request.channel
         logger.exception(
-            f"Slack API error posting to {request.channel}",
-            channel=request.channel,
+            f"Slack API error posting to {target}",
+            target=target,
             workspace=request.workspace_name,
         )
         raise HTTPException(
@@ -78,9 +88,10 @@ def post_chat(
             detail=f"Slack API error: {e}",
         ) from e
 
+    target = request.user or request.channel
     logger.info(
-        f"Posted message to {request.channel}",
-        channel=request.channel,
+        f"Posted message to {target}",
+        target=target,
         workspace=request.workspace_name,
         ts=result.ts,
     )

--- a/qontract_api/qontract_api/external/slack/schemas.py
+++ b/qontract_api/qontract_api/external/slack/schemas.py
@@ -1,33 +1,31 @@
 """API schemas for Slack external chat endpoint."""
 
-from pydantic import BaseModel, Field
+from typing import Self
+
+from pydantic import BaseModel, Field, model_validator
 
 from qontract_api.models import Secret
 
 
 class ChatRequest(BaseModel, frozen=True):
-    """Request model for posting a Slack message.
+    """Request model for posting a Slack message or DM.
 
-    Immutable model with all fields required to send a chat message.
-
-    Attributes:
-        workspace_name: Slack workspace name
-        channel: Channel name to post to
-        text: Message text
-        thread_ts: Optional thread timestamp for replies
-        icon_emoji: Emoji to use as the message icon
-        icon_url: URL to an image to use as the message icon
-        username: Bot username to display
-        secret: Secret reference for Slack bot token
+    Exactly one of `channel` or `user` must be set:
+    - `channel`: post to a Slack channel by name
+    - `user`: send a DM to a user by org_username
     """
 
     workspace_name: str = Field(
         ...,
         description="Slack workspace name",
     )
-    channel: str = Field(
-        ...,
+    channel: str | None = Field(
+        default=None,
         description="Channel name to post to (e.g., 'sd-app-sre-reconcile')",
+    )
+    user: str | None = Field(
+        default=None,
+        description="org_username to send a DM to (e.g., 'jsmith@redhat.com')",
     )
     text: str = Field(
         ...,
@@ -53,6 +51,13 @@ class ChatRequest(BaseModel, frozen=True):
         ...,
         description="Secret reference for Slack bot token",
     )
+
+    @model_validator(mode="after")
+    def validate_target(self) -> Self:
+        """Exactly one of 'channel' or 'user' must be set."""
+        if bool(self.channel) == bool(self.user):
+            raise ValueError("Exactly one of 'channel' or 'user' must be set")
+        return self
 
 
 class ChatResponse(BaseModel, frozen=True):

--- a/qontract_api/qontract_api/integrations/slack_usergroups/schemas.py
+++ b/qontract_api/qontract_api/integrations/slack_usergroups/schemas.py
@@ -5,7 +5,7 @@ from typing import Literal
 from pydantic import BaseModel, Field, field_serializer, field_validator
 
 from qontract_api.models import TaskResult, TaskStatus
-from qontract_api.slack.domain import SlackWorkspace
+from qontract_api.slack.domain import SlackWorkspace, UsergroupNotification
 
 _USERS_TRUNCATE_THRESHOLD = 30
 
@@ -63,6 +63,10 @@ class SlackUsergroupActionUpdateUsers(BaseModel, frozen=True):
     users: list[str] = Field(..., description="List of users after update")
     users_to_add: list[str] = Field(..., description="List of users to add")
     users_to_remove: list[str] = Field(..., description="List of users to remove")
+    notifications: list[UsergroupNotification] = Field(
+        default_factory=list,
+        description="Notification actions triggered on membership changes",
+    )
 
     @field_validator("users", mode="after")
     @classmethod

--- a/qontract_api/qontract_api/integrations/slack_usergroups/service.py
+++ b/qontract_api/qontract_api/integrations/slack_usergroups/service.py
@@ -147,7 +147,6 @@ class SlackUsergroupsService:
             )
             for add in diffs.add.values()
         ]
-        # TODO delete usergroup if empty?
         for handle, change in diffs.change.items():
             if change.current.config.users != change.desired.config.users:
                 logger.debug(
@@ -166,6 +165,7 @@ class SlackUsergroupsService:
                             set(change.current.config.users)
                             - set(change.desired.config.users)
                         ),
+                        notifications=change.desired.config.notifications,
                     )
                 )
             if (

--- a/qontract_api/qontract_api/integrations/slack_usergroups/tasks.py
+++ b/qontract_api/qontract_api/integrations/slack_usergroups/tasks.py
@@ -12,17 +12,52 @@ from qontract_utils.events import Event
 from qontract_api.cache.factory import get_cache
 from qontract_api.config import settings
 from qontract_api.event_manager import get_event_manager
+from qontract_api.event_manager._base import EventManager
 from qontract_api.integrations.slack_usergroups.schemas import (
+    SlackUsergroupActionUpdateUsers,
     SlackUsergroupsTaskResult,
 )
 from qontract_api.integrations.slack_usergroups.service import SlackUsergroupsService
 from qontract_api.logger import get_logger
 from qontract_api.models import TaskStatus
 from qontract_api.secret_manager._factory import get_secret_manager
-from qontract_api.slack.domain import SlackWorkspace
+from qontract_api.slack.domain import (
+    NotificationAddUser,
+    NotificationRemoveUser,
+    SlackWorkspace,
+)
 from qontract_api.tasks import celery_app, deduplicated_task
 
 logger = get_logger(__name__)
+
+_DM_NOTIFICATION_EVENT_TYPE = "qontract-api.slack-usergroups.dm-notification"
+
+
+def _publish_dm_notifications(
+    event_manager: EventManager,
+    action: SlackUsergroupActionUpdateUsers,
+) -> None:
+    """Publish DM notification events for usergroup membership changes."""
+    for notification in action.notifications:
+        match notification:
+            case NotificationAddUser(message=msg) if action.users_to_add:
+                users = action.users_to_add
+            case NotificationRemoveUser(message=msg) if action.users_to_remove:
+                users = action.users_to_remove
+            case _:
+                continue
+        event_manager.publish_event(
+            Event(
+                source=__name__,
+                type=_DM_NOTIFICATION_EVENT_TYPE,
+                data={
+                    "usergroup": action.usergroup,
+                    "users": users,
+                    "message": msg,
+                },
+                datacontenttype="application/json",
+            )
+        )
 
 
 def generate_lock_key(_self: Task, workspaces: list[SlackWorkspace], **_: Any) -> str:
@@ -108,6 +143,11 @@ def reconcile_slack_usergroups_task(
                         datacontenttype="application/json",
                     )
                 )
+                if (
+                    isinstance(action, SlackUsergroupActionUpdateUsers)
+                    and action.notifications
+                ):
+                    _publish_dm_notifications(event_manager, action)
 
             for error in result.errors:
                 event_manager.publish_event(

--- a/qontract_api/qontract_api/slack/domain.py
+++ b/qontract_api/qontract_api/slack/domain.py
@@ -1,8 +1,30 @@
 """Pydantic domain models for Slack usergroups reconciliation."""
 
+from typing import Annotated, Literal
+
 from pydantic import BaseModel, Field, field_validator
 
 from qontract_api.models import Secret
+
+
+class NotificationAddUser(BaseModel, frozen=True):
+    """Notify users when they are added to the usergroup."""
+
+    action: Literal["add-user"] = "add-user"
+    message: str = Field(..., description="DM message to send to added users")
+
+
+class NotificationRemoveUser(BaseModel, frozen=True):
+    """Notify users when they are removed from the usergroup."""
+
+    action: Literal["remove-user"] = "remove-user"
+    message: str = Field(..., description="DM message to send to removed users")
+
+
+UsergroupNotification = Annotated[
+    NotificationAddUser | NotificationRemoveUser,
+    Field(discriminator="action"),
+]
 
 
 class SlackUsergroupConfig(BaseModel, frozen=True):
@@ -16,6 +38,10 @@ class SlackUsergroupConfig(BaseModel, frozen=True):
     channels: list[str] = Field(
         [],
         description="List of channel names (e.g., #general, team-channel)",
+    )
+    notifications: list[UsergroupNotification] = Field(
+        default_factory=list,
+        description="Notification actions triggered on membership changes",
     )
 
     @field_validator("users", "channels", mode="after")

--- a/qontract_api/qontract_api/slack/slack_workspace_client.py
+++ b/qontract_api/qontract_api/slack/slack_workspace_client.py
@@ -13,7 +13,12 @@ from collections.abc import Iterable
 from typing import TYPE_CHECKING, Protocol, TypeVar, runtime_checkable
 
 from pydantic import BaseModel, Field
-from qontract_utils.slack_api import ChatPostMessageResponse, SlackApi, SlackApiError
+from qontract_utils.slack_api import (
+    ChatPostMessageResponse,
+    SlackApi,
+    SlackApiError,
+    UserNotFoundError,
+)
 from qontract_utils.slack_api import SlackChannel as SlackChannelAPI
 from qontract_utils.slack_api import SlackUser as SlackUserAPI
 from qontract_utils.slack_api import SlackUsergroup as SlackUsergroupAPI
@@ -321,7 +326,9 @@ class SlackWorkspaceClient:
             for ug in usergroups
         ]
 
-    def clean_slack_usergroups(self, usergroups: Iterable) -> list:
+    def clean_slack_usergroups(
+        self, usergroups: Iterable[SlackUsergroup]
+    ) -> list[SlackUsergroup]:
         """Clean usergroups by removing non-existing users/channels (efficient batch operation).
 
         Args:
@@ -349,6 +356,7 @@ class SlackWorkspaceClient:
                         for name in ug.config.channels
                         if name.lstrip("#") in valid_channel_names
                     ],
+                    notifications=ug.config.notifications,
                 ),
             )
             for ug in usergroups
@@ -506,6 +514,24 @@ class SlackWorkspaceClient:
             icon_url=icon_url,
             username=username,
         )
+
+    def _resolve_user_id(self, org_username: str) -> str:
+        """Resolve org_username to Slack user ID via cached users."""
+        for user in self.get_users().values():
+            if user.org_username == org_username:
+                return user.id
+        raise UserNotFoundError(f"User '{org_username}' not found")
+
+    def send_dm(
+        self,
+        *,
+        org_username: str,
+        text: str,
+    ) -> ChatPostMessageResponse:
+        """Send a DM to a user by org_username."""
+        user_id = self._resolve_user_id(org_username)
+        dm_channel_id = self.slack_api.conversations_open(user_ids=[user_id])
+        return self.slack_api.chat_post_message(channel_id=dm_channel_id, text=text)
 
     def _resolve_channel_id(self, channel_name: str) -> str:
         """Resolve a channel name to its ID.

--- a/qontract_api/qontract_api/subscriber/_client.py
+++ b/qontract_api/qontract_api/subscriber/_client.py
@@ -68,3 +68,32 @@ async def post_to_slack(message: str) -> None:
         channel=settings.subscriber.slack_channel,
         workspace=settings.subscriber.slack_workspace,
     )
+
+
+async def send_dm(org_username: str, text: str) -> None:
+    """Send a DM to a user via qontract-api chat endpoint."""
+    if settings.subscriber.slack_token is None:
+        raise RuntimeError("Subscriber settings slack_token not configured!")
+
+    chat_request = ChatRequest(
+        workspace_name=settings.subscriber.slack_workspace,
+        user=org_username,
+        text=text,
+        secret=Secret(
+            path=settings.subscriber.slack_token.path,
+            field=settings.subscriber.slack_token.field,
+            version=settings.subscriber.slack_token.version,
+            secret_manager_url=settings.secrets.default_provider_url,
+        ),
+        username=settings.subscriber.slack_username,
+        icon_emoji=settings.subscriber.slack_icon_emoji,
+    )
+
+    client = _get_client()
+    await post_chat(client=client, body=chat_request)
+
+    logger.info(
+        "DM sent via qontract-api",
+        user=org_username,
+        workspace=settings.subscriber.slack_workspace,
+    )

--- a/qontract_api/qontract_api/subscriber/_subscriptions.py
+++ b/qontract_api/qontract_api/subscriber/_subscriptions.py
@@ -10,7 +10,7 @@ from qontract_api.config import settings
 from qontract_api.logger import get_logger
 
 from ._base import broker
-from ._client import post_to_slack
+from ._client import post_to_slack, send_dm
 from ._formatters import format_event
 from ._metrics import (
     event_processing_duration,
@@ -45,8 +45,12 @@ async def event_handler(event: Event) -> None:
     start_time = time.perf_counter()
 
     try:
-        message = format_event(event)
-        await post_to_slack(message)
+        match event.type:
+            case "qontract-api.slack-usergroups.dm-notification":
+                await _handle_dm_notifications(event)
+            case _:
+                message = format_event(event)
+                await post_to_slack(message)
         events_posted.labels(event_type=event.type).inc()
         logger.info(
             "Event posted to Slack",
@@ -69,3 +73,21 @@ async def event_handler(event: Event) -> None:
     finally:
         duration = time.perf_counter() - start_time
         event_processing_duration.labels(event_type=event.type).observe(duration)
+
+
+async def _handle_dm_notifications(event: Event) -> None:
+    """Send DM notifications to users."""
+    users: list[str] = event.data["users"]
+    message: str = event.data["message"]
+    usergroup: str = event.data["usergroup"]
+
+    for org_username in users:
+        try:
+            await send_dm(org_username=org_username, text=message)
+            logger.info("DM sent", org_username=org_username, usergroup=usergroup)
+        except Exception:
+            logger.exception(
+                "Failed to send DM",
+                org_username=org_username,
+                usergroup=usergroup,
+            )

--- a/qontract_api/tests/slack/test_slack_workspace_client_dm.py
+++ b/qontract_api/tests/slack/test_slack_workspace_client_dm.py
@@ -1,0 +1,111 @@
+"""Tests for SlackWorkspaceClient.send_dm and _resolve_user_id."""
+
+from unittest.mock import MagicMock
+
+import pytest
+from qontract_utils.slack_api import (
+    ChatPostMessageResponse,
+    SlackUser,
+    SlackUserProfile,
+    UserNotFoundError,
+)
+
+from qontract_api.config import Settings
+from qontract_api.slack.slack_workspace_client import (
+    CachedUsers,
+    SlackWorkspaceClient,
+)
+
+
+@pytest.fixture
+def client(
+    mock_slack_api: MagicMock, mock_cache: MagicMock, mock_settings: Settings
+) -> SlackWorkspaceClient:
+    """Create SlackWorkspaceClient with mocks."""
+    return SlackWorkspaceClient(
+        slack_api=mock_slack_api,
+        cache=mock_cache,
+        settings=mock_settings,
+    )
+
+
+@pytest.fixture
+def cached_users() -> CachedUsers:
+    """Create cached users fixture."""
+    return CachedUsers(
+        items=[
+            SlackUser(
+                id="U1",
+                name="Alice",
+                deleted=False,
+                profile=SlackUserProfile(email="alice@example.com"),
+            ),
+            SlackUser(
+                id="U2",
+                name="Bob",
+                deleted=False,
+                profile=SlackUserProfile(email="bob@example.com"),
+            ),
+        ]
+    )
+
+
+def test_resolve_user_id_found(
+    client: SlackWorkspaceClient,
+    mock_cache: MagicMock,
+    cached_users: CachedUsers,
+) -> None:
+    """Test _resolve_user_id returns user ID for known org_username."""
+    mock_cache.get_obj.return_value = cached_users
+
+    assert client._resolve_user_id("alice") == "U1"
+    assert client._resolve_user_id("bob") == "U2"
+
+
+def test_resolve_user_id_not_found(
+    client: SlackWorkspaceClient,
+    mock_cache: MagicMock,
+    cached_users: CachedUsers,
+) -> None:
+    """Test _resolve_user_id raises UserNotFoundError for unknown org_username."""
+    mock_cache.get_obj.return_value = cached_users
+
+    with pytest.raises(UserNotFoundError, match="unknown"):
+        client._resolve_user_id("unknown")
+
+
+def test_send_dm_success(
+    client: SlackWorkspaceClient,
+    mock_slack_api: MagicMock,
+    mock_cache: MagicMock,
+    cached_users: CachedUsers,
+) -> None:
+    """Test send_dm resolves user, opens DM channel, sends message."""
+    mock_cache.get_obj.return_value = cached_users
+    mock_slack_api.conversations_open.return_value = "D_DM_CHANNEL"
+    mock_slack_api.chat_post_message.return_value = ChatPostMessageResponse(
+        ts="1234567890.000000",
+        channel="D_DM_CHANNEL",
+    )
+
+    result = client.send_dm(org_username="alice", text="Hello!")
+
+    mock_slack_api.conversations_open.assert_called_once_with(user_ids=["U1"])
+    mock_slack_api.chat_post_message.assert_called_once_with(
+        channel_id="D_DM_CHANNEL",
+        text="Hello!",
+    )
+    assert result.ts == "1234567890.000000"
+    assert result.channel == "D_DM_CHANNEL"
+
+
+def test_send_dm_user_not_found(
+    client: SlackWorkspaceClient,
+    mock_cache: MagicMock,
+    cached_users: CachedUsers,
+) -> None:
+    """Test send_dm raises UserNotFoundError for unknown user."""
+    mock_cache.get_obj.return_value = cached_users
+
+    with pytest.raises(UserNotFoundError, match="nonexistent"):
+        client.send_dm(org_username="nonexistent", text="Hello!")

--- a/qontract_api/tests/slack/test_slack_workspace_client_dm.py
+++ b/qontract_api/tests/slack/test_slack_workspace_client_dm.py
@@ -50,16 +50,21 @@ def cached_users() -> CachedUsers:
     )
 
 
+@pytest.mark.parametrize(
+    ("org_username", "expected_id"),
+    [("alice", "U1"), ("bob", "U2")],
+)
 def test_resolve_user_id_found(
     client: SlackWorkspaceClient,
     mock_cache: MagicMock,
     cached_users: CachedUsers,
+    org_username: str,
+    expected_id: str,
 ) -> None:
     """Test _resolve_user_id returns user ID for known org_username."""
     mock_cache.get_obj.return_value = cached_users
 
-    assert client._resolve_user_id("alice") == "U1"
-    assert client._resolve_user_id("bob") == "U2"
+    assert client._resolve_user_id(org_username) == expected_id
 
 
 def test_resolve_user_id_not_found(

--- a/qontract_api/tests/subscriber/test_dm_notifications.py
+++ b/qontract_api/tests/subscriber/test_dm_notifications.py
@@ -19,7 +19,7 @@ def dm_notification_event() -> Event:
         type="qontract-api.slack-usergroups.dm-notification",
         data={
             "usergroup": "oncall-team",
-            "users": ["alice@example.com", "bob@example.com"],
+            "users": ["alice", "bob"],
             "message": "You have been added to @oncall-team.",
         },
     )
@@ -36,11 +36,11 @@ async def test_handle_dm_notifications_sends_dm_per_user(
 
     assert mock_send_dm.call_count == 2
     mock_send_dm.assert_any_call(
-        org_username="alice@example.com",
+        org_username="alice",
         text="You have been added to @oncall-team.",
     )
     mock_send_dm.assert_any_call(
-        org_username="bob@example.com",
+        org_username="bob",
         text="You have been added to @oncall-team.",
     )
 

--- a/qontract_api/tests/subscriber/test_dm_notifications.py
+++ b/qontract_api/tests/subscriber/test_dm_notifications.py
@@ -1,0 +1,95 @@
+"""Tests for DM notification handling in subscriber."""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from qontract_utils.events import Event
+
+from qontract_api.subscriber._subscriptions import (
+    _handle_dm_notifications,
+    event_handler,
+)
+
+
+@pytest.fixture
+def dm_notification_event() -> Event:
+    """Create a DM notification event."""
+    return Event(
+        source="test-source",
+        type="qontract-api.slack-usergroups.dm-notification",
+        data={
+            "usergroup": "oncall-team",
+            "users": ["alice@example.com", "bob@example.com"],
+            "message": "You have been added to @oncall-team.",
+        },
+    )
+
+
+@pytest.mark.asyncio
+@patch("qontract_api.subscriber._subscriptions.send_dm", new_callable=AsyncMock)
+async def test_handle_dm_notifications_sends_dm_per_user(
+    mock_send_dm: AsyncMock,
+    dm_notification_event: Event,
+) -> None:
+    """Test _handle_dm_notifications sends a DM to each user."""
+    await _handle_dm_notifications(dm_notification_event)
+
+    assert mock_send_dm.call_count == 2
+    mock_send_dm.assert_any_call(
+        org_username="alice@example.com",
+        text="You have been added to @oncall-team.",
+    )
+    mock_send_dm.assert_any_call(
+        org_username="bob@example.com",
+        text="You have been added to @oncall-team.",
+    )
+
+
+@pytest.mark.asyncio
+@patch("qontract_api.subscriber._subscriptions.send_dm", new_callable=AsyncMock)
+async def test_handle_dm_notifications_isolates_per_user_errors(
+    mock_send_dm: AsyncMock,
+    dm_notification_event: Event,
+) -> None:
+    """Test one failed DM does not block others."""
+    mock_send_dm.side_effect = [Exception("DM failed"), None]
+
+    await _handle_dm_notifications(dm_notification_event)
+
+    assert mock_send_dm.call_count == 2
+
+
+@pytest.mark.asyncio
+@patch("qontract_api.subscriber._subscriptions.send_dm", new_callable=AsyncMock)
+@patch("qontract_api.subscriber._subscriptions.post_to_slack", new_callable=AsyncMock)
+@patch("qontract_api.subscriber._subscriptions.format_event")
+async def test_event_handler_dispatches_dm_notification(
+    mock_format: MagicMock,
+    mock_post: AsyncMock,
+    mock_send_dm: AsyncMock,
+    dm_notification_event: Event,
+) -> None:
+    """Test event_handler dispatches dm-notification events to _handle_dm_notifications."""
+    await event_handler(dm_notification_event)
+
+    assert mock_send_dm.call_count == 2
+    mock_format.assert_not_called()
+    mock_post.assert_not_called()
+
+
+@pytest.mark.asyncio
+@patch("qontract_api.subscriber._subscriptions.send_dm", new_callable=AsyncMock)
+@patch("qontract_api.subscriber._subscriptions.post_to_slack", new_callable=AsyncMock)
+@patch("qontract_api.subscriber._subscriptions.format_event", return_value="formatted")
+async def test_event_handler_non_dm_events_use_default_path(
+    mock_format: MagicMock,
+    mock_post: AsyncMock,
+    mock_send_dm: AsyncMock,
+    sample_event: Event,
+) -> None:
+    """Test non-DM events still go through format_event + post_to_slack."""
+    await event_handler(sample_event)
+
+    mock_format.assert_called_once_with(sample_event)
+    mock_post.assert_called_once_with("formatted")
+    mock_send_dm.assert_not_called()

--- a/qontract_api/tests/tasks/test_dm_notifications.py
+++ b/qontract_api/tests/tasks/test_dm_notifications.py
@@ -1,0 +1,140 @@
+"""Tests for _publish_dm_notifications in slack usergroups tasks."""
+
+from unittest.mock import MagicMock
+
+import pytest
+from qontract_utils.events import Event
+
+from qontract_api.integrations.slack_usergroups.schemas import (
+    SlackUsergroupActionUpdateUsers,
+)
+from qontract_api.integrations.slack_usergroups.tasks import (
+    _DM_NOTIFICATION_EVENT_TYPE,
+    _publish_dm_notifications,
+)
+from qontract_api.slack.domain import NotificationAddUser, NotificationRemoveUser
+
+
+@pytest.fixture
+def mock_event_manager() -> MagicMock:
+    return MagicMock()
+
+
+def test_publish_dm_add_notification(mock_event_manager: MagicMock) -> None:
+    """Test DM event published for users_to_add when NotificationAddUser is configured."""
+    action = SlackUsergroupActionUpdateUsers(
+        workspace="coreos",
+        usergroup="oncall",
+        users=["alice", "bob"],
+        users_to_add=["alice"],
+        users_to_remove=["charlie"],
+        notifications=[NotificationAddUser(message="Welcome to @oncall!")],
+    )
+
+    _publish_dm_notifications(mock_event_manager, action)
+
+    mock_event_manager.publish_event.assert_called_once()
+    event: Event = mock_event_manager.publish_event.call_args[0][0]
+    assert event.type == _DM_NOTIFICATION_EVENT_TYPE
+    assert event.data == {
+        "usergroup": "oncall",
+        "users": ["alice"],
+        "message": "Welcome to @oncall!",
+    }
+
+
+def test_publish_dm_remove_notification(mock_event_manager: MagicMock) -> None:
+    """Test DM event published for users_to_remove when NotificationRemoveUser is configured."""
+    action = SlackUsergroupActionUpdateUsers(
+        workspace="coreos",
+        usergroup="oncall",
+        users=["alice"],
+        users_to_add=["alice"],
+        users_to_remove=["charlie"],
+        notifications=[NotificationRemoveUser(message="You have been removed.")],
+    )
+
+    _publish_dm_notifications(mock_event_manager, action)
+
+    mock_event_manager.publish_event.assert_called_once()
+    event: Event = mock_event_manager.publish_event.call_args[0][0]
+    assert event.data["users"] == ["charlie"]
+    assert event.data["message"] == "You have been removed."
+
+
+def test_publish_dm_both_notifications(mock_event_manager: MagicMock) -> None:
+    """Test two separate events published when both add and remove notifications configured."""
+    action = SlackUsergroupActionUpdateUsers(
+        workspace="coreos",
+        usergroup="oncall",
+        users=["alice"],
+        users_to_add=["alice"],
+        users_to_remove=["charlie"],
+        notifications=[
+            NotificationAddUser(message="Welcome!"),
+            NotificationRemoveUser(message="Goodbye!"),
+        ],
+    )
+
+    _publish_dm_notifications(mock_event_manager, action)
+
+    assert mock_event_manager.publish_event.call_count == 2
+    events = [c[0][0] for c in mock_event_manager.publish_event.call_args_list]
+    assert events[0].data["users"] == ["alice"]
+    assert events[0].data["message"] == "Welcome!"
+    assert events[1].data["users"] == ["charlie"]
+    assert events[1].data["message"] == "Goodbye!"
+
+
+def test_publish_dm_skips_add_when_no_users_to_add(
+    mock_event_manager: MagicMock,
+) -> None:
+    """Test no event published for NotificationAddUser when users_to_add is empty."""
+    action = SlackUsergroupActionUpdateUsers(
+        workspace="coreos",
+        usergroup="oncall",
+        users=["alice"],
+        users_to_add=[],
+        users_to_remove=["charlie"],
+        notifications=[NotificationAddUser(message="Welcome!")],
+    )
+
+    _publish_dm_notifications(mock_event_manager, action)
+
+    mock_event_manager.publish_event.assert_not_called()
+
+
+def test_publish_dm_skips_remove_when_no_users_to_remove(
+    mock_event_manager: MagicMock,
+) -> None:
+    """Test no event published for NotificationRemoveUser when users_to_remove is empty."""
+    action = SlackUsergroupActionUpdateUsers(
+        workspace="coreos",
+        usergroup="oncall",
+        users=["alice"],
+        users_to_add=["alice"],
+        users_to_remove=[],
+        notifications=[NotificationRemoveUser(message="Goodbye!")],
+    )
+
+    _publish_dm_notifications(mock_event_manager, action)
+
+    mock_event_manager.publish_event.assert_not_called()
+
+
+def test_publish_dm_no_notifications_configured(
+    mock_event_manager: MagicMock,
+) -> None:
+    """Test no events published when notifications list is empty."""
+    action = SlackUsergroupActionUpdateUsers(
+        workspace="coreos",
+        usergroup="oncall",
+        users=["alice"],
+        users_to_add=["alice"],
+        users_to_remove=[],
+        notifications=[],
+    )
+
+    _publish_dm_notifications(mock_event_manager, action)
+
+    mock_event_manager.publish_event.assert_not_called()

--- a/qontract_api_client/qontract_api_client/api/external/slack_chat_post_message.py
+++ b/qontract_api_client/qontract_api_client/api/external/slack_chat_post_message.py
@@ -58,35 +58,29 @@ def sync_detailed(
 ) -> Response[ChatResponse]:
     """Post Chat
 
-     Post a message to a Slack channel.
+     Post a message to a Slack channel or send a DM to a user.
 
-    Sends a chat message to the specified channel in the given workspace.
-    Supports threaded replies via thread_ts.
+    Exactly one of `channel` or `user` must be set in the request:
+    - `channel`: post to a Slack channel by name
+    - `user`: send a DM to a user by org_username
 
     Args:
-        request: Chat request with channel, text, and credentials
+        request: Chat request with channel/user, text, and credentials
 
     Returns:
         ChatResponse with ts, channel, and optional thread_ts
 
     Raises:
         HTTPException:
+            - 404 Not Found: Channel or user not found
             - 502 Bad Gateway: If Slack API call fails
 
     Args:
-        body (ChatRequest): Request model for posting a Slack message.
+        body (ChatRequest): Request model for posting a Slack message or DM.
 
-            Immutable model with all fields required to send a chat message.
-
-            Attributes:
-                workspace_name: Slack workspace name
-                channel: Channel name to post to
-                text: Message text
-                thread_ts: Optional thread timestamp for replies
-                icon_emoji: Emoji to use as the message icon
-                icon_url: URL to an image to use as the message icon
-                username: Bot username to display
-                secret: Secret reference for Slack bot token
+            Exactly one of `channel` or `user` must be set:
+            - `channel`: post to a Slack channel by name
+            - `user`: send a DM to a user by org_username
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -114,35 +108,29 @@ def sync(
 ) -> ChatResponse:
     """Post Chat
 
-     Post a message to a Slack channel.
+     Post a message to a Slack channel or send a DM to a user.
 
-    Sends a chat message to the specified channel in the given workspace.
-    Supports threaded replies via thread_ts.
+    Exactly one of `channel` or `user` must be set in the request:
+    - `channel`: post to a Slack channel by name
+    - `user`: send a DM to a user by org_username
 
     Args:
-        request: Chat request with channel, text, and credentials
+        request: Chat request with channel/user, text, and credentials
 
     Returns:
         ChatResponse with ts, channel, and optional thread_ts
 
     Raises:
         HTTPException:
+            - 404 Not Found: Channel or user not found
             - 502 Bad Gateway: If Slack API call fails
 
     Args:
-        body (ChatRequest): Request model for posting a Slack message.
+        body (ChatRequest): Request model for posting a Slack message or DM.
 
-            Immutable model with all fields required to send a chat message.
-
-            Attributes:
-                workspace_name: Slack workspace name
-                channel: Channel name to post to
-                text: Message text
-                thread_ts: Optional thread timestamp for replies
-                icon_emoji: Emoji to use as the message icon
-                icon_url: URL to an image to use as the message icon
-                username: Bot username to display
-                secret: Secret reference for Slack bot token
+            Exactly one of `channel` or `user` must be set:
+            - `channel`: post to a Slack channel by name
+            - `user`: send a DM to a user by org_username
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -168,35 +156,29 @@ async def asyncio_detailed(
 ) -> Response[ChatResponse]:
     """Post Chat
 
-     Post a message to a Slack channel.
+     Post a message to a Slack channel or send a DM to a user.
 
-    Sends a chat message to the specified channel in the given workspace.
-    Supports threaded replies via thread_ts.
+    Exactly one of `channel` or `user` must be set in the request:
+    - `channel`: post to a Slack channel by name
+    - `user`: send a DM to a user by org_username
 
     Args:
-        request: Chat request with channel, text, and credentials
+        request: Chat request with channel/user, text, and credentials
 
     Returns:
         ChatResponse with ts, channel, and optional thread_ts
 
     Raises:
         HTTPException:
+            - 404 Not Found: Channel or user not found
             - 502 Bad Gateway: If Slack API call fails
 
     Args:
-        body (ChatRequest): Request model for posting a Slack message.
+        body (ChatRequest): Request model for posting a Slack message or DM.
 
-            Immutable model with all fields required to send a chat message.
-
-            Attributes:
-                workspace_name: Slack workspace name
-                channel: Channel name to post to
-                text: Message text
-                thread_ts: Optional thread timestamp for replies
-                icon_emoji: Emoji to use as the message icon
-                icon_url: URL to an image to use as the message icon
-                username: Bot username to display
-                secret: Secret reference for Slack bot token
+            Exactly one of `channel` or `user` must be set:
+            - `channel`: post to a Slack channel by name
+            - `user`: send a DM to a user by org_username
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -222,35 +204,29 @@ async def asyncio(
 ) -> ChatResponse:
     """Post Chat
 
-     Post a message to a Slack channel.
+     Post a message to a Slack channel or send a DM to a user.
 
-    Sends a chat message to the specified channel in the given workspace.
-    Supports threaded replies via thread_ts.
+    Exactly one of `channel` or `user` must be set in the request:
+    - `channel`: post to a Slack channel by name
+    - `user`: send a DM to a user by org_username
 
     Args:
-        request: Chat request with channel, text, and credentials
+        request: Chat request with channel/user, text, and credentials
 
     Returns:
         ChatResponse with ts, channel, and optional thread_ts
 
     Raises:
         HTTPException:
+            - 404 Not Found: Channel or user not found
             - 502 Bad Gateway: If Slack API call fails
 
     Args:
-        body (ChatRequest): Request model for posting a Slack message.
+        body (ChatRequest): Request model for posting a Slack message or DM.
 
-            Immutable model with all fields required to send a chat message.
-
-            Attributes:
-                workspace_name: Slack workspace name
-                channel: Channel name to post to
-                text: Message text
-                thread_ts: Optional thread timestamp for replies
-                icon_emoji: Emoji to use as the message icon
-                icon_url: URL to an image to use as the message icon
-                username: Bot username to display
-                secret: Secret reference for Slack bot token
+            Exactly one of `channel` or `user` must be set:
+            - `channel`: post to a Slack channel by name
+            - `user`: send a DM to a user by org_username
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.

--- a/qontract_api_client/qontract_api_client/models/__init__.py
+++ b/qontract_api_client/qontract_api_client/models/__init__.py
@@ -61,6 +61,8 @@ from .ldap_user_status import LdapUserStatus
 from .ldap_users_check_request import LdapUsersCheckRequest
 from .ldap_users_check_response import LdapUsersCheckResponse
 from .liveness_response_liveness import LivenessResponseLiveness
+from .notification_add_user import NotificationAddUser
+from .notification_remove_user import NotificationRemoveUser
 from .pager_duty_user import PagerDutyUser
 from .recipient_type import RecipientType
 from .repo_owners_response import RepoOwnersResponse
@@ -137,6 +139,8 @@ __all__ = (
     "LdapUsersCheckRequest",
     "LdapUsersCheckResponse",
     "LivenessResponseLiveness",
+    "NotificationAddUser",
+    "NotificationRemoveUser",
     "PagerDutyUser",
     "RecipientType",
     "RepoOwnersResponse",

--- a/qontract_api_client/qontract_api_client/models/chat_request.py
+++ b/qontract_api_client/qontract_api_client/models/chat_request.py
@@ -17,49 +17,47 @@ T = TypeVar("T", bound="ChatRequest")
 
 @_attrs_define
 class ChatRequest:
-    """Request model for posting a Slack message.
+    """Request model for posting a Slack message or DM.
 
-    Immutable model with all fields required to send a chat message.
-
-    Attributes:
-        workspace_name: Slack workspace name
-        channel: Channel name to post to
-        text: Message text
-        thread_ts: Optional thread timestamp for replies
-        icon_emoji: Emoji to use as the message icon
-        icon_url: URL to an image to use as the message icon
-        username: Bot username to display
-        secret: Secret reference for Slack bot token
+    Exactly one of `channel` or `user` must be set:
+    - `channel`: post to a Slack channel by name
+    - `user`: send a DM to a user by org_username
 
         Attributes:
-            channel (str): Channel name to post to (e.g., 'sd-app-sre-reconcile')
             secret (Secret): Reference to a secret stored in a secret manager.
             text (str): Message text
             workspace_name (str): Slack workspace name
+            channel (None | str | Unset): Channel name to post to (e.g., 'sd-app-sre-reconcile')
             icon_emoji (None | str | Unset): Emoji to use as the message icon (e.g., ':robot_face:')
             icon_url (None | str | Unset): URL to an image to use as the message icon
             thread_ts (None | str | Unset): Optional thread timestamp for replies
+            user (None | str | Unset): org_username to send a DM to (e.g., 'jsmith@redhat.com')
             username (None | str | Unset): Bot username to display
     """
 
-    channel: str
     secret: Secret
     text: str
     workspace_name: str
+    channel: None | str | Unset = UNSET
     icon_emoji: None | str | Unset = UNSET
     icon_url: None | str | Unset = UNSET
     thread_ts: None | str | Unset = UNSET
+    user: None | str | Unset = UNSET
     username: None | str | Unset = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
-        channel = self.channel
-
         secret = self.secret.to_dict()
 
         text = self.text
 
         workspace_name = self.workspace_name
+
+        channel: None | str | Unset
+        if isinstance(self.channel, Unset):
+            channel = UNSET
+        else:
+            channel = self.channel
 
         icon_emoji: None | str | Unset
         if isinstance(self.icon_emoji, Unset):
@@ -79,6 +77,12 @@ class ChatRequest:
         else:
             thread_ts = self.thread_ts
 
+        user: None | str | Unset
+        if isinstance(self.user, Unset):
+            user = UNSET
+        else:
+            user = self.user
+
         username: None | str | Unset
         if isinstance(self.username, Unset):
             username = UNSET
@@ -88,17 +92,20 @@ class ChatRequest:
         field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update({
-            "channel": channel,
             "secret": secret,
             "text": text,
             "workspace_name": workspace_name,
         })
+        if channel is not UNSET:
+            field_dict["channel"] = channel
         if icon_emoji is not UNSET:
             field_dict["icon_emoji"] = icon_emoji
         if icon_url is not UNSET:
             field_dict["icon_url"] = icon_url
         if thread_ts is not UNSET:
             field_dict["thread_ts"] = thread_ts
+        if user is not UNSET:
+            field_dict["user"] = user
         if username is not UNSET:
             field_dict["username"] = username
 
@@ -109,13 +116,20 @@ class ChatRequest:
         from ..models.secret import Secret
 
         d = dict(src_dict)
-        channel = d.pop("channel")
-
         secret = Secret.from_dict(d.pop("secret"))
 
         text = d.pop("text")
 
         workspace_name = d.pop("workspace_name")
+
+        def _parse_channel(data: object) -> None | str | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(None | str | Unset, data)
+
+        channel = _parse_channel(d.pop("channel", UNSET))
 
         def _parse_icon_emoji(data: object) -> None | str | Unset:
             if data is None:
@@ -144,6 +158,15 @@ class ChatRequest:
 
         thread_ts = _parse_thread_ts(d.pop("thread_ts", UNSET))
 
+        def _parse_user(data: object) -> None | str | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(None | str | Unset, data)
+
+        user = _parse_user(d.pop("user", UNSET))
+
         def _parse_username(data: object) -> None | str | Unset:
             if data is None:
                 return data
@@ -154,13 +177,14 @@ class ChatRequest:
         username = _parse_username(d.pop("username", UNSET))
 
         chat_request = cls(
-            channel=channel,
             secret=secret,
             text=text,
             workspace_name=workspace_name,
+            channel=channel,
             icon_emoji=icon_emoji,
             icon_url=icon_url,
             thread_ts=thread_ts,
+            user=user,
             username=username,
         )
 

--- a/qontract_api_client/qontract_api_client/models/notification_add_user.py
+++ b/qontract_api_client/qontract_api_client/models/notification_add_user.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import (
+    Any,
+    Literal,
+    TypeVar,
+    cast,
+)
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+from ..types import UNSET, Unset
+
+T = TypeVar("T", bound="NotificationAddUser")
+
+
+@_attrs_define
+class NotificationAddUser:
+    """Notify users when they are added to the usergroup.
+
+    Attributes:
+        message (str): DM message to send to added users
+        action (Literal['add-user'] | Unset):  Default: 'add-user'.
+    """
+
+    message: str
+    action: Literal["add-user"] | Unset = "add-user"
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        message = self.message
+
+        action = self.action
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update({
+            "message": message,
+        })
+        if action is not UNSET:
+            field_dict["action"] = action
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        d = dict(src_dict)
+        message = d.pop("message")
+
+        action = cast(Literal["add-user"] | Unset, d.pop("action", UNSET))
+        if action != "add-user" and not isinstance(action, Unset):
+            raise ValueError(f"action must match const 'add-user', got '{action}'")
+
+        notification_add_user = cls(
+            message=message,
+            action=action,
+        )
+
+        notification_add_user.additional_properties = d
+        return notification_add_user
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/qontract_api_client/qontract_api_client/models/notification_remove_user.py
+++ b/qontract_api_client/qontract_api_client/models/notification_remove_user.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import (
+    Any,
+    Literal,
+    TypeVar,
+    cast,
+)
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+from ..types import UNSET, Unset
+
+T = TypeVar("T", bound="NotificationRemoveUser")
+
+
+@_attrs_define
+class NotificationRemoveUser:
+    """Notify users when they are removed from the usergroup.
+
+    Attributes:
+        message (str): DM message to send to removed users
+        action (Literal['remove-user'] | Unset):  Default: 'remove-user'.
+    """
+
+    message: str
+    action: Literal["remove-user"] | Unset = "remove-user"
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        message = self.message
+
+        action = self.action
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update({
+            "message": message,
+        })
+        if action is not UNSET:
+            field_dict["action"] = action
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        d = dict(src_dict)
+        message = d.pop("message")
+
+        action = cast(Literal["remove-user"] | Unset, d.pop("action", UNSET))
+        if action != "remove-user" and not isinstance(action, Unset):
+            raise ValueError(f"action must match const 'remove-user', got '{action}'")
+
+        notification_remove_user = cls(
+            message=message,
+            action=action,
+        )
+
+        notification_remove_user.additional_properties = d
+        return notification_remove_user
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/qontract_api_client/qontract_api_client/models/slack_usergroup_action_update_users.py
+++ b/qontract_api_client/qontract_api_client/models/slack_usergroup_action_update_users.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from collections.abc import Mapping
 from typing import (
+    TYPE_CHECKING,
     Any,
     Literal,
     TypeVar,
@@ -12,6 +13,11 @@ from attrs import define as _attrs_define
 from attrs import field as _attrs_field
 
 from ..types import UNSET, Unset
+
+if TYPE_CHECKING:
+    from ..models.notification_add_user import NotificationAddUser
+    from ..models.notification_remove_user import NotificationRemoveUser
+
 
 T = TypeVar("T", bound="SlackUsergroupActionUpdateUsers")
 
@@ -27,6 +33,8 @@ class SlackUsergroupActionUpdateUsers:
         users_to_remove (list[str]): List of users to remove
         workspace (str): Workspace name
         action_type (Literal['update_users'] | Unset):  Default: 'update_users'.
+        notifications (list[NotificationAddUser | NotificationRemoveUser] | Unset): Notification actions triggered on
+            membership changes
     """
 
     usergroup: str
@@ -35,9 +43,12 @@ class SlackUsergroupActionUpdateUsers:
     users_to_remove: list[str]
     workspace: str
     action_type: Literal["update_users"] | Unset = "update_users"
+    notifications: list[NotificationAddUser | NotificationRemoveUser] | Unset = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
+        from ..models.notification_add_user import NotificationAddUser
+
         usergroup = self.usergroup
 
         users = self.users
@@ -50,6 +61,18 @@ class SlackUsergroupActionUpdateUsers:
 
         action_type = self.action_type
 
+        notifications: list[dict[str, Any]] | Unset = UNSET
+        if not isinstance(self.notifications, Unset):
+            notifications = []
+            for notifications_item_data in self.notifications:
+                notifications_item: dict[str, Any]
+                if isinstance(notifications_item_data, NotificationAddUser):
+                    notifications_item = notifications_item_data.to_dict()
+                else:
+                    notifications_item = notifications_item_data.to_dict()
+
+                notifications.append(notifications_item)
+
         field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update({
@@ -61,11 +84,16 @@ class SlackUsergroupActionUpdateUsers:
         })
         if action_type is not UNSET:
             field_dict["action_type"] = action_type
+        if notifications is not UNSET:
+            field_dict["notifications"] = notifications
 
         return field_dict
 
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        from ..models.notification_add_user import NotificationAddUser
+        from ..models.notification_remove_user import NotificationRemoveUser
+
         d = dict(src_dict)
         usergroup = d.pop("usergroup")
 
@@ -83,6 +111,35 @@ class SlackUsergroupActionUpdateUsers:
                 f"action_type must match const 'update_users', got '{action_type}'"
             )
 
+        _notifications = d.pop("notifications", UNSET)
+        notifications: list[NotificationAddUser | NotificationRemoveUser] | Unset = (
+            UNSET
+        )
+        if _notifications is not UNSET:
+            notifications = []
+            for notifications_item_data in _notifications:
+
+                def _parse_notifications_item(
+                    data: object,
+                ) -> NotificationAddUser | NotificationRemoveUser:
+                    try:
+                        if not isinstance(data, dict):
+                            raise TypeError()
+                        notifications_item_type_0 = NotificationAddUser.from_dict(data)
+
+                        return notifications_item_type_0
+                    except (TypeError, ValueError, AttributeError, KeyError):
+                        pass
+                    if not isinstance(data, dict):
+                        raise TypeError()
+                    notifications_item_type_1 = NotificationRemoveUser.from_dict(data)
+
+                    return notifications_item_type_1
+
+                notifications_item = _parse_notifications_item(notifications_item_data)
+
+                notifications.append(notifications_item)
+
         slack_usergroup_action_update_users = cls(
             usergroup=usergroup,
             users=users,
@@ -90,6 +147,7 @@ class SlackUsergroupActionUpdateUsers:
             users_to_remove=users_to_remove,
             workspace=workspace,
             action_type=action_type,
+            notifications=notifications,
         )
 
         slack_usergroup_action_update_users.additional_properties = d

--- a/qontract_api_client/qontract_api_client/models/slack_usergroup_config.py
+++ b/qontract_api_client/qontract_api_client/models/slack_usergroup_config.py
@@ -1,12 +1,17 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
-from typing import Any, TypeVar, cast
+from typing import TYPE_CHECKING, Any, TypeVar, cast
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
 
 from ..types import UNSET, Unset
+
+if TYPE_CHECKING:
+    from ..models.notification_add_user import NotificationAddUser
+    from ..models.notification_remove_user import NotificationRemoveUser
+
 
 T = TypeVar("T", bound="SlackUsergroupConfig")
 
@@ -18,20 +23,37 @@ class SlackUsergroupConfig:
     Attributes:
         channels (list[str] | Unset): List of channel names (e.g., #general, team-channel)
         description (str | Unset): Usergroup description Default: ''.
+        notifications (list[NotificationAddUser | NotificationRemoveUser] | Unset): Notification actions triggered on
+            membership changes
         users (list[str] | Unset): List of user emails (e.g., user@example.com)
     """
 
     channels: list[str] | Unset = UNSET
     description: str | Unset = ""
+    notifications: list[NotificationAddUser | NotificationRemoveUser] | Unset = UNSET
     users: list[str] | Unset = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
+        from ..models.notification_add_user import NotificationAddUser
+
         channels: list[str] | Unset = UNSET
         if not isinstance(self.channels, Unset):
             channels = self.channels
 
         description = self.description
+
+        notifications: list[dict[str, Any]] | Unset = UNSET
+        if not isinstance(self.notifications, Unset):
+            notifications = []
+            for notifications_item_data in self.notifications:
+                notifications_item: dict[str, Any]
+                if isinstance(notifications_item_data, NotificationAddUser):
+                    notifications_item = notifications_item_data.to_dict()
+                else:
+                    notifications_item = notifications_item_data.to_dict()
+
+                notifications.append(notifications_item)
 
         users: list[str] | Unset = UNSET
         if not isinstance(self.users, Unset):
@@ -44,6 +66,8 @@ class SlackUsergroupConfig:
             field_dict["channels"] = channels
         if description is not UNSET:
             field_dict["description"] = description
+        if notifications is not UNSET:
+            field_dict["notifications"] = notifications
         if users is not UNSET:
             field_dict["users"] = users
 
@@ -51,16 +75,49 @@ class SlackUsergroupConfig:
 
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        from ..models.notification_add_user import NotificationAddUser
+        from ..models.notification_remove_user import NotificationRemoveUser
+
         d = dict(src_dict)
         channels = cast(list[str], d.pop("channels", UNSET))
 
         description = d.pop("description", UNSET)
+
+        _notifications = d.pop("notifications", UNSET)
+        notifications: list[NotificationAddUser | NotificationRemoveUser] | Unset = (
+            UNSET
+        )
+        if _notifications is not UNSET:
+            notifications = []
+            for notifications_item_data in _notifications:
+
+                def _parse_notifications_item(
+                    data: object,
+                ) -> NotificationAddUser | NotificationRemoveUser:
+                    try:
+                        if not isinstance(data, dict):
+                            raise TypeError()
+                        notifications_item_type_0 = NotificationAddUser.from_dict(data)
+
+                        return notifications_item_type_0
+                    except (TypeError, ValueError, AttributeError, KeyError):
+                        pass
+                    if not isinstance(data, dict):
+                        raise TypeError()
+                    notifications_item_type_1 = NotificationRemoveUser.from_dict(data)
+
+                    return notifications_item_type_1
+
+                notifications_item = _parse_notifications_item(notifications_item_data)
+
+                notifications.append(notifications_item)
 
         users = cast(list[str], d.pop("users", UNSET))
 
         slack_usergroup_config = cls(
             channels=channels,
             description=description,
+            notifications=notifications,
             users=users,
         )
 

--- a/qontract_utils/qontract_utils/slack_api/client.py
+++ b/qontract_utils/qontract_utils/slack_api/client.py
@@ -363,6 +363,16 @@ class SlackApi:
 
     @invoke_with_hooks(
         lambda self: SlackApiCallContext(
+            method="conversations.open", verb="POST", workspace=self.workspace_name
+        )
+    )
+    def conversations_open(self, *, user_ids: list[str]) -> str:
+        """Open a DM channel with user(s). Returns the DM channel ID."""
+        response = self._sc.conversations_open(users=user_ids)
+        return response["channel"]["id"]
+
+    @invoke_with_hooks(
+        lambda self: SlackApiCallContext(
             method="conversations.list", verb="GET", workspace=self.workspace_name
         )
     )

--- a/qontract_utils/tests/test_slack_api_conversations_open.py
+++ b/qontract_utils/tests/test_slack_api_conversations_open.py
@@ -1,7 +1,5 @@
 """Tests for SlackApi.conversations_open method."""
 
-# ruff: noqa: ARG001
-
 from collections.abc import Generator
 from unittest.mock import MagicMock, patch
 
@@ -17,7 +15,16 @@ def mock_webclient() -> Generator[MagicMock, None, None]:
         yield mock_client
 
 
-def test_conversations_open_returns_channel_id(mock_webclient: MagicMock) -> None:
+@pytest.mark.parametrize(
+    ("user_ids", "expected_channel_id"),
+    [
+        (["U12345"], "D0123ABC"),
+        (["U1", "U2"], "G0123ABC"),
+    ],
+    ids=["single-user-dm", "multi-user-group-dm"],
+)
+@pytest.mark.usefixtures("mock_webclient")
+def test_conversations_open(user_ids: list[str], expected_channel_id: str) -> None:
     """Test conversations_open returns the DM channel ID."""
     api = SlackApi(
         slack_api_url="https://slack.com/api/",
@@ -27,29 +34,10 @@ def test_conversations_open_returns_channel_id(mock_webclient: MagicMock) -> Non
         max_retries=5,
     )
     api._sc.conversations_open = MagicMock(  # type: ignore[method-assign]
-        return_value={"channel": {"id": "D0123ABC"}}
+        return_value={"channel": {"id": expected_channel_id}}
     )
 
-    result = api.conversations_open(user_ids=["U12345"])
+    result = api.conversations_open(user_ids=user_ids)
 
-    assert result == "D0123ABC"
-    api._sc.conversations_open.assert_called_once_with(users=["U12345"])
-
-
-def test_conversations_open_multiple_users(mock_webclient: MagicMock) -> None:
-    """Test conversations_open with multiple user IDs (group DM)."""
-    api = SlackApi(
-        slack_api_url="https://slack.com/api/",
-        workspace_name="test-workspace",
-        token="xoxb-test-token",
-        timeout=30,
-        max_retries=5,
-    )
-    api._sc.conversations_open = MagicMock(  # type: ignore[method-assign]
-        return_value={"channel": {"id": "G0123ABC"}}
-    )
-
-    result = api.conversations_open(user_ids=["U1", "U2"])
-
-    assert result == "G0123ABC"
-    api._sc.conversations_open.assert_called_once_with(users=["U1", "U2"])
+    assert result == expected_channel_id
+    api._sc.conversations_open.assert_called_once_with(users=user_ids)

--- a/qontract_utils/tests/test_slack_api_conversations_open.py
+++ b/qontract_utils/tests/test_slack_api_conversations_open.py
@@ -1,0 +1,55 @@
+"""Tests for SlackApi.conversations_open method."""
+
+# ruff: noqa: ARG001
+
+from collections.abc import Generator
+from unittest.mock import MagicMock, patch
+
+import pytest
+from qontract_utils.slack_api import SlackApi
+
+
+@pytest.fixture
+def mock_webclient() -> Generator[MagicMock, None, None]:
+    """Mock Slack WebClient."""
+    with patch("qontract_utils.slack_api.client.WebClient") as mock_client:
+        mock_client.return_value.retry_handlers = []
+        yield mock_client
+
+
+def test_conversations_open_returns_channel_id(mock_webclient: MagicMock) -> None:
+    """Test conversations_open returns the DM channel ID."""
+    api = SlackApi(
+        slack_api_url="https://slack.com/api/",
+        workspace_name="test-workspace",
+        token="xoxb-test-token",
+        timeout=30,
+        max_retries=5,
+    )
+    api._sc.conversations_open = MagicMock(  # type: ignore[method-assign]
+        return_value={"channel": {"id": "D0123ABC"}}
+    )
+
+    result = api.conversations_open(user_ids=["U12345"])
+
+    assert result == "D0123ABC"
+    api._sc.conversations_open.assert_called_once_with(users=["U12345"])
+
+
+def test_conversations_open_multiple_users(mock_webclient: MagicMock) -> None:
+    """Test conversations_open with multiple user IDs (group DM)."""
+    api = SlackApi(
+        slack_api_url="https://slack.com/api/",
+        workspace_name="test-workspace",
+        token="xoxb-test-token",
+        timeout=30,
+        max_retries=5,
+    )
+    api._sc.conversations_open = MagicMock(  # type: ignore[method-assign]
+        return_value={"channel": {"id": "G0123ABC"}}
+    )
+
+    result = api.conversations_open(user_ids=["U1", "U2"])
+
+    assert result == "G0123ABC"
+    api._sc.conversations_open.assert_called_once_with(users=["U1", "U2"])

--- a/reconcile/gql_definitions/introspection.json
+++ b/reconcile/gql_definitions/introspection.json
@@ -29572,6 +29572,30 @@
                             "deprecationReason": null
                         },
                         {
+                            "name": "merge_limit",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "SCALAR",
+                                "name": "Int",
+                                "ofType": null
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "consecutive_failure_limit",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "SCALAR",
+                                "name": "Int",
+                                "ofType": null
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
                             "name": "enable_closing",
                             "description": null,
                             "args": [],
@@ -34999,6 +35023,26 @@
                             "deprecationReason": null
                         },
                         {
+                            "name": "notifications",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "LIST",
+                                "name": null,
+                                "ofType": {
+                                    "kind": "NON_NULL",
+                                    "name": null,
+                                    "ofType": {
+                                        "kind": "OBJECT",
+                                        "name": "SlackUsergroupNotification_v1",
+                                        "ofType": null
+                                    }
+                                }
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
                             "name": "skip",
                             "description": null,
                             "args": [],
@@ -35044,6 +35088,49 @@
                             "ofType": null
                         }
                     ],
+                    "enumValues": null,
+                    "possibleTypes": null
+                },
+                {
+                    "kind": "OBJECT",
+                    "name": "SlackUsergroupNotification_v1",
+                    "description": null,
+                    "fields": [
+                        {
+                            "name": "action",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "NON_NULL",
+                                "name": null,
+                                "ofType": {
+                                    "kind": "SCALAR",
+                                    "name": "String",
+                                    "ofType": null
+                                }
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "message",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "NON_NULL",
+                                "name": null,
+                                "ofType": {
+                                    "kind": "SCALAR",
+                                    "name": "String",
+                                    "ofType": null
+                                }
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        }
+                    ],
+                    "inputFields": null,
+                    "interfaces": [],
                     "enumValues": null,
                     "possibleTypes": null
                 },
@@ -53804,7 +53891,22 @@
                         {
                             "name": "directives",
                             "description": "A list of all directives supported by this server.",
-                            "args": [],
+                            "args": [
+                                {
+                                    "name": "includeDeprecated",
+                                    "description": null,
+                                    "type": {
+                                        "kind": "NON_NULL",
+                                        "name": null,
+                                        "ofType": {
+                                            "kind": "SCALAR",
+                                            "name": "Boolean",
+                                            "ofType": null
+                                        }
+                                    },
+                                    "defaultValue": "false"
+                                }
+                            ],
                             "type": {
                                 "kind": "NON_NULL",
                                 "name": null,
@@ -54497,6 +54599,34 @@
                             },
                             "isDeprecated": false,
                             "deprecationReason": null
+                        },
+                        {
+                            "name": "isDeprecated",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "NON_NULL",
+                                "name": null,
+                                "ofType": {
+                                    "kind": "SCALAR",
+                                    "name": "Boolean",
+                                    "ofType": null
+                                }
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "deprecationReason",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "SCALAR",
+                                "name": "String",
+                                "ofType": null
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
                         }
                     ],
                     "inputFields": null,
@@ -54623,6 +54753,12 @@
                         {
                             "name": "INPUT_FIELD_DEFINITION",
                             "description": "Location adjacent to an input object field definition.",
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "DIRECTIVE_DEFINITION",
+                            "description": "Location adjacent to a directive definition.",
                             "isDeprecated": false,
                             "deprecationReason": null
                         }

--- a/reconcile/gql_definitions/introspection.json
+++ b/reconcile/gql_definitions/introspection.json
@@ -54824,7 +54824,8 @@
                         "FIELD_DEFINITION",
                         "ARGUMENT_DEFINITION",
                         "INPUT_FIELD_DEFINITION",
-                        "ENUM_VALUE"
+                        "ENUM_VALUE",
+                        "DIRECTIVE_DEFINITION"
                     ],
                     "args": [
                         {

--- a/reconcile/gql_definitions/slack_usergroups_api/permissions.gql
+++ b/reconcile/gql_definitions/slack_usergroups_api/permissions.gql
@@ -7,6 +7,10 @@ query SlackUsergroupApiPermission {
       channels
       description
       handle
+      notifications {
+        action
+        message
+      }
       ownersFromRepos
       skip
       pagerduty {

--- a/reconcile/gql_definitions/slack_usergroups_api/permissions.py
+++ b/reconcile/gql_definitions/slack_usergroups_api/permissions.py
@@ -44,6 +44,10 @@ query SlackUsergroupApiPermission {
       channels
       description
       handle
+      notifications {
+        action
+        message
+      }
       ownersFromRepos
       skip
       pagerduty {
@@ -98,6 +102,11 @@ class PermissionV1(ConfiguredBaseModel):
     service: str = Field(..., alias="service")
 
 
+class SlackUsergroupNotificationV1(ConfiguredBaseModel):
+    action: str = Field(..., alias="action")
+    message: str = Field(..., alias="message")
+
+
 class PagerDutyInstanceV1(ConfiguredBaseModel):
     token: VaultSecret = Field(..., alias="token")
 
@@ -140,6 +149,7 @@ class PermissionSlackUsergroupV1(PermissionV1):
     channels: list[str] = Field(..., alias="channels")
     description: str = Field(..., alias="description")
     handle: str = Field(..., alias="handle")
+    notifications: Optional[list[SlackUsergroupNotificationV1]] = Field(..., alias="notifications")
     owners_from_repos: Optional[list[str]] = Field(..., alias="ownersFromRepos")
     skip: Optional[bool] = Field(..., alias="skip")
     pagerduty: Optional[list[PagerDutyTargetV1]] = Field(..., alias="pagerduty")

--- a/reconcile/slack_usergroups_api.py
+++ b/reconcile/slack_usergroups_api.py
@@ -51,6 +51,8 @@ from qontract_api_client.models import (
     SlackUsergroupActionUpdateUsers,
     SlackUsergroupsTaskResult,
 )
+from qontract_api_client.models.notification_add_user import NotificationAddUser
+from qontract_api_client.models.notification_remove_user import NotificationRemoveUser
 from qontract_api_client.models.secret import Secret
 from qontract_api_client.models.slack_usergroup import SlackUsergroup
 from qontract_api_client.models.slack_usergroup_config import SlackUsergroupConfig
@@ -431,6 +433,12 @@ class SlackUsergroupsIntegration(
             description=permission.description or "",
             users=sorted(users),
             channels=sorted(set(permission.channels or [])),
+            notifications=[
+                NotificationAddUser(message=n.message)
+                if n.action == "addUser"
+                else NotificationRemoveUser(message=n.message)
+                for n in permission.notifications or []
+            ],
         )
         usergroup = SlackUsergroup(handle=usergroup_handle, config=config)
 

--- a/reconcile/slack_usergroups_api.py
+++ b/reconcile/slack_usergroups_api.py
@@ -429,16 +429,21 @@ class SlackUsergroupsIntegration(
         )
 
         # Create config and usergroup
+        notifications = []
+        for n in permission.notifications or []:
+            match n.action:
+                case "addUser":
+                    notifications.append(NotificationAddUser(message=n.message))
+                case "removeUser":
+                    notifications.append(NotificationRemoveUser(message=n.message))
+                case _:
+                    raise ValueError(f"Unknown notification action: {n.action!r}")
+
         config = SlackUsergroupConfig(
             description=permission.description or "",
             users=sorted(users),
             channels=sorted(set(permission.channels or [])),
-            notifications=[
-                NotificationAddUser(message=n.message)
-                if n.action == "addUser"
-                else NotificationRemoveUser(message=n.message)
-                for n in permission.notifications or []
-            ],
+            notifications=notifications,
         )
         usergroup = SlackUsergroup(handle=usergroup_handle, config=config)
 

--- a/reconcile/slack_usergroups_api.py
+++ b/reconcile/slack_usergroups_api.py
@@ -429,7 +429,7 @@ class SlackUsergroupsIntegration(
         )
 
         # Create config and usergroup
-        notifications = []
+        notifications: list[NotificationAddUser | NotificationRemoveUser] = []
         for n in permission.notifications or []:
             match n.action:
                 case "addUser":

--- a/uv.lock
+++ b/uv.lock
@@ -108,25 +108,26 @@ wheels = [
 
 [[package]]
 name = "ast-serialize"
-version = "0.3.0"
+version = "0.5.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/a9/9d/912fefab0e30aee6a3af8a62bbea4a81b29afa4ba2c973d31170620a26de/ast_serialize-0.3.0.tar.gz", hash = "sha256:1bc3ca09a63a021376527c4e938deedd11d11d675ce850e6f9c7487f5889992b", size = 60689, upload-time = "2026-04-30T23:24:48.104Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/81/9d/09e27731bd5864a9ce04e3244074e674bb8936bf62b45e0357248717adac/ast_serialize-0.5.0.tar.gz", hash = "sha256:5880091bfe6f4f986f22866375c2e884843e7a0b6343ae41aeea659613d879b6", size = 61157, upload-time = "2026-05-17T17:48:29.429Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/bc/93/72abad83966ed6235647c9f956417dc1e17e997696388521910e3d1fa3f4/ast_serialize-0.3.0-cp39-abi3-macosx_10_12_x86_64.whl", hash = "sha256:2ec2fafa5e4313cc8feed96e436ebe19ac7bc6fa41fbc2827e826c48b9e4c3a9", size = 1190024, upload-time = "2026-04-30T23:24:22.486Z" },
-    { url = "https://files.pythonhosted.org/packages/85/4f/eb88584b2f0234e581762011208ca203252bf6c98e59b4769daa571f3576/ast_serialize-0.3.0-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:ef6d3c08b7b4cd29b48410338e134764a00e76d25841eb02c1084e868c888ecc", size = 1178633, upload-time = "2026-04-30T23:24:24.35Z" },
-    { url = "https://files.pythonhosted.org/packages/56/51/cf1ec1ff3e616373d0dcbd5fad502e0029dc541f13ab642259762a7d127f/ast_serialize-0.3.0-cp39-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3d841424f41b886e98044abc80769c14a956e6e5ccd5fb5b0d9f5ead72be18a4", size = 1241351, upload-time = "2026-04-30T23:24:25.987Z" },
-    { url = "https://files.pythonhosted.org/packages/0d/44/68fcf50478cf1093f2d423f034ae06453122c8b415d8e21a44668eca485d/ast_serialize-0.3.0-cp39-abi3-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:d21453734ad39367ede5d37efe4f59f830ce1c09f432fc72a90e368f77a4a3e7", size = 1239582, upload-time = "2026-04-30T23:24:27.808Z" },
-    { url = "https://files.pythonhosted.org/packages/9d/c1/a6c9fa284eceb5fc6f21347e968445a051d7ca2c4d34e6a04314646dbcee/ast_serialize-0.3.0-cp39-abi3-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:f5e110cdce2a347e1dd987529c88ef54d26f67848dce3eba1b3b2cc2cf085c94", size = 1448853, upload-time = "2026-04-30T23:24:29.534Z" },
-    { url = "https://files.pythonhosted.org/packages/23/5f/8ad3829a09e4e8c5328a53ce7d4711d660944e3e164c5f6abcc2c8f27167/ast_serialize-0.3.0-cp39-abi3-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:3b6e23a98e57560a055f5c4b68700a0fd5ce483d2814c23140b3638c7f5d1e61", size = 1262204, upload-time = "2026-04-30T23:24:31.482Z" },
-    { url = "https://files.pythonhosted.org/packages/25/13/44aa28d97f10e25247e8576b5f6b2795d4fa1a80acc88acc942c508d06f7/ast_serialize-0.3.0-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c1c9e763d70293d65ce1e1ea8c943140c68d0953f0268c7ee0998f2e07f77dd0", size = 1266458, upload-time = "2026-04-30T23:24:33.088Z" },
-    { url = "https://files.pythonhosted.org/packages/d8/58/b3a8be3777cd3744324fd5cec0d80d37cd96fc7cbb0fb010e03dff1e870f/ast_serialize-0.3.0-cp39-abi3-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:4388a1796c228f1ce5c391426f7d21a0003ad3b47f677dbeded9bd1a85c7209f", size = 1308700, upload-time = "2026-04-30T23:24:34.657Z" },
-    { url = "https://files.pythonhosted.org/packages/13/03/f8312d6b57f5471a9dc7946f22b8798a1fc296d38c25766223aacadec42c/ast_serialize-0.3.0-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:5283cdcc0c64c3d8b9b688dc6aaa012d9c0cf1380a7f774a6bae6a1c01b3205a", size = 1416724, upload-time = "2026-04-30T23:24:36.562Z" },
-    { url = "https://files.pythonhosted.org/packages/50/5d/13fc3789a7abac00559da2e2e9f386db4612aa1f84fc53d09bf714c37545/ast_serialize-0.3.0-cp39-abi3-musllinux_1_2_armv7l.whl", hash = "sha256:f5ef88cc5842a5d7a6ac09dc0d5fc2c98f5d276c1f076f866d55047ce886785b", size = 1515441, upload-time = "2026-04-30T23:24:38.018Z" },
-    { url = "https://files.pythonhosted.org/packages/eb/b9/7ab43fc7a23b1f970281093228f5f79bed6edeed7a3e672bde6d7a832a58/ast_serialize-0.3.0-cp39-abi3-musllinux_1_2_i686.whl", hash = "sha256:cc14bf402bdc0978594ecce783793de2c7470cd4f5cd7eb286ca97ed8ff7cba9", size = 1510522, upload-time = "2026-04-30T23:24:39.798Z" },
-    { url = "https://files.pythonhosted.org/packages/56/ec/d75fc2b788d319f1fad77c14156896f31afdfc68af85b505e5bdebcb9592/ast_serialize-0.3.0-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:11eae0cf1b7b3e0678133cc2daa974ea972caf02eb4b3aa062af6fa9acd52c57", size = 1460917, upload-time = "2026-04-30T23:24:41.305Z" },
-    { url = "https://files.pythonhosted.org/packages/95/74/f99c81193a2725911e1911ae567ed27c2f2419332c7f3537366f9d238cac/ast_serialize-0.3.0-cp39-abi3-win32.whl", hash = "sha256:2db3dd99de5e6a5a11d7dda73de8750eb6e5baaf25245adf7bdcfe64b6108ae2", size = 1067804, upload-time = "2026-04-30T23:24:43.091Z" },
-    { url = "https://files.pythonhosted.org/packages/16/81/76af00c47daa151e89f98ae21fbbcb2840aaa9f5766579c4da76a3c57188/ast_serialize-0.3.0-cp39-abi3-win_amd64.whl", hash = "sha256:a2cd125adccf7969470621905d302750cd25951f22ea430d9a25b7be031e5549", size = 1105561, upload-time = "2026-04-30T23:24:44.578Z" },
-    { url = "https://files.pythonhosted.org/packages/bd/46/d3ec57ad500f598d1554bd14ce4df615960549ab2844961bc4e1f5fbd174/ast_serialize-0.3.0-cp39-abi3-win_arm64.whl", hash = "sha256:0dd00da29985f15f50dc35728b7e1e7c84507bccfea1d9914738530f1c72238a", size = 1077165, upload-time = "2026-04-30T23:24:46.377Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/9e/dc2530acb3a60dc6e46d65abf27d1d9f86721694757906a148d90a6860de/ast_serialize-0.5.0-cp39-abi3-macosx_10_12_x86_64.whl", hash = "sha256:0668aa9459cfa8c9c49ddd2163ebcf43088ba045ef7492af6fe22e0098303101", size = 1191380, upload-time = "2026-05-17T17:48:03.738Z" },
+    { url = "https://files.pythonhosted.org/packages/26/0a/bd3d18a582f273d6c843d16bb9e22e9e16365ff7991e92f18f798e9f1224/ast_serialize-0.5.0-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:bf683d6363edf2b39eed6b6d4fe22d34b6203867a67e27134d9e2a2680c4bc4a", size = 1183879, upload-time = "2026-05-17T17:48:05.463Z" },
+    { url = "https://files.pythonhosted.org/packages/40/ae/1f919100f8620887af58fcc381c61a1f218cdf89c6e155f87b213e61010a/ast_serialize-0.5.0-cp39-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9cc22cf0c9be65e71cf88fda130af60d61eb4a79370ad4cfe7900d48a4aa2211", size = 1244529, upload-time = "2026-05-17T17:48:07.008Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/ca/6376559dcce707cdbc1d0d9a13c8d3baaaa501e949ce0ebdc4230cd881aa/ast_serialize-0.5.0-cp39-abi3-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:f66173891548c9f2726bf27957b41cabce12fa679dc6da505ddbde4d4b3b31cf", size = 1240560, upload-time = "2026-05-17T17:48:08.46Z" },
+    { url = "https://files.pythonhosted.org/packages/35/b2/a620e206b5aeb7efbf2710336df57d457cffbb3991076bbcc1147ef9abd4/ast_serialize-0.5.0-cp39-abi3-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:e42d729ef2be96a14efbad355093284739e3670ece3e534f82cc8832790911d9", size = 1451172, upload-time = "2026-05-17T17:48:09.922Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/e0/4ad5c04c24a40481b2935ce9a0ccdb6023dc8b667167d06ae530cc3512f2/ast_serialize-0.5.0-cp39-abi3-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:b725026bafa801dbd7310eb13a75f0a2e370e7e51b2cb225f9d21fcfadf919ee", size = 1265072, upload-time = "2026-05-17T17:48:11.469Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/71/4d1d479aa56d0101c40e17720c3d6ac2af7269ea0487a80b18e7bfd1a5b7/ast_serialize-0.5.0-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b54f60c1d78767a53b67eaa663f0dfac3afe606aa07f1301572f588b73d64809", size = 1270488, upload-time = "2026-05-17T17:48:13.575Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/4f/0de1bbe06f6edef9fde4ed12ca8e7b3ec7e6e2bd4e672c5af487f7957665/ast_serialize-0.5.0-cp39-abi3-manylinux_2_31_riscv64.whl", hash = "sha256:27d51654fc240a1e87e742d353d98eb45b75f62f129086b3596ab53df2ac2a43", size = 1260702, upload-time = "2026-05-17T17:48:15.141Z" },
+    { url = "https://files.pythonhosted.org/packages/75/61/e00872439cfdddcc3c1b6cdaa6e5d904ba8e26a18807c67c4e14409d0ca8/ast_serialize-0.5.0-cp39-abi3-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:2782c36237c46dd1674542f2109740ea5ea485a169bf1431939ada0434e17934", size = 1311182, upload-time = "2026-05-17T17:48:16.779Z" },
+    { url = "https://files.pythonhosted.org/packages/76/8e/699a5b955f7926956c95e9e1d74132acad73c2fe7a426f94da89123c20aa/ast_serialize-0.5.0-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:1943db345233cc7194a470f13afa9c59772c0b123dea0c9414c4d4ca54369759", size = 1421410, upload-time = "2026-05-17T17:48:18.527Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/ae/d5b7626874478997adc7a29ab28accf21e596fb590c944290401dfd0b29e/ast_serialize-0.5.0-cp39-abi3-musllinux_1_2_armv7l.whl", hash = "sha256:df1c00022cbbcb064bfaa505aa9c9295362443ce5dacb459d1331d3da353f887", size = 1516587, upload-time = "2026-05-17T17:48:20.133Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/ce/b59e02a82d9c4244d64cde502e0b00e83e38816abe19155ceb5437402c7f/ast_serialize-0.5.0-cp39-abi3-musllinux_1_2_i686.whl", hash = "sha256:cae65289fc456fde04af979a2be09302ef5d8ab92ef23e596d6746dc267ada27", size = 1515171, upload-time = "2026-05-17T17:48:21.921Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/38/d8d90042747d05aa08d4efcf1c99035a5f670a6bf4c214d31644392afbca/ast_serialize-0.5.0-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:239a4c354e8d676e9d94631d1d4a64edc6b266f86ff3a5a80aedd344f342c01d", size = 1464668, upload-time = "2026-05-17T17:48:23.544Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/51/5b840c4df7334104cecffa28f23904fe81ca89ca223d2450e288de39fd3c/ast_serialize-0.5.0-cp39-abi3-win32.whl", hash = "sha256:143a4ef63285a075871908fda3672dc21864b83a8ec3ee12304aa3e4c5387b9a", size = 1068311, upload-time = "2026-05-17T17:48:25.027Z" },
+    { url = "https://files.pythonhosted.org/packages/41/11/ca5672c7d491825bc4cd6702dea106a6b60d928707712ec257c7833ae476/ast_serialize-0.5.0-cp39-abi3-win_amd64.whl", hash = "sha256:cf25572c526add400f26a4750dc6ce0c3bb93fc1f75e7ae0cad4ce4f2cd5c590", size = 1108931, upload-time = "2026-05-17T17:48:26.591Z" },
+    { url = "https://files.pythonhosted.org/packages/45/19/cc8bd127d28a43da249aa955cfd164cf8fd534e79e42cea96c4854d72fd0/ast_serialize-0.5.0-cp39-abi3-win_arm64.whl", hash = "sha256:92a31c9c20d25a076edaeec76b128a3535d74a24f340b9a8a7e96c9b86dc9642", size = 1081181, upload-time = "2026-05-17T17:48:28.122Z" },
 ]
 
 [[package]]
@@ -384,14 +385,14 @@ wheels = [
 
 [[package]]
 name = "click"
-version = "8.3.3"
+version = "8.4.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "colorama", marker = "sys_platform == 'win32'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/bb/63/f9e1ea081ce35720d8b92acde70daaedace594dc93b693c869e0d5910718/click-8.3.3.tar.gz", hash = "sha256:398329ad4837b2ff7cbe1dd166a4c0f8900c3ca3a218de04466f38f6497f18a2", size = 328061, upload-time = "2026-04-22T15:11:27.506Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/23/e4/796662cd90cf80e3a363c99db2b88e0e394b988a575f60a17e16440cd011/click-8.4.0.tar.gz", hash = "sha256:638f1338fe1235c8f4e008e4a8a254fb5c5fbdcbb40ece3c9142ebb78e792973", size = 350843, upload-time = "2026-05-17T00:47:58.425Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ae/44/c1221527f6a71a01ec6fbad7fa78f1d50dfa02217385cf0fa3eec7087d59/click-8.3.3-py3-none-any.whl", hash = "sha256:a2bf429bb3033c89fa4936ffb35d5cb471e3719e1f3c8a7c3fff0b8314305613", size = 110502, upload-time = "2026-04-22T15:11:25.044Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/ae/8e92f8058baf87f6c7d86ee7e457668690195cc77efedb8d3797a06e3940/click-8.4.0-py3-none-any.whl", hash = "sha256:40c50b7c6c6adac2823d411041ec84f3f103f1b280d5e9ce0d7f998995832f81", size = 116147, upload-time = "2026-05-17T00:47:56.842Z" },
 ]
 
 [[package]]
@@ -743,15 +744,15 @@ wheels = [
 
 [[package]]
 name = "google-auth"
-version = "2.52.0"
+version = "2.53.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "cryptography" },
     { name = "pyasn1-modules" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/d4/f8/80d2493cbedece1c623dc3e3cb1883300871af0dcdae254409522985ac23/google_auth-2.52.0.tar.gz", hash = "sha256:01f30e1a9e3638698d89464f5e603ce29d18e1c0e63ec31ac570aba4e164aaf5", size = 335027, upload-time = "2026-05-07T19:45:24.033Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c6/ad/ff781329bbbdc0974a098d996e89c9e1f7024262f9e3eec442fbb9ad1ac6/google_auth-2.53.0.tar.gz", hash = "sha256:e7e6aa16f6bee7b2b264830fd04f08087a1d5a836df516251a5d15327b246c9c", size = 335844, upload-time = "2026-05-15T20:53:07.928Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ee/fc/2cdc74252746f547f81ff3f02d4d4234a3f411b5de5b61af97e633a060b9/google_auth-2.52.0-py3-none-any.whl", hash = "sha256:aee92803ba0ff93a70a3b8a35c7b4797837751cd6380b63ff38372b98f3ed627", size = 245614, upload-time = "2026-05-07T19:45:21.914Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/c9/db44165ba7c581268c6d46017ef63339110378305062830104fc7fa144cb/google_auth-2.53.0-py3-none-any.whl", hash = "sha256:6e7449917c599b35126a99ec268ec6880301f2fea41dce198fe8fd83ff642b68", size = 246071, upload-time = "2026-05-15T20:53:05.609Z" },
 ]
 
 [[package]]
@@ -839,11 +840,11 @@ wheels = [
 
 [[package]]
 name = "idna"
-version = "3.14"
+version = "3.15"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/05/b1/efac073e0c297ecf2fb33c346989a529d4e19164f1759102dee5953ee17e/idna-3.14.tar.gz", hash = "sha256:466d810d7a2cc1022bea9b037c39728d51ae7dad40d480fc9b7d7ecf98ba8ee3", size = 198272, upload-time = "2026-05-10T20:32:15.935Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/82/77/7b3966d0b9d1d31a36ddf1746926a11dface89a83409bf1483f0237aa758/idna-3.15.tar.gz", hash = "sha256:ca962446ea538f7092a95e057da437618e886f4d349216d2b1e294abfdb65fdc", size = 199245, upload-time = "2026-05-12T22:45:57.011Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/6c/3c/3f62dee257eb3d6b2c1ef2a09d36d9793c7111156a73b5654d2c2305e5ce/idna-3.14-py3-none-any.whl", hash = "sha256:e677eaf072e290f7b725f9acf0b3a2bd55f9fd6f7c70abe5f0e34823d0accf69", size = 72184, upload-time = "2026-05-10T20:32:14.295Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/23/408243171aa9aaba178d3e2559159c24c1171a641aa83b67bdd3394ead8e/idna-3.15-py3-none-any.whl", hash = "sha256:048adeaf8c2d788c40fee287673ccaa74c24ffd8dcf09ffa555a2fbb59f10ac8", size = 72340, upload-time = "2026-05-12T22:45:55.733Z" },
 ]
 
 [[package]]
@@ -1934,15 +1935,15 @@ wheels = [
 
 [[package]]
 name = "qenerate"
-version = "0.9.1"
+version = "0.9.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "graphql-core" },
     { name = "requests" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/25/c7/7ebda429e968496141f7d9e9d07ac9aafb432e790d7fcf2d918cc758e182/qenerate-0.9.1.tar.gz", hash = "sha256:afe7fe3d7a1d864581b4ee783cdd6d773fa8108f4212d76d2dfc7d5a5f311743", size = 17440, upload-time = "2025-11-03T08:25:02.718Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/5f/1e/34db3f832d8e96677343456e42a197b7b4ad3ca441d76629a5b08902d838/qenerate-0.9.2.tar.gz", hash = "sha256:15e1bb7d752626e2ca781fc7ddf5a75a2fe6681c13fc23fde26c5dc71fa029be", size = 17888, upload-time = "2026-05-18T08:20:45.456Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a6/d5/ce64c4070a7875b895438b8d610335d8dd69f8da8773ac37a79ad247a012/qenerate-0.9.1-py3-none-any.whl", hash = "sha256:a7904a3498ca468f0e5a96bdb7dd8312a0ed7e3f0fb11983906957dcc90ad2b3", size = 21515, upload-time = "2025-11-03T08:25:01.521Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/69/47c59636c2ad44bc8b8b7790e3979ec7470aa5b90dd5bf602bda2d07bcc4/qenerate-0.9.2-py3-none-any.whl", hash = "sha256:43d8fbee3259171d417a1ed12169b2153ebbff4748eee448ca4263f9aeaa7658", size = 21984, upload-time = "2026-05-18T08:20:44.111Z" },
 ]
 
 [[package]]
@@ -2199,7 +2200,7 @@ dev = [
     { name = "pytest-cov", specifier = "==7.0.0" },
     { name = "pytest-httpserver", specifier = "==1.1.3" },
     { name = "pytest-mock", specifier = "==3.15.1" },
-    { name = "qenerate", specifier = "==0.9.1" },
+    { name = "qenerate", specifier = "==0.9.2" },
     { name = "responses", specifier = "==0.25.0" },
     { name = "ruff", specifier = "==0.15.12" },
     { name = "smtpdfix", specifier = "==0.5.3" },
@@ -2759,14 +2760,14 @@ wheels = [
 
 [[package]]
 name = "types-cffi"
-version = "2.0.0.20260508"
+version = "2.0.0.20260518"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "types-setuptools" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/f9/17/dd80304dade64eefae44f273e829734fc01243bf94555e787386c09146a9/types_cffi-2.0.0.20260508.tar.gz", hash = "sha256:746b081b4bf84f9d8855c517a67c2dff717f3c18657fcff8e9c251fb5778f311", size = 17750, upload-time = "2026-05-08T04:51:48.365Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/bd/0b/b352742758a6054d1053783887bf8cfb739deda1102fda8722294bdc01f7/types_cffi-2.0.0.20260518.tar.gz", hash = "sha256:f9707e66c13454789a58f8843d1ded4a66f1e9c8b10bd24d5eb5e0f25c0c5472", size = 17790, upload-time = "2026-05-18T06:06:50.672Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/18/02/95d98d4473197da55bb5b9c67f7ff1e49c0a12ca870e29004129f635be18/types_cffi-2.0.0.20260508-py3-none-any.whl", hash = "sha256:d094065daf4edcfbdd3e11c37d2fa9511eaf7c509da7a9d9573c276398a8e745", size = 20174, upload-time = "2026-05-08T04:51:47.548Z" },
+    { url = "https://files.pythonhosted.org/packages/68/44/d3b4aafa20a3f76384ba19a513d39272add13746dcfe0409d8d4974fd464/types_cffi-2.0.0.20260518-py3-none-any.whl", hash = "sha256:5b68a215a95d0eac4203b58e766ff7fe40c2e091b1fa1a9e54111f04cc560084", size = 20198, upload-time = "2026-05-18T06:06:49.83Z" },
 ]
 
 [[package]]
@@ -2780,20 +2781,20 @@ wheels = [
 
 [[package]]
 name = "types-croniter"
-version = "6.2.2.20260508"
+version = "6.2.2.20260518"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/b6/e0/06272cc8dea1d0f0599a150c81e44c4f21270d40cfd10117c2e4fbfa1503/types_croniter-6.2.2.20260508.tar.gz", hash = "sha256:fdbe8984b4a490b2ea446a308fb4d1998214312c90e4b09d6271bc4fa0456e7e", size = 12077, upload-time = "2026-05-08T04:46:30.761Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/20/02/f03a44ded34e6abb125c339647b070f2705a0583782f5638d62ab958cdc2/types_croniter-6.2.2.20260518.tar.gz", hash = "sha256:aceb426b9187bb9255b89d17713d07ac034a2b96b437bfdd5d3a56b46b4eb656", size = 12120, upload-time = "2026-05-18T06:03:11.885Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/23/86/856e2b7795d74ce30e685390ccb61ce0a075b6e4111e88c49fafaca8ed0d/types_croniter-6.2.2.20260508-py3-none-any.whl", hash = "sha256:9038aa3fa264ef16a4e1034f8f8a1fcc7d73da4c56ed1f508e008abab8773bad", size = 9732, upload-time = "2026-05-08T04:46:29.738Z" },
+    { url = "https://files.pythonhosted.org/packages/37/3d/f12c417944d00c42db71de3e334f36a69cafa6767ff3fb705c9e1d101e53/types_croniter-6.2.2.20260518-py3-none-any.whl", hash = "sha256:85018c7ce091428d3643be239ad348e27f9a8fb77ca94335cc39ebeb9403b240", size = 9743, upload-time = "2026-05-18T06:03:10.608Z" },
 ]
 
 [[package]]
 name = "types-dateparser"
-version = "1.4.0.20260508"
+version = "1.4.0.20260518"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/20/14/e38c41741dfb55836cc8c6e3e7ac4bb7b3662ec71f4d0ba4f82213fd6f30/types_dateparser-1.4.0.20260508.tar.gz", hash = "sha256:b4c998ec46b3b047d01b3086bf34f8a7d23a5b1fc0132f95077ec2669a539c32", size = 17604, upload-time = "2026-05-08T04:47:34.974Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c4/ac/e2b54e9aa5c2f9b02563af880e5efa0829277a1cb6121ee159c0b27cb815/types_dateparser-1.4.0.20260518.tar.gz", hash = "sha256:db4ca45883e98e9247db1e7cc0cc09c763d641b87bda7a31cbd6e1cdf80127a9", size = 17642, upload-time = "2026-05-18T06:03:38.555Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/8c/54/9e8beaae7bf54f0f9588a40a1b7b2b4aaa457ec2833b4e07b3cfc9a0120a/types_dateparser-1.4.0.20260508-py3-none-any.whl", hash = "sha256:b829afe62f3d18ad95dec1308e3a832cedc5c2f87fe639f3897697cde0bebd83", size = 24862, upload-time = "2026-05-08T04:47:34.141Z" },
+    { url = "https://files.pythonhosted.org/packages/23/d8/35b5983cf4667d11f19c60f43b747465f1a5b31dd64f33dfc07444596a85/types_dateparser-1.4.0.20260518-py3-none-any.whl", hash = "sha256:c20b4e0979da9edf2729daba71b36b749b7afc18bec6afb6f89f1052d085a0e3", size = 24869, upload-time = "2026-05-18T06:03:37.706Z" },
 ]
 
 [[package]]
@@ -2822,14 +2823,14 @@ wheels = [
 
 [[package]]
 name = "types-ldap3"
-version = "2.9.13.20260508"
+version = "2.9.13.20260518"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "types-pyasn1" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/cd/a0/9286e43759770e9e82f6b383b57b269a9f3924a43fd8935b716879fe764e/types_ldap3-2.9.13.20260508.tar.gz", hash = "sha256:ee4d7900b6ec707d48e9ba1026a4f8f719f0fa1c35abcc9a27df3d9751587dd9", size = 33888, upload-time = "2026-05-08T04:50:27.287Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/fa/6f/d6094c70e3b1d62baacedaa56a41e5a64412313ad1db80acbf66dc05fd9b/types_ldap3-2.9.13.20260518.tar.gz", hash = "sha256:d1ab194a677da0e153ee686b7b7a606cec601d742266a2367d51e2be6d014c08", size = 33911, upload-time = "2026-05-18T06:07:05.497Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/5e/dc/2866cc7a92ef138aaba7ef68f9db50f166f95a058061b0e0296dc1683183/types_ldap3-2.9.13.20260508-py3-none-any.whl", hash = "sha256:85b5b31fb36b394791328f473e57f40072bd7916c114fb1fd26f21d7b6d3948f", size = 56739, upload-time = "2026-05-08T04:50:26.318Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/d7/2ee992a0957c9a36713935b215f55fcea262eb55002468690369bbac1ed0/types_ldap3-2.9.13.20260518-py3-none-any.whl", hash = "sha256:c70656b7e31fc1497ea5e666e7a3a46311898c6b75f526193ba28eb5c649c668", size = 56752, upload-time = "2026-05-18T06:07:04.57Z" },
 ]
 
 [[package]]
@@ -2843,29 +2844,29 @@ wheels = [
 
 [[package]]
 name = "types-mock"
-version = "5.2.0.20260508"
+version = "5.2.0.20260518"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/a7/54/cefdd866e8b69be4ce93288710a55506bf3f8c5eba8c0b0b8322131bd25d/types_mock-5.2.0.20260508.tar.gz", hash = "sha256:2049474a82a678e1979d7a1273891daccab4c19bbf1b28df5594836d675873d3", size = 11535, upload-time = "2026-05-08T04:49:03.87Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ec/a4/26595e2a9407752c2e3cd5b17d7884db847e39834a2575cf15b5c3b19a27/types_mock-5.2.0.20260518.tar.gz", hash = "sha256:49af9c18aac4caa90e0e1e8437e2160cd8b3f126053dae6453d65b393590fcf9", size = 11577, upload-time = "2026-05-18T06:02:42.607Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/86/bf/080b185263af2fc0c25ddf26163f9c59d24caa0edc8c885ba93725fd1ad6/types_mock-5.2.0.20260508-py3-none-any.whl", hash = "sha256:eb90adc8527fba4d800b0d65268f141978789a0398a78ba6bda453cd62de4862", size = 10455, upload-time = "2026-05-08T04:49:03.045Z" },
+    { url = "https://files.pythonhosted.org/packages/82/d6/da3bf7cc26ebe587e8c50a505d302f5755840fc24fbbd704b770c43b764b/types_mock-5.2.0.20260518-py3-none-any.whl", hash = "sha256:3c511875b6f37d30c70add3e72265d1c21202b8544751361e3ca94f7a757a03d", size = 10459, upload-time = "2026-05-18T06:02:41.224Z" },
 ]
 
 [[package]]
 name = "types-oauthlib"
-version = "3.3.0.20260508"
+version = "3.3.0.20260518"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/33/66/e456b222eba5f340a85b75710a2e776467d58feb2f904b26a0a9c732d904/types_oauthlib-3.3.0.20260508.tar.gz", hash = "sha256:a241318a95e101b100dacd636b653dd38f4bd5cc39ff4b3571de69ee9db6b501", size = 26120, upload-time = "2026-05-08T04:47:22.381Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/4f/b9/272610e9b91ce274bd50a34ef9793a1a6e6666fe1acc97462ed5df11e262/types_oauthlib-3.3.0.20260518.tar.gz", hash = "sha256:b713f6c32a0e544d165afed6b953780d99ef6997a6b6ddc07491f72bdaf5307b", size = 26126, upload-time = "2026-05-18T06:02:13.485Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/dc/ee/5d70ed4a10e9c3b41fb01dd0561fc3d759f226848576fc08b88a1e941d57/types_oauthlib-3.3.0.20260508-py3-none-any.whl", hash = "sha256:cb51259d326c2dc686ad9b32ad95a9301cfd7f206bfe260306a477961ad43843", size = 48960, upload-time = "2026-05-08T04:47:21.051Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/64/8890a1bd403dc90711c15298e1054d72e8865967d169abaf30fb93a750f6/types_oauthlib-3.3.0.20260518-py3-none-any.whl", hash = "sha256:7e35e6e8731e49fc131fb0a94b5e473ac70722dd039c308501de2a5c137ed024", size = 48964, upload-time = "2026-05-18T06:02:12.098Z" },
 ]
 
 [[package]]
 name = "types-psycopg2"
-version = "2.9.21.20260509"
+version = "2.9.21.20260518"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/71/9e/a78cffd63e14c45fc05664c42739b2b15938acff92ca59e22b22ced5695e/types_psycopg2-2.9.21.20260509.tar.gz", hash = "sha256:0422105f691a409e9d8048c2205aca9d694b70823248c6614393444017e9f088", size = 27215, upload-time = "2026-05-09T04:58:40.256Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/3e/46/61f27369bd1426ea718f759249a5160463522ace6325bcfcbb846305646d/types_psycopg2-2.9.21.20260518.tar.gz", hash = "sha256:8b1f80d90d6799a4fcdac12198b382a8feee9ed4340d5f69b56fc5ffa0644143", size = 27241, upload-time = "2026-05-18T06:01:42.167Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/be/b3/f4d11df63430d7e14b2889caf73f6f6bf9147a51d866ce2da4c07d9f3c8b/types_psycopg2-2.9.21.20260509-py3-none-any.whl", hash = "sha256:69f6dae384bbea830dff23621936423035db152af901331e6f9c46f7c4f4b24f", size = 24940, upload-time = "2026-05-09T04:58:39.208Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/87/41f48317ec5fea2cc9e881547600f40bcf9021f2b63183d9b0705d0aa72b/types_psycopg2-2.9.21.20260518-py3-none-any.whl", hash = "sha256:2fd728a4fa3860db0a4a9813e5f49c30ed329b3d2e60e73530d9db01b2b98420", size = 24955, upload-time = "2026-05-18T06:01:40.764Z" },
 ]
 
 [[package]]
@@ -2892,45 +2893,45 @@ wheels = [
 
 [[package]]
 name = "types-python-dateutil"
-version = "2.9.0.20260508"
+version = "2.9.0.20260518"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/bd/9b/ee1674cbe9ec50bb824f35a5dc0ce5fd1f1b6196ba1213e3fe6f33b4ce32/types_python_dateutil-2.9.0.20260508.tar.gz", hash = "sha256:596a6d63d81f587bf04c8254fb78df9d2344e915ce67948d7400512e3a6206d5", size = 17033, upload-time = "2026-05-08T04:47:08.248Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/8d/e8/c01bdf0d7c3659428c091fbd693177093639565bcbc86bc20098e6d37cc6/types_python_dateutil-2.9.0.20260518.tar.gz", hash = "sha256:51f02dc03b61c7f6a07df45797d4dfe8a1aa47f0b7db9ad89f6fd3a1a70e1b51", size = 17082, upload-time = "2026-05-18T06:05:24.508Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/db/7c/1788ff10edf56031d74ad3fba40947e0e8b82e3a529b30e6b7d71c191dec/types_python_dateutil-2.9.0.20260508-py3-none-any.whl", hash = "sha256:bfc6fd2d81aa86e5ac97206a64304f6bd247426eedbca9b98619bbc48c6a1c10", size = 18425, upload-time = "2026-05-08T04:47:07.207Z" },
+    { url = "https://files.pythonhosted.org/packages/36/22/169273273ca34e9ab0ae2f387ba72ed7e09faaaf834da01d6b89c2bea71a/types_python_dateutil-2.9.0.20260518-py3-none-any.whl", hash = "sha256:d6a9c5bd0de61460c8fdef8ab2b400f956a1a1075cce08d4e2b4434e478c50b8", size = 18431, upload-time = "2026-05-18T06:05:23.641Z" },
 ]
 
 [[package]]
 name = "types-pyyaml"
-version = "6.0.12.20260510"
+version = "6.0.12.20260518"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/36/85/0d9fafce21be112e977a89677f1ce9d1aef921d745b17c758c93e861c11f/types_pyyaml-6.0.12.20260510.tar.gz", hash = "sha256:09c1f1cb65a6eebea1e2e51ccf4918b8288e152909609a35cdb0d805efd125ad", size = 17831, upload-time = "2026-05-10T05:26:28.136Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/b8/83/4a1afc3fbfcf5b8d46fc390cd95ed6b0dc9010a265f4e9f46314efffa37a/types_pyyaml-6.0.12.20260518.tar.gz", hash = "sha256:d917f83fb38462550338c1297faedd860b3ec83912b96b1e3d73255f7473e466", size = 17850, upload-time = "2026-05-18T06:01:58.675Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d3/ad/fd618a218925daada7b8a5e7326e662599fa5fdff4a4c44ab2795bd2d9ca/types_pyyaml-6.0.12.20260510-py3-none-any.whl", hash = "sha256:3492eb9ba4d9d833473214c4d5736cccf5f37d93f5854059721e1c84f785309d", size = 20304, upload-time = "2026-05-10T05:26:26.981Z" },
+    { url = "https://files.pythonhosted.org/packages/06/a2/c01db32be2ae7d6a1689972f3c492b149ee4e164b12fdfd9f64b50888215/types_pyyaml-6.0.12.20260518-py3-none-any.whl", hash = "sha256:d2150f75a231c9fe9c7463bd29487d93e60bac90400287351384bc2284eba7cd", size = 20312, upload-time = "2026-05-18T06:01:57.368Z" },
 ]
 
 [[package]]
 name = "types-requests"
-version = "2.33.0.20260508"
+version = "2.33.0.20260518"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "urllib3" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/c7/6b/eb226bdd61a982c9a03e02c657fb4ab001733506e6423906ac142331f2e3/types_requests-2.33.0.20260508.tar.gz", hash = "sha256:81b2ae5f0d20967714a6aa5ef9284c05570d7cb06b7de8f2a77b918b63ddd411", size = 23991, upload-time = "2026-05-08T04:50:56.818Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e0/01/c5a19253fe1ac159159ddf9a3a07cec8bb5e486ec4d9002ad2821da0e5d2/types_requests-2.33.0.20260518.tar.gz", hash = "sha256:df7bd3bfe0ca8402dfb841e7d9be714bb5578203283d66d7dc4ef69343449a5e", size = 24752, upload-time = "2026-05-18T06:07:37.966Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/cb/96/080db0afdf2c5cc5fe512b41354e8d114fe8f65e9510c56ff8dfd40216ce/types_requests-2.33.0.20260508-py3-none-any.whl", hash = "sha256:fa01459cca184229713df03709db46a905325906d27e042cd4fd7ea3d15d3400", size = 20722, upload-time = "2026-05-08T04:50:55.548Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/bc/b139710a3b6018f7fb2b9508b35c8af564e61bf2bf4fa619d088f3e16f85/types_requests-2.33.0.20260518-py3-none-any.whl", hash = "sha256:626d697d1adaaff76e2044dc8c5c051d8f21abc157bdfe204a75558076fe0bf0", size = 21391, upload-time = "2026-05-18T06:07:37.044Z" },
 ]
 
 [[package]]
 name = "types-requests-oauthlib"
-version = "2.0.0.20260508"
+version = "2.0.0.20260518"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "types-oauthlib" },
     { name = "types-requests" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/da/c5/ace9a3aa168cb7467575dbe8fba01952f2056e594c818b111ad525d0f4d4/types_requests_oauthlib-2.0.0.20260508.tar.gz", hash = "sha256:eb5a73f1a990b9b02b4e800ad9c19686a82e1421cecc143b110675de7995e85b", size = 11174, upload-time = "2026-05-08T04:52:31.66Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ba/46/4ec142a7092ef6c2b7ba9e54768dfec183c96e3ff91790e30eb0796e61e5/types_requests_oauthlib-2.0.0.20260518.tar.gz", hash = "sha256:734f0c71c647aa5fe2718992a85e62138386b5b4cd19f40c3e5aaa2892076edd", size = 11227, upload-time = "2026-05-18T06:08:01.176Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/9b/6c/7f33df8d3cdc88e2118cafb1a2dd08d9558cc87cddea8d3d674d476e5864/types_requests_oauthlib-2.0.0.20260508-py3-none-any.whl", hash = "sha256:f649bbe1f14704d4b056bd5bd3795209c9e8389bb4155869549c632ac51e4bde", size = 14321, upload-time = "2026-05-08T04:52:30.843Z" },
+    { url = "https://files.pythonhosted.org/packages/87/6a/c9248922e77af1ae051110d4f3252dd82ac688c68563a3d4075dbd13dc68/types_requests_oauthlib-2.0.0.20260518-py3-none-any.whl", hash = "sha256:086cebd125808af81e41795ccf09a002dcc4523920a155e8926fdae98c4a0a90", size = 14326, upload-time = "2026-05-18T06:08:00.281Z" },
 ]
 
 [[package]]
@@ -2944,11 +2945,11 @@ wheels = [
 
 [[package]]
 name = "types-setuptools"
-version = "82.0.0.20260508"
+version = "82.0.0.20260518"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/a3/53/8c7ca2263165f13b493f5258a317acb09cab02742e816c38cd5fe6f09e5a/types_setuptools-82.0.0.20260508.tar.gz", hash = "sha256:e76ade6f42ba9b4211636b84b65a8e55948a67ffe81f9a44e66b8af93d57e77e", size = 44919, upload-time = "2026-05-08T04:47:48.32Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/38/bc/73c2c27e047e42f114ac50fb3bdef986c56cbdb68096f8690eeafb839a93/types_setuptools-82.0.0.20260518.tar.gz", hash = "sha256:3b743cfe63d0981ea4c15b90710fc1ed41e3464a537d51e705be514e891c1d07", size = 44999, upload-time = "2026-05-18T06:02:55.642Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d0/67/f49414a00fc61a4bc64bd0ff879bb230818b68e62c5cf91fc7c098912aac/types_setuptools-82.0.0.20260508-py3-none-any.whl", hash = "sha256:ba1d863bbd11526d7232bca8d5a4aebe1d38fa1677a550f47a2692b7d5776900", size = 68395, upload-time = "2026-05-08T04:47:47.391Z" },
+    { url = "https://files.pythonhosted.org/packages/32/8f/d5e2d493f09a7a98c95619edda1cb37cee377626c0a869d53274c26f2858/types_setuptools-82.0.0.20260518-py3-none-any.whl", hash = "sha256:31c04a62b57a653a5021caf191be0f10f70df890f813b51f02bab3969d300f20", size = 68444, upload-time = "2026-05-18T06:02:54.582Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Why

Slack's built-in Slackbot notification ("You have been added to @handle") no longer fires reliably. When the `slack-usergroups` integration reassigns a usergroup handle (e.g., `@app-sre-onboarding-ic`), the new member has no way of knowing the handle now points to them — unless they happen to notice.

Previously, Slack sent an automatic DM like:

> You have been added to the AppSRE Onboarding IC (@app-sre-onboarding-ic) user group on the Internal Red Hat workspace by @app-sre-bot.

This no longer happens, so we implement it ourselves.

## Summary

- Add an optional `notifications` field to the slack-usergroups schema (list of typed notification actions, following the `FileSyncFileOperation` discriminated union pattern)
- When configured per-usergroup in app-interface, the integration sends DM notifications to users added to or removed from a usergroup
- When not configured, behavior is unchanged (backward compatible)

Example app-interface data:
```yaml
notifications:
  - action: addUser
    message: "Heads up — this handle has been reassigned to you."
  - action: removeUser
    message: "You have been removed from this usergroup."
```

### Changes across layers

- **Layer 1** (`SlackApi`): add `conversations_open` for opening DM channels
- **Layer 2** (`SlackWorkspaceClient`): add `send_dm` with org_username → user_id resolution
- **External router**: extend `ChatRequest` with optional `user` field (mutually exclusive with `channel`) — same endpoint handles both channel posts and DMs
- **Domain model**: add `NotificationAddUser` / `NotificationRemoveUser` discriminated union types on `SlackUsergroupConfig.notifications`
- **Task**: publish `dm-notification` events per configured notification type after successful `update_users` actions
- **Subscriber**: dispatch `dm-notification` events to `send_dm` using subscriber's own configured workspace/token (zero business logic — just iterate users, send message)
- **Client-side**: wire `notifications` from GQL permissions query

### Schema changes (separate PR in qontract-schemas)

- `permission-1.yml`: add `notifications` array with `action` enum (`addUser` / `removeUser`) and `message`
- `schema.yml`: add `SlackUsergroupNotification_v1` type on `PermissionSlackUsergroup_v1`

## Test plan

- [x] `qontract_utils` tests: `conversations_open` on `SlackApi`
- [x] `qontract_api` tests: `send_dm` and `_resolve_user_id` on `SlackWorkspaceClient`
- [x] `qontract_api` tests: `_publish_dm_notifications` — add, remove, both, skip when empty
- [x] `qontract_api` tests: subscriber DM notification dispatch and per-user error isolation
- [x] Full test suites pass: 539 (qontract_utils) + 422 (qontract_api)
- [ ] Deploy with a test usergroup that has `notifications` configured, verify DMs arrive

Jira: https://issues.redhat.com/browse/APPSRE-14273

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Send Slack chat as either a channel message or a direct message to a user.
  * Configure Slack usergroups with add/remove DM notification actions that publish per-user DM events and trigger per-user DMs.
  * Client libraries and workspace client now support resolving users and sending DMs; notification models are publicly exported.

* **Documentation**
  * API docs updated to require exactly one of channel or user and document 404/502 error cases.

* **Tests**
  * Added tests for DM sending, notification publishing, and event handling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/app-sre/qontract-reconcile/pull/5550)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->