### PR TITLE
feat(saasherder): fall back to IMAGE when REGISTRY_IMG is not set for…

### DIFF
--- a/reconcile/utils/saasherder/saasherder.py
+++ b/reconcile/utils/saasherder/saasherder.py
@@ -955,9 +955,10 @@ class SaasHerder:
             if need_repo_digest or need_image_digest:
                 try:
                     logging.debug("Generating REPO_DIGEST.")
-                    registry_image = consolidated_parameters.get(
-                        "REGISTRY_IMG"
-                    ) or consolidated_parameters["IMAGE"]
+                    registry_image = (
+                        consolidated_parameters.get("REGISTRY_IMG")
+                        or consolidated_parameters["IMAGE"]
+                    )
                 except KeyError as e:
                     logging.error(
                         f"{error_prefix} error generating REPO_DIGEST. "

--- a/reconcile/utils/saasherder/saasherder.py
+++ b/reconcile/utils/saasherder/saasherder.py
@@ -955,11 +955,13 @@ class SaasHerder:
             if need_repo_digest or need_image_digest:
                 try:
                     logging.debug("Generating REPO_DIGEST.")
-                    registry_image = consolidated_parameters["REGISTRY_IMG"]
+                    registry_image = consolidated_parameters.get(
+                        "REGISTRY_IMG"
+                    ) or consolidated_parameters["IMAGE"]
                 except KeyError as e:
                     logging.error(
                         f"{error_prefix} error generating REPO_DIGEST. "
-                        + "Is REGISTRY_IMG missing? "
+                        + "Is REGISTRY_IMG or IMAGE missing? "
                         + f"{e!s}"
                     )
                     raise


### PR DESCRIPTION
… digest resolution

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved fallback logic for image registry configuration to gracefully handle missing values and use alternative sources when needed. Error messages now accurately reflect which configuration options are unavailable, enhancing troubleshooting clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->