### PR TITLE
update openshift-saas-deploy message to link to specific pipelinerun logs

### DIFF
--- a/reconcile/cli.py
+++ b/reconcile/cli.py
@@ -1388,6 +1388,11 @@ def openshift_resources(
     metavar="URL",
     help=("Grafana dashboard URL"),
 )
+@click.option(
+    "--pipelinerun-name",
+    default=None,
+    help="Tekton PipelineRun name for Grafana log links.",
+)
 @trigger_integration
 @trigger_reason
 @click.pass_context
@@ -1399,6 +1404,7 @@ def openshift_saas_deploy(
     saas_file_name: str | None,
     env_name: str | None,
     grafana_saas_deploy_url: str | None,
+    pipelinerun_name: str | None,
     trigger_integration: str | None,
     trigger_reason: str | None,
 ) -> None:
@@ -1413,6 +1419,7 @@ def openshift_saas_deploy(
         saas_file_name=saas_file_name,
         env_name=env_name,
         grafana_saas_deploy_url=grafana_saas_deploy_url,
+        pipelinerun_name=pipelinerun_name,
         trigger_integration=trigger_integration,
         trigger_reason=trigger_reason,
     )

--- a/reconcile/openshift_saas_deploy.py
+++ b/reconcile/openshift_saas_deploy.py
@@ -79,6 +79,7 @@ def compose_grafana_logs_url(
     *,
     pipeline_name: str,
     grafana_saas_deploy_url: str,
+    pipelinerun_name: str | None = None,
 ) -> str:
     if not isinstance(saas_file.pipelines_provider, PipelinesProviderTektonV1):
         raise TypeError(
@@ -86,12 +87,14 @@ def compose_grafana_logs_url(
         )
     pipelines_provider = saas_file.pipelines_provider
     grafana_base_url = grafana_saas_deploy_url.rstrip("/")
-    params = urlencode({
+    params = {
         "var-cluster": pipelines_provider.namespace.cluster.name,
         "var-namespace": pipelines_provider.namespace.name,
         "var-pipeline": pipeline_name,
-    })
-    return f"{grafana_base_url}?{params}"
+    }
+    if pipelinerun_name:
+        params["var-pipelinerun"] = pipelinerun_name
+    return f"{grafana_base_url}?{urlencode(params)}"
 
 
 def slack_notify(
@@ -126,20 +129,22 @@ def slack_notify(
     else:
         icon = ":red_jenkins_circle:"
         description = "Failure"
-    message = (
-        f"{icon} SaaS file *{saas_file_name}* "
-        + f"deployment to environment *{env_name}*: "
-        + f"{description} - (<{console_url}|PipelineRuns>)"
-    )
-    if grafana_logs_url:
-        message += f" (<{grafana_logs_url}|Logs>)"
-    if trigger_reason:
-        message += f". Reason: {trigger_reason}"
+    lines = [
+        f"{icon} *SaaS deploy: {description}*",
+        f"*SaaS File:* `{saas_file_name}`",
+        f"*Deployment to environment:* `{env_name}`",
+    ]
     if trigger_integration:
-        message += f" triggered by _{trigger_integration}_"
+        lines.append(f"*Triggered by:* {trigger_integration}")
+    if trigger_reason:
+        lines.append(f"*Reason:* {trigger_reason}")
+    links = f"<{console_url}|PipelineRun>"
+    if grafana_logs_url:
+        links += f" | <{grafana_logs_url}|Logs>"
+    lines.append(links)
     if in_progress and skip_successful_notifications:
-        message += ". There will not be a notice for success."
-    slack.chat_post_message(message)
+        lines.append("There will not be a notice for success.")
+    slack.chat_post_message("\n".join(lines))
 
 
 @defer
@@ -154,6 +159,7 @@ def run(
     trigger_reason: str | None = None,
     saas_file_list: SaasFileList | None = None,
     grafana_saas_deploy_url: str | None = None,
+    pipelinerun_name: str | None = None,
     defer: Callable | None = None,
 ) -> None:
     vault_settings = get_app_interface_vault_settings()
@@ -202,6 +208,7 @@ def run(
                     saas_file,
                     pipeline_name=pipeline_name,
                     grafana_saas_deploy_url=grafana_url,
+                    pipelinerun_name=pipelinerun_name,
                 )
                 if grafana_url
                 else None

--- a/reconcile/test/test_openshift_saas_deploy.py
+++ b/reconcile/test/test_openshift_saas_deploy.py
@@ -74,6 +74,25 @@ def test_compose_grafana_logs_url(
     )
 
 
+def test_compose_grafana_logs_url_with_pipelinerun(
+    saas_file_builder: Callable[..., SaasFile],
+) -> None:
+    saas_file = saas_file_builder("saas_name")
+    pipeline_name = _saas_file_tekton_pipeline_name(saas_file)
+    pipelinerun_name = "test-pipelinerun-name-abcde"
+    url = compose_grafana_logs_url(
+        saas_file,
+        pipeline_name=pipeline_name,
+        grafana_saas_deploy_url=TEST_GRAFANA_SAAS_DEPLOY_URL,
+        pipelinerun_name=pipelinerun_name,
+    )
+    assert (
+        url == f"{TEST_GRAFANA_SAAS_DEPLOY_URL.rstrip('/')}?var-cluster=cluster_name&"
+        "var-namespace=namespace_name&var-pipeline=o-saas-deploy-saas_name&"
+        f"var-pipelinerun={pipelinerun_name}"
+    )
+
+
 def test_compose_console_url(
     saas_file_builder: Callable[..., SaasFile],
 ) -> None:
@@ -150,10 +169,10 @@ def test_slack_notify_unskipped_success() -> None:
         grafana_logs_url="https://test.local/grafana",
     )
     api.chat_post_message.assert_called_once_with(
-        ":green_jenkins_circle: SaaS file *test-slack_notify--unskipped-success.yaml* "
-        "deployment to environment *test*: Success "
-        "- (<https://test.local/console|PipelineRuns>) "
-        "(<https://test.local/grafana|Logs>)"
+        ":green_jenkins_circle: *SaaS deploy: Success*\n"
+        "*SaaS File:* `test-slack_notify--unskipped-success.yaml`\n"
+        "*Deployment to environment:* `test`\n"
+        "<https://test.local/console|PipelineRun> | <https://test.local/grafana|Logs>"
     )
 
 
@@ -172,10 +191,10 @@ def test_slack_notify_unskipped_failure() -> None:
         grafana_logs_url="https://test.local/grafana",
     )
     api.chat_post_message.assert_called_once_with(
-        ":red_jenkins_circle: SaaS file *test-saas-file-name.yaml* "
-        "deployment to environment *test*: Failure "
-        "- (<https://test.local/console|PipelineRuns>) "
-        "(<https://test.local/grafana|Logs>)"
+        ":red_jenkins_circle: *SaaS deploy: Failure*\n"
+        "*SaaS File:* `test-saas-file-name.yaml`\n"
+        "*Deployment to environment:* `test`\n"
+        "<https://test.local/console|PipelineRun> | <https://test.local/grafana|Logs>"
     )
 
 
@@ -194,10 +213,10 @@ def test_slack_notify_skipped_failure() -> None:
         grafana_logs_url="https://test.local/grafana",
     )
     api.chat_post_message.assert_called_once_with(
-        ":red_jenkins_circle: SaaS file *test-saas-file-name.yaml* "
-        "deployment to environment *test*: Failure "
-        "- (<https://test.local/console|PipelineRuns>) "
-        "(<https://test.local/grafana|Logs>)"
+        ":red_jenkins_circle: *SaaS deploy: Failure*\n"
+        "*SaaS File:* `test-saas-file-name.yaml`\n"
+        "*Deployment to environment:* `test`\n"
+        "<https://test.local/console|PipelineRun> | <https://test.local/grafana|Logs>"
     )
 
 
