### PR TITLE
feat(qontract-api): OPA-based authorization

### DIFF
--- a/.tekton/opa-master-pull-request.yaml
+++ b/.tekton/opa-master-pull-request.yaml
@@ -1,0 +1,60 @@
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+metadata:
+  annotations:
+    build.appstudio.openshift.io/repo: https://github.com/app-sre/qontract-reconcile?rev={{revision}}
+    build.appstudio.redhat.com/commit_sha: '{{revision}}'
+    build.appstudio.redhat.com/pull_request_number: '{{pull_request_number}}'
+    build.appstudio.redhat.com/target_branch: '{{target_branch}}'
+    pipelinesascode.tekton.dev/max-keep-runs: "3"
+    pipelinesascode.tekton.dev/on-cel-expression: (event == "pull_request" && target_branch == "master") || (event == "push" && target_branch.startsWith("gh-readonly-queue/master/"))
+  creationTimestamp: null
+  labels:
+    appstudio.openshift.io/application: qontract-reconcile-master
+    appstudio.openshift.io/component: opa-master
+    pipelines.appstudio.openshift.io/type: build
+  name: opa-master-on-pull-request
+  namespace: app-sre-tenant
+spec:
+  params:
+  - name: git-url
+    value: '{{source_url}}'
+  - name: revision
+    value: '{{revision}}'
+  - name: output-image
+    value: quay.io/redhat-user-workloads/app-sre-tenant/qontract-reconcile-master/opa-master:on-pr-{{revision}}
+  - name: image-expires-after
+    value: 5d
+  - name: dockerfile
+    value: opa/Dockerfile
+  - name: path-context
+    value: .
+  - name: target-stage
+    value: prod
+  pipelineRef:
+    params:
+    - name: url
+      value: https://github.com/app-sre/shared-pipelines
+    - name: revision
+      value: main
+    - name: pathInRepo
+      value: pipelines/multi-arch-build-pipeline.yaml
+    resolver: git
+  taskRunTemplate:
+    serviceAccountName: build-pipeline-opa-master
+  workspaces:
+  - name: workspace
+    volumeClaimTemplate:
+      metadata:
+        creationTimestamp: null
+      spec:
+        accessModes:
+        - ReadWriteOnce
+        resources:
+          requests:
+            storage: 1Gi
+      status: {}
+  - name: git-auth
+    secret:
+      secretName: '{{ git_auth_secret }}'
+status: {}

--- a/.tekton/opa-master-push.yaml
+++ b/.tekton/opa-master-push.yaml
@@ -1,0 +1,58 @@
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+metadata:
+  annotations:
+    build.appstudio.openshift.io/repo: https://github.com/app-sre/qontract-reconcile?rev={{revision}}
+    build.appstudio.redhat.com/commit_sha: '{{revision}}'
+    build.appstudio.redhat.com/target_branch: '{{target_branch}}'
+    pipelinesascode.tekton.dev/max-keep-runs: "3"
+    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
+      == "master"
+  creationTimestamp: null
+  labels:
+    appstudio.openshift.io/application: qontract-reconcile-master
+    appstudio.openshift.io/component: opa-master
+    pipelines.appstudio.openshift.io/type: build
+  name: opa-master-on-push
+  namespace: app-sre-tenant
+spec:
+  params:
+  - name: git-url
+    value: '{{source_url}}'
+  - name: revision
+    value: '{{revision}}'
+  - name: output-image
+    value: quay.io/redhat-user-workloads/app-sre-tenant/qontract-reconcile-master/opa-master:{{revision}}
+  - name: dockerfile
+    value: opa/Dockerfile
+  - name: path-context
+    value: .
+  - name: target-stage
+    value: prod
+  pipelineRef:
+    params:
+    - name: url
+      value: https://github.com/app-sre/shared-pipelines
+    - name: revision
+      value: main
+    - name: pathInRepo
+      value: pipelines/multi-arch-build-pipeline.yaml
+    resolver: git
+  taskRunTemplate:
+    serviceAccountName: build-pipeline-opa-master
+  workspaces:
+  - name: workspace
+    volumeClaimTemplate:
+      metadata:
+        creationTimestamp: null
+      spec:
+        accessModes:
+        - ReadWriteOnce
+        resources:
+          requests:
+            storage: 1Gi
+      status: {}
+  - name: git-auth
+    secret:
+      secretName: '{{ git_auth_secret }}'
+status: {}

