### PR TITLE
Revert "fix(prometheus-rules-tester): add dvo-tests-ns to tested name…

### DIFF
--- a/reconcile/prometheus_rules_tester/integration.py
+++ b/reconcile/prometheus_rules_tester/integration.py
@@ -44,7 +44,6 @@ PROVIDERS = ["prometheus-rule"]
 NAMESPACE_NAMES = frozenset([
     "openshift-customer-monitoring",
     "app-sre-observability-per-cluster",
-    "dvo-tests-ns",
 ])
 DEFAULT_PROMTOOL_VERSION = "3.2.1"
 


### PR DESCRIPTION
…space names (#5586)"

This reverts commit 1aae350663db941c772cb45568a9e684ed14cdb2.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the integration runner to discontinue monitoring Prometheus rules from a specific namespace, streamlining test discovery and execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->