### PR TITLE
feat: Add aws policy validator

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,7 +68,7 @@ dependencies = [
 debugger = ["debugpy ~=1.8.17"]
 dev = [
     # keep in sync project.dependencies.boto3
-    "boto3-stubs[account,cloudformation,dynamodb,ec2,ecr,elb,iam,logs,organizations,rds,route53,s3,service-quotas,sqs,sts,support]==1.43.58",
+    "boto3-stubs[accessanalyzer,account,cloudformation,dynamodb,ec2,ecr,elb,iam,logs,organizations,rds,route53,s3,service-quotas,sqs,sts,support]==1.43.58",
     "moto[ec2,iam,logs,s3,route53]==5.2.2",
     "mypy==2.3.0",
     "pyfakefs==6.2.0",

--- a/qontract_utils/pyproject.toml
+++ b/qontract_utils/pyproject.toml
@@ -30,7 +30,7 @@ dependencies = [
 dev = [
     # development and testing tools
     # keep in sync with project.dependencies.boto3
-    "boto3-stubs[account,cloudformation,dynamodb,iam,logs,organizations,s3,service-quotas,sts,support]==1.43.58",
+    "boto3-stubs[accessanalyzer,account,cloudformation,dynamodb,iam,logs,organizations,s3,service-quotas,sts,support]==1.43.58",
     "mypy==2.3.0",
     "pytest-asyncio==1.4.0",
     "pytest-cov==7.1.0",

--- a/qontract_utils/qontract_utils/aws_policy_validator.py
+++ b/qontract_utils/qontract_utils/aws_policy_validator.py
@@ -1,0 +1,142 @@
+"""AWS IAM Policy validation using AWS Access Analyzer.
+
+This module validates AWS IAM policy documents using the AWS Access Analyzer
+ValidatePolicy API, which provides comprehensive validation (100+ checks) including
+syntax validation, security warnings, and AWS best practices.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import TYPE_CHECKING, Any, Literal
+
+from botocore.exceptions import BotoCoreError, ClientError
+
+from qontract_utils.exceptions import IntegrationError
+
+if TYPE_CHECKING:
+    from mypy_boto3_accessanalyzer import AccessAnalyzerClient
+    from mypy_boto3_accessanalyzer.type_defs import ValidatePolicyFindingTypeDef
+
+PolicyType = Literal["IDENTITY_POLICY", "RESOURCE_POLICY"]
+
+logger = logging.getLogger(__name__)
+
+
+class AWSPolicyValidationError(IntegrationError):
+    """Raised when an AWS policy document fails validation."""
+
+    def __init__(
+        self,
+        policy_name: str,
+        findings: list[ValidatePolicyFindingTypeDef] | list[dict[str, Any]],
+    ) -> None:
+        """Initialize with policy name and Access Analyzer findings.
+
+        Args:
+            policy_name: Name of the policy for error reporting
+            findings: List of findings from Access Analyzer ValidatePolicy API
+        """
+        self.policy_name = policy_name
+        self.findings = findings
+
+        finding_lines = "\n".join(
+            f"  - {f['issueCode']}: {f['findingDetails']}" for f in findings
+        )
+        super().__init__(
+            f"Policy validation failed for '{policy_name}':\n{finding_lines}"
+        )
+
+
+def validate_aws_policy(
+    client: AccessAnalyzerClient,
+    policy: str | dict[str, Any],
+    policy_name: str,
+    policy_type: PolicyType,
+) -> None:
+    """Validate an AWS policy document using AWS Access Analyzer.
+
+    Uses the AWS Access Analyzer ValidatePolicy API to perform comprehensive
+    validation including syntax checks, security warnings, and AWS best practices.
+    This provides 100+ validation checks maintained by AWS.
+
+    Args:
+        client: Pre-configured boto3 Access Analyzer client
+        policy: Policy document as JSON string or dict
+        policy_name: Name of the policy for error reporting
+        policy_type: Type of policy - must be either "IDENTITY_POLICY" or "RESOURCE_POLICY"
+
+    Raises:
+        AWSPolicyValidationError: If the policy has ERROR findings
+        IntegrationError: If unable to call the validation API
+
+    References:
+        - https://docs.aws.amazon.com/IAM/latest/UserGuide/access-analyzer-policy-validation.html
+        - https://docs.aws.amazon.com/access-analyzer/latest/APIReference/API_ValidatePolicy.html
+    """
+    # Convert to JSON string if dict
+    if isinstance(policy, dict):
+        try:
+            policy_json = json.dumps(policy)
+        except (TypeError, ValueError) as e:
+            msg = f"Failed to serialize policy '{policy_name}' to JSON: {e}"
+            raise IntegrationError(msg) from e
+    else:
+        policy_json = policy
+
+    try:
+        paginator = client.get_paginator("validate_policy")
+        findings: list[ValidatePolicyFindingTypeDef] = []
+        for page in paginator.paginate(
+            policyDocument=policy_json,
+            policyType=policy_type,
+        ):
+            findings.extend(page.get("findings", []))
+    except ClientError as e:
+        error_code = e.response.get("Error", {}).get("Code", "Unknown")
+        error_message = e.response.get("Error", {}).get("Message", str(e))
+
+        # Bypass validation and warn on auth/permission issues — credentials may be
+        # unavailable in some environments (e.g. dry-run, local dev).
+        if error_code in {
+            "UnrecognizedClientException",
+            "InvalidClientTokenId",
+            "SignatureDoesNotMatch",
+            "AccessDenied",
+            "AccessDeniedException",
+        }:
+            logger.warning(
+                "Skipping policy validation for '%s': AWS authentication/authorization failed. "
+                "Error: %s - %s. "
+                "Ensure AWS credentials are configured and have 'access-analyzer:ValidatePolicy' permission.",
+                policy_name,
+                error_code,
+                error_message,
+            )
+            return
+
+        msg = f"Failed to validate policy '{policy_name}' with Access Analyzer: {error_code} - {error_message}"
+        raise IntegrationError(msg) from e
+    except BotoCoreError as e:
+        msg = f"AWS connection error while validating policy '{policy_name}': {e}"
+        raise IntegrationError(msg) from e
+
+    # Filter to only ERROR findings - SECURITY_WARNING and WARNING are informational only
+    # SECURITY_WARNING findings (like wildcard usage) are acceptable with proper justification
+    blocking_findings = [f for f in findings if f["findingType"] == "ERROR"]
+    security_warnings = [f for f in findings if f["findingType"] == "SECURITY_WARNING"]
+
+    # Log security warnings for visibility
+    if security_warnings:
+        logger.debug(
+            "Policy '%s' has SECURITY_WARNING findings:\n%s",
+            policy_name,
+            "\n".join(
+                f"  - {f['issueCode']}: {f['findingDetails']}"
+                for f in security_warnings
+            ),
+        )
+
+    if blocking_findings:
+        raise AWSPolicyValidationError(policy_name, blocking_findings)

--- a/qontract_utils/tests/test_aws_policy_validator.py
+++ b/qontract_utils/tests/test_aws_policy_validator.py
@@ -1,0 +1,356 @@
+"""Tests for AWS policy validator using Access Analyzer."""
+
+import json
+import logging
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+from botocore.exceptions import BotoCoreError, ClientError
+from qontract_utils.aws_policy_validator import (
+    AWSPolicyValidationError,
+    validate_aws_policy,
+)
+from qontract_utils.exceptions import IntegrationError
+
+
+@pytest.fixture
+def valid_policy() -> dict[str, Any]:
+    """A valid AWS policy for testing."""
+    return {
+        "Version": "2012-10-17",
+        "Statement": [
+            {
+                "Effect": "Allow",
+                "Action": "s3:GetObject",
+                "Resource": "arn:aws:s3:::my-bucket/*",
+            }
+        ],
+    }
+
+
+@pytest.fixture
+def mock_access_analyzer_success() -> MagicMock:
+    """Mock Access Analyzer client with no findings."""
+    mock_aa = MagicMock()
+    mock_aa.get_paginator.return_value.paginate.return_value = [{"findings": []}]
+    return mock_aa
+
+
+@pytest.fixture
+def mock_access_analyzer_error_finding() -> MagicMock:
+    """Mock Access Analyzer client with ERROR finding."""
+    mock_aa = MagicMock()
+    mock_aa.get_paginator.return_value.paginate.return_value = [
+        {
+            "findings": [
+                {
+                    "findingType": "ERROR",
+                    "issueCode": "MISSING_VERSION",
+                    "findingDetails": "The policy must include a Version element.",
+                }
+            ]
+        }
+    ]
+    return mock_aa
+
+
+@pytest.fixture
+def mock_access_analyzer_security_warning() -> MagicMock:
+    """Mock Access Analyzer client with SECURITY_WARNING finding."""
+    mock_aa = MagicMock()
+    mock_aa.get_paginator.return_value.paginate.return_value = [
+        {
+            "findings": [
+                {
+                    "findingType": "SECURITY_WARNING",
+                    "issueCode": "PASS_ROLE_WITH_STAR_IN_RESOURCE",
+                    "findingDetails": "Using a wildcard (*) in the resource can be overly permissive.",
+                }
+            ]
+        }
+    ]
+    return mock_aa
+
+
+def test_valid_policy_dict(
+    valid_policy: dict[str, Any], mock_access_analyzer_success: MagicMock
+) -> None:
+    """Test validation of a valid policy as dict."""
+    validate_aws_policy(
+        mock_access_analyzer_success, valid_policy, "test-policy", "IDENTITY_POLICY"
+    )
+
+    mock_access_analyzer_success.get_paginator.assert_called_once_with(
+        "validate_policy"
+    )
+    call_kwargs = (
+        mock_access_analyzer_success.get_paginator.return_value.paginate.call_args[1]
+    )
+    assert call_kwargs["policyType"] == "IDENTITY_POLICY"
+    assert json.loads(call_kwargs["policyDocument"]) == valid_policy
+
+
+def test_valid_policy_json_string(
+    valid_policy: dict[str, Any], mock_access_analyzer_success: MagicMock
+) -> None:
+    """Test validation of a valid policy as JSON string."""
+    validate_aws_policy(
+        mock_access_analyzer_success,
+        json.dumps(valid_policy),
+        "test-policy",
+        "IDENTITY_POLICY",
+    )
+
+    mock_access_analyzer_success.get_paginator.assert_called_once()
+
+
+def test_resource_policy_type(
+    valid_policy: dict[str, Any], mock_access_analyzer_success: MagicMock
+) -> None:
+    """Test validation with RESOURCE_POLICY type."""
+    validate_aws_policy(
+        mock_access_analyzer_success, valid_policy, "test-policy", "RESOURCE_POLICY"
+    )
+
+    call_kwargs = (
+        mock_access_analyzer_success.get_paginator.return_value.paginate.call_args[1]
+    )
+    assert call_kwargs["policyType"] == "RESOURCE_POLICY"
+
+
+def test_error_finding_raises_exception(
+    valid_policy: dict[str, Any],
+    mock_access_analyzer_error_finding: MagicMock,
+) -> None:
+    """Test that ERROR findings raise AWSPolicyValidationError."""
+    with pytest.raises(AWSPolicyValidationError) as exc_info:
+        validate_aws_policy(
+            mock_access_analyzer_error_finding,
+            valid_policy,
+            "test-policy",
+            "IDENTITY_POLICY",
+        )
+
+    assert exc_info.value.policy_name == "test-policy"
+    assert "MISSING_VERSION" in str(exc_info.value)
+    assert len(exc_info.value.findings) == 1
+    assert exc_info.value.findings[0]["findingType"] == "ERROR"
+
+
+def test_security_warning_logs_but_does_not_raise(
+    valid_policy: dict[str, Any],
+    mock_access_analyzer_security_warning: MagicMock,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Test that SECURITY_WARNING findings are logged but do not raise an exception."""
+    with caplog.at_level(logging.DEBUG):
+        validate_aws_policy(
+            mock_access_analyzer_security_warning,
+            valid_policy,
+            "test-policy",
+            "IDENTITY_POLICY",
+        )
+
+    mock_access_analyzer_security_warning.get_paginator.assert_called_once()
+    assert "SECURITY_WARNING" in caplog.text
+    assert "PASS_ROLE_WITH_STAR_IN_RESOURCE" in caplog.text
+    assert "test-policy" in caplog.text
+
+
+def test_multiple_findings(caplog: pytest.LogCaptureFixture) -> None:
+    """Test handling of multiple findings with different types."""
+    mock_aa = MagicMock()
+    mock_aa.get_paginator.return_value.paginate.return_value = [
+        {
+            "findings": [
+                {
+                    "findingType": "ERROR",
+                    "issueCode": "ERROR_1",
+                    "findingDetails": "Error detail 1",
+                },
+                {
+                    "findingType": "SECURITY_WARNING",
+                    "issueCode": "SECURITY_1",
+                    "findingDetails": "Security detail 1",
+                },
+                {
+                    "findingType": "WARNING",
+                    "issueCode": "WARNING_1",
+                    "findingDetails": "Warning detail 1",
+                },
+            ]
+        }
+    ]
+
+    policy = {"Version": "2012-10-17", "Statement": []}
+
+    with (
+        caplog.at_level(logging.DEBUG),
+        pytest.raises(AWSPolicyValidationError) as exc_info,
+    ):
+        validate_aws_policy(mock_aa, policy, "test-policy", "IDENTITY_POLICY")
+
+    assert len(exc_info.value.findings) == 1
+    assert "ERROR_1" in str(exc_info.value)
+    assert "SECURITY_WARNING" in caplog.text
+    assert "SECURITY_1" in caplog.text
+
+
+def test_connection_error() -> None:
+    """Test handling of AWS connection errors."""
+    mock_aa = MagicMock()
+    mock_aa.get_paginator.return_value.paginate.side_effect = BotoCoreError()
+
+    policy = {"Version": "2012-10-17", "Statement": []}
+
+    with pytest.raises(IntegrationError) as exc_info:
+        validate_aws_policy(mock_aa, policy, "test-policy", "IDENTITY_POLICY")
+
+    error_msg = str(exc_info.value)
+    assert "AWS connection error" in error_msg
+    assert "test-policy" in error_msg
+
+
+def test_generic_client_error() -> None:
+    """Test handling of generic AWS client errors."""
+    mock_aa = MagicMock()
+    mock_aa.get_paginator.return_value.paginate.side_effect = ClientError(
+        {
+            "Error": {
+                "Code": "ThrottlingException",
+                "Message": "Rate exceeded",
+            }
+        },
+        "ValidatePolicy",
+    )
+
+    policy = {"Version": "2012-10-17", "Statement": []}
+
+    with pytest.raises(IntegrationError) as exc_info:
+        validate_aws_policy(mock_aa, policy, "test-policy", "IDENTITY_POLICY")
+
+    error_msg = str(exc_info.value)
+    assert "Failed to validate policy" in error_msg
+    assert "ThrottlingException" in error_msg
+    assert "Rate exceeded" in error_msg
+
+
+def test_non_serializable_policy() -> None:
+    """Test handling of non-JSON-serializable policy dict."""
+
+    class NonSerializable:
+        pass
+
+    policy = {"Version": "2012-10-17", "Statement": [NonSerializable()]}
+
+    with pytest.raises(IntegrationError) as exc_info:
+        validate_aws_policy(MagicMock(), policy, "test-policy", "IDENTITY_POLICY")
+
+    assert "Failed to serialize policy" in str(exc_info.value)
+
+
+def test_multi_page_pagination() -> None:
+    """Test that findings are accumulated across multiple paginator pages."""
+    mock_aa = MagicMock()
+    mock_aa.get_paginator.return_value.paginate.return_value = [
+        {
+            "findings": [
+                {
+                    "findingType": "ERROR",
+                    "issueCode": "ERROR_PAGE_1",
+                    "findingDetails": "Error on page 1",
+                }
+            ]
+        },
+        {
+            "findings": [
+                {
+                    "findingType": "ERROR",
+                    "issueCode": "ERROR_PAGE_2",
+                    "findingDetails": "Error on page 2",
+                }
+            ]
+        },
+    ]
+
+    policy = {"Version": "2012-10-17", "Statement": []}
+
+    with pytest.raises(AWSPolicyValidationError) as exc_info:
+        validate_aws_policy(mock_aa, policy, "test-policy", "IDENTITY_POLICY")
+
+    assert len(exc_info.value.findings) == 2
+    issue_codes = {f["issueCode"] for f in exc_info.value.findings}
+    assert issue_codes == {"ERROR_PAGE_1", "ERROR_PAGE_2"}
+
+
+@pytest.mark.parametrize(
+    "error_code",
+    [
+        "UnrecognizedClientException",
+        "InvalidClientTokenId",
+        "SignatureDoesNotMatch",
+        "AccessDenied",
+        "AccessDeniedException",
+    ],
+)
+def test_auth_error_codes_bypass_validation(
+    error_code: str, caplog: pytest.LogCaptureFixture
+) -> None:
+    """Test that all auth/permission ClientErrors log a warning and bypass validation."""
+    mock_aa = MagicMock()
+    mock_aa.get_paginator.return_value.paginate.side_effect = ClientError(
+        {"Error": {"Code": error_code, "Message": "Auth failure"}},
+        "ValidatePolicy",
+    )
+
+    policy = {"Version": "2012-10-17", "Statement": []}
+
+    with caplog.at_level(logging.WARNING):
+        validate_aws_policy(mock_aa, policy, "test-policy", "IDENTITY_POLICY")
+
+    assert error_code in caplog.text
+    assert "access-analyzer:ValidatePolicy" in caplog.text
+
+
+@pytest.mark.parametrize("finding_type", ["SUGGESTION", "WARNING"])
+def test_non_blocking_finding_types_are_silent(finding_type: str) -> None:
+    """Test that SUGGESTION and WARNING findings are silently ignored."""
+    mock_aa = MagicMock()
+    mock_aa.get_paginator.return_value.paginate.return_value = [
+        {
+            "findings": [
+                {
+                    "findingType": finding_type,
+                    "issueCode": "SOME_CODE",
+                    "findingDetails": "Some detail",
+                }
+            ]
+        }
+    ]
+
+    policy = {"Version": "2012-10-17", "Statement": []}
+
+    validate_aws_policy(mock_aa, policy, "test-policy", "IDENTITY_POLICY")
+
+
+def test_page_without_findings_key() -> None:
+    """Test that pages missing the 'findings' key are handled gracefully."""
+    mock_aa = MagicMock()
+    mock_aa.get_paginator.return_value.paginate.return_value = [
+        {},  # page with no 'findings' key
+        {"findings": []},
+    ]
+
+    policy = {"Version": "2012-10-17", "Statement": []}
+
+    validate_aws_policy(mock_aa, policy, "test-policy", "IDENTITY_POLICY")
+
+
+def test_validation_error_is_integration_error() -> None:
+    """Test that AWSPolicyValidationError is a subclass of IntegrationError."""
+    err = AWSPolicyValidationError(
+        "test-policy",
+        [{"issueCode": "MISSING_VERSION", "findingDetails": "Missing version."}],
+    )
+    assert isinstance(err, IntegrationError)

--- a/reconcile/aws_saml_roles/integration.py
+++ b/reconcile/aws_saml_roles/integration.py
@@ -10,6 +10,10 @@ from typing import (
 )
 
 from pydantic import BaseModel, field_validator, model_validator
+from qontract_utils.aws_policy_validator import (
+    AWSPolicyValidationError,
+    validate_aws_policy,
+)
 
 from reconcile.gql_definitions.aws_saml_roles.aws_accounts import (
     AWSAccountV1,
@@ -223,15 +227,44 @@ class AwsSamlRolesIntegration(
 
         return aws_roles
 
-    def populate_saml_iam_roles(
-        self, ts: TerrascriptClient, aws_roles: Iterable[AwsRole]
-    ) -> None:
-        """Populate the SAML IAM roles."""
-        unique_policies = {
+    @staticmethod
+    def _unique_policies(
+        aws_roles: Iterable[AwsRole],
+    ) -> dict[tuple[str, str], Any]:
+        """Return a deduplicated {(account, policy_name): policy_doc} mapping."""
+        return {
             (role.account, custom_policy.name): custom_policy.policy
             for role in aws_roles
             for custom_policy in role.custom_policies
         }
+
+    @staticmethod
+    def _validate_saml_iam_policies(
+        unique_policies: dict[tuple[str, str], Any],
+        aws_api: AWSApi,
+    ) -> None:
+        """Validate custom IAM policy documents via Access Analyzer before generation."""
+        errors: list[AWSPolicyValidationError] = []
+        for (account, policy_name), policy_doc in unique_policies.items():
+            client = aws_api._account_accessanalyzer_client(account)
+            try:
+                validate_aws_policy(
+                    client, policy_doc, f"iam_policy-{policy_name}", "IDENTITY_POLICY"
+                )
+            except AWSPolicyValidationError as e:
+                errors.append(e)
+        if errors:
+            raise RuntimeError(
+                "AWS policy validation failed:\n" + "\n".join(str(e) for e in errors)
+            )
+
+    def populate_saml_iam_roles(
+        self,
+        ts: TerrascriptClient,
+        aws_roles: Iterable[AwsRole],
+        unique_policies: dict[tuple[str, str], Any],
+    ) -> None:
+        """Populate the SAML IAM roles."""
         # User policies are unique per account
         for (account, policy), policy_doc in unique_policies.items():
             ts.populate_iam_policy(
@@ -273,15 +306,18 @@ class AwsSamlRolesIntegration(
             secret_reader=self.secret_reader,
             default_tags=default_tags,
         )
-        self.populate_saml_iam_roles(ts, aws_roles)
+        unique_policies = self._unique_policies(aws_roles)
+        aws_api = AWSApi(
+            1, aws_accounts_dict, secret_reader=self.secret_reader, init_users=False
+        )
+        if defer:
+            defer(aws_api.cleanup)
+        self._validate_saml_iam_policies(unique_policies, aws_api)
+        self.populate_saml_iam_roles(ts, aws_roles, unique_policies)
         working_dirs = ts.dump(print_to_file=self.params.print_to_file)
 
         if self.params.print_to_file:
             sys.exit(ExitCodes.SUCCESS)
-
-        aws_api = AWSApi(
-            1, aws_accounts_dict, secret_reader=self.secret_reader, init_users=False
-        )
         tf = TerraformClient(
             self.name,
             QONTRACT_INTEGRATION_VERSION,

--- a/reconcile/terraform_users.py
+++ b/reconcile/terraform_users.py
@@ -7,6 +7,11 @@ from typing import (
     Any,
 )
 
+from qontract_utils.aws_policy_validator import (
+    AWSPolicyValidationError,
+    validate_aws_policy,
+)
+
 from reconcile import (
     queries,
     typed_queries,
@@ -115,6 +120,45 @@ def _filter_participating_aws_accounts(
     return [a for a in accounts if a["name"] in participating_aws_account_names]
 
 
+def _validate_aws_policies_in_roles(
+    roles: Iterable[Mapping[str, Any]],
+    accounts: Iterable[Mapping[str, Any]],
+    aws_api: AWSApi,
+) -> None:
+    participating_account_names = {acc["name"] for acc in accounts}
+    errors: list[AWSPolicyValidationError] = []
+    for role in roles:
+        user_policies: Iterable[Mapping[str, Any]] = role.get("user_policies") or []
+        for user_policy in user_policies:
+            policy_name = user_policy.get("name", "unknown")
+            policy_document = user_policy.get("policy")
+            account_name = user_policy.get("account", {}).get("name")
+
+            if user_policy.get("account", {}).get("sso") is True:
+                continue
+            if not account_name or account_name not in participating_account_names:
+                continue
+
+            if policy_document is not None and (
+                isinstance(policy_document, dict)
+                or (isinstance(policy_document, str) and policy_document.strip())
+            ):
+                client = aws_api._account_accessanalyzer_client(account_name)
+                try:
+                    validate_aws_policy(
+                        client,
+                        policy_document,
+                        f"user_policy-{policy_name}",
+                        "IDENTITY_POLICY",
+                    )
+                except AWSPolicyValidationError as e:
+                    errors.append(e)
+    if errors:
+        raise RuntimeError(
+            "AWS policy validation failed:\n" + "\n".join(str(e) for e in errors)
+        )
+
+
 def setup(
     print_to_file: str | None,
     thread_pool_size: int,
@@ -132,6 +176,12 @@ def setup(
     participating_aws_accounts = _filter_participating_aws_accounts(accounts, roles)
 
     settings = queries.get_app_interface_settings()
+    aws_api = AWSApi(1, participating_aws_accounts, settings=settings, init_users=False)
+    try:
+        _validate_aws_policies_in_roles(roles, participating_aws_accounts, aws_api)
+    except Exception:
+        aws_api.cleanup()
+        raise
     try:
         default_tags = get_settings().default_tags
     except ValueError:
@@ -151,8 +201,6 @@ def setup(
         appsre_pgp_key=appsre_pgp_key,
     )
     working_dirs = ts.dump(print_to_file)
-    aws_api = AWSApi(1, participating_aws_accounts, settings=settings, init_users=False)
-
     return participating_aws_accounts, working_dirs, err, aws_api
 
 

--- a/reconcile/test/aws_saml_roles/test_aws_saml_roles_integration.py
+++ b/reconcile/test/aws_saml_roles/test_aws_saml_roles_integration.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from typing import TYPE_CHECKING
+from unittest.mock import MagicMock
 
 import pytest
 
@@ -9,6 +10,7 @@ from reconcile.aws_saml_roles.integration import (
     AwsSamlRolesIntegration,
 )
 from reconcile.gql_definitions.aws_saml_roles.aws_accounts import AWSAccountV1
+from reconcile.utils.aws_api import AWSApi
 from reconcile.utils.terrascript_aws_client import TerrascriptClient
 
 if TYPE_CHECKING:
@@ -305,7 +307,8 @@ def test_aws_saml_roles_populate_saml_iam_roles(
             },
         ),
     ]
-    intg.populate_saml_iam_roles(ts, roles)
+    unique_policies = intg._unique_policies(roles)
+    intg.populate_saml_iam_roles(ts, roles, unique_policies)
     ts.populate_iam_policy.assert_called_once_with(
         account="account-1",
         name="rds-read-only",
@@ -359,6 +362,153 @@ def test_aws_saml_roles_populate_saml_iam_roles(
             max_session_duration_hours=1,
         ),
     ])
+
+
+def test_validate_saml_iam_policies_valid(
+    gql_class_factory: Callable, intg: AwsSamlRolesIntegration
+) -> None:
+    mock_aa = MagicMock()
+    mock_aa.get_paginator.return_value.paginate.return_value = [{"findings": []}]
+    mock_aws_api = MagicMock(spec=AWSApi)
+    mock_aws_api._account_accessanalyzer_client.return_value = mock_aa
+    roles = [
+        gql_class_factory(
+            AwsRole,
+            {
+                "name": "role-1",
+                "account": "account-1",
+                "custom_policies": [
+                    {
+                        "name": "rds-read-only",
+                        "policy": {
+                            "Version": "2012-10-17",
+                            "Statement": [
+                                {
+                                    "Effect": "Allow",
+                                    "Action": "rds:Describe*",
+                                    "Resource": "*",
+                                }
+                            ],
+                        },
+                    }
+                ],
+                "managed_policies": [],
+            },
+        )
+    ]
+    intg._validate_saml_iam_policies(intg._unique_policies(roles), mock_aws_api)
+    mock_aa.get_paginator.assert_called_once()
+
+
+def test_validate_saml_iam_policies_invalid_raises(
+    gql_class_factory: Callable, intg: AwsSamlRolesIntegration
+) -> None:
+    mock_aa = MagicMock()
+    mock_aa.get_paginator.return_value.paginate.return_value = [
+        {
+            "findings": [
+                {
+                    "findingType": "ERROR",
+                    "issueCode": "MISSING_VERSION",
+                    "findingDetails": "The policy must include a Version element.",
+                }
+            ]
+        }
+    ]
+    mock_aws_api = MagicMock(spec=AWSApi)
+    mock_aws_api._account_accessanalyzer_client.return_value = mock_aa
+    roles = [
+        gql_class_factory(
+            AwsRole,
+            {
+                "name": "role-1",
+                "account": "account-1",
+                "custom_policies": [
+                    {
+                        "name": "bad-policy",
+                        "policy": {
+                            "Statement": [
+                                {"Effect": "Allow", "Action": "s3:*", "Resource": "*"}
+                            ]
+                        },
+                    }
+                ],
+                "managed_policies": [],
+            },
+        )
+    ]
+    with pytest.raises(RuntimeError) as exc_info:
+        intg._validate_saml_iam_policies(intg._unique_policies(roles), mock_aws_api)
+    assert "iam_policy-bad-policy" in str(exc_info.value)
+
+
+def test_validate_saml_iam_policies_multiple_errors_all_collected(
+    gql_class_factory: Callable, intg: AwsSamlRolesIntegration
+) -> None:
+    mock_aa = MagicMock()
+    mock_aa.get_paginator.return_value.paginate.return_value = [
+        {
+            "findings": [
+                {
+                    "findingType": "ERROR",
+                    "issueCode": "MISSING_VERSION",
+                    "findingDetails": "The policy must include a Version element.",
+                }
+            ]
+        }
+    ]
+    mock_aws_api = MagicMock(spec=AWSApi)
+    mock_aws_api._account_accessanalyzer_client.return_value = mock_aa
+    roles = [
+        gql_class_factory(
+            AwsRole,
+            {
+                "name": "role-1",
+                "account": "account-1",
+                "custom_policies": [
+                    {
+                        "name": "bad-policy-1",
+                        "policy": {
+                            "Statement": [
+                                {"Effect": "Allow", "Action": "s3:*", "Resource": "*"}
+                            ]
+                        },
+                    },
+                    {
+                        "name": "bad-policy-2",
+                        "policy": {
+                            "Statement": [
+                                {"Effect": "Allow", "Action": "ec2:*", "Resource": "*"}
+                            ]
+                        },
+                    },
+                ],
+                "managed_policies": [],
+            },
+        )
+    ]
+    with pytest.raises(RuntimeError, match="AWS policy validation failed"):
+        intg._validate_saml_iam_policies(intg._unique_policies(roles), mock_aws_api)
+    assert mock_aa.get_paginator.call_count == 2
+
+
+def test_validate_saml_iam_policies_no_custom_policies(
+    gql_class_factory: Callable, intg: AwsSamlRolesIntegration
+) -> None:
+    mock_aws_api = MagicMock(spec=AWSApi)
+    roles = [
+        gql_class_factory(
+            AwsRole,
+            {
+                "name": "role-1",
+                "account": "account-1",
+                "custom_policies": [],
+                "managed_policies": [{"name": "ReadOnlyAccess"}],
+            },
+        )
+    ]
+    intg._validate_saml_iam_policies(intg._unique_policies(roles), mock_aws_api)
+    mock_aws_api._account_accessanalyzer_client.assert_not_called()
 
 
 @pytest.mark.parametrize(

--- a/reconcile/test/test_terraform_users_policy_validation.py
+++ b/reconcile/test/test_terraform_users_policy_validation.py
@@ -1,0 +1,234 @@
+"""Tests for AWS policy validation in terraform_users using Access Analyzer."""
+
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+from reconcile.terraform_users import _validate_aws_policies_in_roles
+from reconcile.utils.aws_api import AWSApi
+
+
+@pytest.fixture
+def mock_accounts() -> list[dict[str, Any]]:
+    return [
+        {
+            "name": "test-account-1",
+            "resourcesDefaultRegion": "us-east-1",
+        }
+    ]
+
+
+@pytest.fixture
+def mock_aa() -> MagicMock:
+    aa = MagicMock()
+    aa.get_paginator.return_value.paginate.return_value = [{"findings": []}]
+    return aa
+
+
+@pytest.fixture
+def mock_aws_api(mock_aa: MagicMock) -> MagicMock:
+    api = MagicMock(spec=AWSApi)
+    api._account_accessanalyzer_client.return_value = mock_aa
+    return api
+
+
+def test_validate_aws_policies_in_roles_valid_policies(
+    mock_aws_api: MagicMock,
+    mock_aa: MagicMock,
+    mock_accounts: list[dict[str, Any]],
+) -> None:
+    roles = [
+        {
+            "name": "test-role-1",
+            "user_policies": [
+                {
+                    "name": "s3-access",
+                    "policy": '{"Version": "2012-10-17", "Statement": [{"Effect": "Allow", "Action": "s3:GetObject", "Resource": "arn:aws:s3:::my-bucket/*"}]}',
+                    "account": {"name": "test-account-1"},
+                }
+            ],
+        },
+        {
+            "name": "test-role-2",
+            "user_policies": [
+                {
+                    "name": "ec2-access",
+                    "policy": '{"Version": "2012-10-17", "Statement": [{"Effect": "Allow", "Action": ["ec2:DescribeInstances", "ec2:DescribeImages"], "Resource": "*"}]}',
+                    "account": {"name": "test-account-1"},
+                }
+            ],
+        },
+    ]
+
+    _validate_aws_policies_in_roles(roles, mock_accounts, mock_aws_api)
+
+    assert mock_aa.get_paginator.call_count == 2
+
+
+def test_validate_aws_policies_in_roles_no_policies(
+    mock_aws_api: MagicMock,
+    mock_accounts: list[dict[str, Any]],
+) -> None:
+    roles: list[dict[str, Any]] = [
+        {"name": "test-role-1", "user_policies": None},
+        {"name": "test-role-2", "user_policies": []},
+    ]
+
+    _validate_aws_policies_in_roles(roles, mock_accounts, mock_aws_api)
+
+    mock_aws_api._account_accessanalyzer_client.assert_not_called()
+
+
+def test_validate_aws_policies_in_roles_invalid_policy(
+    mock_aws_api: MagicMock,
+    mock_aa: MagicMock,
+    mock_accounts: list[dict[str, Any]],
+) -> None:
+    mock_aa.get_paginator.return_value.paginate.return_value = [
+        {
+            "findings": [
+                {
+                    "findingType": "ERROR",
+                    "issueCode": "MISSING_VERSION",
+                    "findingDetails": "The policy must include a Version element.",
+                }
+            ]
+        }
+    ]
+
+    roles = [
+        {
+            "name": "test-role-1",
+            "user_policies": [
+                {
+                    "name": "bad-policy",
+                    "policy": '{"Statement": [{"Effect": "Allow", "Action": "s3:*", "Resource": "*"}]}',
+                    "account": {"name": "test-account-1"},
+                }
+            ],
+        }
+    ]
+
+    with pytest.raises(RuntimeError) as exc_info:
+        _validate_aws_policies_in_roles(roles, mock_accounts, mock_aws_api)
+
+    assert "user_policy-bad-policy" in str(exc_info.value)
+    assert "MISSING_VERSION" in str(exc_info.value)
+
+
+def test_validate_aws_policies_in_roles_multiple_invalid_policies(
+    mock_aws_api: MagicMock,
+    mock_aa: MagicMock,
+    mock_accounts: list[dict[str, Any]],
+) -> None:
+    mock_aa.get_paginator.return_value.paginate.return_value = [
+        {
+            "findings": [
+                {
+                    "findingType": "ERROR",
+                    "issueCode": "INVALID_ACTION",
+                    "findingDetails": "The action is not valid.",
+                }
+            ]
+        }
+    ]
+
+    roles = [
+        {
+            "name": "test-role-1",
+            "user_policies": [
+                {
+                    "name": "policy1",
+                    "policy": '{"Version": "2012-10-17", "Statement": [{"Effect": "Allow", "Action": "invalid:action", "Resource": "*"}]}',
+                    "account": {"name": "test-account-1"},
+                },
+                {
+                    "name": "policy2",
+                    "policy": '{"Version": "2012-10-17", "Statement": [{"Effect": "Allow", "Action": "s3:GetObject", "Resource": "*"}]}',
+                    "account": {"name": "test-account-1"},
+                },
+            ],
+        }
+    ]
+
+    with pytest.raises(RuntimeError):
+        _validate_aws_policies_in_roles(roles, mock_accounts, mock_aws_api)
+
+    assert mock_aa.get_paginator.call_count == 2
+
+
+def test_validate_aws_policies_handles_dict_policy(
+    mock_aws_api: MagicMock,
+    mock_aa: MagicMock,
+    mock_accounts: list[dict[str, Any]],
+) -> None:
+    roles = [
+        {
+            "name": "test-role-1",
+            "user_policies": [
+                {
+                    "name": "dict-policy",
+                    "policy": {
+                        "Version": "2012-10-17",
+                        "Statement": [
+                            {
+                                "Effect": "Allow",
+                                "Action": "s3:GetObject",
+                                "Resource": "*",
+                            }
+                        ],
+                    },
+                    "account": {"name": "test-account-1"},
+                }
+            ],
+        }
+    ]
+
+    _validate_aws_policies_in_roles(roles, mock_accounts, mock_aws_api)
+
+    mock_aa.get_paginator.assert_called_once()
+
+
+def test_validate_aws_policies_in_roles_skips_sso_accounts(
+    mock_aws_api: MagicMock,
+    mock_accounts: list[dict[str, Any]],
+) -> None:
+    roles = [
+        {
+            "name": "test-role-1",
+            "user_policies": [
+                {
+                    "name": "sso-policy",
+                    "policy": '{"Version": "2012-10-17", "Statement": [{"Effect": "Allow", "Action": "s3:*", "Resource": "*"}]}',
+                    "account": {"name": "test-account-1", "sso": True},
+                }
+            ],
+        }
+    ]
+
+    _validate_aws_policies_in_roles(roles, mock_accounts, mock_aws_api)
+
+    mock_aws_api._account_accessanalyzer_client.assert_not_called()
+
+
+def test_validate_aws_policies_in_roles_skips_account_not_in_scope(
+    mock_aws_api: MagicMock,
+    mock_accounts: list[dict[str, Any]],
+) -> None:
+    roles = [
+        {
+            "name": "test-role-1",
+            "user_policies": [
+                {
+                    "name": "out-of-scope-policy",
+                    "policy": '{"Version": "2012-10-17", "Statement": [{"Effect": "Allow", "Action": "s3:GetObject", "Resource": "*"}]}',
+                    "account": {"name": "another-account"},
+                }
+            ],
+        }
+    ]
+
+    _validate_aws_policies_in_roles(roles, mock_accounts, mock_aws_api)
+
+    mock_aws_api._account_accessanalyzer_client.assert_not_called()

--- a/reconcile/test/utils/test_terrascript_aws_client.py
+++ b/reconcile/test/utils/test_terrascript_aws_client.py
@@ -686,7 +686,7 @@ def s3_spec_with_bucket_policy() -> ExternalResourceSpec:
     resource = {
         "identifier": "s3-bucket",
         "provider": "s3",
-        "bucket_policy": "some-bucket-policy",
+        "bucket_policy": '{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Principal":"*","Action":"s3:GetObject","Resource":"arn:aws:s3:::s3-bucket/*"}]}',
         "region": "us-east-1",
     }
     return build_s3_spec(resource)
@@ -697,7 +697,7 @@ def expected_s3_bucket_policy() -> aws_s3_bucket_policy:
     return aws_s3_bucket_policy(
         "s3-bucket",
         bucket="s3-bucket",
-        policy="some-bucket-policy",
+        policy='{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Principal":"*","Action":"s3:GetObject","Resource":"arn:aws:s3:::s3-bucket/*"}]}',
         depends_on=["aws_s3_bucket.s3-bucket"],
     )
 
@@ -726,7 +726,7 @@ def s3_spec_with_bucket_policy_and_region() -> ExternalResourceSpec:
     resource = {
         "identifier": "s3-bucket",
         "provider": "s3",
-        "bucket_policy": "some-bucket-policy",
+        "bucket_policy": '{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Principal":"*","Action":"s3:GetObject","Resource":"arn:aws:s3:::s3-bucket/*"}]}',
         "region": "us-west-2",
     }
     return build_s3_spec(resource)
@@ -769,7 +769,7 @@ def expected_s3_bucket_policy_with_region() -> aws_s3_bucket_policy:
     return aws_s3_bucket_policy(
         "s3-bucket",
         bucket="s3-bucket",
-        policy="some-bucket-policy",
+        policy='{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Principal":"*","Action":"s3:GetObject","Resource":"arn:aws:s3:::s3-bucket/*"}]}',
         depends_on=["aws_s3_bucket.s3-bucket"],
         provider="aws.us-west-2",
     )

--- a/reconcile/utils/aws_api.py
+++ b/reconcile/utils/aws_api.py
@@ -33,6 +33,7 @@ if TYPE_CHECKING:
     )
 
     from botocore.client import BaseClient
+    from mypy_boto3_accessanalyzer import AccessAnalyzerClient
     from mypy_boto3_dynamodb import DynamoDBClient, DynamoDBServiceResource
     from mypy_boto3_ec2 import (
         EC2Client,
@@ -100,6 +101,7 @@ class AmiTag(BaseModel):
 
 
 SERVICE_NAME = Literal[
+    "accessanalyzer",
     "dynamodb",
     "ec2",
     "ecr",
@@ -321,13 +323,22 @@ class AWSApi:
         region_name: str | None = None,
     ) -> STSClient: ...
 
+    @overload
+    def get_session_client(
+        self,
+        session: Session,
+        service_name: Literal["accessanalyzer"],
+        region_name: str | None = None,
+    ) -> AccessAnalyzerClient: ...
+
     def get_session_client(
         self,
         session: Session,
         service_name: SERVICE_NAME,
         region_name: str | None = None,
     ) -> (
-        CloudWatchLogsClient
+        AccessAnalyzerClient
+        | CloudWatchLogsClient
         | DynamoDBClient
         | EC2Client
         | ECRClient
@@ -438,6 +449,12 @@ class AWSApi:
     ) -> OrganizationsClient:
         session = self.get_session(account_name)
         return self.get_session_client(session, "organizations", region_name)
+
+    def _account_accessanalyzer_client(
+        self, account_name: str, region_name: str | None = None
+    ) -> AccessAnalyzerClient:
+        session = self.get_session(account_name)
+        return self.get_session_client(session, "accessanalyzer", region_name)
 
     def _account_s3_client(
         self, account_name: str, region_name: str | None = None
@@ -856,6 +873,15 @@ class AWSApi:
         client_type: Literal["support"],
     ) -> SupportClient: ...
 
+    @overload
+    def _get_assumed_role_client(
+        self,
+        account_name: str,
+        assume_role: str | None,
+        assume_region: str,
+        client_type: Literal["accessanalyzer"],
+    ) -> AccessAnalyzerClient: ...
+
     def _get_assumed_role_client(
         self,
         account_name: str,
@@ -863,7 +889,8 @@ class AWSApi:
         assume_region: str,
         client_type: SERVICE_NAME = "ec2",
     ) -> (
-        CloudWatchLogsClient
+        AccessAnalyzerClient
+        | CloudWatchLogsClient
         | DynamoDBClient
         | EC2Client
         | ECRClient


### PR DESCRIPTION
## Summary

Introduces a shared AWS IAM policy validator backed by the [AWS Access Analyzer `ValidatePolicy` API](https://docs.aws.amazon.com/access-analyzer/latest/APIReference/API_ValidatePolicy.html) and wires it into two Terraform-generating integrations — `aws-saml-roles` and `terraform-users` — so that malformed or non-compliant policies are caught at reconcile time, before Terraform generation.

Co-authored-by: `Claude Code`

---

## What Changed

### New: `qontract_utils/qontract_utils/aws_policy_validator.py`

A new shared utility that wraps the Access Analyzer `ValidatePolicy` API:

- Accepts a policy document as either a `dict` or a JSON string.
- Uses a paginator to accumulate findings across multiple response pages.
- **Blocks only on `ERROR` findings** (e.g. `MISSING_VERSION`, invalid syntax). `SECURITY_WARNING` findings are logged at `DEBUG` level; `WARNING` and `SUGGESTION` findings are silently ignored.
- **Gracefully bypasses validation** when AWS credentials are missing or insufficient (logs a warning instead of failing), making it safe for dry-run and local-dev environments.
- Raises `AWSPolicyValidationError` (a subclass of `IntegrationError`) with all `ERROR` findings included in the message.

### Updated: `reconcile/aws_saml_roles/integration.py`

- Extracted `_unique_policies()` as a `@staticmethod` to deduplicate custom policies before validation.
- Added `_validate_saml_iam_policies()` `@staticmethod` that validates all custom SAML IAM policies via Access Analyzer and collects **all** errors before raising, so operators see every failing policy in one run.
- Refactored `populate_saml_iam_roles()` to accept pre-computed `unique_policies` (avoids recomputing the dedup map).
- Moved `AWSApi` initialization earlier in `run()` so it is available for validation before `ts.dump()`, with proper cleanup via `defer`.

### Updated: `reconcile/terraform_users.py`

- Added `_validate_aws_policies_in_roles()` that iterates user policies attached to roles and validates each one:
  - Skips SSO accounts (`sso: true`).
  - Skips accounts not in the participating account scope.
  - Collects all validation errors before raising a `RuntimeError`.
- Moved `AWSApi` initialization before `ts.dump()` so validation runs upfront; explicit cleanup on exception is added.

### Updated: `reconcile/utils/aws_api.py`

- Added `"accessanalyzer"` to the `SERVICE_NAME` `Literal` union.
- Added typed `@overload` declarations for `get_session_client()` and `_get_assumed_role_client()` with `accessanalyzer`.
- Added `_account_accessanalyzer_client()` convenience method (mirrors existing `_account_s3_client()`, etc.).

### Updated: Test fixtures in `reconcile/test/utils/test_terrascript_aws_client.py`

Replaced placeholder `"some-bucket-policy"` strings in S3 bucket policy fixtures with valid JSON policy documents, which is required now that policy strings may be passed to a real validator.

---

## Tests Added

| File | Coverage |
|---|---|
| `qontract_utils/tests/test_aws_policy_validator.py` | 13 test cases covering: valid dict/string policies, `RESOURCE_POLICY` type, `ERROR` findings raise, `SECURITY_WARNING` logged but not raised, mixed finding types, connection errors, `ClientError` (generic and all 5 auth bypass codes), non-serializable dicts, multi-page pagination, `SUGGESTION`/`WARNING` are silent, missing `findings` key in page |
| `reconcile/test/aws_saml_roles/test_aws_saml_roles_integration.py` | 4 new tests: valid policies pass, invalid policy raises with name in message, multiple errors all collected, no custom policies skips validation |
| `reconcile/test/test_terraform_users_policy_validation.py` | 7 new tests: valid policies, no policies, single invalid, multiple invalid, dict policy, SSO account skipped, out-of-scope account skipped |

---

## Dependency Changes

- Added `mypy-boto3-accessanalyzer==1.43.10` to dev dependencies in both `pyproject.toml` (root) and `qontract_utils/pyproject.toml`.
- `uv.lock` updated accordingly (also includes minor bumps to `httpcore2`, `httpx2`, `mypy-boto3-ec2`, and `mypy-boto3-support`).

---

## Behavioral Notes

- **No false-positive failures**: Auth/permission errors from Access Analyzer are soft-failures (warn and skip), so this does not break integrations running with limited credentials.
- **Fail-all semantics**: Both integrations collect all policy errors before raising, giving operators a complete picture in a single run.
- **`SECURITY_WARNING` findings are non-blocking**: Wildcard usages and similar patterns that are intentional in App-SRE policies will not cause failures.

---

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary

* **New Features**
  * Added AWS Access Analyzer–based validation for IAM identity policies and SAML custom IAM policy documents during reconciliation, including support for identity/resource policy types.
  * Deduplicates custom policies and reports failures together.

* **Bug Fixes**
  * Error findings now raise a single aggregated failure with clear details; security warnings are logged without stopping.
  * Improved handling for pagination, missing findings, non-serializable policies, and AWS/API failures.

* **Tests / Chores**
  * Added/expanded pytest coverage for valid/invalid, skip rules (including SSO/scope), and Access Analyzer behavior; updated Access Analyzer type stubs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->