### PR TITLE
Added merge commit sha guard

### DIFF
--- a/reconcile/gitlab_housekeeping.py
+++ b/reconcile/gitlab_housekeeping.py
@@ -1069,6 +1069,16 @@ def _process_omm_group(
         clear_omm_group(dry_run, gl, lead=lead)
         return 0
 
+    if not lead.merge_commit_sha:
+        logging.warning([
+            "omm-group",
+            "lead-missing-merge-sha",
+            gl.project.name,
+            lead.iid,
+            "will retry next loop",
+        ])
+        return 0
+
     current_head = gl.project.branches.get(lead.target_branch).commit["id"]
     if current_head != lead.merge_commit_sha:
         # Head moved since the lead merged.  This is expected when pending

--- a/reconcile/test/test_gitlab_housekeeping.py
+++ b/reconcile/test/test_gitlab_housekeeping.py
@@ -2180,6 +2180,36 @@ def test_omm_group_head_drift_invalidates_group(
     clear_mock.assert_called_once_with(False, mocked_gl, lead=lead)
 
 
+def test_omm_group_lead_missing_merge_commit_sha(
+    mocker: MockerFixture,
+) -> None:
+    """When lead.merge_commit_sha is None (GitLab hasn't populated it yet),
+    return 0 without crashing and leave the group intact for the next loop."""
+    _setup_omm_group_mocks(mocker)
+    clear_mock = mocker.patch(
+        "reconcile.gitlab_housekeeping.clear_omm_group",
+    )
+
+    lead = create_autospec(ProjectMergeRequest)
+    lead.merge_commit_sha = None
+    lead.target_branch = "master"
+    lead.iid = 99999
+
+    mocked_gl = _make_omm_gl(head_sha="some-sha")
+
+    merges = gl_h._process_omm_group(
+        dry_run=False,
+        gl=mocked_gl,
+        lead=lead,
+        app_sre_usernames=set(),
+    )
+
+    assert merges == 0
+    clear_mock.assert_not_called()
+    mocked_gl.project.branches.get.assert_not_called()
+    mocked_gl.project.repository_compare.assert_not_called()
+
+
 def test_omm_group_head_advanced_but_reachable_continues(
     mocker: MockerFixture,
 ) -> None:


### PR DESCRIPTION
In gitlab_housekeeping.py, return 0 early if merge_commit_sha is not yet populated, letting the next reconcile loop retry naturally.

Fixes a bug where `lead.merge_commit_sha` can be None


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced error resilience with safeguards for missing merge information, allowing automatic retry on subsequent operations instead of proceeding with incomplete data.

* **Tests**
  * Added comprehensive test coverage to verify proper handling of missing merge information scenarios and confirm automatic retry behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->