### PR TITLE
Set template file with separate Slack webhooks in multiple environments

### DIFF
--- a/helm/qontract-reconcile/templates/template.yaml
+++ b/helm/qontract-reconcile/templates/template.yaml
@@ -85,13 +85,11 @@ objects:
               secretKeyRef:
                 key: slack.webhook_url
                 name: app-interface
-          {{- if $logs.govSlack }}
           - name: SLACK_TRIGGERS_WEBHOOK_URL
             valueFrom:
               secretKeyRef:
                 key: slack.triggers_url
                 name: app-interface
-          {{- end }}
           {{- if $logs.slackErrorFilter }}
           - name: SLACK_ERRORS_ONLY_WEBHOOK_URL
             valueFrom:

--- a/helm/qontract-reconcile/templates/template.yaml
+++ b/helm/qontract-reconcile/templates/template.yaml
@@ -217,21 +217,12 @@ objects:
               {{- if $logs.slack }}
               <store>
                 @type slack
-                {{- if $logs.govSlack }}
                 {{- if $integration.trigger }}
                 webhook_url ${SLACK_TRIGGERS_WEBHOOK_URL}
                 channel ${SLACK_CHANNEL_TRIGGER}
                 {{- else }}
                 webhook_url ${SLACK_WEBHOOK_URL}
                 channel ${SLACK_CHANNEL}
-                {{- end }}
-                {{- else }}
-                webhook_url ${SLACK_WEBHOOK_URL}
-                {{- if $integration.trigger }}
-                channel ${SLACK_CHANNEL_TRIGGER}
-                {{- else }}
-                channel ${SLACK_CHANNEL}
-                {{- end }}
                 {{- end }}
                 icon_emoji ${SLACK_ICON_EMOJI}
                 username sd-app-sre-bot

--- a/openshift/qontract-manager.yaml
+++ b/openshift/qontract-manager.yaml
@@ -45,6 +45,11 @@ objects:
               secretKeyRef:
                 key: slack.webhook_url
                 name: app-interface
+          - name: SLACK_TRIGGERS_WEBHOOK_URL
+            valueFrom:
+              secretKeyRef:
+                key: slack.triggers_url
+                name: app-interface
           - name: SLACK_CHANNEL
             value: ${SLACK_CHANNEL}
           - name: SLACK_ICON_EMOJI

--- a/reconcile/test/fixtures/helm/logs_slack.yml
+++ b/reconcile/test/fixtures/helm/logs_slack.yml
@@ -45,6 +45,11 @@ objects:
               secretKeyRef:
                 key: slack.webhook_url
                 name: app-interface
+          - name: SLACK_TRIGGERS_WEBHOOK_URL
+            valueFrom:
+              secretKeyRef:
+                key: slack.triggers_url
+                name: app-interface
           - name: SLACK_CHANNEL
             value: ${SLACK_CHANNEL}
           - name: SLACK_ICON_EMOJI


### PR DESCRIPTION
Commercial Slack was running a deprecated webhook, which has now been deleted. With the deletion, the two Slack channels mentioned in the `template.yml` file needs separate webhooks. The current `template.yaml` commercial setup is set to only recognize one webhook, which is the removed deprecated webhook. This change will mimic in-boundary patterns and treat the reconcile and triggers Slack channels as Slack channels with its own unique webhook.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Slack notifications now consistently route integration messages using trigger-based webhook and channel selection when applicable.

* **Chores**
  * The trigger webhook URL (SLACK_TRIGGERS_WEBHOOK_URL) is now provided whenever Slack integration is enabled, ensuring trigger messages can be delivered.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/app-sre/qontract-reconcile/pull/5551?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->