### PR TITLE
feat(mr): add autopromote MR class for qontract-validator

### DIFF
--- a/reconcile/utils/mr/__init__.py
+++ b/reconcile/utils/mr/__init__.py
@@ -18,6 +18,7 @@ from reconcile.utils.mr.promote_qontract import (
     PromoteQontractReconcileCommercial,
     PromoteQontractSchemas,
     PromoteQontractServer,
+    PromoteQontractValidator,
 )
 from reconcile.utils.mr.user_maintenance import (
     CreateDeleteUserAppInterface,
@@ -37,6 +38,7 @@ __all__ = [
     "PromoteQontractReconcileCommercial",
     "PromoteQontractSchemas",
     "PromoteQontractServer",
+    "PromoteQontractValidator",
     "UnknownMergeRequestTypeError",
     "init_from_sqs_message",
 ]

--- a/reconcile/utils/mr/promote_qontract.py
+++ b/reconcile/utils/mr/promote_qontract.py
@@ -266,6 +266,20 @@ Please use `/retest` once the RPA finished (that should be the case after ~5min 
         )
 
 
+class PromoteQontractValidator(PromoteQontractReconcileCommercial):
+    name = "promote_qontract_validator"
+    project_display_name = "qontract-validator"
+
+    def process(self, gitlab_cli: GitLabApi) -> None:
+        self._process_by(
+            "line_search",
+            gitlab_cli=gitlab_cli,
+            path=".env",
+            search_text="export VALIDATOR_IMAGE_TAG=",
+            replace_text=f"export VALIDATOR_IMAGE_TAG={self.version}",
+        )
+
+
 class PromoteQontractServer(PromoteQontractReconcileCommercial):
     name = "promote_qontract_server"
     project_display_name = "qontract-server"


### PR DESCRIPTION
Adds PromoteQontractValidator, which updates VALIDATOR_IMAGE_TAG in app-interface's .env when triggered via the promote_qontract_validator SQS message type.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for promoting and updating validator image tags in merge requests.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/app-sre/qontract-reconcile/pull/5556?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->