### PR TITLE
APPSRE 13230 hold mr owner re-land

### DIFF
--- a/reconcile/change_owners/change_owners.py
+++ b/reconcile/change_owners/change_owners.py
@@ -459,13 +459,15 @@ def run(
                     approval_body=DecisionCommand.APPROVED.value,
                 )
             )
+            mr_author = gl.get_merge_request_author_username(merge_request)
             change_decisions = apply_decisions_to_changes(
                 changes,
                 approver_decisions,
                 {
                     gl.user.username,
-                    gl.get_merge_request_author_username(merge_request),
+                    mr_author,
                 },
+                mr_author=mr_author,
             )
             hold = any(d.is_held() for d in change_decisions)
             approved = all(

--- a/reconcile/change_owners/change_owners.py
+++ b/reconcile/change_owners/change_owners.py
@@ -446,9 +446,10 @@ def run(
                 c.username for c in comments if c.body.strip() == "/ok-to-test"
             }
 
+            mr_author = gl.get_merge_request_author_username(merge_request)
             change_admitted = is_change_admitted(
                 changes,
-                gl.get_merge_request_author_username(merge_request),
+                mr_author,
                 ok_to_test_approvers,
             )
             approver_decisions = get_approver_decisions_from_mr_comments(
@@ -459,7 +460,6 @@ def run(
                     approval_body=DecisionCommand.APPROVED.value,
                 )
             )
-            mr_author = gl.get_merge_request_author_username(merge_request)
             change_decisions = apply_decisions_to_changes(
                 changes,
                 approver_decisions,

--- a/reconcile/change_owners/decision.py
+++ b/reconcile/change_owners/decision.py
@@ -224,13 +224,22 @@ def _apply_decision_to_diff(
             if not ctx.disabled
         )
         if not is_approver:
-            for d in approver_decisions:
-                is_author_hold = d.approver_name == mr_author and d.command == DecisionCommand.HOLD
+            for decision in approver_decisions:
+                is_author_hold = (
+                    decision.approver_name == mr_author
+                    and decision.command == DecisionCommand.HOLD
+                )
                 is_owner_cancel = (
-                    d.command == DecisionCommand.CANCEL_HOLD
-                    and d.approver_name != mr_author
-                    and any(ctx.includes_approver(d.approver_name) for ctx in diff.coverage if not ctx.disabled)
+                    decision.command == DecisionCommand.CANCEL_HOLD
+                    and decision.approver_name != mr_author
+                    and any(
+                        ctx.includes_approver(decision.approver_name)
+                        for ctx in diff.coverage
+                        if not ctx.disabled
+                    )
                 )
                 if is_author_hold or is_owner_cancel:
-                    change_decision.apply_context_decision("mr-author", d.command)
+                    change_decision.apply_context_decision(
+                        "mr-author", decision.command
+                    )
     return change_decision

--- a/reconcile/change_owners/decision.py
+++ b/reconcile/change_owners/decision.py
@@ -136,6 +136,7 @@ def apply_decisions_to_changes(
     changes: Iterable[BundleFileChange],
     approver_decisions: Iterable[Decision],
     auto_approver_usernames: set[str],
+    mr_author: str = "",
 ) -> list[ChangeDecision]:
     """
     Apply and aggregate approver decisions to changes. Each diff of a
@@ -150,6 +151,7 @@ def apply_decisions_to_changes(
             d,
             approver_decisions,
             auto_approver_usernames,
+            mr_author,
         )
         for c in changes
         for d in c.diff_coverage
@@ -161,6 +163,7 @@ def _apply_decision_to_diff(
     diff: DiffCoverage,
     approver_decisions: Iterable[Decision],
     auto_approver_usernames: set[str],
+    mr_author: str = "",
 ) -> ChangeDecision:
     approvers_decisions_by_name = {
         d.approver_name: d.command for d in approver_decisions
@@ -176,7 +179,7 @@ def _apply_decision_to_diff(
         change_decision.coverable_by_fragment_decisions = True
         fragment_decisions = [
             _apply_decision_to_diff(
-                c, fragment, approver_decisions, auto_approver_usernames
+                c, fragment, approver_decisions, auto_approver_usernames, mr_author
             )
             for fragment in diff.diff_fragments
         ]
@@ -211,4 +214,23 @@ def _apply_decision_to_diff(
             if change_type_context.includes_approver(decision.approver_name):
                 change_decision.apply_decision(change_type_context, decision.command)
 
+    # The MR author can /hold their own MR even if they are not a change owner.
+    # Only /hold is honored from the author -- /hold cancel from the author is
+    # ignored so that only a change owner can release the hold.
+    if mr_author:
+        is_approver = any(
+            ctx.includes_approver(mr_author)
+            for ctx in diff.coverage
+            if not ctx.disabled
+        )
+        if not is_approver:
+            for d in approver_decisions:
+                is_author_hold = d.approver_name == mr_author and d.command == DecisionCommand.HOLD
+                is_owner_cancel = (
+                    d.command == DecisionCommand.CANCEL_HOLD
+                    and d.approver_name != mr_author
+                    and any(ctx.includes_approver(d.approver_name) for ctx in diff.coverage if not ctx.disabled)
+                )
+                if is_author_hold or is_owner_cancel:
+                    change_decision.apply_context_decision("mr-author", d.command)
     return change_decision

--- a/reconcile/test/change_owners/test_change_type_decision.py
+++ b/reconcile/test/change_owners/test_change_type_decision.py
@@ -537,6 +537,48 @@ def test_mr_author_hold_coexists_with_approval(
     assert change_decision[0].is_held()
 
 
+def test_mr_author_hold_as_approver_uses_normal_context(
+    saas_file_changetype: ChangeTypeV1,
+) -> None:
+    """
+    When the MR author is already a change owner, /hold is applied through the
+    normal approver path (context = the change-type context) and NOT through
+    the special "mr-author" context.
+    """
+    change = build_bundle_datafile_change(
+        path="/my/file.yml",
+        schema="/my/schema.yml",
+        old_content={"foo": "bar"},
+        new_content={"foo": "baz"},
+    )
+    assert change and len(change.diff_coverage) == 1
+    change.diff_coverage[0].coverage = [
+        ChangeTypeContext(
+            change_type_processor=change_type_to_processor(saas_file_changetype),
+            context="team-context",
+            origin="",
+            approvers=[
+                Approver(org_username=MR_AUTHOR, tag_on_merge_requests=False),
+                Approver(org_username=APPROVER_USER, tag_on_merge_requests=False),
+            ],
+            context_file=change.fileref,
+        )
+    ]
+
+    change_decision = apply_decisions_to_changes(
+        approver_decisions=[
+            Decision(approver_name=MR_AUTHOR, command=DecisionCommand.HOLD),
+        ],
+        changes=[change],
+        auto_approver_usernames=set(),
+        mr_author=MR_AUTHOR,
+    )
+
+    assert change_decision[0].is_held()
+    assert "team-context" in change_decision[0].hold
+    assert "mr-author" not in change_decision[0].hold
+
+
 def test_change_owner_can_unhold_author_hold(
     change_with_coverage: BundleFileChange,
 ) -> None:

--- a/reconcile/test/change_owners/test_change_type_decision.py
+++ b/reconcile/test/change_owners/test_change_type_decision.py
@@ -4,6 +4,7 @@ from reconcile.change_owners.change_types import (
     Approver,
     ChangeTypeContext,
 )
+from reconcile.change_owners.changes import BundleFileChange
 from reconcile.change_owners.decision import (
     Decision,
     DecisionCommand,
@@ -424,3 +425,132 @@ def test_change_decision_auto_approver_hold_decision(
 
     assert not change_decision[0].is_approved()
     assert change_decision[0].is_held()
+
+
+#
+# test MR author hold decisions
+#
+
+MR_AUTHOR = "mr-author"
+APPROVER_USER = "approver-user"
+
+
+@pytest.fixture
+def change_with_coverage(
+    saas_file_changetype: ChangeTypeV1,
+) -> BundleFileChange:
+    change = build_bundle_datafile_change(
+        path="/my/file.yml",
+        schema="/my/schema.yml",
+        old_content={"foo": "bar"},
+        new_content={"foo": "baz"},
+    )
+    assert change and len(change.diff_coverage) == 1
+    change.diff_coverage[0].coverage = [
+        ChangeTypeContext(
+            change_type_processor=change_type_to_processor(saas_file_changetype),
+            context="team-context",
+            origin="",
+            approvers=[
+                Approver(org_username=APPROVER_USER, tag_on_merge_requests=False),
+            ],
+            context_file=change.fileref,
+        )
+    ]
+    return change
+
+
+def test_mr_author_hold_as_non_approver(
+    change_with_coverage: BundleFileChange,
+) -> None:
+    """
+    The MR author can /hold their own MR even when not in any approver group.
+    """
+    change_decision = apply_decisions_to_changes(
+        approver_decisions=[
+            Decision(approver_name=MR_AUTHOR, command=DecisionCommand.HOLD),
+        ],
+        changes=[change_with_coverage],
+        auto_approver_usernames=set(),
+        mr_author=MR_AUTHOR,
+    )
+
+    assert change_decision[0].is_held()
+
+
+def test_non_author_non_approver_hold_ignored(
+    change_with_coverage: BundleFileChange,
+) -> None:
+    """
+    A user who is neither the MR author nor an approver cannot hold the MR.
+    """
+    change_decision = apply_decisions_to_changes(
+        approver_decisions=[
+            Decision(approver_name="random-user", command=DecisionCommand.HOLD),
+        ],
+        changes=[change_with_coverage],
+        auto_approver_usernames=set(),
+        mr_author=MR_AUTHOR,
+    )
+
+    assert not change_decision[0].is_held()
+
+
+def test_mr_author_hold_cancel_ignored(
+    change_with_coverage: BundleFileChange,
+) -> None:
+    """
+    The MR author cannot /hold cancel their own hold -- only change owners can
+    release a hold.
+    """
+    change_decision = apply_decisions_to_changes(
+        approver_decisions=[
+            Decision(approver_name=MR_AUTHOR, command=DecisionCommand.HOLD),
+            Decision(approver_name=MR_AUTHOR, command=DecisionCommand.CANCEL_HOLD),
+        ],
+        changes=[change_with_coverage],
+        auto_approver_usernames=set(),
+        mr_author=MR_AUTHOR,
+    )
+
+    assert change_decision[0].is_held()
+
+
+def test_mr_author_hold_coexists_with_approval(
+    change_with_coverage: BundleFileChange,
+) -> None:
+    """
+    An approver /lgtm and the MR author (non-approver) /hold should result in
+    the change being both approved and held.
+    """
+    change_decision = apply_decisions_to_changes(
+        approver_decisions=[
+            Decision(approver_name=APPROVER_USER, command=DecisionCommand.APPROVED),
+            Decision(approver_name=MR_AUTHOR, command=DecisionCommand.HOLD),
+        ],
+        changes=[change_with_coverage],
+        auto_approver_usernames=set(),
+        mr_author=MR_AUTHOR,
+    )
+
+    assert change_decision[0].is_approved()
+    assert change_decision[0].is_held()
+
+
+def test_change_owner_can_unhold_author_hold(
+    change_with_coverage: BundleFileChange,
+) -> None:
+    """
+    A change owner can /hold cancel an MR that was held by the author.
+    """
+    change_decision = apply_decisions_to_changes(
+        approver_decisions=[
+            Decision(approver_name=MR_AUTHOR, command=DecisionCommand.HOLD),
+            Decision(approver_name=APPROVER_USER, command=DecisionCommand.CANCEL_HOLD),
+        ],
+        changes=[change_with_coverage],
+        auto_approver_usernames=set(),
+        mr_author=MR_AUTHOR,
+    )
+
+    assert not change_decision[0].is_held()


### PR DESCRIPTION
Re-land of #5543 (reverted in #5555).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Merge request authors can now apply hold-type approvals to changes, even when not designated as change owners. Special rules govern hold cancellation operations based on user roles.

* **Tests**
  * Added comprehensive test coverage for merge request author hold approval behavior and interactions with approver holds.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/app-sre/qontract-reconcile/pull/5559?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->