### PR TITLE
fix(pagerduty): add missing JWT authentication to PagerDuty endpoints

### DIFF
--- a/qontract_api/Dockerfile
+++ b/qontract_api/Dockerfile
@@ -1,6 +1,6 @@
 #
 # Base image with defaults for all stages
-FROM registry.access.redhat.com/ubi9-minimal@sha256:fe9e574f04371b333ed4e21d30d984f6b7fcd1046e579f5ddab4816c0c8e231d AS base
+FROM registry.access.redhat.com/ubi9-minimal:9.8-1777554822@sha256:24650313873554b6ba16c1a1b6b9f9142604f6ab735113e1695faf2dd07fdede AS base
 
 COPY LICENSE /licenses/
 
@@ -36,7 +36,7 @@ WORKDIR ${APP_ROOT}/src
 #
 # Builder image
 #
-FROM registry.access.redhat.com/ubi9/python-312-minimal@sha256:df1c6dcb266a265011595fa1f149b3add42b66d8ac0e7f4244d5b64ef04c7fe1 AS builder
+FROM registry.access.redhat.com/ubi9/python-312-minimal:9.8-1777554822@sha256:6bffc78910c5843cbfc1c33dd98c574b52c9a02ad539e45b11814d45a7e88f3f AS builder
 COPY --from=ghcr.io/astral-sh/uv:0.11.13@sha256:841c8e6fe30a8b07b4478d12d0c608cba6de66102d29d65d1cc423af86051563 /uv /bin/uv
 
 ENV APP_ROOT=/opt/app-root

