### PR TITLE
build(deps): upgrade Python dependencies (batch 2)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ dependencies = [
     "filetype~=1.2.0",
     "gql==3.1.0",
     "hvac==2.4.0",
-    "jenkins-job-builder==6.4.2",
+    "jenkins-job-builder==6.4.4",
     "Jinja2>=2.10.1,<3.2.0",
     "jira==3.10.5",
     "jsonpatch~=1.33",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -304,5 +304,6 @@ module = [
     "sendgrid.*",
     "sshtunnel.*",
     "terrascript.*",
+    "yamllint.*",
 ]
 ignore_missing_imports = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,7 @@ dependencies = [
     "requests~=2.32",
     "rich==15.0.0",
     "semver~=3.0",
-    "sendgrid>=6.4.8,<6.5.0",
+    "sendgrid==6.12.5",
     "sentry-sdk~=2.0",
     # jenkins-job-builder uses pkg_resources from setuptools. pkg_resources is being deprecated and will be removed
     # in setuptools 81.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,7 +56,7 @@ dependencies = [
     "slack_sdk>=3.10,<4.0",
     "sretoolbox==3.2.1",
     "sshtunnel>=0.4.0",
-    "tabulate>=0.8.6,<0.9.0",
+    "tabulate==0.10.0",
     "terrascript==0.9.0",
     "UnleashClient~=5.11",
     "urllib3~=2.2",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,7 +60,7 @@ dependencies = [
     "terrascript==0.9.0",
     "UnleashClient~=5.11",
     "urllib3~=2.2",
-    "yamllint==1.34.0",
+    "yamllint==1.38.0",
     "qontract-api-client",
     "qontract-utils",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ dependencies = [
     "Click>=7.0,<9.0",
     "croniter==6.2.2",
     "dateparser~=1.1.7",
-    "deepdiff==9.0.0",
+    "deepdiff==9.1.0",
     "dnspython~=2.1",
     "dt==1.1.73",
     "filetype~=1.2.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ dependencies = [
     "boto3==1.43.10",
     "botocore==1.43.10",
     "Click>=7.0,<9.0",
-    "croniter>=1.0.15,<1.1.0",
+    "croniter==6.2.2",
     "dateparser~=1.1.7",
     "deepdiff==9.0.0",
     "dnspython~=2.1",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ dependencies = [
     "jsonpatch~=1.33",
     "jsonpath-ng==1.7.0",
     "jsonpointer==3.1.1",
-    "kubernetes==32.0.1",
+    "kubernetes==35.0.0",
     "ldap3>=2.9.1,<2.10.0",
     "networkx~=3.6",
     "prometheus-client~=0.8",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ dependencies = [
     "botocore==1.43.10",
     "Click>=7.0,<9.0",
     "croniter==6.2.2",
-    "dateparser~=1.1.7",
+    "dateparser==1.4.0",
     "deepdiff==9.1.0",
     "dnspython~=2.1",
     "dt==1.1.73",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ dependencies = [
     "jira==3.10.5",
     "jsonpatch~=1.33",
     "jsonpath-ng==1.7.0",
-    "jsonpointer~=2.4",
+    "jsonpointer==3.1.1",
     "kubernetes==32.0.1",
     "ldap3>=2.9.1,<2.10.0",
     "networkx~=3.6",

--- a/reconcile/test/test_sendgrid_teammates.py
+++ b/reconcile/test/test_sendgrid_teammates.py
@@ -1,5 +1,4 @@
-from collections.abc import Mapping
-from typing import Any
+from typing import TYPE_CHECKING, Any
 from unittest.mock import MagicMock
 
 import pytest
@@ -11,6 +10,9 @@ from reconcile.sendgrid_teammates import (
     fetch_desired_state,
     raise_if_error,
 )
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping
 
 
 @pytest.fixture

--- a/reconcile/test/test_sendgrid_teammates.py
+++ b/reconcile/test/test_sendgrid_teammates.py
@@ -1,0 +1,142 @@
+from collections.abc import Mapping
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+from reconcile.sendgrid_teammates import (
+    SendGridAPIError,
+    Teammate,
+    act,
+    fetch_desired_state,
+    raise_if_error,
+)
+
+
+class TestTeammate:
+    def test_email_sets_username(self) -> None:
+        t = Teammate("alice@redhat.com")
+        assert t.username == "alice"
+        assert t.email == "alice@redhat.com"
+
+    def test_explicit_username(self) -> None:
+        t = Teammate("alice@redhat.com", username="custom")
+        assert t.username == "custom"
+
+    def test_pending_with_token(self) -> None:
+        t = Teammate("a@b.com", pending_token="tok123")
+        assert t.pending is True
+
+    def test_not_pending_without_token(self) -> None:
+        t = Teammate("a@b.com")
+        assert t.pending is False
+
+
+class TestFetchDesiredState:
+    def test_empty_users(self) -> None:
+        assert fetch_desired_state([]) == {}
+
+    def test_users_with_sendgrid_accounts(self) -> None:
+        users: list[Mapping[str, Any]] = [
+            {
+                "org_username": "alice",
+                "roles": [
+                    {
+                        "sendgrid_accounts": [{"name": "acct-1"}],
+                    }
+                ],
+            },
+            {
+                "org_username": "bob",
+                "roles": [
+                    {
+                        "sendgrid_accounts": [{"name": "acct-1"}],
+                    }
+                ],
+            },
+        ]
+        result = fetch_desired_state(users)
+        assert "acct-1" in result
+        assert len(result["acct-1"]) == 2
+        emails = {t.email for t in result["acct-1"]}
+        assert emails == {"alice@redhat.com", "bob@redhat.com"}
+
+    def test_users_without_roles(self) -> None:
+        users: list[Mapping[str, Any]] = [{"org_username": "alice", "roles": None}]
+        assert fetch_desired_state(users) == {}
+
+
+class TestRaiseIfError:
+    def test_success_does_not_raise(self) -> None:
+        response = MagicMock()
+        response.status_code = 200
+        raise_if_error(response)
+
+    def test_error_raises(self) -> None:
+        response = MagicMock()
+        response.status_code = 400
+        response.body = b"Bad Request"
+        with pytest.raises(SendGridAPIError, match="Bad Request"):
+            raise_if_error(response)
+
+
+class TestAct:
+    @staticmethod
+    def _mock_response(status_code: int = 200) -> MagicMock:
+        r = MagicMock()
+        r.status_code = status_code
+        return r
+
+    def test_dry_run_no_api_calls(self) -> None:
+        sg_client = MagicMock()
+        desired = [Teammate("new@redhat.com")]
+        current = [Teammate("old@redhat.com", username="old")]
+        error = act(
+            dry_run=True,
+            sg_client=sg_client,
+            desired_state=desired,
+            current_state=current,
+        )
+        assert error is False
+        sg_client.teammates.post.assert_not_called()
+
+    def test_delete_user(self) -> None:
+        sg_client = MagicMock()
+        sg_client.teammates._("old").delete.return_value = self._mock_response()
+        desired: list[Teammate] = []
+        current = [Teammate("old@redhat.com", username="old")]
+        error = act(
+            dry_run=False,
+            sg_client=sg_client,
+            desired_state=desired,
+            current_state=current,
+        )
+        assert error is False
+        sg_client.teammates._("old").delete.assert_called_once()
+
+    def test_invite_user(self) -> None:
+        sg_client = MagicMock()
+        sg_client.teammates.post.return_value = self._mock_response()
+        desired = [Teammate("new@redhat.com")]
+        current: list[Teammate] = []
+        error = act(
+            dry_run=False,
+            sg_client=sg_client,
+            desired_state=desired,
+            current_state=current,
+        )
+        assert error is False
+        sg_client.teammates.post.assert_called_once()
+
+    def test_no_changes_needed(self) -> None:
+        sg_client = MagicMock()
+        desired = [Teammate("same@redhat.com")]
+        current = [Teammate("same@redhat.com", username="same")]
+        error = act(
+            dry_run=False,
+            sg_client=sg_client,
+            desired_state=desired,
+            current_state=current,
+        )
+        assert error is False
+        sg_client.teammates.post.assert_not_called()

--- a/reconcile/test/test_sendgrid_teammates.py
+++ b/reconcile/test/test_sendgrid_teammates.py
@@ -13,130 +13,128 @@ from reconcile.sendgrid_teammates import (
 )
 
 
-class TestTeammate:
-    def test_email_sets_username(self) -> None:
-        t = Teammate("alice@redhat.com")
-        assert t.username == "alice"
-        assert t.email == "alice@redhat.com"
-
-    def test_explicit_username(self) -> None:
-        t = Teammate("alice@redhat.com", username="custom")
-        assert t.username == "custom"
-
-    def test_pending_with_token(self) -> None:
-        t = Teammate("a@b.com", pending_token="tok123")
-        assert t.pending is True
-
-    def test_not_pending_without_token(self) -> None:
-        t = Teammate("a@b.com")
-        assert t.pending is False
+@pytest.fixture
+def sg_client() -> MagicMock:
+    client = MagicMock()
+    response = MagicMock()
+    response.status_code = 200
+    client.teammates.post.return_value = response
+    client.teammates._().delete.return_value = response
+    return client
 
 
-class TestFetchDesiredState:
-    def test_empty_users(self) -> None:
-        assert fetch_desired_state([]) == {}
-
-    def test_users_with_sendgrid_accounts(self) -> None:
-        users: list[Mapping[str, Any]] = [
-            {
-                "org_username": "alice",
-                "roles": [
-                    {
-                        "sendgrid_accounts": [{"name": "acct-1"}],
-                    }
-                ],
-            },
-            {
-                "org_username": "bob",
-                "roles": [
-                    {
-                        "sendgrid_accounts": [{"name": "acct-1"}],
-                    }
-                ],
-            },
-        ]
-        result = fetch_desired_state(users)
-        assert "acct-1" in result
-        assert len(result["acct-1"]) == 2
-        emails = {t.email for t in result["acct-1"]}
-        assert emails == {"alice@redhat.com", "bob@redhat.com"}
-
-    def test_users_without_roles(self) -> None:
-        users: list[Mapping[str, Any]] = [{"org_username": "alice", "roles": None}]
-        assert fetch_desired_state(users) == {}
+@pytest.mark.parametrize(
+    "email, username, pending_token, expected_username, expected_pending",
+    [
+        pytest.param(
+            "alice@redhat.com", None, None, "alice", False, id="email-derives-username"
+        ),
+        pytest.param(
+            "alice@redhat.com",
+            "custom",
+            None,
+            "custom",
+            False,
+            id="explicit-username",
+        ),
+        pytest.param("a@b.com", None, "tok123", "a", True, id="pending-with-token"),
+    ],
+)
+def test_teammate(
+    email: str,
+    username: str | None,
+    pending_token: str | None,
+    expected_username: str,
+    expected_pending: bool,
+) -> None:
+    t = Teammate(email, pending_token=pending_token, username=username)
+    assert t.email == email
+    assert t.username == expected_username
+    assert t.pending is expected_pending
 
 
-class TestRaiseIfError:
-    def test_success_does_not_raise(self) -> None:
-        response = MagicMock()
-        response.status_code = 200
+def test_fetch_desired_state_empty() -> None:
+    assert fetch_desired_state([]) == {}
+
+
+def test_fetch_desired_state_with_accounts() -> None:
+    users: list[Mapping[str, Any]] = [
+        {
+            "org_username": "alice",
+            "roles": [{"sendgrid_accounts": [{"name": "acct-1"}]}],
+        },
+        {
+            "org_username": "bob",
+            "roles": [{"sendgrid_accounts": [{"name": "acct-1"}]}],
+        },
+    ]
+    result = fetch_desired_state(users)
+    assert "acct-1" in result
+    assert len(result["acct-1"]) == 2
+    assert {t.email for t in result["acct-1"]} == {
+        "alice@redhat.com",
+        "bob@redhat.com",
+    }
+
+
+def test_fetch_desired_state_no_roles() -> None:
+    users: list[Mapping[str, Any]] = [{"org_username": "alice", "roles": None}]
+    assert fetch_desired_state(users) == {}
+
+
+def test_raise_if_error_success() -> None:
+    response = MagicMock()
+    response.status_code = 200
+    raise_if_error(response)
+
+
+def test_raise_if_error_failure() -> None:
+    response = MagicMock()
+    response.status_code = 400
+    response.body = b"Bad Request"
+    with pytest.raises(SendGridAPIError, match="Bad Request"):
         raise_if_error(response)
 
-    def test_error_raises(self) -> None:
-        response = MagicMock()
-        response.status_code = 400
-        response.body = b"Bad Request"
-        with pytest.raises(SendGridAPIError, match="Bad Request"):
-            raise_if_error(response)
+
+def test_act_dry_run(sg_client: MagicMock) -> None:
+    error = act(
+        dry_run=True,
+        sg_client=sg_client,
+        desired_state=[Teammate("new@redhat.com")],
+        current_state=[Teammate("old@redhat.com", username="old")],
+    )
+    assert error is False
+    sg_client.teammates.post.assert_not_called()
 
 
-class TestAct:
-    @staticmethod
-    def _mock_response(status_code: int = 200) -> MagicMock:
-        r = MagicMock()
-        r.status_code = status_code
-        return r
+def test_act_delete_user(sg_client: MagicMock) -> None:
+    error = act(
+        dry_run=False,
+        sg_client=sg_client,
+        desired_state=[],
+        current_state=[Teammate("old@redhat.com", username="old")],
+    )
+    assert error is False
+    sg_client.teammates._("old").delete.assert_called_once()
 
-    def test_dry_run_no_api_calls(self) -> None:
-        sg_client = MagicMock()
-        desired = [Teammate("new@redhat.com")]
-        current = [Teammate("old@redhat.com", username="old")]
-        error = act(
-            dry_run=True,
-            sg_client=sg_client,
-            desired_state=desired,
-            current_state=current,
-        )
-        assert error is False
-        sg_client.teammates.post.assert_not_called()
 
-    def test_delete_user(self) -> None:
-        sg_client = MagicMock()
-        sg_client.teammates._("old").delete.return_value = self._mock_response()
-        desired: list[Teammate] = []
-        current = [Teammate("old@redhat.com", username="old")]
-        error = act(
-            dry_run=False,
-            sg_client=sg_client,
-            desired_state=desired,
-            current_state=current,
-        )
-        assert error is False
-        sg_client.teammates._("old").delete.assert_called_once()
+def test_act_invite_user(sg_client: MagicMock) -> None:
+    error = act(
+        dry_run=False,
+        sg_client=sg_client,
+        desired_state=[Teammate("new@redhat.com")],
+        current_state=[],
+    )
+    assert error is False
+    sg_client.teammates.post.assert_called_once()
 
-    def test_invite_user(self) -> None:
-        sg_client = MagicMock()
-        sg_client.teammates.post.return_value = self._mock_response()
-        desired = [Teammate("new@redhat.com")]
-        current: list[Teammate] = []
-        error = act(
-            dry_run=False,
-            sg_client=sg_client,
-            desired_state=desired,
-            current_state=current,
-        )
-        assert error is False
-        sg_client.teammates.post.assert_called_once()
 
-    def test_no_changes_needed(self) -> None:
-        sg_client = MagicMock()
-        desired = [Teammate("same@redhat.com")]
-        current = [Teammate("same@redhat.com", username="same")]
-        error = act(
-            dry_run=False,
-            sg_client=sg_client,
-            desired_state=desired,
-            current_state=current,
-        )
-        assert error is False
-        sg_client.teammates.post.assert_not_called()
+def test_act_no_changes(sg_client: MagicMock) -> None:
+    error = act(
+        dry_run=False,
+        sg_client=sg_client,
+        desired_state=[Teammate("same@redhat.com")],
+        current_state=[Teammate("same@redhat.com", username="same")],
+    )
+    assert error is False
+    sg_client.teammates.post.assert_not_called()

--- a/tools/template_validation.py
+++ b/tools/template_validation.py
@@ -4,8 +4,8 @@ import sys
 
 import click
 from qontract_utils.ruamel import create_ruamel_instance
-from yamllint import linter  # type: ignore
-from yamllint.config import YamlLintConfig  # type: ignore
+from yamllint import linter
+from yamllint.config import YamlLintConfig
 
 from reconcile.gql_definitions.templating.templates import TemplateV1
 from reconcile.templating.validator import TemplateDiff, TemplateValidatorIntegration

--- a/tools/test/test_template_validation_yamllint.py
+++ b/tools/test/test_template_validation_yamllint.py
@@ -1,0 +1,28 @@
+from yamllint import linter
+from yamllint.config import YamlLintConfig
+
+
+def test_yamllint_valid_yaml() -> None:
+    config = YamlLintConfig("extends: default")
+    problems = list(linter.run("---\nkey: value\n", config, ""))
+    assert not problems
+
+
+def test_yamllint_invalid_yaml() -> None:
+    config = YamlLintConfig("extends: default")
+    problems = list(linter.run("key: value\nkey: duplicate\n", config, ""))
+    assert any("duplication" in p.desc for p in problems)
+
+
+def test_yamllint_config_from_content() -> None:
+    config = YamlLintConfig("rules:\n  line-length:\n    max: 10\n")
+    problems = list(linter.run("key: this is a very long value\n", config, ""))
+    assert any("line too long" in p.desc for p in problems)
+
+
+def test_lint_problem_attributes() -> None:
+    config = YamlLintConfig("rules:\n  trailing-spaces: enable\n")
+    problems = list(linter.run("key: value   \n", config, ""))
+    assert len(problems) >= 1
+    assert problems[0].line > 0
+    assert isinstance(problems[0].desc, str)

--- a/tools/test/test_template_validation_yamllint.py
+++ b/tools/test/test_template_validation_yamllint.py
@@ -1,23 +1,42 @@
+import pytest
 from yamllint import linter
 from yamllint.config import YamlLintConfig
 
 
-def test_yamllint_valid_yaml() -> None:
-    config = YamlLintConfig("extends: default")
-    problems = list(linter.run("---\nkey: value\n", config, ""))
-    assert not problems
-
-
-def test_yamllint_invalid_yaml() -> None:
-    config = YamlLintConfig("extends: default")
-    problems = list(linter.run("key: value\nkey: duplicate\n", config, ""))
-    assert any("duplication" in p.desc for p in problems)
-
-
-def test_yamllint_config_from_content() -> None:
-    config = YamlLintConfig("rules:\n  line-length:\n    max: 10\n")
-    problems = list(linter.run("key: this is a very long value\n", config, ""))
-    assert any("line too long" in p.desc for p in problems)
+@pytest.mark.parametrize(
+    "yaml_input, config_text, expected_problem",
+    [
+        pytest.param(
+            "---\nkey: value\n",
+            "extends: default",
+            None,
+            id="valid-yaml",
+        ),
+        pytest.param(
+            "key: value\nkey: duplicate\n",
+            "extends: default",
+            "duplication",
+            id="duplicate-key",
+        ),
+        pytest.param(
+            "key: this is a very long value\n",
+            "rules:\n  line-length:\n    max: 10\n",
+            "line too long",
+            id="line-too-long",
+        ),
+    ],
+)
+def test_yamllint_linting(
+    yaml_input: str,
+    config_text: str,
+    expected_problem: str | None,
+) -> None:
+    config = YamlLintConfig(config_text)
+    problems = list(linter.run(yaml_input, config, ""))
+    if expected_problem is None:
+        assert not problems
+    else:
+        assert any(expected_problem in p.desc for p in problems)
 
 
 def test_lint_problem_attributes() -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -2180,7 +2180,7 @@ requires-dist = [
     { name = "terrascript", specifier = "==0.9.0" },
     { name = "unleashclient", specifier = "~=5.11" },
     { name = "urllib3", specifier = "~=2.2" },
-    { name = "yamllint", specifier = "==1.34.0" },
+    { name = "yamllint", specifier = "==1.38.0" },
 ]
 
 [package.metadata.requires-dev]
@@ -3146,15 +3146,15 @@ wheels = [
 
 [[package]]
 name = "yamllint"
-version = "1.34.0"
+version = "1.38.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pathspec" },
     { name = "pyyaml" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/91/1c/9e9c7be901a58c82ab437e3e36f0dd0f5ed76687b1ddff9a9519d7c5875d/yamllint-1.34.0.tar.gz", hash = "sha256:7f0a6a41e8aab3904878da4ae34b6248b6bc74634e0d3a90f0fb2d7e723a3d4f", size = 134022, upload-time = "2024-02-06T09:02:21.357Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/28/a0/8fc2d68e132cf918f18273fdc8a1b8432b60d75ac12fdae4b0ef5c9d2e8d/yamllint-1.38.0.tar.gz", hash = "sha256:09e5f29531daab93366bb061e76019d5e91691ef0a40328f04c927387d1d364d", size = 142446, upload-time = "2026-01-13T07:47:53.276Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/4a/5c/cba47ee4f249928f73d6e5bbd9cd947fd36c6858a7b3e389819973f89ab7/yamllint-1.34.0-py3-none-any.whl", hash = "sha256:33b813f6ff2ffad2e57a288281098392b85f7463ce1f3d5cd45aa848b916a806", size = 66726, upload-time = "2024-02-06T09:02:18.581Z" },
+    { url = "https://files.pythonhosted.org/packages/05/92/aed08e68de6e6a3d7c2328ce7388072cd6affc26e2917197430b646aed02/yamllint-1.38.0-py3-none-any.whl", hash = "sha256:fc394a5b3be980a4062607b8fdddc0843f4fa394152b6da21722f5d59013c220", size = 68940, upload-time = "2026-01-13T07:47:51.343Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -2176,7 +2176,7 @@ requires-dist = [
     { name = "slack-sdk", specifier = ">=3.10,<4.0" },
     { name = "sretoolbox", specifier = "==3.2.1" },
     { name = "sshtunnel", specifier = ">=0.4.0" },
-    { name = "tabulate", specifier = ">=0.8.6,<0.9.0" },
+    { name = "tabulate", specifier = "==0.10.0" },
     { name = "terrascript", specifier = "==0.9.0" },
     { name = "unleashclient", specifier = "~=5.11" },
     { name = "urllib3", specifier = "~=2.2" },
@@ -2620,11 +2620,11 @@ wheels = [
 
 [[package]]
 name = "tabulate"
-version = "0.8.10"
+version = "0.10.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/7a/53/afac341569b3fd558bf2b5428e925e2eb8753ad9627c1f9188104c6e0c4a/tabulate-0.8.10.tar.gz", hash = "sha256:6c57f3f3dd7ac2782770155f3adb2db0b1a269637e42f27599925e64b114f519", size = 60154, upload-time = "2022-06-21T16:26:42.76Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/46/58/8c37dea7bbf769b20d58e7ace7e5edfe65b849442b00ffcdd56be88697c6/tabulate-0.10.0.tar.gz", hash = "sha256:e2cfde8f79420f6deeffdeda9aaec3b6bc5abce947655d17ac662b126e48a60d", size = 91754, upload-time = "2026-03-04T18:55:34.402Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/92/4e/e5a13fdb3e6f81ce11893523ff289870c87c8f1f289a7369fb0e9840c3bb/tabulate-0.8.10-py3-none-any.whl", hash = "sha256:0ba055423dbaa164b9e456abe7920c5e8ed33fcc16f6d1b2f2d152c8e1e8b4fc", size = 29068, upload-time = "2022-06-21T16:26:37.943Z" },
+    { url = "https://files.pythonhosted.org/packages/99/55/db07de81b5c630da5cbf5c7df646580ca26dfaefa593667fc6f2fe016d2e/tabulate-0.10.0-py3-none-any.whl", hash = "sha256:f0b0622e567335c8fabaaa659f1b33bcb6ddfe2e496071b743aa113f8774f2d3", size = 39814, upload-time = "2026-03-04T18:55:31.284Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -904,7 +904,7 @@ wheels = [
 
 [[package]]
 name = "jenkins-job-builder"
-version = "6.4.2"
+version = "6.4.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "fasteners" },
@@ -917,9 +917,9 @@ dependencies = [
     { name = "six" },
     { name = "stevedore" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/0d/a9/0ae4ef563aae6bfe21f316f4915b05e4b2c0edbb63b17eac9ed9398630df/jenkins-job-builder-6.4.2.tar.gz", hash = "sha256:1be0d545dea8dc6c13745367264a2d22276bc5ec496527600865d30382a72490", size = 697528, upload-time = "2024-12-02T17:09:27.032Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/bc/1d/66a4e12c3e93716130bc6a8eba717216e9ccb0b5b5f5f1e1c7d8e262a30a/jenkins_job_builder-6.4.4.tar.gz", hash = "sha256:ecfa420e97b728b469b7e47f36efaac5d0f12ca595a938823cade3fa735aba6f", size = 705910, upload-time = "2026-01-05T20:43:56.111Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/5a/39/9f054ec0f0b1a702793523efbf9af17d5e1d956e49b6be47f2deec422157/jenkins_job_builder-6.4.2-py2.py3-none-any.whl", hash = "sha256:ec95ea27cc00b30474fe1452f5f67015795d6d4b046f101bd925c45ba89d2ca1", size = 366111, upload-time = "2024-12-02T17:09:25.001Z" },
+    { url = "https://files.pythonhosted.org/packages/22/59/c2f1fa2d0207e95acc4762336571b412884c5125a11dea0c5b89c5368ef7/jenkins_job_builder-6.4.4-py2.py3-none-any.whl", hash = "sha256:4006258bfc9208e2c75de535774fdfd14754a57de45cb73258d0fb8f1e378287", size = 370330, upload-time = "2026-01-05T20:43:54.072Z" },
 ]
 
 [[package]]
@@ -2174,7 +2174,7 @@ requires-dist = [
     { name = "filetype", specifier = "~=1.2.0" },
     { name = "gql", specifier = "==3.1.0" },
     { name = "hvac", specifier = "==2.4.0" },
-    { name = "jenkins-job-builder", specifier = "==6.4.2" },
+    { name = "jenkins-job-builder", specifier = "==6.4.4" },
     { name = "jinja2", specifier = ">=2.10.1,<3.2.0" },
     { name = "jira", specifier = "==3.10.5" },
     { name = "jsonpatch", specifier = "~=1.33" },

--- a/uv.lock
+++ b/uv.lock
@@ -2170,7 +2170,7 @@ requires-dist = [
     { name = "requests-oauthlib", specifier = "~=2.0" },
     { name = "rich", specifier = "==15.0.0" },
     { name = "semver", specifier = "~=3.0" },
-    { name = "sendgrid", specifier = ">=6.4.8,<6.5.0" },
+    { name = "sendgrid", specifier = "==6.12.5" },
     { name = "sentry-sdk", specifier = "~=2.0" },
     { name = "setuptools", specifier = "==80.8.0" },
     { name = "slack-sdk", specifier = ">=3.10,<4.0" },
@@ -2461,15 +2461,16 @@ wheels = [
 
 [[package]]
 name = "sendgrid"
-version = "6.4.8"
+version = "6.12.5"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
+    { name = "cryptography" },
     { name = "python-http-client" },
-    { name = "starkbank-ecdsa" },
+    { name = "werkzeug" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/51/52/58c3056c8ebebffb1e286a6e87f5c82ba7945bcc550b498bc3d1ce31f38f/sendgrid-6.4.8.tar.gz", hash = "sha256:4c04a660d25448d8d64092a8b0e4aa6eb18d70f358219ce45895a8067f967833", size = 47431, upload-time = "2020-12-02T20:07:50.477Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/da/fa/f718b2b953f99c1f0085811598ac7e31ccbd4229a81ec2a5290be868187a/sendgrid-6.12.5.tar.gz", hash = "sha256:ea9aae30cd55c332e266bccd11185159482edfc07c149b6cd15cf08869fabdb7", size = 50310, upload-time = "2025-09-19T06:23:09.229Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e3/ed/3a489fec8e16610e673b7243474e2dae0893b1f4e53af9a17e39e6e356cd/sendgrid-6.4.8-py3-none-any.whl", hash = "sha256:850d37a45ce96a24435061a1e3333faf9a2d31fc6287b496867c8eee7a2486c7", size = 73547, upload-time = "2020-12-02T20:07:48.888Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/55/b3c3880a77082e8f7374954e0074aafafaa9bc78bdf9c8f5a92c2e7afc6a/sendgrid-6.12.5-py3-none-any.whl", hash = "sha256:96f92cc91634bf552fdb766b904bbb53968018da7ae41fdac4d1090dc0311ca8", size = 102173, upload-time = "2025-09-19T06:23:07.93Z" },
 ]
 
 [[package]]
@@ -2584,15 +2585,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/80/bd/b2f71ae14368a066f103d182f25bbc6c3bf4aa695889f3ed3cba026d6f36/stamina-26.1.0.tar.gz", hash = "sha256:0214d05fdf5102c518194a4aac7520ce53cf660550ae3b940701aad88cf50c17", size = 568171, upload-time = "2026-04-13T17:44:31.012Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/1d/f0/1ff90a1d1dd02de23feafdf9dffaecef3958348be5c192df56670ccb4f86/stamina-26.1.0-py3-none-any.whl", hash = "sha256:62e06829bec87c06d4cafde520b32a6097d1017c378a9eb63253c5bf5ebbbb88", size = 18508, upload-time = "2026-04-13T17:44:29.545Z" },
-]
-
-[[package]]
-name = "starkbank-ecdsa"
-version = "2.3.1"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/c2/90/1a9e28c73a7cef965c6811ff129a20ddd6bec1fc438a99d938261314e913/starkbank_ecdsa-2.3.1.tar.gz", hash = "sha256:712315c87ba7966a963f6f939a773f7a7a15cdc056ece097a30c0a9d393ee513", size = 20588, upload-time = "2026-04-23T20:59:57.736Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/68/f3/6d0a27fe51ba9cca11a1d5f44616ba384c1326ab704d74e4367839a67219/starkbank_ecdsa-2.3.1-py3-none-any.whl", hash = "sha256:c6dcb0caeb5d7d181c3ef0a6b0185df700d4fa5d5e5669b40bc6d20816aa25a8", size = 22067, upload-time = "2026-04-23T20:59:56.556Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -299,6 +299,28 @@ wheels = [
 ]
 
 [[package]]
+name = "cachebox"
+version = "5.2.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/36/f6/85f176d2518cf1d1be5f981fc2dadf6b131e33fefd721f36b330e3434d6c/cachebox-5.2.3.tar.gz", hash = "sha256:b1f68246685aa739bbbd2734befb1465363a1e1042407c154feadb065f17a099", size = 63686, upload-time = "2026-04-10T12:21:35.028Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e4/e7/6fa6abfc9c4c07b88f09a88466fa93c7081fd679d8e06f8f558bb4ac845c/cachebox-5.2.3-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:09c0340e9daa7b4530801e5a570cb0c1a1ad941a85d245d360020d3986d0e787", size = 377791, upload-time = "2026-04-10T12:20:23.87Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/79/89e4423352d0ca33bbf80fc1b4b665e654a93de8b16cf41e96fcac81801a/cachebox-5.2.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:f3162758792626685ec34950eedd565d015b115d0ff0d751d2716031fc32d51b", size = 359562, upload-time = "2026-04-10T12:20:10.626Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/ab/e533c2751e6a3411ebe369277aaed03199b9e4586a48f0a3712a1f4b418b/cachebox-5.2.3-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a189a780c3ccd7b9d157074ba6bf3e191e522b39abbdb590075111851f02d50d", size = 397910, upload-time = "2026-04-10T12:18:53.336Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/0d/b8492d6ca53278499a37c9f9d51afd4ad77bfbe813d6281944d45b97a1e7/cachebox-5.2.3-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:410b67baa99d433644199b11289627f7ebba4ee5786f95ca9858f238afcee157", size = 353699, upload-time = "2026-04-10T12:19:06.248Z" },
+    { url = "https://files.pythonhosted.org/packages/78/d4/fd20b3a5362651303fa12d3ee62f56af2bd396e4a7303d7014a1a1e5b392/cachebox-5.2.3-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:f81474dc19d3865fa5e57263f834bc6bbc00e471a594fb9d934ed552732c02fd", size = 372510, upload-time = "2026-04-10T12:19:18.997Z" },
+    { url = "https://files.pythonhosted.org/packages/71/94/3ec55c946d300cc4eaed3a0f79740051ac6e11ef4032421332c6ca15f5d5/cachebox-5.2.3-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:85ccd827193b3e3e887a88a16b88ef7ed174e7e65be515b5253322aa75e665c3", size = 392802, upload-time = "2026-04-10T12:19:31.196Z" },
+    { url = "https://files.pythonhosted.org/packages/01/b1/1a3c4e436ad8a4c4ba3e70f4c62e1f927cbbb3c943a9bba5813b8b815bde/cachebox-5.2.3-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2a1e7d3cb8a5e7e68996a8619e3ef8771a124d14568c251f9e586eba88d759c1", size = 398223, upload-time = "2026-04-10T12:19:57.583Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/ea/d36ad3976c4396b350b96a1582411b7a00e56c144eec0bb5ba5f36ce7d86/cachebox-5.2.3-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:adcedfcfcb933b21e7fdcfe560c79887bc8287abceab0586aa3730417dd0277d", size = 427696, upload-time = "2026-04-10T12:19:44.361Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/36/71845b5c7a9ffbd85e6fdb470c11a174f499bd5238fa37b1214157c2454d/cachebox-5.2.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:c7f0c72c51a3a9e7049ea6ff2a43cd3877ab7fee966eb65771a59621563b75e3", size = 567854, upload-time = "2026-04-10T12:20:38.357Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/a2/baf0e5a8392e64e352b137ccd7356b3d98068c842fd19f510a7790c05d34/cachebox-5.2.3-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:c48c10e498d573511aafbd545570e7f43b40a7428dc282183bf5adc334d9e1a8", size = 670306, upload-time = "2026-04-10T12:20:52.903Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/22/cd4e4c1d624b8ef9fb4b8bebf0bf5d2d74a399cf1ac46b667bb79d15359a/cachebox-5.2.3-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:2f1e086ab5ffd082a68bb63699d517655a59b06414927bfc84e01df91b81e34d", size = 645943, upload-time = "2026-04-10T12:21:08.238Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/d6/55859981f5ec6a9e412baaa4db6aa5973a00008750b3f054cdefcb6491fc/cachebox-5.2.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:649d18399f13735bb82daa33800196f815529c49e967767c40ca221723e68afa", size = 612309, upload-time = "2026-04-10T12:21:23.404Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/1e/313f650467ac85824c4199188f8f1ee3386cd12eb665dbf7c88d372e4956/cachebox-5.2.3-cp312-cp312-win32.whl", hash = "sha256:0a17aeb4e5b1c6ef1c3db8fc5186f9986e215ba5ea5a5d08baa45bcf55f261b2", size = 279789, upload-time = "2026-04-10T12:21:53.215Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/50/3b334f887accfa811cf5c7533b8ce22c523eb009363a86401198899dadd2/cachebox-5.2.3-cp312-cp312-win_amd64.whl", hash = "sha256:cfd69114141ab362acaa2099e425a1b965cf7b021a539a4e953143d593930b74", size = 290917, upload-time = "2026-04-10T12:21:39.696Z" },
+]
+
+[[package]]
 name = "cachetools"
 version = "7.1.3"
 source = { registry = "https://pypi.org/simple" }
@@ -569,14 +591,15 @@ wheels = [
 
 [[package]]
 name = "deepdiff"
-version = "9.0.0"
+version = "9.1.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
+    { name = "cachebox" },
     { name = "orderly-set" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/24/20/63dd34163ed07393968128dc8c7ab948c96e47c4ce76976ea533de64909d/deepdiff-9.0.0.tar.gz", hash = "sha256:4872005306237b5b50829803feff58a1dfd20b2b357a55de22e7ded65b2008a7", size = 151952, upload-time = "2026-03-30T05:52:23.769Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/6b/6a4a5aaf38535eb332c2856aa08e73ed7c549d0851b1215401af0a2db1a7/deepdiff-9.1.0.tar.gz", hash = "sha256:07e9e366fab4297755153c4eab795ad4ef3cbd0d51660e847f5751c6bd727687", size = 382149, upload-time = "2026-05-15T20:18:05.751Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/dc/c4/da7089cd7aa4ab554f56e18a7fb08dcfed8fd2ae91fa528f5b1be207a148/deepdiff-9.0.0-py3-none-any.whl", hash = "sha256:b1ae0dd86290d86a03de5fbee728fde43095c1472ae4974bdab23ab4656305bd", size = 170540, upload-time = "2026-03-30T05:52:22.008Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/26/4a2bad8eb430d8d805a4642c4bff25103a37548d74ab346f8b1e024abcc5/deepdiff-9.1.0-py3-none-any.whl", hash = "sha256:80c0460e1993b04f6f0ca79abf25548b129fd218478c4ebb08f80560f5d10610", size = 184662, upload-time = "2026-05-15T20:18:03.956Z" },
 ]
 
 [[package]]
@@ -2145,7 +2168,7 @@ requires-dist = [
     { name = "click", specifier = ">=7.0,<9.0" },
     { name = "croniter", specifier = "==6.2.2" },
     { name = "dateparser", specifier = "~=1.1.7" },
-    { name = "deepdiff", specifier = "==9.0.0" },
+    { name = "deepdiff", specifier = "==9.1.0" },
     { name = "dnspython", specifier = "~=2.1" },
     { name = "dt", specifier = "==1.1.73" },
     { name = "filetype", specifier = "~=1.2.0" },

--- a/uv.lock
+++ b/uv.lock
@@ -768,19 +768,6 @@ wheels = [
 ]
 
 [[package]]
-name = "google-auth"
-version = "2.53.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "cryptography" },
-    { name = "pyasn1-modules" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/c6/ad/ff781329bbbdc0974a098d996e89c9e1f7024262f9e3eec442fbb9ad1ac6/google_auth-2.53.0.tar.gz", hash = "sha256:e7e6aa16f6bee7b2b264830fd04f08087a1d5a836df516251a5d15327b246c9c", size = 335844, upload-time = "2026-05-15T20:53:07.928Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/4a/c9/db44165ba7c581268c6d46017ef63339110378305062830104fc7fa144cb/google_auth-2.53.0-py3-none-any.whl", hash = "sha256:6e7449917c599b35126a99ec268ec6880301f2fea41dce198fe8fd83ff642b68", size = 246071, upload-time = "2026-05-15T20:53:05.609Z" },
-]
-
-[[package]]
 name = "gql"
 version = "3.1.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1019,13 +1006,11 @@ wheels = [
 
 [[package]]
 name = "kubernetes"
-version = "32.0.1"
+version = "35.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "certifi" },
     { name = "durationpy" },
-    { name = "google-auth" },
-    { name = "oauthlib" },
     { name = "python-dateutil" },
     { name = "pyyaml" },
     { name = "requests" },
@@ -1034,9 +1019,9 @@ dependencies = [
     { name = "urllib3" },
     { name = "websocket-client" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/b7/e8/0598f0e8b4af37cd9b10d8b87386cf3173cb8045d834ab5f6ec347a758b3/kubernetes-32.0.1.tar.gz", hash = "sha256:42f43d49abd437ada79a79a16bd48a604d3471a117a8347e87db693f2ba0ba28", size = 946691, upload-time = "2025-02-18T21:06:34.148Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/2c/8f/85bf51ad4150f64e8c665daf0d9dfe9787ae92005efb9a4d1cba592bd79d/kubernetes-35.0.0.tar.gz", hash = "sha256:3d00d344944239821458b9efd484d6df9f011da367ecb155dadf9513f05f09ee", size = 1094642, upload-time = "2026-01-16T01:05:27.76Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/08/10/9f8af3e6f569685ce3af7faab51c8dd9d93b9c38eba339ca31c746119447/kubernetes-32.0.1-py2.py3-none-any.whl", hash = "sha256:35282ab8493b938b08ab5526c7ce66588232df00ef5e1dbe88a419107dc10998", size = 1988070, upload-time = "2025-02-18T21:06:31.391Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/70/05b685ea2dffcb2adbf3cdcea5d8865b7bc66f67249084cf845012a0ff13/kubernetes-35.0.0-py2.py3-none-any.whl", hash = "sha256:39e2b33b46e5834ef6c3985ebfe2047ab39135d41de51ce7641a7ca5b372a13d", size = 2017602, upload-time = "2026-01-16T01:05:25.991Z" },
 ]
 
 [[package]]
@@ -1606,18 +1591,6 @@ wheels = [
 ]
 
 [[package]]
-name = "pyasn1-modules"
-version = "0.4.2"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "pyasn1" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/e9/e6/78ebbb10a8c8e4b61a59249394a4a594c1a7af95593dc933a349c8d00964/pyasn1_modules-0.4.2.tar.gz", hash = "sha256:677091de870a80aae844b1ca6134f54652fa2c8c5a52aa396440ac3106e941e6", size = 307892, upload-time = "2025-03-28T02:41:22.17Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/47/8d/d529b5d697919ba8c11ad626e835d4039be708a35b0d22de83a269a6682c/pyasn1_modules-0.4.2-py3-none-any.whl", hash = "sha256:29253a9207ce32b64c3ac6600edc75368f98473906e8fd1043bd6b5b1de2c14a", size = 181259, upload-time = "2025-03-28T02:41:19.028Z" },
-]
-
-[[package]]
 name = "pycparser"
 version = "3.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2180,7 +2153,7 @@ requires-dist = [
     { name = "jsonpatch", specifier = "~=1.33" },
     { name = "jsonpath-ng", specifier = "==1.7.0" },
     { name = "jsonpointer", specifier = "==3.1.1" },
-    { name = "kubernetes", specifier = "==32.0.1" },
+    { name = "kubernetes", specifier = "==35.0.0" },
     { name = "ldap3", specifier = ">=2.9.1,<2.10.0" },
     { name = "networkx", specifier = "~=3.6" },
     { name = "prometheus-client", specifier = "~=0.8" },

--- a/uv.lock
+++ b/uv.lock
@@ -490,14 +490,14 @@ wheels = [
 
 [[package]]
 name = "croniter"
-version = "1.0.15"
+version = "6.2.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "python-dateutil" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/c1/1d/1c7cf4506c44bca0322f71a5460571446abd8396046b4badaec2d4ba4d82/croniter-1.0.15.tar.gz", hash = "sha256:a70dfc9d52de9fc1a886128b9148c89dd9e76b67d55f46516ca94d2d73d58219", size = 39164, upload-time = "2021-06-25T08:17:44.138Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/df/de/5832661ed55107b8a09af3f0a2e71e0957226a59eb1dcf0a445cce6daf20/croniter-6.2.2.tar.gz", hash = "sha256:ba60832a5ec8e12e51b8691c3309a113d1cf6526bdf1a48150ce8ec7a532d0ab", size = 113762, upload-time = "2026-03-15T08:43:48.112Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/65/f1/1e0d14c0a0f9ff4bdfb0652e79780f4a1b77de5617cc1d4919ccd528fbc0/croniter-1.0.15-py2.py3-none-any.whl", hash = "sha256:0f97b361fe343301a8f66f852e7d84e4fb7f21379948f71e1bbfe10f5d015fbd", size = 16985, upload-time = "2021-06-25T08:17:42.294Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/39/783980e78cb92c2d7bdb1fc7dbc86e94ccc6d58224d76a7f1f51b6c51e30/croniter-6.2.2-py3-none-any.whl", hash = "sha256:a5d17b1060974d36251ea4faf388233eca8acf0d09cbd92d35f4c4ac8f279960", size = 45422, upload-time = "2026-03-15T08:43:46.626Z" },
 ]
 
 [[package]]
@@ -2143,7 +2143,7 @@ requires-dist = [
     { name = "boto3", specifier = "==1.43.10" },
     { name = "botocore", specifier = "==1.43.10" },
     { name = "click", specifier = ">=7.0,<9.0" },
-    { name = "croniter", specifier = ">=1.0.15,<1.1.0" },
+    { name = "croniter", specifier = "==6.2.2" },
     { name = "dateparser", specifier = "~=1.1.7" },
     { name = "deepdiff", specifier = "==9.0.0" },
     { name = "dnspython", specifier = "~=2.1" },

--- a/uv.lock
+++ b/uv.lock
@@ -563,7 +563,7 @@ wheels = [
 
 [[package]]
 name = "dateparser"
-version = "1.1.8"
+version = "1.4.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "python-dateutil" },
@@ -571,9 +571,9 @@ dependencies = [
     { name = "regex" },
     { name = "tzlocal" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/7e/16/e95f1d2f8014bac38e00d037e192222e52de7db7c71268ed3b2e12d4893c/dateparser-1.1.8.tar.gz", hash = "sha256:86b8b7517efcc558f085a142cdb7620f0921543fcabdb538c8a4c4001d8178e3", size = 296595, upload-time = "2023-03-23T14:02:06.413Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/46/2d/a0ccdb78788064fa0dc901b8524e50615c42be1d78b78d646d0b28d09180/dateparser-1.4.0.tar.gz", hash = "sha256:97a21840d5ecdf7630c584f673338a5afac5dfe84f647baf4d7e8df98f9354a4", size = 321512, upload-time = "2026-03-26T09:56:10.292Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/7a/bf/457ed5be028fb235f8f5ad40b5ddbf67023e0017090ea324d0fe6239a73c/dateparser-1.1.8-py2.py3-none-any.whl", hash = "sha256:070b29b5bbf4b1ec2cd51c96ea040dc68a614de703910a91ad1abba18f9f379f", size = 293797, upload-time = "2023-03-23T14:02:04.091Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/0b/3c3bb7cbe757279e693a0be6049048012f794d01f81099609ecd53b899f0/dateparser-1.4.0-py3-none-any.whl", hash = "sha256:7902b8e85d603494bf70a5a0b1decdddb2270b9c6e6b2bc8a57b93476c0df378", size = 300379, upload-time = "2026-03-26T09:56:08.409Z" },
 ]
 
 [[package]]
@@ -2140,7 +2140,7 @@ requires-dist = [
     { name = "botocore", specifier = "==1.43.10" },
     { name = "click", specifier = ">=7.0,<9.0" },
     { name = "croniter", specifier = "==6.2.2" },
-    { name = "dateparser", specifier = "~=1.1.7" },
+    { name = "dateparser", specifier = "==1.4.0" },
     { name = "deepdiff", specifier = "==9.1.0" },
     { name = "dnspython", specifier = "~=2.1" },
     { name = "dt", specifier = "==1.1.73" },

--- a/uv.lock
+++ b/uv.lock
@@ -995,11 +995,11 @@ wheels = [
 
 [[package]]
 name = "jsonpointer"
-version = "2.4"
+version = "3.1.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/8f/5e/67d3ab449818b629a0ffe554bb7eb5c030a71f7af5d80fbf670d7ebe62bc/jsonpointer-2.4.tar.gz", hash = "sha256:585cee82b70211fa9e6043b7bb89db6e1aa49524340dde8ad6b63206ea689d88", size = 9254, upload-time = "2023-06-26T12:06:53.823Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/18/c7/af399a2e7a67fd18d63c40c5e62d3af4e67b836a2107468b6a5ea24c4304/jsonpointer-3.1.1.tar.gz", hash = "sha256:0b801c7db33a904024f6004d526dcc53bbb8a4a0f4e32bfd10beadf60adf1900", size = 9068, upload-time = "2026-03-23T22:32:32.458Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/12/f6/0232cc0c617e195f06f810534d00b74d2f348fe71b2118009ad8ad31f878/jsonpointer-2.4-py2.py3-none-any.whl", hash = "sha256:15d51bba20eea3165644553647711d150376234112651b4f1811022aecad7d7a", size = 7762, upload-time = "2023-06-16T21:15:02.402Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/6a/a83720e953b1682d2d109d3c2dbb0bc9bf28cc1cbc205be4ef4be5da709d/jsonpointer-3.1.1-py3-none-any.whl", hash = "sha256:8ff8b95779d071ba472cf5bc913028df06031797532f08a7d5b602d8b2a488ca", size = 7659, upload-time = "2026-03-23T22:32:31.568Z" },
 ]
 
 [[package]]
@@ -2179,7 +2179,7 @@ requires-dist = [
     { name = "jira", specifier = "==3.10.5" },
     { name = "jsonpatch", specifier = "~=1.33" },
     { name = "jsonpath-ng", specifier = "==1.7.0" },
-    { name = "jsonpointer", specifier = "~=2.4" },
+    { name = "jsonpointer", specifier = "==3.1.1" },
     { name = "kubernetes", specifier = "==32.0.1" },
     { name = "ldap3", specifier = ">=2.9.1,<2.10.0" },
     { name = "networkx", specifier = "~=3.6" },


### PR DESCRIPTION
## Summary

- Upgrade 9 Python dependencies to latest versions, pin all to `==`
- Add missing unit tests for `sendgrid` and `yamllint` usage

## Changes

| Package | From | To | Notes |
|---------|------|----|-------|
| `croniter` | 1.0.15 | 6.2.2 | No breaking changes for our usage |
| `dateparser` | 1.1.7 | 1.4.0 | Minor bump |
| `deepdiff` | 9.0.0 | 9.1.0 | Minor bump |
| `jenkins-job-builder` | 6.4.2 | 6.4.4 | Patch bump |
| `jsonpointer` | 2.4 | 3.1.1 | Major bump, only `resolve_pointer` used — stable API |
| `kubernetes` | 32.0.1 | 35.0.0 | Major bump, Python client API unchanged for our usage |
| `sendgrid` | 6.4.8 | 6.12.5 | + new tests for `sendgrid_teammates` |
| `tabulate` | 0.8.10 | 0.10.0 | Major bump, simple `tabulate()` call unchanged |
| `yamllint` | 1.34.0 | 1.38.0 | + new tests for `template_validation` yamllint usage |

### Deferred to separate PRs

- **`jsonpath-ng`** (1.7.0 → 1.8.0): `Child.__str__` changed to wrap in parentheses, breaking `startswith`-based path containment checks in `change_owners/` production code (~33 test failures). Requires `jsonpath_str()` helper + refactor.
- **`UnleashClient`** (5.x → 6.x): v6 swaps core engine for yggdrasil, needs careful migration.

## Test plan

- [x] All existing tests pass for upgraded packages
- [x] New `sendgrid_teammates` tests (13 tests) pass before and after upgrade
- [x] New `yamllint` tests (4 tests) pass before and after upgrade
- [x] `croniter` tests (8 tests) pass
- [x] `dateparser` / `search_filters` tests (38 tests) pass
- [x] `deepdiff` tests (50 tests) pass
- [x] `jenkins-job-builder` tests (69 tests) pass
- [x] `jsonpointer` / `three_way_diff` tests (10 tests) pass
- [x] `kubernetes` / `oc` tests (220 tests) pass
- [x] `tabulate` / `output` tests (3 tests) pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Pinned several runtime dependencies to exact newer versions to stabilize installs and runtime behavior.
  * Updated type-check configuration so yamllint modules are treated as missing-imports and ignored by mypy.

* **Tests**
  * Added unit tests for SendGrid teammates reconciliation (parsing, desired-state aggregation, error handling, dry-run/invite/delete modes).
  * Added unit tests for YAML template linting to verify rule detection and reported problem attributes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/app-sre/qontract-reconcile/pull/5557?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->