### PR TITLE
ERROR_LABELS added to review queue

### DIFF
--- a/tools/qontract_cli.py
+++ b/tools/qontract_cli.py
@@ -2422,7 +2422,7 @@ def app_interface_review_queue(ctx: click.Context) -> None:
                 mr, app_sre_team_members, glhk.HOLD_LABELS
             )
 
-            if is_last_action_by_app_sre:
+            if is_last_action_by_app_sre and not (good_to_merge and has_error_label):
                 last_comment = gl.last_comment(mr, exclude_bot=True)
                 # skip only if the last comment isn't a trigger phrase
                 if (

--- a/tools/qontract_cli.py
+++ b/tools/qontract_cli.py
@@ -2380,7 +2380,9 @@ def app_interface_review_queue(ctx: click.Context) -> None:
                 continue
 
             labels = mr.attributes.get("labels") or []
-            if glhk.is_good_to_merge(labels):
+            good_to_merge = glhk.is_good_to_merge(labels)
+            has_error_label = any(l in glhk.ERROR_LABELS for l in labels)
+            if good_to_merge and not has_error_label:
                 continue
             if "stale" in labels:
                 continue
@@ -2402,7 +2404,9 @@ def app_interface_review_queue(ctx: click.Context) -> None:
             if running_pipelines:
                 continue
             last_pipeline_result = pipelines[0].status
-            if last_pipeline_result != PipelineStatus.SUCCESS:
+            if last_pipeline_result != PipelineStatus.SUCCESS and not (
+                good_to_merge and has_error_label
+            ):
                 continue
 
             author = mr.author["username"]

--- a/tools/test/test_qontract_cli.py
+++ b/tools/test/test_qontract_cli.py
@@ -2,9 +2,11 @@ from unittest.mock import Mock
 
 import pytest
 from click.testing import CliRunner
+from gitlab.const import PipelineStatus
 from pytest_mock import MockerFixture
 
 from reconcile.utils.early_exit_cache import CacheHeadResult, CacheKey, CacheStatus
+from reconcile.utils.mr.labels import LGTM, PIPELINE_ERROR
 from tools import qontract_cli
 
 
@@ -384,3 +386,111 @@ def test_cidr_blocks_within_invalid_cidr(mock_cidr_deps: Mock) -> None:
     )
     assert result.exit_code != 0
     assert "Invalid CIDR" in result.output
+
+
+@pytest.fixture
+def mock_review_queue_gl(mocker: MockerFixture) -> Mock:
+    mocker.patch(
+        "tools.qontract_cli.queries.get_app_interface_settings",
+        autospec=True,
+        return_value={},
+    )
+    mocker.patch(
+        "tools.qontract_cli.queries.get_gitlab_instance",
+        autospec=True,
+        return_value={},
+    )
+    mocker.patch("tools.qontract_cli.SecretReader", autospec=True)
+    mocker.patch("tools.qontract_cli.init_jjb", autospec=True)
+    mocker.patch("tools.qontract_cli.slackapi_from_queries", autospec=True)
+
+    mock_gl = mocker.patch("tools.qontract_cli.GitLabApi", autospec=True)
+    gl_instance = mock_gl.return_value
+    gl_instance.get_app_sre_group_users.return_value = []
+    gl_instance.is_assigned_by_team.return_value = False
+    gl_instance.is_last_action_by_team.return_value = True
+
+    mocker.patch(
+        "tools.qontract_cli.queries.get_review_repos",
+        autospec=True,
+        return_value=[
+            {
+                "name": "app-interface",
+                "url": "https://gitlab.example.com/service/app-interface",
+            }
+        ],
+    )
+
+    return gl_instance
+
+
+def _mock_mr(iid: int, labels: list[str]) -> Mock:
+    mr = Mock()
+    mr.iid = iid
+    mr.draft = False
+    mr.title = f"MR {iid}"
+    mr.web_url = f"https://gitlab.example.com/mr/{iid}"
+    mr.updated_at = "2026-06-10T00:00:00Z"
+    mr.merge_status = "can_be_merged"
+    mr.author = {"username": "tenant-user"}
+    mr.attributes = {"labels": labels}
+    mr.commits.return_value = [Mock()]
+    return mr
+
+
+def test_review_queue_includes_approved_mr_with_pipeline_error(
+    mock_review_queue_gl: Mock,
+) -> None:
+    mock_review_queue_gl.get_merge_requests.return_value = [
+        _mock_mr(1, [LGTM, PIPELINE_ERROR])
+    ]
+    mock_review_queue_gl.get_merge_request_pipelines.return_value = [
+        Mock(status=PipelineStatus.FAILED)
+    ]
+
+    runner = CliRunner()
+    result = runner.invoke(
+        qontract_cli.get,
+        ["app-interface-review-queue"],
+        obj={"options": {"output": "table", "sort": True}},
+    )
+    assert result.exit_code == 0
+    assert "MR 1" in result.output
+
+
+def test_review_queue_excludes_approved_mr_without_error(
+    mock_review_queue_gl: Mock,
+) -> None:
+    mock_review_queue_gl.get_merge_requests.return_value = [_mock_mr(2, [LGTM])]
+    mock_review_queue_gl.get_merge_request_pipelines.return_value = [
+        Mock(status=PipelineStatus.SUCCESS)
+    ]
+
+    runner = CliRunner()
+    result = runner.invoke(
+        qontract_cli.get,
+        ["app-interface-review-queue"],
+        obj={"options": {"output": "table", "sort": True}},
+    )
+    assert result.exit_code == 0
+    assert "MR 2" not in result.output
+
+
+def test_review_queue_excludes_pipeline_error_without_approval(
+    mock_review_queue_gl: Mock,
+) -> None:
+    mock_review_queue_gl.get_merge_requests.return_value = [
+        _mock_mr(3, [PIPELINE_ERROR])
+    ]
+    mock_review_queue_gl.get_merge_request_pipelines.return_value = [
+        Mock(status=PipelineStatus.FAILED)
+    ]
+
+    runner = CliRunner()
+    result = runner.invoke(
+        qontract_cli.get,
+        ["app-interface-review-queue"],
+        obj={"options": {"output": "table", "sort": True}},
+    )
+    assert result.exit_code == 0
+    assert "MR 3" not in result.output


### PR DESCRIPTION
Slack Thread: https://redhat-internal.slack.com/archives/C098G63A9JQ/p1780383584718759

## Summary

Approved MRs with `pipeline-error` or `merge-error` labels are now surfaced in the review queue. These MRs are stuck — approved but unable to auto-merge due to repeated pipeline failures or merge errors — and require IC intervention. Previously they were invisible because the review queue skipped all "good to merge" MRs and all MRs with non-successful pipelines.

## Changes

Three filters in `app_interface_review_queue` are bypassed when an MR is both approved and has an error label:
- `is_good_to_merge` skip
- Pipeline status check
- "Last action by AppSRE" skip

## Jira

[APPSRE-14402](https://redhat.atlassian.net/browse/APPSRE-14402)

Created by Claude

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Updated Merge Request filtering logic in the app interface review queue to refine how requests marked as good to merge are processed. Improved prioritization for requests with error labels despite pipeline status concerns, and enhanced consistency in how recent actions are evaluated during filtering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->