### PR TITLE
:bug: close clientele async client before event loop shutdown

### DIFF
--- a/reconcile/utils/runtime/runner.py
+++ b/reconcile/utils/runtime/runner.py
@@ -15,6 +15,8 @@ from reconcile.utils.runtime.desired_state_diff import (
     DesiredStateDiff,
     build_desired_state_diff,
 )
+from qontract_api_client.client import client as qontract_api_client
+
 from reconcile.utils.runtime.integration import (
     QontractReconcileApiIntegration,
     QontractReconcileIntegration,
@@ -167,6 +169,22 @@ def run_integration_cfg(run_cfg: IntegrationRunConfiguration) -> None:
         _integration_wet_run(run_cfg.integration)
 
 
+async def _run_api_integration(
+    integration: QontractReconcileApiIntegration[Any],
+    dry_run: bool,
+) -> None:
+    """Run an API integration and close the HTTP client before the event loop shuts down.
+
+    httpx2's AsyncClient holds TCP connections bound to the current event loop.
+    If those connections survive past asyncio.run(), cleanup triggers
+    RuntimeError('Event loop is closed'). Closing here avoids that.
+    """
+    try:
+        await integration.async_run(dry_run)
+    finally:
+        await qontract_api_client.aclose()
+
+
 def _integration_wet_run[RunParamsTypeVar: RunParams](
     integration: QontractReconcileIntegration[RunParamsTypeVar]
     | QontractReconcileApiIntegration[RunParamsTypeVar],
@@ -178,7 +196,7 @@ def _integration_wet_run[RunParamsTypeVar: RunParams](
         integration.run(False)
     else:
         setup_qontract_api_client()
-        asyncio.run(integration.async_run(False))
+        asyncio.run(_run_api_integration(integration, dry_run=False))
 
 
 def _integration_dry_run[RunParamsTypeVar: RunParams](
@@ -244,7 +262,7 @@ def _integration_dry_run[RunParamsTypeVar: RunParams](
         integration.run(True)
     else:
         setup_qontract_api_client()
-        asyncio.run(integration.async_run(True))
+        asyncio.run(_run_api_integration(integration, dry_run=True))
 
 
 def _is_task_result_an_error(result: Any) -> bool:

--- a/reconcile/utils/runtime/runner.py
+++ b/reconcile/utils/runtime/runner.py
@@ -7,6 +7,7 @@ from typing import (
     TypeVar,
 )
 
+from qontract_api_client.client import client as qontract_api_client
 from sretoolbox.utils import threaded as sretoolbox_threaded
 
 from reconcile.status import ExitCodes
@@ -15,8 +16,6 @@ from reconcile.utils.runtime.desired_state_diff import (
     DesiredStateDiff,
     build_desired_state_diff,
 )
-from qontract_api_client.client import client as qontract_api_client
-
 from reconcile.utils.runtime.integration import (
     QontractReconcileApiIntegration,
     QontractReconcileIntegration,


### PR DESCRIPTION
## Summary

- Follows https://github.com/app-sre/qontract-reconcile/pull/5582
- Fix `RuntimeError: Event loop is closed` in all API-based integrations after the clientele migration (9f45b54e)
- The clientele httpx2 backend uses a singleton `AsyncClient` whose TCP connections are bound to the event loop created by `asyncio.run()`. When `asyncio.run()` closes the loop, httpcore2 crashes trying to clean up stale connections
- Wrap `integration.async_run()` in `_run_api_integration()` which calls `qontract_api_client.aclose()` in a `finally` block — ensuring cleanup happens while the event loop is still alive

Fixes: `github-owners-api`, `glitchtip-api`, `glitchtip-project-alerts-api`, `slack-usergroups-api`

## Test plan

- [x] mypy passes
- [x] All 33 runner tests pass
- [ ] Deploy and verify no more `RuntimeError: Event loop is closed` in API integrations

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cleanup for integration runs: shared HTTP connections are now reliably closed after both wet and dry executions, ensuring connections are released even on errors. This prevents connection leaks, improves stability for repeated runs, and reduces resource consumption.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->