### PR TITLE
fix(prometheus-rule): add monitoring.rhobs API group to override_managed_types

### DIFF
--- a/reconcile/openshift_resources_base.py
+++ b/reconcile/openshift_resources_base.py
@@ -884,6 +884,7 @@ def canonicalize_namespaces(
                 override = [
                     "PrometheusRule.monitoring.coreos.com",
                     "PrometheusRule.monitoring.rhobs.io",
+                    "PrometheusRule.monitoring.rhobs",
                 ]
 
             namespace_info["openshiftResources"] = ors

--- a/reconcile/test/fixtures/namespaces/openshift-resources-only.yml
+++ b/reconcile/test/fixtures/namespaces/openshift-resources-only.yml
@@ -11,3 +11,5 @@ openshiftResources:
     path: /secret/place.yml
   - provider: route
     path: /route/network.yml
+  - provider: prometheus-rule
+    path: /observability/rules.yaml

--- a/reconcile/test/test_openshift_resources_base.py
+++ b/reconcile/test/test_openshift_resources_base.py
@@ -104,6 +104,18 @@ def test_route(namespaces: list[dict[str, Any]], mocker: MockerFixture) -> None:
     assert (ns, override) == expected
 
 
+def test_prometheus_rule(
+    namespaces: list[dict[str, Any]], mocker: MockerFixture
+) -> None:
+    mocker.patch.object(ob, "aggregate_shared_resources", autospec=True)
+    _, override = canonicalize_namespaces(namespaces, ["prometheus-rule"])
+    assert override == [
+        "PrometheusRule.monitoring.coreos.com",
+        "PrometheusRule.monitoring.rhobs.io",
+        "PrometheusRule.monitoring.rhobs",
+    ]
+
+
 def test_no_overrides(namespaces: list[dict[str, Any]], mocker: MockerFixture) -> None:
     mocker.patch.object(ob, "aggregate_shared_resources", autospec=True)
     expected = (


### PR DESCRIPTION
## Summary

- Add `PrometheusRule.monitoring.rhobs` to the `prometheus-rule` provider's `override_managed_types` in `canonicalize_namespaces`
- COO installs PrometheusRule CRDs under `monitoring.rhobs` (not `monitoring.rhobs.io`), causing the integration to fail finding the API resource and error on reconcile
- Keep the existing `monitoring.rhobs.io` entry for backwards compatibility

## Test plan

- [ ] Added `test_prometheus_rule` unit test asserting all three API groups are present in the override
- [ ] Existing `test_secret`, `test_route`, `test_no_overrides` tests still pass

Fixes: https://redhat.atlassian.net/browse/APPSRE-14375

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for managing Prometheus Rule resources in OpenShift environments.

* **Tests**
  * Added automated test coverage to validate Prometheus Rule resource management functionality.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/app-sre/qontract-reconcile/pull/5567?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->