### PR TITLE
fix(jenkins-roles): update API for Role Strategy plugin upgrade

### DIFF
--- a/reconcile/jenkins_roles.py
+++ b/reconcile/jenkins_roles.py
@@ -90,7 +90,7 @@ def get_current_state(jenkins_map: Mapping[str, JenkinsApi]) -> list[dict[str, s
                 {
                     "instance": instance,
                     "role": role_name,
-                    "user": user,
+                    "user": user["sid"],
                 }
                 for user in users
             )

--- a/reconcile/utils/jenkins_api.py
+++ b/reconcile/utils/jenkins_api.py
@@ -137,8 +137,8 @@ class JenkinsApi:
         return res.json()
 
     def assign_role_to_user(self, role: str, user: str) -> None:
-        url = f"{self.url}/role-strategy/strategy/assignRole"
-        data = {"type": "globalRoles", "roleName": role, "sid": user}
+        url = f"{self.url}/role-strategy/strategy/assignUserRole"
+        data = {"type": "globalRoles", "roleName": role, "user": user}
         res = requests.post(
             url,
             verify=self.ssl_verify,
@@ -150,8 +150,8 @@ class JenkinsApi:
         res.raise_for_status()
 
     def unassign_role_from_user(self, role: str, user: str) -> None:
-        url = f"{self.url}/role-strategy/strategy/unassignRole"
-        data = {"type": "globalRoles", "roleName": role, "sid": user}
+        url = f"{self.url}/role-strategy/strategy/unassignUserRole"
+        data = {"type": "globalRoles", "roleName": role, "user": user}
         res = requests.post(
             url,
             verify=self.ssl_verify,


### PR DESCRIPTION
## Summary

Updates the Jenkins role management API calls to work with the upgraded Role-based Authorization Strategy plugin:

- **`assignRole` → `assignUserRole`**: Uses explicit `user` param instead of ambiguous `sid`, creating `USER` type entries instead of `EITHER`
- **`unassignRole` → `unassignUserRole`**: Same param change for role removal
- **`get_current_state`**: Parses new response format where users are `{"type": "USER", "sid": "username"}` objects instead of plain strings

This resolves the "ambiguous entries" security warning in Jenkins by ensuring all role assignments are explicitly typed as `USER`.

## Test plan

- [x] Verified `assignUserRole` and `unassignUserRole` endpoints work on ci-stage
- [x] Verified full migration flow: EITHER → USER conversion
- [x] Migrated all entries on ci-stage and ci-ext
- [x] Dry-run shows no spurious diffs after migration

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Jenkins role assignment and unassignment operations to properly interact with role management endpoints.
  * Improved consistency in tracking and comparing user role states.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/app-sre/qontract-reconcile/pull/5573?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->