### PR TITLE
Update saas file paths after ci-ext to tekton rename

### DIFF
--- a/reconcile/utils/mr/promote_qontract.py
+++ b/reconcile/utils/mr/promote_qontract.py
@@ -220,11 +220,11 @@ Please use `/retest` once the RPA finished (that should be the case after ~5min 
             replace_text=f"    qontract_reconcile_image_tag: '{self.version}'",
         )
 
-        # data/services/app-interface/cicd/ci-ext/saas-qontract-dashboards.yaml
+        # data/services/app-interface/cicd/tekton/saas-qontract-dashboards.yaml
         self._process_by(
             "json_path",
             gitlab_cli=gitlab_cli,
-            path="data/services/app-interface/cicd/ci-ext/saas-qontract-dashboards.yaml",
+            path="data/services/app-interface/cicd/tekton/saas-qontract-dashboards.yaml",
             search_text="$.resourceTemplates[?(@.url == 'https://github.com/app-sre/qontract-reconcile')].targets[?(@.name == 'app-sre-observability-production')].ref",
             replace_text=self.commit_sha,
         )
@@ -294,11 +294,11 @@ class PromoteQontractServer(PromoteQontractReconcileCommercial):
             replace_text=f"export QONTRACT_SERVER_IMAGE_TAG={self.version}",
         )
 
-        # data/services/app-interface/cicd/ci-ext/saas-qontract-server.yaml
+        # data/services/app-interface/cicd/tekton/saas-qontract-server.yaml
         # Both the main template and dashboard share the same file — read/write once.
         self._process_file_with_json_paths(
             gitlab_cli=gitlab_cli,
-            path="data/services/app-interface/cicd/ci-ext/saas-qontract-server.yaml",
+            path="data/services/app-interface/cicd/tekton/saas-qontract-server.yaml",
             replacements=[
                 (
                     "$.resourceTemplates[?(@.name == 'qontract-server')].targets[?(@.name == 'app-interface-production')].ref",


### PR DESCRIPTION
The saas-qontract-dashboards.yaml and saas-qontract-server.yaml files were relocated from cicd/ci-ext/ to cicd/tekton/ in app-interface. The hardcoded paths in PromoteQontractReconcileCommercial and PromoteQontractServer still referenced the old location, causing the gitlab-mr-sqs-consumer to fail with a 404 on every promotion attempt.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal references for GitLab YAML configuration files used in the reconciliation process to point to alternate source locations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/app-sre/qontract-reconcile/pull/5572?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->