### PR TITLE
fix(vault): add exponential backoff and transport retry to VaultClient auth

### DIFF
--- a/reconcile/utils/vault.py
+++ b/reconcile/utils/vault.py
@@ -13,11 +13,21 @@ import requests
 from hvac.exceptions import InvalidPath
 from requests.adapters import HTTPAdapter
 from sretoolbox.utils import retry
+from urllib3.util.retry import Retry as Urllib3Retry
 
 from reconcile.utils.config import get_config
 
 LOG = logging.getLogger(__name__)
 VAULT_AUTO_REFRESH_INTERVAL = int(os.getenv("VAULT_AUTO_REFRESH_INTERVAL") or 600)
+VAULT_AUTH_MAX_ATTEMPTS = int(os.getenv("VAULT_AUTH_MAX_ATTEMPTS") or 5)
+VAULT_AUTH_BACKOFF_BASE = float(os.getenv("VAULT_AUTH_BACKOFF_BASE") or 2.0)
+VAULT_AUTH_BACKOFF_MAX = float(os.getenv("VAULT_AUTH_BACKOFF_MAX") or 30.0)
+
+_VAULT_RETRYABLE_EXCEPTIONS = (
+    requests.exceptions.ConnectionError,
+    requests.exceptions.Timeout,
+    requests.exceptions.TooManyRedirects,
+)
 
 
 class PathAccessForbiddenError(Exception):
@@ -120,27 +130,40 @@ class VaultClient:
         self._read_all_v2 = lru_cache(maxsize=2048)(self.__read_all_v2)
 
         session = requests.Session()
-        # There are at most 10 working threads in reconcile, plus 1 daemon thread for auto refresh
-        adapter = HTTPAdapter(pool_maxsize=11)
+        transport_retry = Urllib3Retry(
+            total=3,
+            connect=3,
+            backoff_factor=0.5,
+        )
+        adapter = HTTPAdapter(pool_maxsize=11, max_retries=transport_retry)
         session.mount("https://", adapter)
         self._client = hvac.Client(url=server, session=session)
         self._close_lock = threading.Lock()
         self._closed = False
 
         authenticated = False
-        for _ in range(3):
+        last_error: Exception | None = None
+        for attempt in range(VAULT_AUTH_MAX_ATTEMPTS):
             try:
                 self._refresh_client_auth()
                 authenticated = self._client.is_authenticated()
-                break
-            except (
-                requests.exceptions.ConnectionError,
-                requests.exceptions.TooManyRedirects,
-            ):
-                time.sleep(1)
+                if authenticated:
+                    break
+            except _VAULT_RETRYABLE_EXCEPTIONS as exc:
+                last_error = exc
+
+            if attempt < VAULT_AUTH_MAX_ATTEMPTS - 1:
+                backoff = min(VAULT_AUTH_BACKOFF_BASE**attempt, VAULT_AUTH_BACKOFF_MAX)
+                LOG.warning(
+                    "Vault auth attempt %d/%d failed, retrying in %.1fs",
+                    attempt + 1,
+                    VAULT_AUTH_MAX_ATTEMPTS,
+                    backoff,
+                )
+                time.sleep(backoff)
 
         if not authenticated:
-            raise VaultConnectionError()
+            raise VaultConnectionError() from last_error
 
         if auto_refresh:
             t = threading.Thread(target=self._auto_refresh_client_auth, daemon=True)
@@ -163,7 +186,9 @@ class VaultClient:
 
     def _auto_refresh_client_auth(self) -> None:
         """
-        Thread that periodically refreshes the vault token
+        Thread that periodically refreshes the vault token.
+        Failures are logged but do not kill the thread; the next
+        interval will retry.
         """
         while True:
             time.sleep(VAULT_AUTO_REFRESH_INTERVAL)
@@ -172,11 +197,17 @@ class VaultClient:
                     LOG.debug("client is closed, exiting auto refresh")
                     break
                 LOG.debug("auto refresh client auth")
-                self._refresh_client_auth()
+                try:
+                    self._refresh_client_auth()
+                except Exception:
+                    LOG.warning(
+                        "auto refresh auth failed, will retry in %ds",
+                        VAULT_AUTO_REFRESH_INTERVAL,
+                        exc_info=True,
+                    )
 
     def _refresh_client_auth(self) -> None:
         if self.kube_auth_enabled:
-            # must read each time to account for sa token refresh
             with open(self.kube_sa_token_path, encoding="locale") as f:
                 try:
                     self._client.auth.kubernetes.login(
@@ -186,9 +217,14 @@ class VaultClient:
                     )
                 except Exception as e:
                     LOG.error(
-                        f"Failed to authenticate to Vault server {self._client.url} "
-                        f"using role '{self.kube_auth_role}' on mount '{self.kube_auth_mount}': {e}"
+                        "Failed to authenticate to Vault server %s "
+                        "using role '%s' on mount '%s': %s",
+                        self._client.url,
+                        self.kube_auth_role,
+                        self.kube_auth_mount,
+                        e,
                     )
