### PR TITLE
github-repo-permissions-validator: update job type from gh-pr-check to gh-pr-and-build

### DIFF
--- a/reconcile/github_repo_permissions_validator.py
+++ b/reconcile/github_repo_permissions_validator.py
@@ -19,7 +19,7 @@ QONTRACT_INTEGRATION_VERSION = make_semver(0, 1, 0)
 
 def get_jobs(jjb: JJB, instance_name: str) -> list[dict] | None:
     pr_check_jobs = jjb.get_all_jobs(
-        job_types=["gh-pr-check"], instance_name=instance_name
+        job_types=["gh-pr-and-build"], instance_name=instance_name
     ).get(instance_name)
 
     return pr_check_jobs


### PR DESCRIPTION
## Description

Update `github-repo-permissions-validator` to check the correct job type after migrating from GitHub Pull Request Builder (GHPRB) to GitHub Branch Source plugin.

The bot account still uses a PAT, so push permission is still required to post commit statuses. Only the job type filter changes: `gh-pr-check` → `gh-pr-and-build`.