@@ -215,8 +234,39 @@ def test_slack_notify_skipped_in_progress() -> None:
         grafana_logs_url="https://test.local/grafana",
     )
     api.chat_post_message.assert_called_once_with(
-        ":yellow_jenkins_circle: SaaS file *test-saas-file-name.yaml* "
-        "deployment to environment *test*: In Progress "
-        "- (<https://test.local/console|PipelineRuns>) "
-        "(<https://test.local/grafana|Logs>). There will not be a notice for success."
+        ":yellow_jenkins_circle: *SaaS deploy: In Progress*\n"
+        "*SaaS File:* `test-saas-file-name.yaml`\n"
+        "*Deployment to environment:* `test`\n"
+        "<https://test.local/console|PipelineRun> | <https://test.local/grafana|Logs>\n"
+        "There will not be a notice for success."
+    )
+
+
+def test_slack_notify_with_trigger_details() -> None:
+    api = create_autospec(slack_api.SlackApi)
+    slack_notify(
+        saas_file_name="saas-terraform-repo",
+        env_name="app-interface-production-int",
+        slack=api,
+        ri=openshift_resource.ResourceInventory(),
+        console_url="https://console.example.test/pipelinerun",
+        in_progress=False,
+        skip_successful_notifications=False,
+        grafana_logs_url="https://grafana.example.test/logs",
+        trigger_integration="openshift-saas-deploy-trigger-configs",
+        trigger_reason=(
+            "https://gitlab.example.test/service/app-interface/commit/"
+            "59d510fd5d37d66898cf744777c230ae9b66215f [auto-promotion]"
+        ),
+    )
+    api.chat_post_message.assert_called_once_with(
+        ":green_jenkins_circle: *SaaS deploy: Success*\n"
+        "*SaaS File:* `saas-terraform-repo`\n"
+        "*Deployment to environment:* `app-interface-production-int`\n"
+        "*Triggered by:* openshift-saas-deploy-trigger-configs\n"
+        "*Reason:* "
+        "https://gitlab.example.test/service/app-interface/commit/"
+        "59d510fd5d37d66898cf744777c230ae9b66215f [auto-promotion]\n"
+        "<https://console.example.test/pipelinerun|PipelineRun> | "
+        "<https://grafana.example.test/logs|Logs>"
     )