--- a/docs/adr/ADR-021-opa-authorization.md
+++ b/docs/adr/ADR-021-opa-authorization.md
@@ -1,0 +1,64 @@
+# ADR-021: OPA-Based Authorization for qontract-api
+
+## Status
+
+Selected
+
+## Context
+
+qontract-api centralizes external API calls for reconcile integrations (ADR-013). Integrations pass Vault paths and external service URLs as request parameters. qontract-api resolves secrets and connects to the specified services.
+
+The problem: **any caller with a valid JWT can provide arbitrary parameters.** This enables two attack vectors:
+
+1. **Arbitrary Vault secret reads** — attacker specifies any Vault path; the secret is used in subsequent operations
+2. **Credential exfiltration via SSRF** — attacker provides their own server URL alongside a Vault path; qontract-api resolves the secret and sends it to the attacker-controlled server
+
+## Decision
+
+Deploy OPA (Open Policy Agent) as a sidecar alongside qontract-api, following the proven pattern from [automated-actions](https://github.com/app-sre/automated-actions/tree/main/packages/opa).
+
+### How it works
+
+1. Every authenticated request is checked against OPA before reaching the endpoint handler
+2. qontract-api sends an input document to OPA: `{username, obj (operation_id), params (flattened)}`
+3. OPA evaluates the request against role-based policies with regex parameter matching
+4. Denied requests get HTTP 403; OPA errors also result in 403 (fail-closed)
+
+### Key design choices
+
+- **Integrated into `UserDep`** — authorization runs as part of the existing `get_current_user` dependency chain (`_authenticate` → `_authorize`). No separate `AuthZDep` needed; every endpoint using `UserDep` is automatically protected.
+- **Fail-closed** — any OPA error (timeout, connection, invalid response) denies the request with HTTP 403, not 500.
+- **HTTP 403 for authZ failures** — distinguished from HTTP 401 (authentication failures).
+- **Connection pooling** — single `httpx.AsyncClient` with keep-alive connections to the OPA sidecar.
+- **POST body flattening** — nested request bodies are flattened to dot-notation (e.g., `secret.path`) for uniform OPA regex matching.
+- **Parameter collection for all HTTP methods** — path params, query params, and body are collected regardless of HTTP method.
+- **Reused Rego policies** — identical `rbac.rego` and `user.rego` from automated-actions, same input document format and policy data structure.
+- **No rate limiting in OPA** — qontract-api uses its own token bucket rate limiting.
+
+### Observability
+
+- `qontract_api_opa_decision_duration_seconds` histogram — tracks OPA call latency
+- `qontract_api_opa_decisions_total` counter (labels: `result`, `obj`) — tracks allow/deny/error rates
+- Audit logging on denials with structlog (username, operation, params)
+- OPA included in `/health/ready` readiness probe
+
+## Alternatives Considered
+
+### Static allowlists in qontract-api config
+
+Discarded: not per-subject, not scalable, changes require redeployment.
+
+### Named service references (eliminate URLs from API)
+
+Discarded: contradicts ADR-013 (qontract-api should not own service configs), breaking API change.
+
+### JWT token scoping
+
+Discarded: requires token re-issuance on policy changes, OPA provides the same with hot-reloadable policies.
+
+## References
+
+- [Design doc](https://github.com/openshift-online/platform-engineering-enhancements/pull/51)
+- [ADR-013: Centralize external API calls](./ADR-013-centralize-external-api-calls-in-api-gateway.md)
+- [automated-actions OPA implementation](https://github.com/app-sre/automated-actions/tree/main/packages/opa)
+- [APPSRE-14303](https://issues.redhat.com/browse/APPSRE-14303)

--- a/opa/Dockerfile
+++ b/opa/Dockerfile
@@ -1,0 +1,33 @@
+FROM registry.access.redhat.com/ubi10/ubi-minimal@sha256:2c20ac20ca1ecbbbd583603feabd9cc51e7e8ea5a82e5088e20a9494794b2574 AS base
+COPY --from=openpolicyagent/opa:1.17.1-static /opa /opa
+
+ENV PATH=${PATH}:/ \
+    IS_TESTED_FLAG="/tmp/is_tested"
+
+USER 1000:1000
+
+COPY LICENSE /licenses/
+COPY opa/authz /authz
+
+#
+# Test image
+#
+FROM base AS test
+COPY --from=ghcr.io/styrainc/regal:0.35.1@sha256:7caf9953f1c49054c94030ec7be087b46ae501fc347cdaace9557a57abd3f4ff /ko-app/regal /bin/regal
+
+USER 0
+RUN microdnf install -y make
+USER 1000:1000
+
+COPY opa/Makefile /
+RUN make -C / test
+RUN touch ${IS_TESTED_FLAG}
+
+#
+# Prod image
+#
+FROM base AS prod
+COPY --from=test ${IS_TESTED_FLAG} ${IS_TESTED_FLAG}
+
+ENTRYPOINT ["/opa"]
+CMD ["run"]

--- a/opa/Makefile
+++ b/opa/Makefile
@@ -1,0 +1,7 @@
+.PHONY: test lint
+
+test:
+	opa test -v authz
+
+lint:
+	regal lint authz

--- a/opa/authz/rbac.rego
+++ b/opa/authz/rbac.rego
@@ -1,0 +1,48 @@
+package authz
+
+default authorized := false
+
+# METADATA
+# description: Allow access to an action if the user has the required permissions
+# entrypoint: true
+# scope: document
+authorized if {
+	# Check if the user has specific roles
+	user_roles := data.users[input.username]
+	some role_name in user_roles
+	check_role_permissions(data.roles[role_name], input.username, input.obj, input.params)
+}
+
+authorized if {
+	# Check if there are default roles for all users
+	default_roles := data.users["*"]
+	some role_name in default_roles
+	check_role_permissions(data.roles[role_name], input.username, input.obj, input.params)
+}
+
+check_role_permissions(role_permissions, username, current_input_obj, current_input_params) if {
+	some permission in role_permissions
+	object_matches(permission.obj, current_input_obj)
+	valid_params(permission.params, current_input_params)
+}
+
+# Match any input if permission_obj is "*"
+object_matches("*", _) := true
+
+object_matches(permission_obj, input_obj) if {
+	permission_obj == input_obj
+}
+
+valid_params(expected, provided) if {
+	# Check that null values in expected mean that the key should not be present in provided
+	null_keys := {k | expected[k] == null}
+	every k in null_keys {
+		not provided[k]
+	}
+
+	# For non-null values, ensure they match using regex
+	non_null_keys := {k | expected[k] != null}
+	every k in non_null_keys {
+		regex.match(sprintf("(?i)%s", [expected[k]]), provided[k])
+	}
+}

--- a/opa/authz/rbac_test.rego
+++ b/opa/authz/rbac_test.rego
@@ -288,3 +288,69 @@ test_scoped_token_wrong_endpoint_denied if {
 		with data.users as mock_data.users
 		with data.roles as mock_data.roles
 }
+
+# ── valid_params edge cases ──────────────────────────────────────
+
+test_null_param_must_not_be_present if {
+	mock_roles_with_null := {"null-role": [{
+		"obj": "test-op",
+		"params": {"forbidden_key": null},
+	}]}
+	mock_users_with_null := {"null-user": ["null-role"]}
+
+	# authorized when forbidden_key is absent
+	authz.authorized with input as {
+		"username": "null-user",
+		"obj": "test-op",
+		"params": {"other_key": "value"},
+	}
+		with data.users as mock_users_with_null
+		with data.roles as mock_roles_with_null
+}
+
+test_null_param_present_denied if {
+	mock_roles_with_null := {"null-role": [{
+		"obj": "test-op",
+		"params": {"forbidden_key": null},
+	}]}
+	mock_users_with_null := {"null-user": ["null-role"]}
+
+	# denied when forbidden_key IS present
+	not authz.authorized with input as {
+		"username": "null-user",
+		"obj": "test-op",
+		"params": {"forbidden_key": "any-value"},
+	}
+		with data.users as mock_users_with_null
+		with data.roles as mock_roles_with_null
+}
+
+test_empty_params_authorized if {
+	mock_roles_empty := {"empty-role": [{
+		"obj": "test-op",
+		"params": {},
+	}]}
+	mock_users_empty := {"empty-user": ["empty-role"]}
+
+	authz.authorized with input as {
+		"username": "empty-user",
+		"obj": "test-op",
+		"params": {"anything": "goes"},
+	}
+		with data.users as mock_users_empty
+		with data.roles as mock_roles_empty
+}
+
+test_missing_required_param_denied if {
+	# role requires secret.path but input doesn't provide it
+	not authz.authorized with input as {
+		"username": "ldap-users-api",
+		"obj": "ldap-users-check",
+		"params": {
+			"secret.server_url": "ldap://freeipa.example.com",
+			"secret.secret_manager_url": "https://vault.example.com",
+		},
+	}
+		with data.users as mock_data.users
+		with data.roles as mock_data.roles
+}

--- a/opa/authz/rbac_test.rego
+++ b/opa/authz/rbac_test.rego
@@ -1,0 +1,290 @@
+package authz_test
+
+import rego.v1
+
+import data.authz
+
+# ── Test data ────────────────────────────────────────────────────
+
+mock_data := {
+	"users": {
+		"admin": ["admin-role"],
+		"ldap-users-api": ["ldap-role"],
+		"vcs-api": ["vcs-role"],
+		"ci-bot": ["slack-chat-role"],
+		"leaked-token-subject": [],
+		"*": ["default-role"],
+	},
+	"roles": {
+		"admin-role": [{"obj": "*", "params": {}}],
+		"default-role": [{"obj": "liveness", "params": {}}],
+		"ldap-role": [{
+			"obj": "ldap-users-check",
+			"params": {
+				"secret.server_url": "^ldaps?://freeipa\\.example\\.com$",
+				"secret.path": "^app-sre/creds/ldap",
+				"secret.secret_manager_url": "^https://vault\\.example\\.com$",
+			},
+		}],
+		"vcs-role": [{
+			"obj": "vcs-repo-owners",
+			"params": {
+				"repo_url": "^https://(github\\.com|gitlab\\.cee\\.redhat\\.com)/",
+				"path": "^app-sre/creds/",
+			},
+		}],
+		"slack-chat-role": [{
+			"obj": "slack-chat-post-message",
+			"params": {"secret.path": "^app-sre/creds/slack"},
+		}],
+	},
+}
+
+# ── Basic authorization ──────────────────────────────────────────
+
+test_admin_wildcard_authorized if {
+	authz.authorized with input as {
+		"username": "admin",
+		"obj": "any-endpoint",
+		"params": {"anything": "goes"},
+	}
+		with data.users as mock_data.users
+		with data.roles as mock_data.roles
+}
+
+test_unknown_user_denied if {
+	not authz.authorized with input as {
+		"username": "unknown-user",
+		"obj": "ldap-users-check",
+		"params": {},
+	}
+		with data.users as {"*": []}
+		with data.roles as mock_data.roles
+}
+
+test_blocked_user_denied if {
+	not authz.authorized with input as {
+		"username": "leaked-token-subject",
+		"obj": "ldap-users-check",
+		"params": {
+			"secret.server_url": "ldap://freeipa.example.com",
+			"secret.path": "app-sre/creds/ldap-prod",
+			"secret.secret_manager_url": "https://vault.example.com",
+		},
+	}
+		with data.users as mock_data.users
+		with data.roles as mock_data.roles
+}
+
+test_default_roles_apply if {
+	authz.authorized with input as {
+		"username": "any-user",
+		"obj": "liveness",
+		"params": {},
+	}
+		with data.users as mock_data.users
+		with data.roles as mock_data.roles
+}
+
+test_matching_obj_and_params_authorized if {
+	authz.authorized with input as {
+		"username": "ldap-users-api",
+		"obj": "ldap-users-check",
+		"params": {
+			"secret.server_url": "ldap://freeipa.example.com",
+			"secret.path": "app-sre/creds/ldap-prod",
+			"secret.secret_manager_url": "https://vault.example.com",
+		},
+	}
+		with data.users as mock_data.users
+		with data.roles as mock_data.roles
+}
+
+test_wrong_obj_denied if {
+	not authz.authorized with input as {
+		"username": "ldap-users-api",
+		"obj": "vcs-repo-owners",
+		"params": {},
+	}
+		with data.users as mock_data.users
+		with data.roles as mock_data.roles
+}
+
+test_wrong_params_denied if {
+	not authz.authorized with input as {
+		"username": "ldap-users-api",
+		"obj": "ldap-users-check",
+		"params": {
+			"secret.server_url": "ldap://wrong-server.com",
+			"secret.path": "app-sre/creds/ldap-prod",
+			"secret.secret_manager_url": "https://vault.example.com",
+		},
+	}
+		with data.users as mock_data.users
+		with data.roles as mock_data.roles
+}
+
+test_case_insensitive_params if {
+	authz.authorized with input as {
+		"username": "ldap-users-api",
+		"obj": "ldap-users-check",
+		"params": {
+			"secret.server_url": "LDAP://FREEIPA.EXAMPLE.COM",
+			"secret.path": "APP-SRE/CREDS/LDAP-PROD",
+			"secret.secret_manager_url": "HTTPS://VAULT.EXAMPLE.COM",
+		},
+	}
+		with data.users as mock_data.users
+		with data.roles as mock_data.roles
+}
+
+test_extra_params_allowed if {
+	authz.authorized with input as {
+		"username": "ldap-users-api",
+		"obj": "ldap-users-check",
+		"params": {
+			"secret.server_url": "ldap://freeipa.example.com",
+			"secret.path": "app-sre/creds/ldap-prod",
+			"secret.secret_manager_url": "https://vault.example.com",
+			"extra_param": "this-is-not-in-policy",
+		},
+	}
+		with data.users as mock_data.users
+		with data.roles as mock_data.roles
+}
+
+# ── SSRF prevention: LDAP ────────────────────────────────────────
+
+test_ssrf_ldap_attacker_server_denied if {
+	not authz.authorized with input as {
+		"username": "ldap-users-api",
+		"obj": "ldap-users-check",
+		"params": {
+			"secret.server_url": "ldap://evil.com",
+			"secret.path": "app-sre/creds/ldap-prod",
+			"secret.secret_manager_url": "https://vault.example.com",
+		},
+	}
+		with data.users as mock_data.users
+		with data.roles as mock_data.roles
+}
+
+test_ssrf_ldap_legit_server_allowed if {
+	authz.authorized with input as {
+		"username": "ldap-users-api",
+		"obj": "ldap-users-check",
+		"params": {
+			"secret.server_url": "ldaps://freeipa.example.com",
+			"secret.path": "app-sre/creds/ldap-prod",
+			"secret.secret_manager_url": "https://vault.example.com",
+		},
+	}
+		with data.users as mock_data.users
+		with data.roles as mock_data.roles
+}
+
+# ── SSRF prevention: VCS ─────────────────────────────────────────
+
+test_ssrf_vcs_attacker_repo_denied if {
+	not authz.authorized with input as {
+		"username": "vcs-api",
+		"obj": "vcs-repo-owners",
+		"params": {
+			"repo_url": "https://evil.com/attacker/repo",
+			"path": "app-sre/creds/github-token",
+		},
+	}
+		with data.users as mock_data.users
+		with data.roles as mock_data.roles
+}
+
+test_ssrf_vcs_legit_github_allowed if {
+	authz.authorized with input as {
+		"username": "vcs-api",
+		"obj": "vcs-repo-owners",
+		"params": {
+			"repo_url": "https://github.com/app-sre/qontract-reconcile",
+			"path": "app-sre/creds/github-token",
+		},
+	}
+		with data.users as mock_data.users
+		with data.roles as mock_data.roles
+}
+
+test_ssrf_vcs_legit_gitlab_allowed if {
+	authz.authorized with input as {
+		"username": "vcs-api",
+		"obj": "vcs-repo-owners",
+		"params": {
+			"repo_url": "https://gitlab.cee.redhat.com/service/repo",
+			"path": "app-sre/creds/gitlab-token",
+		},
+	}
+		with data.users as mock_data.users
+		with data.roles as mock_data.roles
+}
+
+# ── Vault path restriction ───────────────────────────────────────
+
+test_arbitrary_vault_path_denied if {
+	not authz.authorized with input as {
+		"username": "ldap-users-api",
+		"obj": "ldap-users-check",
+		"params": {
+			"secret.server_url": "ldap://freeipa.example.com",
+			"secret.path": "other-team/secrets/aws-keys",
+			"secret.secret_manager_url": "https://vault.example.com",
+		},
+	}
+		with data.users as mock_data.users
+		with data.roles as mock_data.roles
+}
+
+test_allowed_vault_path_authorized if {
+	authz.authorized with input as {
+		"username": "ldap-users-api",
+		"obj": "ldap-users-check",
+		"params": {
+			"secret.server_url": "ldap://freeipa.example.com",
+			"secret.path": "app-sre/creds/ldap/production",
+			"secret.secret_manager_url": "https://vault.example.com",
+		},
+	}
+		with data.users as mock_data.users
+		with data.roles as mock_data.roles
+}
+
+# ── Token blocking / scoping ────────────────────────────────────
+
+test_leaked_token_subject_denied_all_endpoints if {
+	not authz.authorized with input as {
+		"username": "leaked-token-subject",
+		"obj": "slack-chat-post-message",
+		"params": {"secret.path": "app-sre/creds/slack"},
+	}
+		with data.users as mock_data.users
+		with data.roles as mock_data.roles
+}
+
+test_scoped_token_allowed_correct_endpoint if {
+	authz.authorized with input as {
+		"username": "ci-bot",
+		"obj": "slack-chat-post-message",
+		"params": {"secret.path": "app-sre/creds/slack-bot"},
+	}
+		with data.users as mock_data.users
+		with data.roles as mock_data.roles
+}
+
+test_scoped_token_wrong_endpoint_denied if {
+	not authz.authorized with input as {
+		"username": "ci-bot",
+		"obj": "vcs-repo-owners",
+		"params": {
+			"repo_url": "https://github.com/org/repo",
+			"path": "app-sre/creds/github",
+		},
+	}
+		with data.users as mock_data.users
+		with data.roles as mock_data.roles
+}

--- a/opa/authz/user.rego
+++ b/opa/authz/user.rego
@@ -1,0 +1,13 @@
+package authz
+
+objects contains obj if {
+	some role in data.users[input.username]
+	some permission in data.roles[role]
+	obj := permission.obj
+}
+
+objects contains obj if {
+	some role in data.users["*"]
+	some permission in data.roles[role]
+	obj := permission.obj
+}

--- a/opa/authz/user_test.rego
+++ b/opa/authz/user_test.rego
@@ -1,0 +1,49 @@
+package authz_test
+
+import rego.v1
+
+import data.authz
+
+# ── Test data ────────────────────────────────────────────────────
+
+mock_users := {
+	"ldap-users-api": ["ldap-role"],
+	"admin": ["admin-role"],
+	"*": ["default-role"],
+}
+
+mock_roles := {
+	"admin-role": [{"obj": "*", "params": {}}],
+	"default-role": [{"obj": "liveness", "params": {}}],
+	"ldap-role": [{
+		"obj": "ldap-users-check",
+		"params": {"secret.path": "^app-sre/creds/ldap"},
+	}],
+}
+
+# ── Objects rule tests ───────────────────────────────────────────
+
+test_user_objects_include_role_objs if {
+	objects := authz.objects with input as {"username": "ldap-users-api"}
+		with data.users as mock_users
+		with data.roles as mock_roles
+	"ldap-users-check" in objects
+	"liveness" in objects
+}
+
+test_admin_objects_include_wildcard if {
+	objects := authz.objects with input as {"username": "admin"}
+		with data.users as mock_users
+		with data.roles as mock_roles
+	"*" in objects
+	"liveness" in objects
+}
+
+test_unknown_user_gets_default_objs_only if {
+	objects := authz.objects with input as {"username": "unknown-user"}
+		with data.users as mock_users
+		with data.roles as mock_roles
+	"liveness" in objects
+	not "ldap-users-check" in objects
+	not "*" in objects
+}

--- a/opa/dev/config.yaml
+++ b/opa/dev/config.yaml
@@ -1,0 +1,2 @@
+decision_logs:
+  console: true

--- a/opa/dev/roles.yml
+++ b/opa/dev/roles.yml
@@ -63,7 +63,7 @@ roles:
     - obj: ldap-users-check
       params:
         secret.server_url: "^ldaps?://freeipa\\.example\\.com$"
-        secret.path: "^app-sre/creds/ldap"
+        secret.path: "^app-sre/creds/ldap(/.*)?$"
         secret.secret_manager_url: "^https://vault\\.example\\.com$"
 
   # ── SSRF prevention: VCS ───────────────────────────────────────
@@ -73,41 +73,41 @@ roles:
     - obj: vcs-repo-owners
       params:
         repo_url: "^https://(github\\.com|gitlab\\.cee\\.redhat\\.com)/"
-        path: "^app-sre/creds/"
+        path: "^app-sre/creds/[^/]+$"
     - obj: vcs-get-file
       params:
         repo_url: "^https://(github\\.com|gitlab\\.cee\\.redhat\\.com)/"
-        path: "^app-sre/creds/"
+        path: "^app-sre/creds/[^/]+$"
     - obj: vcs-file-sync
       params:
-        token.path: "^app-sre/creds/"
+        token.path: "^app-sre/creds/[^/]+$"
         repo_url: "^https://(github\\.com|gitlab\\.cee\\.redhat\\.com)/"
 
   # ── Secret-read prevention: PagerDuty ──────────────────────────
   slack-pd-role:
     - obj: pagerduty-schedule-users
       params:
-        path: "^app-sre/creds/pagerduty"
+        path: "^app-sre/creds/pagerduty(/.*)?$"
     - obj: pagerduty-escalation-policy-users
       params:
-        path: "^app-sre/creds/pagerduty"
+        path: "^app-sre/creds/pagerduty(/.*)?$"
 
   # ── Secret-read prevention: Slack ──────────────────────────────
   slack-chat-role:
     - obj: slack-chat-post-message
       params:
-        secret.path: "^app-sre/creds/slack"
+        secret.path: "^app-sre/creds/slack(/.*)?$"
 
   # ── SSRF prevention: Slack + VCS combo ─────────────────────────
   slack-vcs-role:
     - obj: vcs-repo-owners
       params:
         repo_url: "^https://(github\\.com|gitlab\\.cee\\.redhat\\.com)/"
-        path: "^app-sre/creds/"
+        path: "^app-sre/creds/[^/]+$"
     - obj: vcs-get-file
       params:
         repo_url: "^https://(github\\.com|gitlab\\.cee\\.redhat\\.com)/"
-        path: "^app-sre/creds/"
+        path: "^app-sre/creds/[^/]+$"
 
   # ── Glitchtip integration ──────────────────────────────────────
   glitchtip-role:

--- a/opa/dev/roles.yml
+++ b/opa/dev/roles.yml
@@ -1,0 +1,128 @@
+# qontract-api OPA authorization policy data (dev)
+#
+# Structure:
+#   users:  maps JWT subject → list of role names
+#   roles:  maps role name → list of permissions (obj + params regex)
+#
+# HOW THIS PREVENTS SSRF AND SECRET EXFILTRATION
+# ===============================================
+#
+# Without OPA, a compromised JWT can call e.g. POST /external/ldap/users/check
+# with an attacker-controlled server_url and an arbitrary Vault path.
+# qontract-api resolves the Vault secret and sends the credential to the
+# attacker's LDAP server -> credential exfiltration via SSRF.
+#
+# With OPA, the "ldap-role" below restricts:
+#   - secret.server_url MUST match ^ldaps?://freeipa\.example\.com$
+#   - secret.path MUST match ^app-sre/creds/ldap
+# An attacker providing server_url: "ldap://evil.com" or
+# path: "other-team/creds/aws" gets HTTP 403.
+#
+# Similarly, "vcs-role" restricts repo_url to known Git hosts,
+# preventing VCS tokens from being sent to attacker-controlled repos.
+#
+# PARAMETER MATCHING
+# ==================
+#
+# - All param values are case-insensitive regex patterns
+# - Parameters not listed in a role permission are not checked
+#   (extra params in the request are allowed)
+# - A param set to null means it must NOT be present in the request
+
+users:
+  # ── Integration service accounts (realistic examples) ──────────
+  "ldap-users-api":
+    - ldap-role
+  "slack-usergroups-api":
+    - slack-vcs-role
+    - slack-pd-role
+    - slack-chat-role
+  "glitchtip-api":
+    - glitchtip-role
+  "vcs-api":
+    - vcs-role
+
+  # ── Scoped user token (route-level access only) ────────────────
+  "ci-bot":
+    - slack-chat-role
+
+  # ── Blocked subject (empty role list = denied everywhere) ──────
+  "leaked-token-subject": []
+
+  # ── Dev wildcard (REMOVE IN PRODUCTION) ────────────────────────
+  "dev":
+    - dev-all-access
+  # "*":
+  #   - dev-all-access
+
+roles:
+  # ── SSRF prevention: LDAP ──────────────────────────────────────
+  # Restricts which LDAP servers and Vault paths can be used.
+  # Prevents: attacker provides ldap://evil.com + arbitrary Vault path
+  ldap-role:
+    - obj: ldap-users-check
+      params:
+        secret.server_url: "^ldaps?://freeipa\\.example\\.com$"
+        secret.path: "^app-sre/creds/ldap"
+        secret.secret_manager_url: "^https://vault\\.example\\.com$"
+
+  # ── SSRF prevention: VCS ───────────────────────────────────────
+  # Restricts which Git hosts and Vault paths can be used.
+  # Prevents: attacker provides repo_url: https://evil.com/repo
+  vcs-role:
+    - obj: vcs-repo-owners
+      params:
+        repo_url: "^https://(github\\.com|gitlab\\.cee\\.redhat\\.com)/"
+        path: "^app-sre/creds/"
+    - obj: vcs-get-file
+      params:
+        repo_url: "^https://(github\\.com|gitlab\\.cee\\.redhat\\.com)/"
+        path: "^app-sre/creds/"
+    - obj: vcs-file-sync
+      params:
+        token.path: "^app-sre/creds/"
+        repo_url: "^https://(github\\.com|gitlab\\.cee\\.redhat\\.com)/"
+
+  # ── Secret-read prevention: PagerDuty ──────────────────────────
+  slack-pd-role:
+    - obj: pagerduty-schedule-users
+      params:
+        path: "^app-sre/creds/pagerduty"
+    - obj: pagerduty-escalation-policy-users
+      params:
+        path: "^app-sre/creds/pagerduty"
+
+  # ── Secret-read prevention: Slack ──────────────────────────────
+  slack-chat-role:
+    - obj: slack-chat-post-message
+      params:
+        secret.path: "^app-sre/creds/slack"
+
+  # ── SSRF prevention: Slack + VCS combo ─────────────────────────
+  slack-vcs-role:
+    - obj: vcs-repo-owners
+      params:
+        repo_url: "^https://(github\\.com|gitlab\\.cee\\.redhat\\.com)/"
+        path: "^app-sre/creds/"
+    - obj: vcs-get-file
+      params:
+        repo_url: "^https://(github\\.com|gitlab\\.cee\\.redhat\\.com)/"
+        path: "^app-sre/creds/"
+
+  # ── Glitchtip integration ──────────────────────────────────────
+  glitchtip-role:
+    - obj: glitchtip
+      params:
+        dry_run: ".*"
+    - obj: glitchtip-task-status
+      params: {}
+    - obj: glitchtip-project-alerts
+      params:
+        dry_run: ".*"
+    - obj: glitchtip-project-alerts-task-status
+      params: {}
+
+  # ── Dev wildcard (REMOVE IN PRODUCTION) ────────────────────────
+  dev-all-access:
+    - obj: "*"
+      params: {}

--- a/openshift/qontract-api.yaml
+++ b/openshift/qontract-api.yaml
@@ -95,6 +95,10 @@ objects:
                   value: api
                 - name: QAPI_APP_PORT
                   value: "${QAPI_APP_PORT}"
+                - name: QAPI_OPA__ENABLED
+                  value: "${QAPI_OPA_ENABLED}"
+                - name: QAPI_OPA__HOST
+                  value: "http://localhost:8181"
                 - name: QAPI_SENTRY_DSN
                   valueFrom:
                     secretKeyRef:
@@ -142,6 +146,61 @@ objects:
                   memory: ${{QAPI_API_MEMORY_REQUESTS}}
                 limits:
                   memory: ${{QAPI_API_MEMORY_LIMITS}}
+            # OPA sidecar for parameter-level authorization
+            - name: opa
+              image: "${OPA_IMAGE}:${OPA_IMAGE_TAG}"
+              args:
+                - run
+                - --ignore=.*
+                - --server
+                - --log-level=info
+                - --disable-telemetry
+                - --addr=0.0.0.0:8181
+                - --watch
+                - /authz
+                - /policies
+              ports:
+                - name: opa
+                  containerPort: 8181
+              lifecycle:
+                preStop:
+                  exec:
+                    command:
+                      - sh
+                      - "-c"
+                      - sleep 2
+              livenessProbe:
+                httpGet:
+                  path: /health
+                  port: 8181
+                initialDelaySeconds: 5
+                periodSeconds: 60
+              readinessProbe:
+                httpGet:
+                  path: /health?bundle=true
+                  port: 8181
+                initialDelaySeconds: 5
+                periodSeconds: 10
+              startupProbe:
+                tcpSocket:
+                  port: 8181
+                initialDelaySeconds: 1
+                periodSeconds: 5
+                timeoutSeconds: 5
+              resources:
+                requests:
+                  cpu: ${{QAPI_OPA_CPU_REQUESTS}}
+                  memory: ${{QAPI_OPA_MEMORY_REQUESTS}}
+                limits:
+                  memory: ${{QAPI_OPA_MEMORY_LIMITS}}
+              volumeMounts:
+                - name: opa-policies
+                  mountPath: /policies
+                  readOnly: true
+          volumes:
+            - name: opa-policies
+              configMap:
+                name: qontract-api-opa-policy
 
   # ---------- API SERVICE -----------
   - apiVersion: v1
@@ -546,4 +605,36 @@ parameters:
   - name: QAPI_WORKER_CPU_REQUESTS
     description: Worker cpu requests
     value: "100m"
+    required: true
+
+  # OPA sidecar
+  - name: QAPI_OPA_ENABLED
+    description: Enable OPA authorization (set to false to disable without removing the sidecar)
+    value: "true"
+    required: true
+
+  - name: OPA_IMAGE
+    description: OPA sidecar image
+    # yamllint disable-line rule:line-length
+    value: "quay.io/redhat-services-prod/app-sre-tenant/qontract-reconcile-master/opa-master"
+    required: true
+
+  - name: OPA_IMAGE_TAG
+    description: OPA sidecar image tag
+    value: "latest"
+    required: true
+
+  - name: QAPI_OPA_CPU_REQUESTS
+    description: OPA sidecar cpu requests
+    value: "50m"
+    required: true
+
+  - name: QAPI_OPA_MEMORY_REQUESTS
+    description: OPA sidecar memory requests
+    value: "64Mi"
+    required: true
+
+  - name: QAPI_OPA_MEMORY_LIMITS
+    description: OPA sidecar memory limits
+    value: "128Mi"
     required: true

--- a/qontract_api/qontract_api/config.py
+++ b/qontract_api/qontract_api/config.py
@@ -29,6 +29,36 @@ class Secret(BaseModel):
     )
 
 
+class OPASettings(BaseModel):
+    """OPA sidecar authorization configuration."""
+
+    enabled: bool = Field(
+        default=True,
+        description="Enable OPA authorization. Set to False for local development without OPA sidecar.",
+    )
+    host: str = Field(
+        default="http://localhost:8181",
+        description="OPA sidecar host URL",
+    )
+    package_name: str = Field(
+        default="authz",
+        description="OPA policy package name",
+    )
+    timeout: int = Field(
+        default=5,
+        description="OPA HTTP request timeout in seconds",
+    )
+    skip_endpoints: list[str] = Field(
+        default_factory=lambda: [
+            r"^/health/.*",
+            r"^/docs.*",
+            r"^/metrics$",
+            r"^/$",
+        ],
+        description="Regex patterns for endpoints to skip OPA authorization",
+    )
+
+
 class SlackSettings(BaseModel):
     """Slack API and integration configuration."""
 
@@ -406,6 +436,12 @@ class Settings(BaseSettings):
     worker_metrics_port: int = Field(
         default=8000,
         description="Port for worker metrics HTTP server",
+    )
+
+    # OPA Authorization (nested)
+    opa: OPASettings = Field(
+        default_factory=OPASettings,
+        description="OPA sidecar authorization configuration",
     )
 
     # JWT Authentication

--- a/qontract_api/qontract_api/dependencies.py
+++ b/qontract_api/qontract_api/dependencies.py
@@ -1,5 +1,6 @@
 """Dependency injection container for qontract-api."""
 
+import contextlib
 from typing import Annotated
 
 from fastapi import Depends, HTTPException, Request, status
@@ -11,19 +12,17 @@ from qontract_api.config import settings
 from qontract_api.event_manager import EventManager
 from qontract_api.logger import get_logger
 from qontract_api.models import User
+from qontract_api.opa import OPAClient, flatten_params
 from qontract_api.secret_manager import SecretManager
 
 logger = get_logger(__name__)
 security = HTTPBearer()
 
 
-def get_current_user(
-    credentials: Annotated[HTTPAuthorizationCredentials, Depends(security)],
-) -> User:
-    """Get current user from JWT token."""
+def _authenticate(credentials: HTTPAuthorizationCredentials) -> User:
+    """Authenticate: validate JWT token and return user."""
     try:
-        token = credentials.credentials
-        payload = decode_token(token)
+        payload = decode_token(credentials.credentials)
         if payload.sub in settings.jwt_revoked_subjects:
             logger.warning(f"Token subject '{payload.sub}' has been revoked")
             raise HTTPException(
@@ -38,6 +37,45 @@ def get_current_user(
             detail=str(e),
             headers={"WWW-Authenticate": "Bearer"},
         ) from e
+
+
+async def _authorize(request: Request, user: User) -> None:
+    """Authorize: query OPA sidecar for parameter-level authorization."""
+    opa_client: OPAClient | None = getattr(request.app.state, "opa_client", None)
+    if opa_client is None:
+        return
+
+    if opa_client.should_skip(request.url.path):
+        return
+
+    params: dict[str, str] = {}
+    params.update({k: str(v) for k, v in request.path_params.items()})
+    params.update({k: str(v) for k, v in request.query_params.items()})
+
+    with contextlib.suppress(Exception):
+        body = await request.json()
+        if isinstance(body, dict):
+            params.update(flatten_params(body))
+
+    route = request.scope.get("route")
+    operation_id = getattr(route, "operation_id", None) or request.url.path
+
+    request_id: str = getattr(request.state, "request_id", "")
+
+    await opa_client.authorize(
+        username=user.username,
+        obj=operation_id,
+        params=params,
+        request_id=request_id,
+    )
+
+
+async def get_current_user(request: Request) -> User:
+    """Authenticate and authorize the current user (authN + authZ)."""
+    credentials = await security(request)
+    user = _authenticate(credentials)
+    await _authorize(request, user)
+    return user
 
 
 def get_cache(request: Request) -> CacheBackend:

--- a/qontract_api/qontract_api/dependencies.py
+++ b/qontract_api/qontract_api/dependencies.py
@@ -70,9 +70,11 @@ async def _authorize(request: Request, user: User) -> None:
     )
 
 
-async def get_current_user(request: Request) -> User:
+async def get_current_user(
+    request: Request,
+    credentials: Annotated[HTTPAuthorizationCredentials, Depends(security)],
+) -> User:
     """Authenticate and authorize the current user (authN + authZ)."""
-    credentials = await security(request)
     user = _authenticate(credentials)
     await _authorize(request, user)
     return user

--- a/qontract_api/qontract_api/dependencies.py
+++ b/qontract_api/qontract_api/dependencies.py
@@ -52,7 +52,7 @@ async def _authorize(request: Request, user: User) -> None:
     params.update({k: str(v) for k, v in request.path_params.items()})
     params.update({k: str(v) for k, v in request.query_params.items()})
 
-    with contextlib.suppress(Exception):
+    with contextlib.suppress(ValueError, UnicodeDecodeError):
         body = await request.json()
         if isinstance(body, dict):
             params.update(flatten_params(body))

--- a/qontract_api/qontract_api/health.py
+++ b/qontract_api/qontract_api/health.py
@@ -2,11 +2,13 @@
 
 from typing import Annotated
 
+import httpxyz as httpx
 from fastapi import Depends, Request
 from pydantic import BaseModel, Field
 
 from qontract_api.cache.base import CacheBackend
 from qontract_api.config import settings
+from qontract_api.opa import OPAClient
 
 
 class HealthStatus(BaseModel):
@@ -36,8 +38,14 @@ def get_cache_from_request(request: Request) -> CacheBackend | None:
     return getattr(request.app.state, "cache", None)
 
 
-# Type alias for dependency injection
+def get_opa_client_from_request(request: Request) -> OPAClient | None:
+    """Get OPA client from app state, return None if disabled."""
+    return getattr(request.app.state, "opa_client", None)
+
+
+# Type aliases for dependency injection
 CacheOptionalDep = Annotated[CacheBackend | None, Depends(get_cache_from_request)]
+OPAClientOptionalDep = Annotated[OPAClient | None, Depends(get_opa_client_from_request)]
 
 
 def check_cache_health(cache: CacheBackend | None) -> HealthStatus:
@@ -60,11 +68,36 @@ def check_cache_health(cache: CacheBackend | None) -> HealthStatus:
         return HealthStatus(status="unhealthy", message=f"Cache check failed: {e}")
 
 
-def get_health_status(cache: CacheOptionalDep) -> HealthResponse:
+def check_opa_health(opa_client: OPAClient | None) -> HealthStatus:
+    """Check OPA sidecar health."""
+    if opa_client is None:
+        return HealthStatus(status="healthy", message="OPA authorization disabled")
+
+    opa_health_url = opa_client.opa_url.rsplit("/v1/", maxsplit=1)[0] + "/health"
+    try:
+        response = httpx.get(opa_health_url, timeout=2)
+        if httpx.codes.is_success(response.status_code):
+            return HealthStatus(status="healthy", message="OPA sidecar reachable")
+        return HealthStatus(
+            status="unhealthy",
+            message=f"OPA returned {response.status_code}",
+        )
+    except OSError as e:
+        return HealthStatus(
+            status="unhealthy",
+            message=f"OPA health check failed: {e}",
+        )
+
+
+def get_health_status(
+    cache: CacheOptionalDep,
+    opa_client: OPAClientOptionalDep,
+) -> HealthResponse:
     """Get overall health status including all components.
 
     Args:
         cache: Cache backend from dependency injection
+        opa_client: OPA client from dependency injection
 
     Returns:
         HealthResponse with overall and component health
@@ -73,6 +106,9 @@ def get_health_status(cache: CacheOptionalDep) -> HealthResponse:
 
     # Check cache
     components["cache"] = check_cache_health(cache)
+
+    # Check OPA
+    components["opa"] = check_opa_health(opa_client)
 
     # Determine overall status
     component_statuses = [c.status for c in components.values()]

--- a/qontract_api/qontract_api/health.py
+++ b/qontract_api/qontract_api/health.py
@@ -115,9 +115,9 @@ def get_health_status(
     if all(s == "healthy" for s in component_statuses):
         overall_status = "healthy"
     elif any(s == "unhealthy" for s in component_statuses):
-        overall_status = "degraded"
-    else:
         overall_status = "unhealthy"
+    else:
+        overall_status = "degraded"
 
     return HealthResponse(
         status=overall_status,

--- a/qontract_api/qontract_api/health.py
+++ b/qontract_api/qontract_api/health.py
@@ -82,7 +82,7 @@ def check_opa_health(opa_client: OPAClient | None) -> HealthStatus:
             status="unhealthy",
             message=f"OPA returned {response.status_code}",
         )
-    except OSError as e:
+    except (OSError, httpx.TimeoutException) as e:
         return HealthStatus(
             status="unhealthy",
             message=f"OPA health check failed: {e}",

--- a/qontract_api/qontract_api/health.py
+++ b/qontract_api/qontract_api/health.py
@@ -73,9 +73,8 @@ def check_opa_health(opa_client: OPAClient | None) -> HealthStatus:
     if opa_client is None:
         return HealthStatus(status="healthy", message="OPA authorization disabled")
 
-    opa_health_url = opa_client.opa_url.rsplit("/v1/", maxsplit=1)[0] + "/health"
     try:
-        response = httpx.get(opa_health_url, timeout=2)
+        response = httpx.get(opa_client.health_url, timeout=2)
         if httpx.codes.is_success(response.status_code):
             return HealthStatus(status="healthy", message="OPA sidecar reachable")
         return HealthStatus(

--- a/qontract_api/qontract_api/main.py
+++ b/qontract_api/qontract_api/main.py
@@ -1,9 +1,11 @@
 """qontract-api main FastAPI application."""
 
+import re
 from collections.abc import AsyncGenerator
 from contextlib import asynccontextmanager
 from typing import Any
 
+import httpxyz as httpx
 from fastapi import FastAPI, Response
 from fastapi.exceptions import RequestValidationError
 from fastapi.openapi.utils import get_openapi
@@ -11,7 +13,6 @@ from fastapi.responses import RedirectResponse
 from prometheus_fastapi_instrumentator import Instrumentator
 
 from qontract_api.config import settings
-from qontract_api.dependencies import UserDep
 from qontract_api.exceptions import (
     APIError,
     api_error_handler,
@@ -26,6 +27,7 @@ from qontract_api.middleware import (
     RequestIDMiddleware,
     RequestLoggingMiddleware,
 )
+from qontract_api.opa import OPAClient
 from qontract_api.routers.api_v1 import api_v1_router
 
 log = setup_logging()
@@ -62,7 +64,28 @@ async def lifespan(_app: FastAPI) -> AsyncGenerator[None, None]:
     # Startup: Initialize event manager (None if events are disabled)
     _app.state.event_manager = get_event_manager()
 
-    yield
+    # Startup: Initialize OPA client if enabled
+    if settings.opa.enabled:
+        opa_http_client = httpx.AsyncClient(
+            timeout=settings.opa.timeout,
+            limits=httpx.Limits(max_keepalive_connections=5, max_connections=10),
+        )
+        opa_url = f"{settings.opa.host.rstrip('/')}/v1/data/{settings.opa.package_name.replace('.', '/')}"
+        _app.state.opa_client = OPAClient(
+            opa_url=opa_url,
+            skip_endpoints=[re.compile(p) for p in settings.opa.skip_endpoints],
+            client=opa_http_client,
+        )
+        log.info("OPA authorization enabled", opa_url=opa_url)
+    else:
+        _app.state.opa_client = None
+        log.info("OPA authorization disabled")
+
+    yield  # noqa: RUF075
+
+    # Cleanup OPA client on shutdown
+    if opa_client := getattr(_app.state, "opa_client", None):
+        await opa_client.client.aclose()
 
     # Cleanup secret backend on shutdown
     if hasattr(_app.state, "secret_manager") and _app.state.secret_manager is not None:
@@ -151,12 +174,3 @@ def liveness() -> dict[str, str]:
 def readiness(health_status: HealthResponseDep) -> HealthResponse:
     """Readiness probe - returns 200 if service is ready to accept requests."""
     return health_status
-
-
-@app.get("/api/protected", include_in_schema=False)
-def protected_endpoint(current_user: UserDep) -> dict[str, str]:
-    """Protected endpoint - requires valid JWT token."""
-    return {
-        "message": "Access granted",
-        "username": current_user.username,
-    }

--- a/qontract_api/qontract_api/main.py
+++ b/qontract_api/qontract_api/main.py
@@ -81,7 +81,7 @@ async def lifespan(_app: FastAPI) -> AsyncGenerator[None, None]:
         _app.state.opa_client = None
         log.info("OPA authorization disabled")
 
-    yield  # noqa: RUF075
+    yield
 
     # Cleanup OPA client on shutdown
     if opa_client := getattr(_app.state, "opa_client", None):

--- a/qontract_api/qontract_api/main.py
+++ b/qontract_api/qontract_api/main.py
@@ -13,6 +13,7 @@ from fastapi.responses import RedirectResponse
 from prometheus_fastapi_instrumentator import Instrumentator
 
 from qontract_api.config import settings
+from qontract_api.dependencies import UserDep
 from qontract_api.exceptions import (
     APIError,
     api_error_handler,
@@ -174,3 +175,15 @@ def liveness() -> dict[str, str]:
 def readiness(health_status: HealthResponseDep) -> HealthResponse:
     """Readiness probe - returns 200 if service is ready to accept requests."""
     return health_status
+
+
+@app.get("/api/protected", include_in_schema=False)
+def protected_endpoint(current_user: UserDep) -> dict[str, str]:
+    """Protected endpoint - requires valid JWT token.
+
+    Keep it to have a dedicated endpoint for testing auth.
+    """
+    return {
+        "message": "Access granted",
+        "username": current_user.username,
+    }

--- a/qontract_api/qontract_api/main.py
+++ b/qontract_api/qontract_api/main.py
@@ -71,13 +71,13 @@ async def lifespan(_app: FastAPI) -> AsyncGenerator[None, None]:
             timeout=settings.opa.timeout,
             limits=httpx.Limits(max_keepalive_connections=5, max_connections=10),
         )
-        opa_url = f"{settings.opa.host.rstrip('/')}/v1/data/{settings.opa.package_name.replace('.', '/')}"
         _app.state.opa_client = OPAClient(
-            opa_url=opa_url,
+            host=settings.opa.host,
+            package_name=settings.opa.package_name,
             skip_endpoints=[re.compile(p) for p in settings.opa.skip_endpoints],
             client=opa_http_client,
         )
-        log.info("OPA authorization enabled", opa_url=opa_url)
+        log.info("OPA authorization enabled", opa_url=_app.state.opa_client.opa_url)
     else:
         _app.state.opa_client = None
         log.info("OPA authorization disabled")

--- a/qontract_api/qontract_api/opa.py
+++ b/qontract_api/qontract_api/opa.py
@@ -53,13 +53,20 @@ class OPAClient:
     def __init__(
         self,
         *,
-        opa_url: str,
+        host: str,
+        package_name: str,
         skip_endpoints: list[re.Pattern[str]],
         client: httpx.AsyncClient,
     ) -> None:
-        self.opa_url = opa_url
+        self.host = host.rstrip("/")
+        self.opa_url = f"{self.host}/v1/data/{package_name.replace('.', '/')}"
         self.skip_endpoints = skip_endpoints
         self.client = client
+
+    @property
+    def health_url(self) -> str:
+        """OPA health endpoint URL."""
+        return f"{self.host}/health"
 
     def should_skip(self, path: str) -> bool:
         """Check if the endpoint should skip OPA authorization."""

--- a/qontract_api/qontract_api/opa.py
+++ b/qontract_api/qontract_api/opa.py
@@ -1,0 +1,127 @@
+"""OPA sidecar authorization client for qontract-api."""
+
+import re
+import time
+from typing import Any
+
+import httpxyz as httpx
+from fastapi import HTTPException, status
+from prometheus_client import Counter, Histogram
+
+from qontract_api.logger import get_logger
+
+logger = get_logger(__name__)
+
+opa_decision_duration = Histogram(
+    "qontract_api_opa_decision_duration_seconds",
+    "OPA authorization decision latency",
+    labelnames=["obj"],
+)
+
+opa_decisions_total = Counter(
+    "qontract_api_opa_decisions_total",
+    "Total OPA authorization decisions",
+    labelnames=["result", "obj"],
+)
+
+
+def flatten_params(data: dict[str, Any], *, prefix: str = "") -> dict[str, str]:
+    """Flatten nested dict to dot-notation for OPA parameter matching.
+
+    Converts nested structures like {"secret": {"path": "x"}} to
+    {"secret.path": "x"} so OPA's valid_params regex matching works
+    uniformly across query params and POST body fields.
+    """
+    result: dict[str, str] = {}
+    for key, value in data.items():
+        full_key = f"{prefix}{key}" if not prefix else f"{prefix}.{key}"
+        match value:
+            case dict():
+                result.update(flatten_params(value, prefix=full_key))
+            case list():
+                pass
+            case None:
+                pass
+            case _:
+                result[full_key] = str(value)
+    return result
+
+
+class OPAClient:
+    """HTTP client for querying OPA sidecar authorization decisions."""
+
+    def __init__(
+        self,
+        *,
+        opa_url: str,
+        skip_endpoints: list[re.Pattern[str]],
+        client: httpx.AsyncClient,
+    ) -> None:
+        self.opa_url = opa_url
+        self.skip_endpoints = skip_endpoints
+        self.client = client
+
+    def should_skip(self, path: str) -> bool:
+        """Check if the endpoint should skip OPA authorization."""
+        return any(pattern.match(path) for pattern in self.skip_endpoints)
+
+    async def authorize(
+        self,
+        *,
+        username: str,
+        obj: str,
+        params: dict[str, str],
+        request_id: str = "",
+    ) -> None:
+        """Query OPA and raise HTTP 403 on denial or error (fail-closed)."""
+        start = time.monotonic()
+        data: dict[str, Any] = {
+            "input": {
+                "username": username,
+                "obj": obj,
+                "params": params,
+                "request_id": request_id,
+            }
+        }
+
+        try:
+            response = await self.client.post(self.opa_url, json=data)
+        except Exception as e:
+            duration = time.monotonic() - start
+            opa_decision_duration.labels(obj=obj).observe(duration)
+            logger.exception(
+                "OPA authorization failed (fail-closed)",
+                username=username,
+                operation=obj,
+            )
+            opa_decisions_total.labels(result="error", obj=obj).inc()
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+            ) from e
+
+        duration = time.monotonic() - start
+        opa_decision_duration.labels(obj=obj).observe(duration)
+
+        if response.status_code != status.HTTP_200_OK:
+            logger.error(
+                "OPA returned unexpected status (fail-closed)",
+                username=username,
+                operation=obj,
+                opa_status=response.status_code,
+            )
+            opa_decisions_total.labels(result="error", obj=obj).inc()
+            raise HTTPException(status_code=status.HTTP_403_FORBIDDEN)
+
+        opa_result = response.json().get("result", {})
+
+        if not opa_result.get("authorized"):
+            logger.warning(
+                "OPA authorization denied",
+                username=username,
+                operation=obj,
+                params=params,
+            )
+            opa_decisions_total.labels(result="deny", obj=obj).inc()
+            raise HTTPException(status_code=status.HTTP_403_FORBIDDEN)
+
+        opa_decisions_total.labels(result="allow", obj=obj).inc()

--- a/qontract_api/qontract_api/scripts/generate_token.py
+++ b/qontract_api/qontract_api/scripts/generate_token.py
@@ -7,7 +7,7 @@ This script will be replace by a proper management CLI in the future.
 
 import argparse
 import os
-from datetime import timedelta
+from datetime import UTC, datetime, timedelta
 
 from rich import print as rich_print
 from rich.panel import Panel
@@ -26,8 +26,7 @@ def setup() -> None:
 
 
 def main() -> None:
-    """Generate JWT token."""
-    # import locally to have all environment setup done before importing qontract_api modules
+    """Generate JWT token with date-stamped subject for OPA authorization."""
     from qontract_api.auth import create_access_token
     from qontract_api.models import TokenData
 
@@ -37,7 +36,7 @@ def main() -> None:
     parser.add_argument(
         "--subject",
         required=True,
-        help="Token subject (e.g., 'admin', 'service-account-name')",
+        help="Token subject base name (e.g., 'qontract-api-prod'). Today's date is appended automatically.",
     )
     parser.add_argument(
         "--expires-days",
@@ -48,12 +47,15 @@ def main() -> None:
 
     args = parser.parse_args()
 
-    token_data = TokenData(sub=args.subject)
+    today = datetime.now(tz=UTC).strftime("%Y-%m-%d")
+    subject = f"{args.subject}-{today}"
+
+    token_data = TokenData(sub=subject)
     expires_delta = timedelta(days=args.expires_days)
     token = create_access_token(data=token_data, expires_delta=expires_delta)
 
     grid = Table(title="JWT", show_header=False, show_lines=True)
-    grid.add_row("Subject", args.subject)
+    grid.add_row("Subject", subject)
     grid.add_row("Expires", f"{args.expires_days} days")
     grid.add_row("Token", f"[green]{token}")
     rich_print(grid)

--- a/qontract_api/tests/conftest.py
+++ b/qontract_api/tests/conftest.py
@@ -23,7 +23,7 @@ def pytest_configure() -> None:
         "QAPI_SECRETS__PROVIDERS", '[{"url": "https://vault.example.org"}]'
     )
     # Disable OPA authorization for tests (no OPA sidecar available)
-    os.environ.setdefault("QAPI_OPA__ENABLED", "false")
+    os.environ["QAPI_OPA__ENABLED"] = "false"
 
 
 @pytest.fixture

--- a/qontract_api/tests/conftest.py
+++ b/qontract_api/tests/conftest.py
@@ -22,6 +22,8 @@ def pytest_configure() -> None:
     os.environ.setdefault(
         "QAPI_SECRETS__PROVIDERS", '[{"url": "https://vault.example.org"}]'
     )
+    # Disable OPA authorization for tests (no OPA sidecar available)
+    os.environ.setdefault("QAPI_OPA__ENABLED", "false")
 
 
 @pytest.fixture

--- a/qontract_api/tests/test_opa.py
+++ b/qontract_api/tests/test_opa.py
@@ -95,13 +95,59 @@ def test_flatten_params(data: dict[str, Any], expected: dict[str, str]) -> None:
     assert flatten_params(data) == expected
 
 
+# ── OPAClient URL construction ──────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    ("host", "package_name", "expected_opa_url", "expected_health_url"),
+    [
+        pytest.param(
+            "http://opa:8181",
+            "authz",
+            "http://opa:8181/v1/data/authz",
+            "http://opa:8181/health",
+            id="simple",
+        ),
+        pytest.param(
+            "http://opa:8181/",
+            "authz",
+            "http://opa:8181/v1/data/authz",
+            "http://opa:8181/health",
+            id="trailing-slash",
+        ),
+        pytest.param(
+            "http://opa:8181",
+            "authz.rbac",
+            "http://opa:8181/v1/data/authz/rbac",
+            "http://opa:8181/health",
+            id="dotted-package",
+        ),
+    ],
+)
+def test_opa_client_urls(
+    host: str,
+    package_name: str,
+    expected_opa_url: str,
+    expected_health_url: str,
+) -> None:
+    client = OPAClient(
+        host=host,
+        package_name=package_name,
+        skip_endpoints=[],
+        client=httpx.AsyncClient(),
+    )
+    assert client.opa_url == expected_opa_url
+    assert client.health_url == expected_health_url
+
+
 # ── OPAClient.should_skip ────────────────────────────────────────
 
 
 @pytest.fixture
 def opa_client() -> OPAClient:
     return OPAClient(
-        opa_url="http://opa:8181/v1/data/authz",
+        host="http://opa:8181",
+        package_name="authz",
         skip_endpoints=[re.compile(r"^/health/.*"), re.compile(r"^/docs.*")],
         client=httpx.AsyncClient(),
     )
@@ -133,7 +179,8 @@ def _mock_response(*, status_code: int = 200, json_data: dict | None = None) -> 
 
 def _make_client(mock: AsyncMock) -> OPAClient:
     return OPAClient(
-        opa_url="http://opa:8181/v1/data/authz",
+        host="http://opa:8181",
+        package_name="authz",
         skip_endpoints=[],
         client=mock,
     )

--- a/qontract_api/tests/test_opa.py
+++ b/qontract_api/tests/test_opa.py
@@ -1,0 +1,198 @@
+"""Tests for OPA client and authorization."""
+
+import re
+from typing import Any
+from unittest.mock import AsyncMock, Mock
+
+import httpxyz as httpx
+import pytest
+from fastapi import HTTPException
+
+from qontract_api.opa import OPAClient, flatten_params
+
+# ── flatten_params ───────────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    ("data", "expected"),
+    [
+        pytest.param(
+            {"a": "1", "b": "2"},
+            {"a": "1", "b": "2"},
+            id="flat",
+        ),
+        pytest.param(
+            {"secret": {"path": "x", "server_url": "y"}},
+            {"secret.path": "x", "secret.server_url": "y"},
+            id="nested",
+        ),
+        pytest.param(
+            {"a": {"b": {"c": "deep"}}},
+            {"a.b.c": "deep"},
+            id="deep-nesting",
+        ),
+        pytest.param(
+            {"a": "1", "b": None, "c": "3"},
+            {"a": "1", "c": "3"},
+            id="none-skipped",
+        ),
+        pytest.param(
+            {"usernames": ["alice", "bob"], "key": "val"},
+            {"key": "val"},
+            id="list-skipped",
+        ),
+        pytest.param(
+            {"version": 42, "enabled": True},
+            {"version": "42", "enabled": "True"},
+            id="scalars-to-string",
+        ),
+        pytest.param({}, {}, id="empty"),
+        pytest.param(
+            {
+                "usernames": ["alice", "bob"],
+                "secret": {
+                    "secret_manager_url": "https://vault.example.com",
+                    "path": "app-sre/creds/ldap",
+                    "field": None,
+                    "version": None,
+                    "server_url": "ldap://freeipa.example.com",
+                    "base_dn": "dc=example,dc=com",
+                },
+            },
+            {
+                "secret.secret_manager_url": "https://vault.example.com",
+                "secret.path": "app-sre/creds/ldap",
+                "secret.server_url": "ldap://freeipa.example.com",
+                "secret.base_dn": "dc=example,dc=com",
+            },
+            id="realistic-ldap-body",
+        ),
+        pytest.param(
+            {
+                "workspace_name": "redhat-internal",
+                "channel": "dev-null",
+                "text": "hello",
+                "secret": {
+                    "secret_manager_url": "https://vault.example.com",
+                    "path": "app-sre/creds/slack",
+                    "field": "token",
+                    "version": None,
+                },
+            },
+            {
+                "workspace_name": "redhat-internal",
+                "channel": "dev-null",
+                "text": "hello",
+                "secret.secret_manager_url": "https://vault.example.com",
+                "secret.path": "app-sre/creds/slack",
+                "secret.field": "token",
+            },
+            id="realistic-slack-body",
+        ),
+    ],
+)
+def test_flatten_params(data: dict[str, Any], expected: dict[str, str]) -> None:
+    assert flatten_params(data) == expected
+
+
+# ── OPAClient.should_skip ────────────────────────────────────────
+
+
+@pytest.fixture
+def opa_client() -> OPAClient:
+    return OPAClient(
+        opa_url="http://opa:8181/v1/data/authz",
+        skip_endpoints=[re.compile(r"^/health/.*"), re.compile(r"^/docs.*")],
+        client=httpx.AsyncClient(),
+    )
+
+
+@pytest.mark.parametrize(
+    ("path", "expected"),
+    [
+        ("/health/ready", True),
+        ("/docs", True),
+        ("/docs/openapi.json", True),
+        ("/api/v1/external/ldap/users/check", False),
+        ("/metrics", False),
+    ],
+)
+def test_should_skip(opa_client: OPAClient, path: str, expected: bool) -> None:
+    assert opa_client.should_skip(path) is expected
+
+
+# ── OPAClient.authorize ─────────────────────────────────────────
+
+
+def _mock_response(*, status_code: int = 200, json_data: dict | None = None) -> Mock:
+    response = Mock()
+    response.status_code = status_code
+    response.json.return_value = json_data or {}
+    return response
+
+
+def _make_client(mock: AsyncMock) -> OPAClient:
+    return OPAClient(
+        opa_url="http://opa:8181/v1/data/authz",
+        skip_endpoints=[],
+        client=mock,
+    )
+
+
+@pytest.mark.anyio
+async def test_authorize_allowed() -> None:
+    mock = AsyncMock()
+    mock.post.return_value = _mock_response(
+        json_data={"result": {"authorized": True, "objects": ["ldap-users-check"]}}
+    )
+    await _make_client(mock).authorize(
+        username="ldap-users-api",
+        obj="ldap-users-check",
+        params={"secret.path": "app-sre/creds/ldap"},
+    )
+
+
+@pytest.mark.parametrize(
+    ("response", "description"),
+    [
+        pytest.param(
+            _mock_response(json_data={"result": {"authorized": False}}),
+            "denied",
+            id="denied",
+        ),
+        pytest.param(
+            _mock_response(status_code=500),
+            "opa-error",
+            id="opa-http-error",
+        ),
+        pytest.param(
+            _mock_response(json_data={"result": {}}),
+            "empty-result",
+            id="empty-result",
+        ),
+    ],
+)
+@pytest.mark.anyio
+async def test_authorize_returns_403(response: Mock, description: str) -> None:
+    mock = AsyncMock()
+    mock.post.return_value = response
+    with pytest.raises(HTTPException) as exc_info:
+        await _make_client(mock).authorize(
+            username="user",
+            obj="some-endpoint",
+            params={},
+        )
+    assert exc_info.value.status_code == 403, description
+
+
+@pytest.mark.anyio
+async def test_authorize_connection_error_returns_403() -> None:
+    mock = AsyncMock()
+    mock.post.side_effect = httpx.ConnectError("connection refused")
+    with pytest.raises(HTTPException) as exc_info:
+        await _make_client(mock).authorize(
+            username="user",
+            obj="some-endpoint",
+            params={},
+        )
+    assert exc_info.value.status_code == 403


### PR DESCRIPTION
## Summary

- Enables role-based access control [APPSRE-14305](https://redhat.atlassian.net/browse/APPSRE-14305)
- Add OPA (Open Policy Agent) authorization to qontract-api, preventing arbitrary Vault secret reads and credential exfiltration via SSRF ([APPSRE-14303](https://issues.redhat.com/browse/APPSRE-14303))
- OPA sidecar validates every request's parameters (Vault paths, service URLs) against role-based policies with regex matching
- Design doc: https://github.com/openshift-online/platform-engineering-enhancements/blob/main/app-sre/design-docs/qontract-api-opa-authorization.md

## App-Interface Dependency

https://gitlab.cee.redhat.com/service/app-interface/-/merge_requests/191745

## Changes

### Milestone 1: OPA client + Rego policies

- `qontract_api/qontract_api/opa.py` — `OPAClient` (fail-closed, connection pooling, audit logging, Prometheus metrics) + `flatten_params()` for POST body dot-notation
- `qontract_api/qontract_api/dependencies.py` — authZ integrated into `UserDep` (`_authenticate` → `_authorize` → `get_current_user`), zero endpoint changes needed
- `qontract_api/qontract_api/health.py` — OPA health in `/health/ready` readiness probe
- `qontract_api/qontract_api/config.py` — `OPASettings` with `enabled`, `host`, `timeout`, `skip_endpoints`
- `opa/authz/` — `rbac.rego` + `user.rego` (reused from automated-actions)
- `opa/dev/roles.yml` — documented dev policies with SSRF-prevention examples
- `opa/Dockerfile` — UBI-based OPA image with Rego tests in build
- 19 Python tests, 20 Rego tests (SSRF prevention, Vault path restriction, token blocking)
- `docs/adr/ADR-021-opa-authorization.md`

### Milestone 2: Production deployment

- `.tekton/opa-master-push.yaml` + `opa-master-pull-request.yaml` — Konflux build pipelines
- `openshift/qontract-api.yaml` — OPA sidecar in API Deployment with probes, `QAPI_OPA_ENABLED` toggle
- `generate_token.py` — appends `-YYYY-MM-DD` for unique subjects (per-token blocking via OPA)

## Behavioral changes

- **Readiness probe status**: Before this PR, an unhealthy component caused `/health/ready` to report `"degraded"`; now it correctly reports `"unhealthy"`. This is more semantically correct (degraded implies partial functionality, unhealthy means a required component is down). Operators should be aware that alerting thresholds based on the `"degraded"` string will need updating.

## Test plan

- [x] `cd qontract_api && make test` — 452 passed
- [x] `cd opa && make test` — Rego tests pass (SSRF prevention, token blocking)
- [x] `uv run mypy` — clean
- [x] `uv run ruff check` — clean
- [ ] Konflux picks up OPA component and builds image
- [ ] Stage deployment with OPA sidecar + dev policy
- [ ] Verify: authorized request → 200, unauthorized params → 403, health endpoint → bypasses OPA

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Optional Open Policy Agent (OPA) sidecar for API authorization with role-based, parameter-aware access controls and fail-closed enforcement
  * Added OPA decision metrics and expanded health checks to include OPA component status
  * JWT token subject generation now includes today’s UTC date stamp
* **Deployment**
  * OpenShift template updated to enable/configure the OPA sidecar and resource sizing
  * CI pipelines added to build/publish OPA images on pull requests and pushes
* **Documentation**
  * ADR added describing the OPA authorization design and threat mitigations
* **Tests**
  * Expanded OPA policy/client test coverage for parameter edge cases, skip-routes, and authorization outcomes
<!-- end of auto-generated comment: release notes by coderabbit.ai -->