### PR TITLE
fix(prometheus-rules-tester): add dvo-tests-ns to tested namespace names

### DIFF
--- a/reconcile/prometheus_rules_tester/integration.py
+++ b/reconcile/prometheus_rules_tester/integration.py
@@ -44,6 +44,7 @@ PROVIDERS = ["prometheus-rule"]
 NAMESPACE_NAMES = frozenset([
     "openshift-customer-monitoring",
     "app-sre-observability-per-cluster",
+    "dvo-tests-ns",
 ])
 DEFAULT_PROMTOOL_VERSION = "3.2.1"
 


### PR DESCRIPTION
## Summary

- Add `dvo-tests-ns` to `NAMESPACE_NAMES` in the prometheus-rules-tester integration

## Why

MR app-interface!190838 added DVO exception labels (`deployment_validation_operator_minimum_three_replicas`, `unset_cpu_requirements`, `unset_memory_requirements`) to `app-sre-observability-per-cluster` via `namespace.labels`. All four DVO promrule tests used this namespace as `exported_namespace`. Once the exception label is present, the rule template skips generating an alert for that namespace — so no alert fires and promtool tests fail with `got:[]`.

The companion app-interface MR (!191037) updates all four DVO promrule tests to use `dvo-tests-ns` instead — a purpose-built test namespace in `test_data/` backed by `test-cluster`, with no exception labels and stable metadata (`app: dvo-tests`, `jiralert: TEST`). This namespace is already rendered in the expected results for the DVO template tests, confirming `test_data/` is loaded by production qontract-server.

Adding `dvo-tests-ns` to `NAMESPACE_NAMES` here ensures the prometheus_rules_tester picks it up and runs the promtool behavioral tests against the `test-cluster` rendering.

## Test plan

- [ ] Verify `dvo-tests-ns` appears in qontract-server GraphQL data in the integration test environment
- [ ] Confirm prometheus-rules-tester passes for `dvo-tests-ns` after the app-interface MR is merged

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Extended the namespace allowlist for Prometheus rule resource collection and testing in the monitoring integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->