--- a/reconcile/test/test_openshift_saas_deploy.py
+++ b/reconcile/test/test_openshift_saas_deploy.py
@@ -240,33 +240,3 @@ def test_slack_notify_skipped_in_progress() -> None:
         "<https://test.local/console|PipelineRun> | <https://test.local/grafana|Logs>\n"
         "There will not be a notice for success."
     )
-
-
-def test_slack_notify_with_trigger_details() -> None:
-    api = create_autospec(slack_api.SlackApi)
-    slack_notify(
-        saas_file_name="saas-terraform-repo",
-        env_name="app-interface-production-int",
-        slack=api,
-        ri=openshift_resource.ResourceInventory(),
-        console_url="https://console.example.test/pipelinerun",
-        in_progress=False,
-        skip_successful_notifications=False,
-        grafana_logs_url="https://grafana.example.test/logs",
-        trigger_integration="openshift-saas-deploy-trigger-configs",
-        trigger_reason=(
-            "https://gitlab.example.test/service/app-interface/commit/"
-            "59d510fd5d37d66898cf744777c230ae9b66215f [auto-promotion]"
-        ),
-    )
-    api.chat_post_message.assert_called_once_with(
-        ":green_jenkins_circle: *SaaS deploy: Success*\n"
-        "*SaaS File:* `saas-terraform-repo`\n"
-        "*Deployment to environment:* `app-interface-production-int`\n"
-        "*Triggered by:* openshift-saas-deploy-trigger-configs\n"
-        "*Reason:* "
-        "https://gitlab.example.test/service/app-interface/commit/"
-        "59d510fd5d37d66898cf744777c230ae9b66215f [auto-promotion]\n"
-        "<https://console.example.test/pipelinerun|PipelineRun> | "
-        "<https://grafana.example.test/logs|Logs>"
-    )


### PR DESCRIPTION
update openshift-saas-deploy message to link to specific pipelinerun logs in grafana,  the message currently only links to the pipeline. also makes slack message output more readable

pipelinerun name comes from task https://gitlab.cee.redhat.com/service/app-interface/-/merge_requests/191727

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `--pipelinerun-name` option to the deployment command, allowing optional specification of a pipeline run identifier
  * Pipeline run information is now included in Grafana logs URLs and Slack notifications for improved traceability

* **Tests**
  * Added test coverage for pipeline run name functionality and notification message formatting

<!-- end of auto-generated comment: release notes by coderabbit.ai -->