### PR TITLE
[draft] [openshift-tekton-resources] Improve  logging on cluster failures

### DIFF
--- a/reconcile/openshift_tekton_resources.py
+++ b/reconcile/openshift_tekton_resources.py
@@ -13,6 +13,7 @@ from reconcile.status import ExitCodes
 from reconcile.utils import gql
 from reconcile.utils.constants import DEFAULT_THREAD_POOL_SIZE
 from reconcile.utils.defer import defer
+from reconcile.utils.oc import OCLogMsg
 from reconcile.utils.openshift_resource import OpenshiftResource as OR
 from reconcile.utils.parse_dhms_duration import (
     dhms_to_seconds,
@@ -420,6 +421,113 @@ def build_one_per_saas_file_tkn_task_name(
     return name
 
 
+def _cluster_provider_map(tkn_providers: dict[str, Any]) -> dict[str, list[str]]:
+    """Map cluster name -> pipeline-provider names using that cluster."""
+    mapping: dict[str, list[str]] = {}
+    for provider_name, tknp in tkn_providers.items():
+        if tknp["namespace"].get("delete"):
+            continue
+        cluster = tknp["namespace"]["cluster"]["name"]
+        namespace = tknp["namespace"]["name"]
+        mapping.setdefault(cluster, []).append(f"{provider_name} ({namespace})")
+    return mapping
+
+
+def _log_tkn_provider_scope(tkn_providers: dict[str, Any]) -> None:
+    """Log which pipeline-providers this run will reconcile and where they live."""
+    clusters = _cluster_provider_map(tkn_providers)
+    LOG.info(
+        "[openshift-tekton-resources] reconciling %s pipeline-provider(s) "
+        "across %s cluster(s)",
+        len(tkn_providers),
+        len(clusters),
+    )
+    for provider_name, tknp in sorted(tkn_providers.items()):
+        if tknp["namespace"].get("delete"):
+            LOG.info(
+                "[openshift-tekton-resources] skipping provider=%s "
+                "(namespace marked for deletion)",
+                provider_name,
+            )
+            continue
+        cluster = tknp["namespace"]["cluster"]["name"]
+        namespace = tknp["namespace"]["name"]
+        LOG.info(
+            "[openshift-tekton-resources] provider=%s cluster=%s namespace=%s "
+            "saas_files=%s",
+            provider_name,
+            cluster,
+            namespace,
+            len(tknp.get("saas_files", [])),
+        )
+
+
+def _log_oc_map_failures(
+    tkn_providers: dict[str, Any],
+    oc_map: ob.OC_Map,
+) -> set[str]:
+    """Log OpenShift client init problems and return affected cluster names."""
+    failed_clusters: set[str] = set()
+    for cluster, providers in sorted(_cluster_provider_map(tkn_providers).items()):
+        oc = oc_map.get(cluster)
+        if not isinstance(oc, OCLogMsg):
+            continue
+        failed_clusters.add(cluster)
+        provider_list = ", ".join(providers)
+        if oc.log_level >= logging.ERROR:
+            LOG.error(
+                "[openshift-tekton-resources] cannot connect to cluster=%s; "
+                "pipeline-providers affected: %s. %s",
+                cluster,
+                provider_list,
+                oc.message,
+            )
+        else:
+            LOG.warning(
+                "[openshift-tekton-resources] cluster=%s skipped; "
+                "pipeline-providers affected: %s. %s",
+                cluster,
+                provider_list,
+                oc.message,
+            )
+    return failed_clusters
+
+
+def _log_reconcile_failure_summary(
+    tkn_providers: dict[str, Any],
+    ri: ob.ResourceInventory,
+    oc_failed_clusters: set[str],
+) -> None:
+    """Summarize why the integration is exiting with an error."""
+    cluster_providers = _cluster_provider_map(tkn_providers)
+    inventory_failed = sorted(
+        cluster
+        for cluster in cluster_providers
+        if ri.has_error_registered(cluster=cluster)
+    )
+    oc_failed = sorted(oc_failed_clusters)
+    if inventory_failed:
+        for cluster in inventory_failed:
+            LOG.error(
+                "[openshift-tekton-resources] resource inventory errors on "
+                "cluster=%s (pipeline-providers: %s). Check earlier logs for "
+                "StatusCodeError while listing Pipeline/Task resources.",
+                cluster,
+                ", ".join(cluster_providers[cluster]),
+            )
+    if oc_failed:
+        LOG.error(
+            "[openshift-tekton-resources] OpenShift API client errors on "
+            "cluster(s): %s",
+            ", ".join(oc_failed),
+        )
+    if not inventory_failed and not oc_failed and ri.has_error_registered():
+        LOG.error(
+            "[openshift-tekton-resources] integration failed but no cluster "
+            "was attributed; check earlier openshift_base logs"
+        )
+
+
 def run(
     dry_run: bool,
     thread_pool_size: int = DEFAULT_THREAD_POOL_SIZE,
@@ -433,6 +541,8 @@ def run(
     if not tkn_providers:
         LOG.debug("No saas files found to be processed")
         sys.exit(0)
+
+    _log_tkn_provider_scope(tkn_providers)
 
     # We need to start with the desired state to know the names of the
     # tekton objects that will be created in the providers' namespaces. We
@@ -453,6 +563,7 @@ def run(
         thread_pool_size=thread_pool_size,
     )
     defer(oc_map.cleanup)
+    oc_failed_clusters = _log_oc_map_failures(tkn_providers, oc_map)
 
     LOG.debug("Adding desired resources to inventory")
     for desired_resource in desired_resources:
@@ -464,6 +575,7 @@ def run(
     ob.realize_data(dry_run, oc_map, ri, thread_pool_size)
 
     if ri.has_error_registered():
+        _log_reconcile_failure_summary(tkn_providers, ri, oc_failed_clusters)
         sys.exit(ExitCodes.ERROR)
 
     sys.exit(0)

--- a/reconcile/test/test_openshift_tekton_resources.py
+++ b/reconcile/test/test_openshift_tekton_resources.py
@@ -4,18 +4,22 @@
 # to be addressed, but it was blocking other changes.
 # type: ignore
 
+import logging
 from copy import deepcopy
 from typing import Any
 from unittest.mock import (
+    Mock,
     create_autospec,
     patch,
 )
 
 import pytest
 
+from reconcile import openshift_base as ob
 from reconcile import openshift_tekton_resources as otr
 from reconcile.queries import PIPELINES_PROVIDERS_QUERY
 from reconcile.utils import gql
+from reconcile.utils.oc import OCLogMsg
 
 from .fixtures import Fixtures
 
@@ -276,3 +280,106 @@ class TestOpenshiftTektonResources:
         )
         with pytest.raises(otr.OpenshiftTektonResourcesNameTooLongError, match=msg):
             otr.fetch_desired_resources(otr.fetch_tkn_providers(None))
+
+
+def _tkn_provider_fixture(
+    provider_name: str,
+    cluster: str,
+    namespace: str,
+    *,
+    delete: bool | None = False,
+    saas_file_count: int = 1,
+) -> dict[str, Any]:
+    return {
+        provider_name: {
+            "name": provider_name,
+            "namespace": {
+                "name": namespace,
+                "delete": delete,
+                "cluster": {"name": cluster},
+            },
+            "saas_files": [{}] * saas_file_count,
+        }
+    }
+
+
+class TestOpenshiftTektonResourcesLogging:
+    def test_log_tkn_provider_scope_includes_cluster_and_provider(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        tkn_providers = {
+            **_tkn_provider_fixture(
+                "tekton-pipelines-provider-a",
+                "cluster-a",
+                "pipelines-namespace-a",
+            ),
+            **_tkn_provider_fixture(
+                "tekton-pipelines-provider-b",
+                "cluster-b",
+                "pipelines-namespace-b",
+            ),
+        }
+
+        with caplog.at_level(logging.INFO):
+            otr._log_tkn_provider_scope(tkn_providers)
+
+        messages = [record.message for record in caplog.records]
+        assert any(
+            "provider=tekton-pipelines-provider-a" in message
+            and "cluster=cluster-a" in message
+            and "namespace=pipelines-namespace-a" in message
+            for message in messages
+        )
+        assert any(
+            "reconciling 2 pipeline-provider(s) across 2 cluster(s)" in message
+            for message in messages
+        )
+
+    def test_log_oc_map_failures_includes_unhealthy_cluster_and_providers(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        tkn_providers = _tkn_provider_fixture(
+            "tekton-pipelines-provider-a",
+            "cluster-a",
+            "pipelines-namespace-a",
+        )
+        oc_map = Mock()
+        oc_map.get.return_value = OCLogMsg(
+            logging.ERROR,
+            '[cluster-a] HTTP response body: b\'{"message":"conversion webhook unavailable"}\'',
+        )
+
+        with caplog.at_level(logging.ERROR):
+            failed_clusters = otr._log_oc_map_failures(tkn_providers, oc_map)
+
+        assert failed_clusters == {"cluster-a"}
+        assert any(
+            record.levelno == logging.ERROR
+            and "cannot connect to cluster=cluster-a" in record.message
+            and "tekton-pipelines-provider-a" in record.message
+            and "pipelines-namespace-a" in record.message
+            and "conversion webhook unavailable" in record.message
+            for record in caplog.records
+        )
+
+    def test_log_reconcile_failure_summary_includes_cluster_and_providers(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        tkn_providers = _tkn_provider_fixture(
+            "tekton-pipelines-provider-a",
+            "cluster-a",
+            "pipelines-namespace-a",
+        )
+        ri = ob.ResourceInventory()
+        ri.register_error(cluster="cluster-a")
+
+        with caplog.at_level(logging.ERROR):
+            otr._log_reconcile_failure_summary(tkn_providers, ri, set())
+
+        assert any(
+            record.levelno == logging.ERROR
+            and "resource inventory errors on cluster=cluster-a" in record.message
+            and "tekton-pipelines-provider-a" in record.message
+            and "pipelines-namespace-a" in record.message
+            for record in caplog.records
+        )


### PR DESCRIPTION
This PR improves detail and quality of error logging for `openshift-tekton-resources` in the event that 1 or more pipeline-providers are in an unhealthy state.

---
 
 ## Further context:
 
This PR is a corrective action following an incident where a non-sharded openshift-tekton-resources integration failed for an extended period and blocked many app-interface merge pipelines. Root cause was an unhealthy OpenShift cluster (broken/missing Tekton conversion webhook after openshift-pipelines subscription removal). Mitigation and diagnosis were slowed because pod logs did not clearly attribute failures to a specific cluster or pipeline-provider.

This PR adds structured, cluster- and pipeline-provider-aware logging to openshift-tekton-resources so engineers can identify which cluster and which Tekton pipeline-providers are affected without inferring from raw API error bodies or cross-referencing app-interface data under pressure.

This PR affects logging behavior only, and does not change reconcile behavior (e.g. still exits with error if any cluster fails). Follow-up work for partial-success / broader openshift_base exception logging is planned from me soon.

---

## Failure scenarios accounted for

Failure mode | Typical symptom in logs | Gap before this PR
-- | -- | --
OpenShift client init failure | OC_Map.get(cluster) returns OCLogMsg with a message like [cluster] HTTP response body: ... | Message might mention a cluster prefix, but not which pipeline-providers on that cluster are impacted by this tekton-resources run
Resource inventory errors (e.g. listing Pipeline/Task) | openshift_base may log [cluster/namespace] ... for StatusCodeError; other exceptions may produce less structured output | No tekton-resources-specific summary tying inventory failure to pipeline-provider names
Integration exit | Process exits 1; generic failure | Hard to answer: “Which cluster/provider should we fix first?” from tekton-resources logs alone

---

## Logging Issues addressed by this PR

Circumstance: Cluster API is broken (e.g. Tekton conversion webhook missing). OC_Map cannot initialize a healthy client; downstream code may log API errors.

Sample "old" log:

```
HTTP response body: b'{"message":"Internal error occurred: conversion webhook for tekton.dev/v1beta1 ... failed: ... tekton-pipelines-webhook ... not found","reason":"InternalError","code":500}'
```

Or, when StatusCodeError is raised during list operations, openshift_base may log:

```
[some-cluster/some-namespace] StatusCodeError: ...
```

Why this is not ideal for tekton-resources:

The raw HTTP body often does not include the pipeline-provider name used in app-interface.
In a multi-cluster / multi-provider pod, it is unclear which reconcile scope produced the line.
On exit, there is no tekton-resources summary like: “cluster X failed; pipeline-providers A, B affected.”

---

## Examples of new logging

All "new" logs are prefixed with [openshift-tekton-resources] for easy filtering.

### Case 1: Run scope (INFO) — start of every successful run() that has providers
When: Immediately after fetch_tkn_providers(), before any cluster API calls.

Sample "new" logs:

```
[openshift-tekton-resources] reconciling 168 pipeline-provider(s) across 42 cluster(s)
[openshift-tekton-resources] provider=tekton-pipelines-provider-a cluster=cluster-a namespace=pipelines-namespace-a saas_files=3
[openshift-tekton-resources] provider=tekton-pipelines-provider-b cluster=cluster-b namespace=pipelines-namespace-b saas_files=1
```

Value: Establishes the full reconcile footprint for this pod/shard before failures occur.

### Case 2: OpenShift client failures (ERROR/WARNING) — after fetch_current_state()
When: OC_Map.get(cluster) returns OCLogMsg (cannot connect, auth failure, API error during client setup, etc.).

Sample "new logs:

```
[openshift-tekton-resources] cannot connect to cluster=cluster-a; pipeline-providers affected: tekton-pipelines-provider-a (pipelines-namespace-a). [cluster-a] HTTP response body: b'{"message":"conversion webhook unavailable",...}'
```

Value: Establishes the full reconcile footprint for this pod/shard before failures occur.

### Case 3: Exit summary (ERROR) — when integration exits with error
When: ri.has_error_registered() after realize_data() (inventory errors and/or earlier OC failures).

sample "new" logs

```
[openshift-tekton-resources] resource inventory errors on cluster=cluster-a (pipeline-providers: tekton-pipelines-provider-a (pipelines-namespace-a)). Check earlier logs for StatusCodeError while listing Pipeline/Task resources.
[openshift-tekton-resources] OpenShift API client errors on cluster(s): cluster-a
````

Value: Final actionable summary aligned with app-interface objects (provider name + namespace). If errors were registered but not attributed to a known cluster, a fallback line is logged to prompt checking openshift_base logs.

---

## Code / logic overview

No change to reconcile semantics (still sys.exit(1) when any error is registered). Changes are logging helpers + wiring in run():


Helper | Role
-- | --
_cluster_provider_map() | Builds cluster → [provider (namespace), ...] from tkn_providers (skips namespaces marked delete)
_log_tkn_provider_scope() | INFO logs for each provider and aggregate counts
_log_oc_map_failures() | Inspects OC_Map per cluster; logs ERROR/WARNING with affected providers; returns failed_clusters set
_log_reconcile_failure_summary() | On error exit, logs per-cluster inventory failures and OC failure clusters

run() wiring:

_log_tkn_provider_scope() after loading providers
_log_oc_map_failures() after fetch_current_state()
_log_reconcile_failure_summary() before sys.exit(1) when errors registered

---

## Tests

Added TestOpenshiftTektonResourcesLogging in reconcile/test/test_openshift_tekton_resources.py — unit tests only (no OpenShift, Tekton, qontract-server, or app-interface required). They call logging helpers directly with minimal fixtures and unittest.mock.Mock / caplog.


Test | What it proves
-- | --
test_log_tkn_provider_scope_includes_cluster_and_provider | _log_tkn_provider_scope emits INFO lines with provider=, cluster=, namespace= and the aggregate provider/cluster count
test_log_oc_map_failures_includes_unhealthy_cluster_and_providers | When oc_map.get() returns OCLogMsg, _log_oc_map_failures logs ERROR with cluster, affected pipeline-provider, namespace, and underlying error text; returns the failed cluster set
test_log_reconcile_failure_summary_includes_cluster_and_providers | When ResourceInventory.register_error(cluster=...) is set, exit summary logs cluster + pipeline-provider attribution

---

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced error logging for pipeline provider reconciliation, including provider scope and consolidated failure summaries
  * Improved visibility into OpenShift client initialization failures with detailed context included in reconciliation error output

* **Tests**
  * Added tests that validate logging of provider scope, OpenShift client failures, and reconciliation failure summaries

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/app-sre/qontract-reconcile/pull/5563?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->