--- a/qontract_api/openapi.json
+++ b/qontract_api/openapi.json
@@ -2863,6 +2863,11 @@
             "description": "Successful Response"
           }
         },
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
         "summary": "Get Escalation Policy Users",
         "tags": [
           "external"
@@ -2954,6 +2959,11 @@
             "description": "Successful Response"
           }
         },
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
         "summary": "Get Schedule Users",
         "tags": [
           "external"

--- a/qontract_api/qontract_api/external/pagerduty/router.py
+++ b/qontract_api/qontract_api/external/pagerduty/router.py
@@ -8,7 +8,7 @@ from typing import Annotated
 from fastapi import APIRouter, Query
 
 from qontract_api.config import settings
-from qontract_api.dependencies import CacheDep, SecretManagerDep
+from qontract_api.dependencies import CacheDep, SecretManagerDep, UserDep
 from qontract_api.external.pagerduty.pagerduty_factory import (
     create_pagerduty_workspace_client,
 )
@@ -36,6 +36,7 @@ def get_schedule_users(
     schedule_id: str,
     cache: CacheDep,
     secret_manager: SecretManagerDep,
+    _user: UserDep,
     secret: Annotated[
         Secret,
         Query(description="PagerDuty secret reference"),
@@ -94,6 +95,7 @@ def get_escalation_policy_users(
     policy_id: str,
     cache: CacheDep,
     secret_manager: SecretManagerDep,
+    _user: UserDep,
     secret: Annotated[
         Secret,
         Query(description="PagerDuty secret reference"),

--- a/qontract_api_client/Dockerfile
+++ b/qontract_api_client/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi9/python-312-minimal@sha256:df1c6dcb266a265011595fa1f149b3add42b66d8ac0e7f4244d5b64ef04c7fe1 AS base
+FROM registry.access.redhat.com/ubi9/python-312-minimal:9.8-1777554822@sha256:6bffc78910c5843cbfc1c33dd98c574b52c9a02ad539e45b11814d45a7e88f3f AS base
 COPY --from=ghcr.io/astral-sh/uv:0.11.13@sha256:841c8e6fe30a8b07b4478d12d0c608cba6de66102d29d65d1cc423af86051563 /uv /bin/uv
 
 COPY LICENSE /licenses/

--- a/qontract_api_client/qontract_api_client/api/external/pagerduty_escalation_policy_users.py
+++ b/qontract_api_client/qontract_api_client/api/external/pagerduty_escalation_policy_users.py
@@ -77,7 +77,7 @@ def _build_response(
 def sync_detailed(
     policy_id: str,
     *,
-    client: AuthenticatedClient | Client,
+    client: AuthenticatedClient,
     secret_manager_url: str,
     path: str,
     field: None | str | Unset = UNSET,
@@ -144,7 +144,7 @@ def sync_detailed(
 def sync(
     policy_id: str,
     *,
-    client: AuthenticatedClient | Client,
+    client: AuthenticatedClient,
     secret_manager_url: str,
     path: str,
     field: None | str | Unset = UNSET,
@@ -209,7 +209,7 @@ def sync(
 async def asyncio_detailed(
     policy_id: str,
     *,
-    client: AuthenticatedClient | Client,
+    client: AuthenticatedClient,
     secret_manager_url: str,
     path: str,
     field: None | str | Unset = UNSET,
@@ -274,7 +274,7 @@ async def asyncio_detailed(
 async def asyncio(
     policy_id: str,
     *,
-    client: AuthenticatedClient | Client,
+    client: AuthenticatedClient,
     secret_manager_url: str,
     path: str,
     field: None | str | Unset = UNSET,

--- a/qontract_api_client/qontract_api_client/api/external/pagerduty_schedule_users.py
+++ b/qontract_api_client/qontract_api_client/api/external/pagerduty_schedule_users.py
@@ -77,7 +77,7 @@ def _build_response(
 def sync_detailed(
     schedule_id: str,
     *,
-    client: AuthenticatedClient | Client,
+    client: AuthenticatedClient,
     secret_manager_url: str,
     path: str,
     field: None | str | Unset = UNSET,
@@ -144,7 +144,7 @@ def sync_detailed(
 def sync(
     schedule_id: str,
     *,
-    client: AuthenticatedClient | Client,
+    client: AuthenticatedClient,
     secret_manager_url: str,
     path: str,
     field: None | str | Unset = UNSET,
@@ -209,7 +209,7 @@ def sync(
 async def asyncio_detailed(
     schedule_id: str,
     *,
-    client: AuthenticatedClient | Client,
+    client: AuthenticatedClient,
     secret_manager_url: str,
     path: str,
     field: None | str | Unset = UNSET,
@@ -274,7 +274,7 @@ async def asyncio_detailed(
 async def asyncio(
     schedule_id: str,
     *,
-    client: AuthenticatedClient | Client,
+    client: AuthenticatedClient,
     secret_manager_url: str,
     path: str,
     field: None | str | Unset = UNSET,

--- a/qontract_utils/Dockerfile
+++ b/qontract_utils/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi9/python-312-minimal@sha256:df1c6dcb266a265011595fa1f149b3add42b66d8ac0e7f4244d5b64ef04c7fe1 AS base
+FROM registry.access.redhat.com/ubi9/python-312-minimal:9.8-1777554822@sha256:6bffc78910c5843cbfc1c33dd98c574b52c9a02ad539e45b11814d45a7e88f3f AS base
 COPY --from=ghcr.io/astral-sh/uv:0.11.13@sha256:841c8e6fe30a8b07b4478d12d0c608cba6de66102d29d65d1cc423af86051563 /uv /bin/uv
 
 COPY LICENSE /licenses/


### PR DESCRIPTION
## Summary
- Add missing `UserDep` JWT authentication dependency to both PagerDuty external endpoints (`get_schedule_users` and `get_escalation_policy_users`)
- All other external endpoints (Slack, LDAP, VCS) already required JWT auth via `UserDep` — PagerDuty was the only one missing it

## Test plan
- [ ] Verify PagerDuty endpoints now return 401 without a valid JWT token
- [ ] Verify PagerDuty endpoints still work correctly with a valid JWT token
- [ ] Run `cd qontract_api && make test` to ensure no test regressions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * PagerDuty schedule users endpoint now requires bearer-token (HTTP Bearer) authentication.
  * PagerDuty escalation policy users endpoint now requires bearer-token (HTTP Bearer) authentication.
  * Generated client libraries for these PagerDuty endpoints now require an authenticated client to call the APIs.
  * Updated pinned base images in Dockerfiles for the API, client, and utils builds.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/app-sre/qontract-reconcile/pull/5560?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->