### PR TITLE
fix(glitchtip): clear team user caches when deleting a user from org

### DIFF
--- a/qontract_api/qontract_api/glitchtip/glitchtip_workspace_client.py
+++ b/qontract_api/qontract_api/glitchtip/glitchtip_workspace_client.py
@@ -334,9 +334,15 @@ class GlitchtipWorkspaceClient:
         return user
 
     def delete_user(self, org_slug: str, pk: int) -> None:
-        """Delete a user and clear organization users cache."""
+        """Delete a user and clear organization and team users caches.
+
+        GlitchTip automatically removes the user from all teams when deleted from
+        an org, so all team user caches must be invalidated too.
+        """
         self.glitchtip_api.delete_user(org_slug, pk)
         self._clear_cache(self._cache_key_org_users(org_slug))
+        for team in self.get_teams(org_slug):
+            self._clear_cache(self._cache_key_team_users(org_slug, team.slug))
 
     def update_user_role(self, org_slug: str, pk: int, role: str) -> User:
         """Update user role and clear organization users cache."""

--- a/qontract_api/tests/integrations/glitchtip/test_workspace_client.py
+++ b/qontract_api/tests/integrations/glitchtip/test_workspace_client.py
@@ -1,6 +1,6 @@
 """Unit tests for GlitchtipWorkspaceClient cache invalidation."""
 
-from unittest.mock import MagicMock, call
+from unittest.mock import MagicMock
 
 import pytest
 from qontract_utils.glitchtip_api import GlitchtipApi

--- a/qontract_api/tests/integrations/glitchtip/test_workspace_client.py
+++ b/qontract_api/tests/integrations/glitchtip/test_workspace_client.py
@@ -1,0 +1,59 @@
+"""Unit tests for GlitchtipWorkspaceClient cache invalidation."""
+
+from unittest.mock import MagicMock, call
+
+import pytest
+from qontract_utils.glitchtip_api import GlitchtipApi
+from qontract_utils.glitchtip_api.models import Team
+
+from qontract_api.cache.base import CacheBackend
+from qontract_api.config import Settings
+from qontract_api.glitchtip.glitchtip_workspace_client import GlitchtipWorkspaceClient
+
+
+@pytest.fixture
+def mock_api() -> MagicMock:
+    return MagicMock(spec=GlitchtipApi)
+
+
+@pytest.fixture
+def mock_cache() -> MagicMock:
+    m = MagicMock(spec=CacheBackend)
+    m.get_obj.return_value = None
+    m.lock.return_value.__enter__ = MagicMock()
+    m.lock.return_value.__exit__ = MagicMock(return_value=False)
+    return m
+
+
+@pytest.fixture
+def client(mock_api: MagicMock, mock_cache: MagicMock) -> GlitchtipWorkspaceClient:
+    return GlitchtipWorkspaceClient(
+        glitchtip_api=mock_api,
+        instance_name="test-instance",
+        cache=mock_cache,
+        settings=Settings(),
+    )
+
+
+def test_delete_user_clears_team_user_caches(
+    client: GlitchtipWorkspaceClient,
+    mock_api: MagicMock,
+    mock_cache: MagicMock,
+) -> None:
+    """delete_user must clear all team user caches for the org.
+
+    GlitchTip removes the user from all teams when they are deleted from the org.
+    Without this, the team user cache retains a stale entry and causes repeated
+    remove_user_from_team 404 errors on every subsequent reconcile run.
+    """
+    mock_api.teams.return_value = [
+        Team(pk=1, slug="team-alpha"),
+        Team(pk=2, slug="team-beta"),
+    ]
+
+    client.delete_user("my-org", pk=42)
+
+    deleted_keys = {c.args[0] for c in mock_cache.delete.call_args_list}
+    assert "glitchtip:test-instance:my-org:users" in deleted_keys
+    assert "glitchtip:test-instance:my-org:team-alpha:team_users" in deleted_keys
+    assert "glitchtip:test-instance:my-org:team-beta:team_users" in deleted_keys


### PR DESCRIPTION
GlitchTip implicitly removes a user from all teams when they are deleted from an organization. Previously, delete_user only cleared the org users cache, leaving team user caches stale. On the next reconcile run the stale team cache caused remove_user_from_team actions to be generated, which hit 404 and never cleared the cache, creating an infinite error loop.

Fix: after deleting the user, iterate get_teams() (already cached, no extra API call) and clear every team user cache for that org.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved cache invalidation when deleting users from organizations to ensure consistency across all user caches.

* **Tests**
  * Added test coverage for cache invalidation behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/app-sre/qontract-reconcile/pull/5558?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->