### PR TITLE
feat: support old_parameter_group resolution in RDS external resources

### DIFF
--- a/reconcile/external_resources/aws.py
+++ b/reconcile/external_resources/aws.py
@@ -163,6 +163,9 @@ class AWSRdsFactory(AWSDefaultResourceFactory):
         if "parameter_group" in data:
             pg_data = rvr._get_values(data["parameter_group"])
             data["parameter_group"] = pg_data
+        if data.get("old_parameter_group"):
+            old_pg_data = rvr._get_values(data["old_parameter_group"])
+            data["old_parameter_group"] = old_pg_data
         if (
             (blue_green_deployment := data.get("blue_green_deployment"))
             and (target := blue_green_deployment.get("target"))

--- a/reconcile/test/external_resources/test_rds_factory.py
+++ b/reconcile/test/external_resources/test_rds_factory.py
@@ -117,6 +117,42 @@ def test_validate_timeouts_nok(timeouts: Any, expected_value_error: str) -> None
         factory.validate(resource, module_conf)
 
 
+def test_resolve_old_parameter_group(
+    factory: AWSRdsFactory,
+    mocker: MockerFixture,
+) -> None:
+    rvr = mocker.patch(
+        "reconcile.external_resources.aws.ResourceValueResolver", autospec=True
+    )
+    rvr.return_value.resolve.return_value = {
+        "identifier": "test-rds",
+        "parameter_group": "/path/to/parameter_group",
+        "old_parameter_group": "/path/to/old_parameter_group",
+    }
+    rvr.return_value._get_values.side_effect = [
+        {"name": "new-pg", "family": "postgres16"},
+        {"name": "old-pg", "family": "postgres14"},
+    ]
+    spec = ExternalResourceSpec(
+        provision_provider="aws",
+        provisioner={"name": "test"},
+        resource={
+            "identifier": "test-rds",
+            "provider": "rds",
+            "parameter_group": "/path/to/parameter_group",
+            "old_parameter_group": "/path/to/old_parameter_group",
+        },
+        namespace={},
+    )
+    module_conf = ExternalResourceModuleConfiguration()
+
+    result = factory.resolve(spec, module_conf)
+
+    assert result["parameter_group"] == {"name": "new-pg", "family": "postgres16"}
+    assert result["old_parameter_group"] == {"name": "old-pg", "family": "postgres14"}
+    assert rvr.return_value._get_values.call_count == 2
+
+
 def test_resolve_blue_green_deployment_parameter_group(
     factory: AWSRdsFactory,
     mocker: MockerFixture,


### PR DESCRIPTION
## Summary
- Resolve `old_parameter_group` field references (via `ResourceValueResolver`) alongside `parameter_group` in the RDS factory
- Ensures the old parameter group data is properly fetched from app-interface before being passed to the er-aws-rds module

## Problem
During RDS major version upgrades, the old parameter group must be kept in Terraform state to avoid `InvalidDBParameterGroupState` errors. The er-aws-rds module now accepts `old_parameter_group`, but qontract-reconcile needs to resolve its references before passing the input.

## Test plan
- [x] `test_resolve_old_parameter_group` — verifies both parameter groups are resolved correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)