### PR TITLE
feat: upgrade gql from v3.1.0 to v4.0.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ dependencies = [
     "dnspython~=2.1",
     "dt==1.1.73",
     "filetype~=1.2.0",
-    "gql~=4.0",
+    "gql==4.0.0",
     "hvac==2.4.0",
     "jenkins-job-builder==6.4.4",
     "Jinja2>=2.10.1,<3.2.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ dependencies = [
     "dnspython~=2.1",
     "dt==1.1.73",
     "filetype~=1.2.0",
-    "gql==3.1.0",
+    "gql~=4.0",
     "hvac==2.4.0",
     "jenkins-job-builder==6.4.4",
     "Jinja2>=2.10.1,<3.2.0",

--- a/reconcile/test/utils/test_gql.py
+++ b/reconcile/test/utils/test_gql.py
@@ -187,6 +187,10 @@ def test_gqlapi_query_full_stack_with_variables(httpserver: HTTPServer) -> None:
     result = gql_api.query.__wrapped__(gql_api, query, variables={"id": "1"})  # type: ignore[attr-defined]
     assert result["user"]["name"] == "test-user"
 
+    request_body = httpserver.log[0][0].json
+    assert "query" in request_body
+    assert request_body["variables"] == {"id": "1"}
+
 
 def test_gqlapi_query_full_stack_transport_error(httpserver: HTTPServer) -> None:
     httpserver.expect_request("/graphql", method="POST").respond_with_json({

--- a/reconcile/test/utils/test_gql.py
+++ b/reconcile/test/utils/test_gql.py
@@ -1,6 +1,8 @@
 import pytest
 import requests
+from gql import Client, gql
 from gql.transport.exceptions import TransportQueryError
+from pytest_httpserver import HTTPServer
 from pytest_mock import MockerFixture
 
 from reconcile.utils.gql import (
@@ -8,6 +10,7 @@ from reconcile.utils.gql import (
     GqlApiError,
     GqlApiErrorForbiddenSchemaError,
     GqlApiIntegrationNotFoundError,
+    PersistentRequestsHTTPTransport,
 )
 
 TEST_QUERY = """
@@ -92,3 +95,98 @@ def test_gqlapi_throws_gqlapierrorforbiddenschema_exception(
     with pytest.raises(GqlApiErrorForbiddenSchemaError):
         gql_api = GqlApi("test_url", "test_token", "INTEGRATION", validate_schemas=True)
         gql_api.query.__wrapped__(gql_api, TEST_QUERY)  # type: ignore[attr-defined]
+
+
+# --- gql library integration tests (no mocking) ---
+
+SIMPLE_QUERY = "{ __typename }"
+
+GQL_RESPONSE = {"data": {"__typename": "Query"}}
+
+
+@pytest.fixture
+def graphql_server(httpserver: HTTPServer) -> HTTPServer:
+    httpserver.expect_request("/graphql", method="POST").respond_with_json(GQL_RESPONSE)
+    return httpserver
+
+
+def test_persistent_transport_constructor(graphql_server: HTTPServer) -> None:
+    session = requests.Session()
+    transport = PersistentRequestsHTTPTransport(
+        session,
+        graphql_server.url_for("/graphql"),
+        headers={"Authorization": "Basic test"},
+        timeout=30,
+    )
+    assert transport.session is session
+    assert transport.url == graphql_server.url_for("/graphql")
+
+
+def test_persistent_transport_connect_close_are_noops() -> None:
+    session = requests.Session()
+    transport = PersistentRequestsHTTPTransport(session, "http://localhost/graphql")
+    transport.connect()
+    transport.close()
+    assert not session.headers.get("_closed")
+
+
+def test_client_execute_with_get_execution_result(
+    graphql_server: HTTPServer,
+) -> None:
+    session = requests.Session()
+    transport = PersistentRequestsHTTPTransport(
+        session, graphql_server.url_for("/graphql")
+    )
+    client = Client(transport=transport)
+    result = client.execute(gql(SIMPLE_QUERY), get_execution_result=True)
+    assert hasattr(result, "formatted")
+    assert "data" in result.formatted
+    assert result.formatted["data"]["__typename"] == "Query"
+
+
+def test_client_execute_returns_data_dict(graphql_server: HTTPServer) -> None:
+    session = requests.Session()
+    transport = PersistentRequestsHTTPTransport(
+        session, graphql_server.url_for("/graphql")
+    )
+    client = Client(transport=transport)
+    result = client.execute(gql(SIMPLE_QUERY))
+    assert isinstance(result, dict)
+    assert result["__typename"] == "Query"
+
+
+def test_gqlapi_query_full_stack(graphql_server: HTTPServer) -> None:
+    gql_api = GqlApi(
+        graphql_server.url_for("/graphql"),
+        token="Basic test-token",
+        validate_schemas=False,
+    )
+    result = gql_api.query.__wrapped__(gql_api, SIMPLE_QUERY)  # type: ignore[attr-defined]
+    assert result["__typename"] == "Query"
+
+
+def test_gqlapi_query_full_stack_with_variables(httpserver: HTTPServer) -> None:
+    httpserver.expect_request("/graphql", method="POST").respond_with_json({
+        "data": {"user": {"name": "test-user"}}
+    })
+    gql_api = GqlApi(
+        httpserver.url_for("/graphql"),
+        token="Basic test-token",
+        validate_schemas=False,
+    )
+    query = "query User($id: ID!) { user(id: $id) { name } }"
+    result = gql_api.query.__wrapped__(gql_api, query, variables={"id": "1"})  # type: ignore[attr-defined]
+    assert result["user"]["name"] == "test-user"
+
+
+def test_gqlapi_query_full_stack_transport_error(httpserver: HTTPServer) -> None:
+    httpserver.expect_request("/graphql", method="POST").respond_with_json({
+        "errors": [{"message": "Something went wrong"}]
+    })
+    gql_api = GqlApi(
+        httpserver.url_for("/graphql"),
+        token="Basic test-token",
+        validate_schemas=False,
+    )
+    with pytest.raises(GqlApiError, match="error.*returned with GraphQL response"):
+        gql_api.query.__wrapped__(gql_api, SIMPLE_QUERY)  # type: ignore[attr-defined]

--- a/reconcile/test/utils/test_gql.py
+++ b/reconcile/test/utils/test_gql.py
@@ -1,9 +1,16 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 import pytest
 import requests
 from gql import Client, gql
 from gql.transport.exceptions import TransportQueryError
-from pytest_httpserver import HTTPServer
-from pytest_mock import MockerFixture
+
+if TYPE_CHECKING:
+    from graphql import ExecutionResult
+    from pytest_httpserver import HTTPServer
+    from pytest_mock import MockerFixture
 
 from reconcile.utils.gql import (
     GqlApi,
@@ -138,10 +145,12 @@ def test_client_execute_with_get_execution_result(
         session, graphql_server.url_for("/graphql")
     )
     client = Client(transport=transport)
-    result = client.execute(gql(SIMPLE_QUERY), get_execution_result=True)
-    assert hasattr(result, "formatted")
-    assert "data" in result.formatted
-    assert result.formatted["data"]["__typename"] == "Query"
+    result: ExecutionResult = client.execute(
+        gql(SIMPLE_QUERY), get_execution_result=True
+    )
+    formatted = result.formatted
+    assert formatted["data"] is not None
+    assert formatted["data"]["__typename"] == "Query"
 
 
 def test_client_execute_returns_data_dict(graphql_server: HTTPServer) -> None:

--- a/reconcile/utils/gql.py
+++ b/reconcile/utils/gql.py
@@ -14,11 +14,12 @@ from gql import (
     Client,
     gql,
 )
-from gql.transport.exceptions import TransportQueryError
+from gql.transport.exceptions import (
+    TransportConnectionFailed,
+    TransportQueryError,
+)
 from gql.transport.requests import RequestsHTTPTransport
 from gql.transport.requests import log as requests_logger
-from requests.auth import AuthBase
-from requests.cookies import RequestsCookieJar
 from sentry_sdk import capture_exception
 from sretoolbox.utils import retry
 
@@ -129,11 +130,7 @@ class GqlApi:
 
     def close(self) -> None:
         logging.debug("Closing GqlApi client")
-        if (
-            self.client.transport is not None
-            and hasattr(self.client.transport, "session")
-            and self.client.transport.session
-        ):
+        if hasattr(self.client.transport, "session") and self.client.transport.session:
             self.client.transport.session.close()
 
     @retry(exceptions=GqlApiError, max_attempts=5, hook=capture_and_forget)
@@ -144,10 +141,11 @@ class GqlApi:
         skip_validation: bool = False,
     ) -> dict[str, Any]:
         try:
-            result = self.client.execute(
-                gql(query), variables, get_execution_result=True
-            ).formatted
-        except requests.exceptions.ConnectionError as e:
+            request = gql(query)
+            if variables:
+                request.variable_values = variables
+            result = self.client.execute(request, get_execution_result=True).formatted
+        except (requests.exceptions.ConnectionError, TransportConnectionFailed) as e:
             raise GqlApiError(f"Could not connect to GraphQL server ({e})") from None
         except TransportQueryError as e:
             raise GqlApiError(f"`error` returned with GraphQL response {e}") from None
@@ -306,40 +304,23 @@ def get_resource(path: str) -> dict[str, Any]:
 
 
 class PersistentRequestsHTTPTransport(RequestsHTTPTransport):
-    """A transport for the GQL Client that uses an existing.
-    Is a reduced version of the RequestsHTTPTransport class from gql library
-    with the connect and close methods removed, cause they are implemented
-    to disconnect after each query.
+    """A RequestsHTTPTransport that uses a pre-existing session.
+
+    Overrides connect/close to prevent the base class from creating or
+    destroying the session — we manage its lifecycle externally.
     """
 
     def __init__(
         self,
         session: requests.Session,
         url: str,
+        *,
         headers: dict[str, Any] | None = None,
-        cookies: dict[str, Any] | RequestsCookieJar | None = None,
-        auth: AuthBase | None = None,
-        use_json: bool = True,
         timeout: int | None = None,
-        verify: bool | str = True,
-        retries: int = 0,
-        method: str = "POST",
         **kwargs: Any,
     ):
-        super().__init__(
-            url,
-            headers,
-            cookies,
-            auth,
-            use_json,
-            timeout,
-            verify,
-            retries,
-            method,
-            **kwargs,
-        )
-        # can't directly assign, due to mypy type checking
-        self.session = session  # type: ignore
+        super().__init__(url=url, headers=headers, timeout=timeout, **kwargs)
+        self.session = session
 
     def connect(self) -> None:
         pass

--- a/uv.lock
+++ b/uv.lock
@@ -149,6 +149,15 @@ wheels = [
 ]
 
 [[package]]
+name = "backoff"
+version = "2.2.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/47/d7/5bbeb12c44d7c4f2fb5b56abce497eb5ed9f34d85701de869acedd602619/backoff-2.2.1.tar.gz", hash = "sha256:03f829f5bb1923180821643f8753b0502c3b682293992485b0eef2807afa5cba", size = 17001, upload-time = "2022-10-05T19:19:32.061Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/df/73/b6e24bd22e6720ca8ee9a85a0c4a2971af8497d8f3193fa05390cbd46e09/backoff-2.2.1-py3-none-any.whl", hash = "sha256:63579f9a0628e06278f7e47b7d7d5b6ce20dc65c5e96a6f3ca99a6adca0396e8", size = 15148, upload-time = "2022-10-05T19:19:30.546Z" },
+]
+
+[[package]]
 name = "bcrypt"
 version = "5.0.0"
 source = { registry = "https://pypi.org/simple" }
@@ -351,11 +360,11 @@ wheels = [
 
 [[package]]
 name = "certifi"
-version = "2026.4.22"
+version = "2026.5.20"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/25/ee/6caf7a40c36a1220410afe15a1cc64993a1f864871f698c0f93acb72842a/certifi-2026.4.22.tar.gz", hash = "sha256:8d455352a37b71bf76a79caa83a3d6c25afee4a385d632127b6afb3963f1c580", size = 137077, upload-time = "2026-04-22T11:26:11.191Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/f3/ce/ee2ecad540810a79593028e88299baeae54d346cc7a0d94b6199988b89b1/certifi-2026.5.20.tar.gz", hash = "sha256:69dea482ab64caa7b9f6aba1c6bf48bb6a5448d1c0f1b17ab42ad8c763a5344d", size = 135422, upload-time = "2026-05-20T11:46:50.073Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/22/30/7cd8fdcdfbc5b869528b079bfb76dcdf6056b1a2097a662e5e8c04f42965/certifi-2026.4.22-py3-none-any.whl", hash = "sha256:3cb2210c8f88ba2318d29b0388d1023c8492ff72ecdde4ebdaddbb13a31b1c4a", size = 135707, upload-time = "2026-04-22T11:26:09.372Z" },
+    { url = "https://files.pythonhosted.org/packages/59/8c/57e832b7af6d7c5abe66eb3fbe3a3a32f4d11ea23a1aa7131371035be991/certifi-2026.5.20-py3-none-any.whl", hash = "sha256:3c52e209ba0a4ad7aebe60436a4ab349c39e1e602e8c134221e546902ad25897", size = 134134, upload-time = "2026-05-20T11:46:48.578Z" },
 ]
 
 [[package]]
@@ -769,13 +778,18 @@ wheels = [
 
 [[package]]
 name = "gql"
-version = "3.1.0"
+version = "4.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
+    { name = "anyio" },
+    { name = "backoff" },
     { name = "graphql-core" },
     { name = "yarl" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/d7/45/431b71ac84815260b044bdc88f032a88df2c8ad5edfc4bcc44f7dad67134/gql-3.1.0.tar.gz", hash = "sha256:4b33029e9214aabd2609f3457b8a158b29a3134b193998c9b701785ba31c7ed3", size = 143495, upload-time = "2022-03-11T11:23:15.517Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/06/9f/cf224a88ed71eb223b7aa0b9ff0aa10d7ecc9a4acdca2279eb046c26d5dc/gql-4.0.0.tar.gz", hash = "sha256:f22980844eb6a7c0266ffc70f111b9c7e7c7c13da38c3b439afc7eab3d7c9c8e", size = 215644, upload-time = "2025-08-17T14:32:35.397Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ac/94/30bbd09e8d45339fa77a48f5778d74d47e9242c11b3cd1093b3d994770a5/gql-4.0.0-py3-none-any.whl", hash = "sha256:f3beed7c531218eb24d97cb7df031b4a84fdb462f4a2beb86e2633d395937479", size = 89900, upload-time = "2025-08-17T14:32:34.029Z" },
+]
 
 [[package]]
 name = "graphql-core"
@@ -2145,7 +2159,7 @@ requires-dist = [
     { name = "dnspython", specifier = "~=2.1" },
     { name = "dt", specifier = "==1.1.73" },
     { name = "filetype", specifier = "~=1.2.0" },
-    { name = "gql", specifier = "==3.1.0" },
+    { name = "gql", specifier = "~=4.0" },
     { name = "hvac", specifier = "==2.4.0" },
     { name = "jenkins-job-builder", specifier = "==6.4.4" },
     { name = "jinja2", specifier = ">=2.10.1,<3.2.0" },
@@ -3159,34 +3173,33 @@ wheels = [
 
 [[package]]
 name = "yarl"
-version = "1.23.0"
+version = "1.24.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "idna" },
     { name = "multidict" },
     { name = "propcache" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/23/6e/beb1beec874a72f23815c1434518bfc4ed2175065173fb138c3705f658d4/yarl-1.23.0.tar.gz", hash = "sha256:53b1ea6ca88ebd4420379c330aea57e258408dd0df9af0992e5de2078dc9f5d5", size = 194676, upload-time = "2026-03-01T22:07:53.373Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/79/12/1e8f37460ea0f7eb59c221fdaf0ed75e7ac43e97f8093b9c6f411df50a78/yarl-1.24.2.tar.gz", hash = "sha256:9ac374123c6fd7abf64d1fec93962b0bd4ee2c19751755a762a72dd96c0378f8", size = 210798, upload-time = "2026-05-19T21:31:05.599Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/88/8a/94615bc31022f711add374097ad4144d569e95ff3c38d39215d07ac153a0/yarl-1.23.0-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:1932b6b8bba8d0160a9d1078aae5838a66039e8832d41d2992daa9a3a08f7860", size = 124737, upload-time = "2026-03-01T22:05:12.897Z" },
-    { url = "https://files.pythonhosted.org/packages/e3/6f/c6554045d59d64052698add01226bc867b52fe4a12373415d7991fdca95d/yarl-1.23.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:411225bae281f114067578891bc75534cfb3d92a3b4dfef7a6ca78ba354e6069", size = 87029, upload-time = "2026-03-01T22:05:14.376Z" },
-    { url = "https://files.pythonhosted.org/packages/19/2a/725ecc166d53438bc88f76822ed4b1e3b10756e790bafd7b523fe97c322d/yarl-1.23.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:13a563739ae600a631c36ce096615fe307f131344588b0bc0daec108cdb47b25", size = 86310, upload-time = "2026-03-01T22:05:15.71Z" },
-    { url = "https://files.pythonhosted.org/packages/99/30/58260ed98e6ff7f90ba84442c1ddd758c9170d70327394a6227b310cd60f/yarl-1.23.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9cbf44c5cb4a7633d078788e1b56387e3d3cf2b8139a3be38040b22d6c3221c8", size = 97587, upload-time = "2026-03-01T22:05:17.384Z" },
-    { url = "https://files.pythonhosted.org/packages/76/0a/8b08aac08b50682e65759f7f8dde98ae8168f72487e7357a5d684c581ef9/yarl-1.23.0-cp312-cp312-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:53ad387048f6f09a8969631e4de3f1bf70c50e93545d64af4f751b2498755072", size = 92528, upload-time = "2026-03-01T22:05:18.804Z" },
-    { url = "https://files.pythonhosted.org/packages/52/07/0b7179101fe5f8385ec6c6bb5d0cb9f76bd9fb4a769591ab6fb5cdbfc69a/yarl-1.23.0-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:4a59ba56f340334766f3a4442e0efd0af895fae9e2b204741ef885c446b3a1a8", size = 105339, upload-time = "2026-03-01T22:05:20.235Z" },
-    { url = "https://files.pythonhosted.org/packages/d3/8a/36d82869ab5ec829ca8574dfcb92b51286fcfb1e9c7a73659616362dc880/yarl-1.23.0-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:803a3c3ce4acc62eaf01eaca1208dcf0783025ef27572c3336502b9c232005e7", size = 105061, upload-time = "2026-03-01T22:05:22.268Z" },
-    { url = "https://files.pythonhosted.org/packages/66/3e/868e5c3364b6cee19ff3e1a122194fa4ce51def02c61023970442162859e/yarl-1.23.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a3d2bff8f37f8d0f96c7ec554d16945050d54462d6e95414babaa18bfafc7f51", size = 100132, upload-time = "2026-03-01T22:05:23.638Z" },
-    { url = "https://files.pythonhosted.org/packages/cf/26/9c89acf82f08a52cb52d6d39454f8d18af15f9d386a23795389d1d423823/yarl-1.23.0-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:c75eb09e8d55bceb4367e83496ff8ef2bc7ea6960efb38e978e8073ea59ecb67", size = 99289, upload-time = "2026-03-01T22:05:25.749Z" },
-    { url = "https://files.pythonhosted.org/packages/6f/54/5b0db00d2cb056922356104468019c0a132e89c8d3ab67d8ede9f4483d2a/yarl-1.23.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:877b0738624280e34c55680d6054a307aa94f7d52fa0e3034a9cc6e790871da7", size = 96950, upload-time = "2026-03-01T22:05:27.318Z" },
-    { url = "https://files.pythonhosted.org/packages/f6/40/10fa93811fd439341fad7e0718a86aca0de9548023bbb403668d6555acab/yarl-1.23.0-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:b5405bb8f0e783a988172993cfc627e4d9d00432d6bbac65a923041edacf997d", size = 93960, upload-time = "2026-03-01T22:05:28.738Z" },
-    { url = "https://files.pythonhosted.org/packages/bc/d2/8ae2e6cd77d0805f4526e30ec43b6f9a3dfc542d401ac4990d178e4bf0cf/yarl-1.23.0-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:1c3a3598a832590c5a3ce56ab5576361b5688c12cb1d39429cf5dba30b510760", size = 104703, upload-time = "2026-03-01T22:05:30.438Z" },
-    { url = "https://files.pythonhosted.org/packages/2f/0c/b3ceacf82c3fe21183ce35fa2acf5320af003d52bc1fcf5915077681142e/yarl-1.23.0-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:8419ebd326430d1cbb7efb5292330a2cf39114e82df5cc3d83c9a0d5ebeaf2f2", size = 98325, upload-time = "2026-03-01T22:05:31.835Z" },
-    { url = "https://files.pythonhosted.org/packages/9d/e0/12900edd28bdab91a69bd2554b85ad7b151f64e8b521fe16f9ad2f56477a/yarl-1.23.0-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:be61f6fff406ca40e3b1d84716fde398fc08bc63dd96d15f3a14230a0973ed86", size = 105067, upload-time = "2026-03-01T22:05:33.358Z" },
-    { url = "https://files.pythonhosted.org/packages/15/61/74bb1182cf79c9bbe4eb6b1f14a57a22d7a0be5e9cedf8e2d5c2086474c3/yarl-1.23.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:3ceb13c5c858d01321b5d9bb65e4cf37a92169ea470b70fec6f236b2c9dd7e34", size = 100285, upload-time = "2026-03-01T22:05:35.4Z" },
-    { url = "https://files.pythonhosted.org/packages/69/7f/cd5ef733f2550de6241bd8bd8c3febc78158b9d75f197d9c7baa113436af/yarl-1.23.0-cp312-cp312-win32.whl", hash = "sha256:fffc45637bcd6538de8b85f51e3df3223e4ad89bccbfca0481c08c7fc8b7ed7d", size = 82359, upload-time = "2026-03-01T22:05:36.811Z" },
-    { url = "https://files.pythonhosted.org/packages/f5/be/25216a49daeeb7af2bec0db22d5e7df08ed1d7c9f65d78b14f3b74fd72fc/yarl-1.23.0-cp312-cp312-win_amd64.whl", hash = "sha256:f69f57305656a4852f2a7203efc661d8c042e6cc67f7acd97d8667fb448a426e", size = 87674, upload-time = "2026-03-01T22:05:38.171Z" },
-    { url = "https://files.pythonhosted.org/packages/d2/35/aeab955d6c425b227d5b7247eafb24f2653fedc32f95373a001af5dfeb9e/yarl-1.23.0-cp312-cp312-win_arm64.whl", hash = "sha256:6e87a6e8735b44816e7db0b2fbc9686932df473c826b0d9743148432e10bb9b9", size = 81879, upload-time = "2026-03-01T22:05:40.006Z" },
-    { url = "https://files.pythonhosted.org/packages/69/68/c8739671f5699c7dc470580a4f821ef37c32c4cb0b047ce223a7f115757f/yarl-1.23.0-py3-none-any.whl", hash = "sha256:a2df6afe50dea8ae15fa34c9f824a3ee958d785fd5d089063d960bae1daa0a3f", size = 48288, upload-time = "2026-03-01T22:07:51.388Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/da/866bcb01076ba49d2b42b309867bed3826421f1c479655eb7a607b44f20b/yarl-1.24.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:b975866c184564c827e0877380f0dae57dcca7e52782128381b72feff6dfceb8", size = 129957, upload-time = "2026-05-19T21:28:51.695Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/1d/fcefb70922ea2268a8971d8e5874d9a8218644200fb8465f1dcad55e6851/yarl-1.24.2-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:3b075301a2836a0e297b1b658cb6d6135df535d62efefdd60366bd589c2c82f2", size = 92164, upload-time = "2026-05-19T21:28:53.242Z" },
+    { url = "https://files.pythonhosted.org/packages/29/b6/170e2b8d4e3bc30e6bfdcca53556537f5bf595e938632dfcb059311f3ff6/yarl-1.24.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:8ae44649b00947634ab0dab2a374a638f52923a6e67083f2c156cd5cbd1a881d", size = 91688, upload-time = "2026-05-19T21:28:54.865Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/a5/c9f655d5553ea0b99fdac9d6a99ad3f9b3e73b8e5758bb46f58c9831f74c/yarl-1.24.2-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:507cc19f0b45454e2d6dcd62ff7d062b9f77a2812404e62dbdaec05b50faa035", size = 102902, upload-time = "2026-05-19T21:28:56.963Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/bc/6b9664d815d79af4ee553337f9d606c56bbf269186ada9172de45f1b5f60/yarl-1.24.2-cp312-cp312-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:c4c17bad5a530912d2111825d3f05e89bab2dd376aaa8cbc77e449e6db63e576", size = 97931, upload-time = "2026-05-19T21:28:58.56Z" },
+    { url = "https://files.pythonhosted.org/packages/98/ec/32ba48acae30fecd60928f5791188b80a9d6ee3840507ffda29fecd37b71/yarl-1.24.2-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:f5f0cbb112838a4a293985b6ed73948a547dadcc1ba6d2089938e7abdedceef8", size = 111030, upload-time = "2026-05-19T21:29:00.148Z" },
+    { url = "https://files.pythonhosted.org/packages/82/5a/6f4cd081e5f4934d2ae3a8ef4abe3afacc010d26f0035ee91b35cd7d7c37/yarl-1.24.2-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:5ec8356b8a6afcf81fc7aeeef13b1ff7a49dec00f313394bbb9e83830d32ccd7", size = 110392, upload-time = "2026-05-19T21:29:02.155Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/da/323a01c349bd5fb01bb6652e314d9bb218cee630a736bdb810ad50e4013f/yarl-1.24.2-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:7e7ebcdef69dec6c6451e616f32b622a6d4a2e92b445c992f7c8e5274a6bbc4c", size = 105612, upload-time = "2026-05-19T21:29:04.247Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/80/264ab684f181e1a876389374519ff05d10248725535ae2ac4e8ac4e563d6/yarl-1.24.2-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:47a55d6cf6db2f401017a9e96e5288844e5051911fb4e0c8311a3980f5e59a7d", size = 104487, upload-time = "2026-05-19T21:29:06.491Z" },
+    { url = "https://files.pythonhosted.org/packages/41/07/efabe5df87e96d7ad5959760b888344be48cd6884db127b407c6b5503adc/yarl-1.24.2-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:3065657c80a2321225e804048597ad55658a7e76b32d6f5ee4074d04c50401db", size = 102333, upload-time = "2026-05-19T21:29:08.267Z" },
+    { url = "https://files.pythonhosted.org/packages/44/0c/bcf7c42603e1009295f586d8890f2ba032c8b53310e815adf0a202c73d9f/yarl-1.24.2-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:cb84b80d88e19ede158619b80813968713d8d008b0e2497a576e6a0557d50712", size = 99025, upload-time = "2026-05-19T21:29:10.682Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/82/84482ab1a57a0f21a08afe6a7004c61d741f8f2ecc3b05c321577c612164/yarl-1.24.2-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:990de4f680b1c217e77ff0d6aa0029f9eb79889c11fb3e9a3942c7eba29c1996", size = 110507, upload-time = "2026-05-19T21:29:12.954Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/8d/a546ba1dfe1b0f290e05fef145cd07614c0f15df1a707195e512d1e39d1d/yarl-1.24.2-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:abb8ec0323b80161e3802da3150ef660b41d0e9be2048b76a363d93eee992c2b", size = 103719, upload-time = "2026-05-19T21:29:14.893Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/b6/267f2a09213138473adfce6b8a6e17791d7fee70bd4d9003218e4dec58b0/yarl-1.24.2-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:e7977781f83638a4c73e0f88425563d70173e0dfd90ac006a45c65036293ee3c", size = 110438, upload-time = "2026-05-19T21:29:16.485Z" },
+    { url = "https://files.pythonhosted.org/packages/48/2d/1c8d89c7c5f9cad9fb2902445d94e2ab1d7aa35de029afbb8ae95c42d00f/yarl-1.24.2-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:e30dd55825dc554ec5b66a94953b8eda8745926514c5089dfcacecb9c99b5bd1", size = 105719, upload-time = "2026-05-19T21:29:18.367Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/25/722e3b93bd687009afb2d59a35e13d30ddd8f80571445bb0c4e4ce26ec66/yarl-1.24.2-cp312-cp312-win_amd64.whl", hash = "sha256:7dafe10c12ddd4d120d528c4b5599c953bd7b12845347d507b95451195bb6cad", size = 92901, upload-time = "2026-05-19T21:29:20.014Z" },
+    { url = "https://files.pythonhosted.org/packages/39/47/4486ccfb674c04854a1ef8aa77868b6a6f765feaf69633409d7ca4f02cb8/yarl-1.24.2-cp312-cp312-win_arm64.whl", hash = "sha256:044a09d8401fcf8681977faef6d286b8ade1e2d2e9dceda175d1cfa5ca496f30", size = 87229, upload-time = "2026-05-19T21:29:22.1Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/4d/4b880086bd0d3e034d25647be1d830afc3e3f610e98c4ab3490af6b1b6d5/yarl-1.24.2-py3-none-any.whl", hash = "sha256:2783d9226db8797636cd6896e4de81feed252d1db72265686c9558d97a4d94b9", size = 53576, upload-time = "2026-05-19T21:31:03.909Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Upgrade `gql` from 3.1.0 to 4.0.0 (new yggdrasil evaluation engine, `GraphQLRequest` replaces `DocumentNode`)
- `gql()` now returns `GraphQLRequest` — variables are set via `request.variable_values` instead of positional arg to `Client.execute()`
- `PersistentRequestsHTTPTransport` simplified for v4 constructor signature
- `TransportConnectionFailed` added to exception handling (v4 wraps connection errors)
- 7 new integration tests exercising the real gql library API without mocking

## Breaking changes addressed
- `gql()` returns `GraphQLRequest` instead of `DocumentNode`
- `Client.execute()` keyword-only params after `request` — variables can no longer be passed positionally
- `RequestsHTTPTransport` constructor has new parameters (`retry_backoff_factor`, `json_serialize`, etc.)
- Connection errors wrapped in `TransportConnectionFailed`

## Test plan
- [x] 13 unit tests pass (6 existing mocked + 7 new integration tests)
- [x] ruff clean
- [x] mypy clean
- [x] Manual dry-run: `query-validator` (queries with and without variables)
- [x] Manual dry-run: `gitlab-housekeeping` (old-style queries.py + State with variables)
- [x] Manual dry-run: `aws-account-manager` (State with variables)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated GraphQL dependency to a v4-compatible release for improved compatibility and future support.

* **Bug Fixes**
  * Broadened connection-failure handling for more robust detection and clearer error propagation when GraphQL endpoints are unreachable.

* **Tests**
  * Added end-to-end integration tests for GraphQL queries, variable handling, response formatting, and error conditions to improve reliability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/app-sre/qontract-reconcile/pull/5562?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->