### PR TITLE
Resolve lead SHA for squash/fast-forward merge projects

### DIFF
--- a/reconcile/gitlab_housekeeping.py
+++ b/reconcile/gitlab_housekeeping.py
@@ -1069,10 +1069,11 @@ def _process_omm_group(
         clear_omm_group(dry_run, gl, lead=lead)
         return 0
 
-    if not lead.merge_commit_sha:
+    lead_sha = lead.squash_commit_sha or lead.merge_commit_sha
+    if not lead_sha:
         logging.warning([
             "omm-group",
-            "lead-missing-merge-sha",
+            "lead-missing-sha",
             gl.project.name,
             lead.iid,
             "will retry next loop",
@@ -1080,14 +1081,14 @@ def _process_omm_group(
         return 0
 
     current_head = gl.project.branches.get(lead.target_branch).commit["id"]
-    if current_head != lead.merge_commit_sha:
+    if current_head != lead_sha:
         # Head moved since the lead merged.  This is expected when pending
         # members merge (each advances the target).  Only invalidate if
         # the lead's commit is no longer reachable — meaning the branch
         # diverged (force push / external reset).
         result = cast(
             "dict",
-            gl.project.repository_compare(current_head, lead.merge_commit_sha),
+            gl.project.repository_compare(current_head, lead_sha),
         )
         if len(result["commits"]) > 0:
             logging.warning([

--- a/reconcile/gitlab_housekeeping.py
+++ b/reconcile/gitlab_housekeeping.py
@@ -1069,7 +1069,7 @@ def _process_omm_group(
         clear_omm_group(dry_run, gl, lead=lead)
         return 0
 
-    lead_sha = lead.squash_commit_sha or lead.merge_commit_sha
+    lead_sha = lead.merge_commit_sha or lead.squash_commit_sha
     if not lead_sha:
         logging.warning([
             "omm-group",

--- a/reconcile/test/test_gitlab_housekeeping.py
+++ b/reconcile/test/test_gitlab_housekeeping.py
@@ -2110,8 +2110,15 @@ def _make_omm_gl(*, head_sha: str = "abc123") -> Mock:
     return mocked_gl
 
 
+@pytest.mark.parametrize(
+    "merge_sha, squash_sha",
+    [("abc123", None), (None, "abc123")],
+    ids=["merge-commit", "squash-commit"],
+)
 def test_omm_group_merge_rejected_applies_merge_error(
     mocker: MockerFixture,
+    merge_sha,
+    squash_sha,
 ) -> None:
     """When a pending MR's merge raises GitlabMRClosedError during OMM
     group processing, merge-error is applied and omm-pending is removed."""
@@ -2125,7 +2132,8 @@ def test_omm_group_merge_rejected_applies_merge_error(
     )
 
     lead = create_autospec(ProjectMergeRequest)
-    lead.merge_commit_sha = "abc123"
+    lead.merge_commit_sha = merge_sha
+    lead.squash_commit_sha = squash_sha
     lead.target_branch = "master"
 
     mr = _make_merge_mr(11, ["approved", "tenant-bar", "omm-pending"])
@@ -2152,10 +2160,17 @@ def test_omm_group_merge_rejected_applies_merge_error(
     mocked_gl.remove_label.assert_called_once_with(mr, "omm-pending")
 
 
+@pytest.mark.parametrize(
+    "merge_sha, squash_sha",
+    [("abc123", None), (None, "abc123")],
+    ids=["merge-commit", "squash-commit"],
+)
 def test_omm_group_head_drift_invalidates_group(
     mocker: MockerFixture,
+    merge_sha,
+    squash_sha,
 ) -> None:
-    """When target branch HEAD differs from lead's merge_commit_sha the
+    """When target branch HEAD differs from the lead's resolved SHA the
     group is invalidated immediately."""
     _setup_omm_group_mocks(mocker)
     clear_mock = mocker.patch(
@@ -2163,7 +2178,8 @@ def test_omm_group_head_drift_invalidates_group(
     )
 
     lead = create_autospec(ProjectMergeRequest)
-    lead.merge_commit_sha = "abc123"
+    lead.merge_commit_sha = merge_sha
+    lead.squash_commit_sha = squash_sha
     lead.target_branch = "master"
 
     mocked_gl = _make_omm_gl(head_sha="different-sha")
@@ -2183,7 +2199,7 @@ def test_omm_group_head_drift_invalidates_group(
 def test_omm_group_lead_missing_merge_commit_sha(
     mocker: MockerFixture,
 ) -> None:
-    """When lead.merge_commit_sha is None (GitLab hasn't populated it yet),
+    """When both merge_commit_sha and squash_commit_sha are None,
     return 0 without crashing and leave the group intact for the next loop."""
     _setup_omm_group_mocks(mocker)
     clear_mock = mocker.patch(
@@ -2192,6 +2208,7 @@ def test_omm_group_lead_missing_merge_commit_sha(
 
     lead = create_autospec(ProjectMergeRequest)
     lead.merge_commit_sha = None
+    lead.squash_commit_sha = None
     lead.target_branch = "master"
     lead.iid = 99999
 
@@ -2210,8 +2227,15 @@ def test_omm_group_lead_missing_merge_commit_sha(
     mocked_gl.project.repository_compare.assert_not_called()
 
 
+@pytest.mark.parametrize(
+    "merge_sha, squash_sha",
+    [("abc123", None), (None, "abc123")],
+    ids=["merge-commit", "squash-commit"],
+)
 def test_omm_group_head_advanced_but_reachable_continues(
     mocker: MockerFixture,
+    merge_sha,
+    squash_sha,
 ) -> None:
     """When HEAD advanced because a pending member merged (lead commit
     still reachable), the group stays valid and processing continues."""
@@ -2225,7 +2249,8 @@ def test_omm_group_head_advanced_but_reachable_continues(
     )
 
     lead = create_autospec(ProjectMergeRequest)
-    lead.merge_commit_sha = "abc123"
+    lead.merge_commit_sha = merge_sha
+    lead.squash_commit_sha = squash_sha
     lead.target_branch = "master"
 
     mr = _make_merge_mr(11, ["approved", "tenant-bar", "omm-pending"])
@@ -2253,8 +2278,15 @@ def test_omm_group_head_advanced_but_reachable_continues(
     )
 
 
+@pytest.mark.parametrize(
+    "merge_sha, squash_sha",
+    [("abc123", None), (None, "abc123")],
+    ids=["merge-commit", "squash-commit"],
+)
 def test_omm_group_skip_ci_rebase_on_success_not_rebased(
     mocker: MockerFixture,
+    merge_sha,
+    squash_sha,
 ) -> None:
     """A pending MR with SUCCESS pipeline that is not rebased (HEAD moved)
     gets a skip_ci rebase and keeps the group active."""
@@ -2268,7 +2300,8 @@ def test_omm_group_skip_ci_rebase_on_success_not_rebased(
     )
 
     lead = create_autospec(ProjectMergeRequest)
-    lead.merge_commit_sha = "abc123"
+    lead.merge_commit_sha = merge_sha
+    lead.squash_commit_sha = squash_sha
     lead.target_branch = "master"
 
     mr = _make_merge_mr(11, ["approved", "tenant-bar", "omm-pending"])
@@ -2294,8 +2327,15 @@ def test_omm_group_skip_ci_rebase_on_success_not_rebased(
     clear_mock.assert_not_called()
 
 
+@pytest.mark.parametrize(
+    "merge_sha, squash_sha",
+    [("abc123", None), (None, "abc123")],
+    ids=["merge-commit", "squash-commit"],
+)
 def test_omm_group_skip_ci_rebase_failure_ejects_member(
     mocker: MockerFixture,
+    merge_sha,
+    squash_sha,
 ) -> None:
     """When skip_ci rebase fails during group processing, the MR is
     ejected (omm-pending removed) and counted as a rejection."""
@@ -2309,7 +2349,8 @@ def test_omm_group_skip_ci_rebase_failure_ejects_member(
     )
 
     lead = create_autospec(ProjectMergeRequest)
-    lead.merge_commit_sha = "abc123"
+    lead.merge_commit_sha = merge_sha
+    lead.squash_commit_sha = squash_sha
     lead.target_branch = "master"
 
     mr = _make_merge_mr(11, ["approved", "tenant-bar", "omm-pending"])
@@ -2335,8 +2376,15 @@ def test_omm_group_skip_ci_rebase_failure_ejects_member(
     mocked_gl.remove_label.assert_called_once_with(mr, "omm-pending")
 
 
+@pytest.mark.parametrize(
+    "merge_sha, squash_sha",
+    [("abc123", None), (None, "abc123")],
+    ids=["merge-commit", "squash-commit"],
+)
 def test_omm_group_merge_limit_enforced(
     mocker: MockerFixture,
+    merge_sha,
+    squash_sha,
 ) -> None:
     """When merge_limit is reached during OMM group processing the group
     is cleared and processing stops."""
@@ -2350,7 +2398,8 @@ def test_omm_group_merge_limit_enforced(
     )
 
     lead = create_autospec(ProjectMergeRequest)
-    lead.merge_commit_sha = "abc123"
+    lead.merge_commit_sha = merge_sha
+    lead.squash_commit_sha = squash_sha
     lead.target_branch = "master"
 
     mr1 = _make_merge_mr(10, ["approved", "tenant-foo", "omm-pending"])

--- a/reconcile/test/test_gitlab_housekeeping.py
+++ b/reconcile/test/test_gitlab_housekeeping.py
@@ -2117,8 +2117,8 @@ def _make_omm_gl(*, head_sha: str = "abc123") -> Mock:
 )
 def test_omm_group_merge_rejected_applies_merge_error(
     mocker: MockerFixture,
-    merge_sha,
-    squash_sha,
+    merge_sha: str | None,
+    squash_sha: str | None,
 ) -> None:
     """When a pending MR's merge raises GitlabMRClosedError during OMM
     group processing, merge-error is applied and omm-pending is removed."""
@@ -2167,8 +2167,8 @@ def test_omm_group_merge_rejected_applies_merge_error(
 )
 def test_omm_group_head_drift_invalidates_group(
     mocker: MockerFixture,
-    merge_sha,
-    squash_sha,
+    merge_sha: str | None,
+    squash_sha: str | None,
 ) -> None:
     """When target branch HEAD differs from the lead's resolved SHA the
     group is invalidated immediately."""
@@ -2234,8 +2234,8 @@ def test_omm_group_lead_missing_merge_commit_sha(
 )
 def test_omm_group_head_advanced_but_reachable_continues(
     mocker: MockerFixture,
-    merge_sha,
-    squash_sha,
+    merge_sha: str | None,
+    squash_sha: str | None,
 ) -> None:
     """When HEAD advanced because a pending member merged (lead commit
     still reachable), the group stays valid and processing continues."""
@@ -2285,8 +2285,8 @@ def test_omm_group_head_advanced_but_reachable_continues(
 )
 def test_omm_group_skip_ci_rebase_on_success_not_rebased(
     mocker: MockerFixture,
-    merge_sha,
-    squash_sha,
+    merge_sha: str | None,
+    squash_sha: str | None,
 ) -> None:
     """A pending MR with SUCCESS pipeline that is not rebased (HEAD moved)
     gets a skip_ci rebase and keeps the group active."""
@@ -2334,8 +2334,8 @@ def test_omm_group_skip_ci_rebase_on_success_not_rebased(
 )
 def test_omm_group_skip_ci_rebase_failure_ejects_member(
     mocker: MockerFixture,
-    merge_sha,
-    squash_sha,
+    merge_sha: str | None,
+    squash_sha: str | None,
 ) -> None:
     """When skip_ci rebase fails during group processing, the MR is
     ejected (omm-pending removed) and counted as a rejection."""
@@ -2383,8 +2383,8 @@ def test_omm_group_skip_ci_rebase_failure_ejects_member(
 )
 def test_omm_group_merge_limit_enforced(
     mocker: MockerFixture,
-    merge_sha,
-    squash_sha,
+    merge_sha: str | None,
+    squash_sha: str | None,
 ) -> None:
     """When merge_limit is reached during OMM group processing the group
     is cleared and processing stops."""


### PR DESCRIPTION
## fix(omm): resolve lead SHA for squash/fast-forward merge projects
Follow up [APPSRE-13998](https://redhat.atlassian.net/browse/APPSRE-13998) 
### Problem

The OMM group processing in `_process_omm_group` relied exclusively on `lead.merge_commit_sha` to track the lead MR's resulting commit. On projects that use squash or fast-forward merges (like app-interface), GitLab never creates a merge commit — the resulting SHA only exists in `squash_commit_sha`, leaving `merge_commit_sha` permanently `None`.

This caused two issues in production:
1. **Before the SHA guard** (initial deploy): `repository_compare(current_head, None)` sent a null SHA to the GitLab API, returning 400 errors.
2. **After the SHA guard was added**: The `if not lead.merge_commit_sha` check fired every loop, logging `lead-missing-merge-sha` indefinitely. The retry never resolved because the field is structurally null — not a race condition.

## Fix
Resolve the lead SHA once at the top of the divergence-check block:

lead_sha = lead.merge_commit_sha or lead.squash_commit_sha
This covers both merge strategies:

Regular merge projects: merge_commit_sha is set, squash_commit_sha is null — resolves to merge_commit_sha
Squash/FF projects: merge_commit_sha is null, squash_commit_sha is set — resolves to squash_commit_sha
The guard for neither SHA being populated is retained as a safety net for the (unlikely) case where GitLab hasn't written either field yet.

## Changes

- reconcile/gitlab_housekeeping.py: Replace three bare lead.merge_commit_sha references with lead_sha (guard, head comparison, repository_compare call). Update warning tag to lead-missing-sha.
- reconcile/test/test_gitlab_housekeeping.py:
- Parametrize 6 existing _process_omm_group tests with ids=["merge-commit", "squash-commit"] so each runs against both SHA paths (12 test cases total).
- Update the missing-SHA guard test to set both fields to None.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced commit validation to accept alternative SHA formats with automatic retry when neither is available
  * Improved branch divergence detection for more robust merge tracking

* **Tests**
  * Expanded test coverage to validate behavior across both merge and squash commit SHA scenarios

<!-- end of auto-generated comment: release notes by coderabbit.ai -->