+                    raise
         else:
             self._client.auth.approle.login(
                 role_id=self.role_id, secret_id=self.secret_id

--- a/reconcile/utils/vault.py
+++ b/reconcile/utils/vault.py
@@ -149,15 +149,26 @@ class VaultClient:
                 authenticated = self._client.is_authenticated()
                 if authenticated:
                     break
+                LOG.warning(
+                    "Vault auth attempt %d/%d: server responded but "
+                    "is_authenticated() returned False (token may be "
+                    "invalid or session rejected)",
+                    attempt + 1,
+                    VAULT_AUTH_MAX_ATTEMPTS,
+                )
             except _VAULT_RETRYABLE_EXCEPTIONS as exc:
                 last_error = exc
+                LOG.warning(
+                    "Vault auth attempt %d/%d hit retryable error: %s",
+                    attempt + 1,
+                    VAULT_AUTH_MAX_ATTEMPTS,
+                    exc,
+                )
 
             if attempt < VAULT_AUTH_MAX_ATTEMPTS - 1:
                 backoff = min(VAULT_AUTH_BACKOFF_BASE**attempt, VAULT_AUTH_BACKOFF_MAX)
                 LOG.warning(
-                    "Vault auth attempt %d/%d failed, retrying in %.1fs",
-                    attempt + 1,
-                    VAULT_AUTH_MAX_ATTEMPTS,
+                    "retrying in %.1fs",
                     backoff,
                 )
                 time.sleep(backoff)

--- a/reconcile/utils/vault.py
+++ b/reconcile/utils/vault.py
@@ -174,6 +174,17 @@ class VaultClient:
                 time.sleep(backoff)
 
         if not authenticated:
+            failure_reason = (
+                f"retryable transport error: {last_error}"
+                if last_error
+                else "is_authenticated() returned False on every attempt"
+            )
+            LOG.error(
+                "Vault auth failed after %d/%d attempts; last failure: %s",
+                VAULT_AUTH_MAX_ATTEMPTS,
+                VAULT_AUTH_MAX_ATTEMPTS,
+                failure_reason,
+            )
             raise VaultConnectionError() from last_error
 
         if auto_refresh:


### PR DESCRIPTION
## Summary

- **Fix broken auth retry**: `_refresh_client_auth` was swallowing all exceptions (caught `Exception`, logged, never re-raised), so the init retry loop never actually retried on transient Vault connectivity failures. The `break` was also unconditional, exiting even when `authenticated=False`. Pods would crash immediately with `VaultConnectionError` on the first transient timeout.
- **Add exponential backoff**: Increased retry attempts from 3→5 with exponential backoff (1s, 2s, 4s, 8s, 16s capped at 30s) instead of flat 1s sleep. Configurable via `VAULT_AUTH_MAX_ATTEMPTS`, `VAULT_AUTH_BACKOFF_BASE`, `VAULT_AUTH_BACKOFF_MAX` env vars.
- **Add urllib3 transport-level retry**: Configure `Retry` on the `HTTPAdapter` with 3 connect retries and 0.5s backoff factor, providing transparent TCP-level retry before exceptions reach the hvac client.
- **Auto-refresh thread resilience**: Wrap `_auto_refresh_client_auth` in try/except so the daemon thread survives transient failures instead of dying silently, retrying on the next interval.

## Context

On 2026-06-03 we experienced intermittent `ConnectTimeoutError` from ~200 integration pods authenticating to `vault.devshift.net` on `appsrep09ue1`. The traffic hairpins through the OpenShift router (pod → ELB → router → vault pod on the same cluster), and the route is fragile under load. Pods were crashing immediately on the first timeout instead of retrying, causing cascading restarts.

Investigation confirmed Vault and node networking were healthy — the issue was purely client-side: stale connection pools from long-running pods + the broken retry logic meant any transient timeout was fatal.

## Test plan

- [x] Existing unit tests pass (`test_vault_utils.py` — 4/4)
- [x] `ruff check` clean
- [x] `mypy` clean
- [ ] Verify in staging that VaultClient retries on transient auth failures instead of crashing
- [ ] Confirm env var overrides work (`VAULT_AUTH_MAX_ATTEMPTS`, `VAULT_AUTH_BACKOFF_BASE`, `VAULT_AUTH_BACKOFF_MAX`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Vault authentication now retries with configurable exponential backoff and more resilient HTTP transport handling for transient failures.
  * Clear connection error is raised if authentication attempts are exhausted after retries.
  * Background token auto-refresh is more resilient: failures are logged and the refresh loop continues.
  * Kubernetes auth failure logs now include server URL, role, and mount for clearer diagnostics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->