### PR TITLE
fix(sapm): add soak buffer and align state fetch with saasherder

### DIFF
--- a/reconcile/saas_auto_promotions_manager/publisher.py
+++ b/reconcile/saas_auto_promotions_manager/publisher.py
@@ -73,6 +73,7 @@ class Publisher:
                 sha=self.commit_sha,
                 channel=channel,
                 target_uid=self.uid,
+                pre_check_sha_exists=False,
             )
             if not (
                 promotion_data

--- a/reconcile/saas_auto_promotions_manager/subscriber.py
+++ b/reconcile/saas_auto_promotions_manager/subscriber.py
@@ -17,6 +17,7 @@ from reconcile.utils.datetime_util import utc_now
 from reconcile.utils.slo_document_manager import SLODocumentManager
 
 CONTENT_HASH_LENGTH = 32
+SOAK_DAYS_BUFFER = timedelta(hours=6)
 
 
 @dataclass
@@ -112,21 +113,49 @@ class Subscriber:
     def _passed_accumulated_soak_days(self) -> bool:
         """
         We accumulate the time a ref is running on all publishers for this subscriber.
-        We compare that accumulated time with the soak_days setting of the subscriber.
+        We compare that accumulated time with the soak_days setting of the subscriber
+        plus a buffer to account for state changes between SAPM evaluation and pipeline
+        validation (APPSRE-14585).
         """
         now = utc_now()
         delta = timedelta(days=0)
+        publisher_details: list[str] = []
         for channel in self.channels:
             for publisher in channel.publishers:
                 deploy_info = publisher.deployment_info_by_channel.get(channel.name)
                 if not deploy_info:
-                    # At this stage we always expect a deploy_info to be present
+                    logging.info(
+                        "[%s] publisher uid=%s has no deploy_info - blocking soak check",
+                        channel.name,
+                        publisher.uid,
+                    )
                     return False
                 deployed_at = deploy_info.check_in
                 if not deployed_at:
+                    publisher_details.append(
+                        f"{publisher.uid}@{channel.name}: no check_in"
+                    )
                     continue
-                delta += now - deployed_at
-        return delta >= timedelta(days=self.soak_days)
+                publisher_delta = now - deployed_at
+                delta += publisher_delta
+                publisher_details.append(
+                    f"{publisher.uid}@{channel.name}: check_in={deployed_at.isoformat()}, delta={publisher_delta}"
+                )
+        required = timedelta(days=self.soak_days)
+        if self.soak_days > 0:
+            required += SOAK_DAYS_BUFFER
+        if delta < required:
+            logging.info(
+                "Subscriber at %s soak not met: accumulated=%s, required=%s (soak_days=%d + buffer=%s). Publishers: [%s]",
+                self.target_file_path,
+                delta,
+                required,
+                self.soak_days,
+                SOAK_DAYS_BUFFER,
+                ", ".join(publisher_details),
+            )
+            return False
+        return True
 
     def _is_valid_deployment_window(self) -> bool:
         # Ideally we would catch that at schema validation time

--- a/reconcile/test/saas_auto_promotions_manager/subscriber/test_soak_days.py
+++ b/reconcile/test/saas_auto_promotions_manager/subscriber/test_soak_days.py
@@ -6,6 +6,7 @@ from datetime import UTC, datetime, timedelta
 from typing import Any
 
 from reconcile.saas_auto_promotions_manager.subscriber import (
+    SOAK_DAYS_BUFFER,
     Subscriber,
 )
 
@@ -33,9 +34,10 @@ def test_single_publisher_soak_days_not_passed(
     assert subscriber.desired_hashes == []
 
 
-def test_single_publisher_soak_days_passed(
+def test_single_publisher_soak_days_passed_without_buffer(
     subscriber_builder: Callable[[Mapping[str, Any]], Subscriber],
 ) -> None:
+    """Soak days technically passed but buffer not met - should NOT promote."""
     subscriber = subscriber_builder({
         "CUR_SUBSCRIBER_REF": "current_sha",
         "SOAK_DAYS": 1,
@@ -51,7 +53,34 @@ def test_single_publisher_soak_days_passed(
     })
     subscriber.compute_desired_state()
 
-    # Soak days passed -> new ref up for promotion
+    # Soak days passed but buffer not met -> no promotion
+    assert subscriber.desired_ref == "current_sha"
+    assert subscriber.desired_hashes == []
+
+
+def test_single_publisher_soak_days_passed_with_buffer(
+    subscriber_builder: Callable[[Mapping[str, Any]], Subscriber],
+) -> None:
+    """Soak days + buffer passed - should promote."""
+    subscriber = subscriber_builder({
+        "CUR_SUBSCRIBER_REF": "current_sha",
+        "SOAK_DAYS": 1,
+        "USE_TARGET_CONFIG_HASH": False,
+        "CHANNELS": {
+            "channel-a": {
+                "publisher_a": {
+                    "REAL_WORLD_SHA": "new_sha",
+                    "CHECK_IN": datetime.now(UTC)
+                    - timedelta(days=1)
+                    - SOAK_DAYS_BUFFER
+                    - timedelta(minutes=1),
+                }
+            },
+        },
+    })
+    subscriber.compute_desired_state()
+
+    # Soak days + buffer passed -> new ref up for promotion
     assert subscriber.desired_ref == "new_sha"
     assert subscriber.desired_hashes == []
 
@@ -88,6 +117,7 @@ def test_multiple_publisher_accumulated_soak_days_not_passed(
 def test_multiple_publisher_accumulated_soak_days_passed(
     subscriber_builder: Callable[[Mapping[str, Any]], Subscriber],
 ) -> None:
+    """3 publishers * 11h = 33h > 24h + 6h buffer = 30h -> should promote."""
     subscriber = subscriber_builder({
         "CUR_SUBSCRIBER_REF": "current_sha",
         "SOAK_DAYS": 1,
@@ -96,23 +126,23 @@ def test_multiple_publisher_accumulated_soak_days_passed(
             "channel-a": {
                 "publisher_a1": {
                     "REAL_WORLD_SHA": "new_sha",
-                    "CHECK_IN": datetime.now(UTC) - timedelta(hours=8),
+                    "CHECK_IN": datetime.now(UTC) - timedelta(hours=11),
                 },
                 "publisher_a2": {
                     "REAL_WORLD_SHA": "new_sha",
-                    "CHECK_IN": datetime.now(UTC) - timedelta(hours=8),
+                    "CHECK_IN": datetime.now(UTC) - timedelta(hours=11),
                 },
             },
             "channel-b": {
                 "publisher_b": {
                     "REAL_WORLD_SHA": "new_sha",
-                    "CHECK_IN": datetime.now(UTC) - timedelta(hours=8),
+                    "CHECK_IN": datetime.now(UTC) - timedelta(hours=11),
                 }
             },
         },
     })
     subscriber.compute_desired_state()
 
-    # Accumulated soak days passed -> new ref up for promotion
+    # Accumulated soak days passed (33h > 30h required) -> new ref up for promotion
     assert subscriber.desired_ref == "new_sha"
     assert subscriber.desired_hashes == []


### PR DESCRIPTION
## Summary

- Adds a 6-hour buffer to the soak days requirement (only when `soak_days > 0`) so SAPM doesn't open promotion MRs that are barely past the threshold. This prevents the TOCTOU race where S3 state changes (check_in resets from redeployments) between SAPM's evaluation and the pipeline validation, causing immediate `pipeline-error` failures.
- Uses `pre_check_sha_exists=False` in publisher state fetch to always read fresh S3 state, aligning with saasherder's validation behavior.
- Adds per-publisher INFO-level logging with check_in timestamps and accumulated deltas when soak blocks a promotion, enabling fast diagnosis of future soak-related failures.

## Root Cause (APPSRE-14585)

SAPM was opening promotion MRs that immediately failed saasherder's pipeline validation because:
1. SAPM calculated accumulated soak at time T and the result was marginally above the threshold
2. Between T and the pipeline run (minutes to hours later), publishers were redeployed (e.g., rolling wave promotions) which reset their `check_in` timestamps in S3
3. Saasherder read fresh S3 state and computed less accumulated soak, failing the validation

This caused a recurring pattern of `pipeline-error`-labeled MRs clogging the merge queue.

## Test plan

- [x] All existing SAPM tests pass (80/80)
- [x] New test for buffer behavior (`test_single_publisher_soak_days_passed_without_buffer`)
- [x] Updated existing test to validate buffer threshold (`test_single_publisher_soak_days_passed_with_buffer`)
- [x] ruff lint + format pass
- [x] mypy type check passes

Closes APPSRE-14585

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced promotion validation by introducing a stricter soak-days gate with an added buffer requirement (6 hours), ensuring promotions are only approved after meeting both the soak period and buffer threshold.
  * Improved diagnostics with enhanced logging when deployment information is unavailable.

* **Tests**
  * Updated test coverage to validate both soak-days scenarios with and without buffer requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->