### PR TITLE
fix(gitlab_housekeeping) Rebase algorithm respects OMM_PENDING label

### DIFF
--- a/reconcile/gitlab_housekeeping.py
+++ b/reconcile/gitlab_housekeeping.py
@@ -960,6 +960,12 @@ def _rebase_merge_requests_active_cap(
                 already_active += 1
             continue
 
+        # OMM pending MRs are managed by _process_omm_group which uses
+        # skip-ci rebases. Don't re-rebase them here with CI enabled.
+        if OMM_PENDING in mr.labels:
+            logging.debug(["rebase", gl.project.name, mr.iid, "skip-omm-pending"])
+            continue
+
         _cancel_timed_out_pipelines(dry_run, gl, mr, pipelines, pipeline_timeout)
 
         if _should_skip_for_running_pipeline(pipelines, wait_for_pipeline):


### PR DESCRIPTION
## Problem
When the OMM group performs a skip_ci=True rebase on a pending MR, _rebase_merge_requests_active_cap runs shortly after and rebases the same MR with CI enabled, triggering a fresh ~8-minute pipeline. This negates the skip-ci optimization and causes the OMM window to expire before pending members can merge.

## Fix
Add an OMM_PENDING label check in _rebase_merge_requests_active_cap so that MRs managed by _process_omm_group are not re-rebased by the independent rebase function.

The check is placed after the is_rebased branch so that OMM pending MRs with active pipelines still count toward already_active (they consume real CI resources), but before the needs_rebase append so they are not re-rebased or given a budget slot.

## Behavior
OMM pending MRs that are already rebased with a running/pending/success pipeline still count toward the active concurrency cap
OMM pending MRs that are not yet rebased are skipped (their rebase is handled by _process_omm_group with skip_ci=True)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Merge requests labeled `OMM_PENDING` are now correctly skipped during the active rebase phase, preventing conflicts between different merge request management workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->