### PR TITLE
:bug: handle empty KV v2 engines in vault replication (APPSRE-14594)

### DIFF
--- a/reconcile/test/test_vault_replication.py
+++ b/reconcile/test/test_vault_replication.py
@@ -567,6 +567,13 @@ def test_get_policy_secret_list(mocker: MockerFixture) -> None:
     }
 
 
+def test_get_policy_secret_list_empty_engine(mocker: MockerFixture) -> None:
+    vault_client = mocker.patch("reconcile.utils.vault.VaultClient", autospec=True)
+    vault_client.list_all.return_value = []
+
+    assert integ.get_policy_secret_list(vault_client, ["policy/path/1/*"]) == []
+
+
 @pytest.mark.parametrize(
     "paths",
     [

--- a/reconcile/test/test_vault_utils.py
+++ b/reconcile/test/test_vault_utils.py
@@ -6,6 +6,7 @@ from unittest.mock import (
     patch,
 )
 
+import hvac.exceptions
 import pytest
 
 from reconcile.utils import vault
@@ -63,3 +64,41 @@ class TestVaultUtils:
             client._read_all_v2.assert_called_once_with(
                 "test/secret", vault.SECRET_VERSION_LATEST
             )
+
+
+def test_list_kv2_empty_engine_returns_empty_dict() -> None:
+    """An empty KV v2 engine raises InvalidPath — _list_kv2 should return {}."""
+    with patch("reconcile.utils.vault.VaultClient.__init__", return_value=None):
+        client = vault.VaultClient()
+        client._client = MagicMock()
+        client._client.secrets.kv.v2.list_secrets.side_effect = (
+            hvac.exceptions.InvalidPath()
+        )
+
+    assert client._list_kv2("engine/some/path") == {}
+
+
+def test_list_empty_kv2_engine_returns_empty_list() -> None:
+    """list() on an empty KV v2 engine should return []."""
+    with patch("reconcile.utils.vault.VaultClient.__init__", return_value=None):
+        client = vault.VaultClient()
+        client._client = MagicMock()
+        client._client.secrets.kv.v2.list_secrets.side_effect = (
+            hvac.exceptions.InvalidPath()
+        )
+
+    with patch.object(client, "_get_mount_version_by_secret_path", return_value=2):
+        assert client.list("engine/some/path") == []
+
+
+def test_list_all_empty_kv2_engine_returns_empty_list() -> None:
+    """list_all() on an empty KV v2 engine should return []."""
+    with patch("reconcile.utils.vault.VaultClient.__init__", return_value=None):
+        client = vault.VaultClient()
+        client._client = MagicMock()
+        client._client.secrets.kv.v2.list_secrets.side_effect = (
+            hvac.exceptions.InvalidPath()
+        )
+
+    with patch.object(client, "_get_mount_version_by_secret_path", return_value=2):
+        assert client.list_all("engine/some/path") == []

--- a/reconcile/test/test_vault_utils.py
+++ b/reconcile/test/test_vault_utils.py
@@ -66,39 +66,33 @@ class TestVaultUtils:
             )
 
 
-def test_list_kv2_empty_engine_returns_empty_dict() -> None:
-    """An empty KV v2 engine raises InvalidPath — _list_kv2 should return {}."""
+@pytest.fixture
+def kv2_client_invalid_path() -> vault.VaultClient:
+    """VaultClient with KV v2 list raising InvalidPath (empty engine)."""
     with patch("reconcile.utils.vault.VaultClient.__init__", return_value=None):
         client = vault.VaultClient()
         client._client = MagicMock()
         client._client.secrets.kv.v2.list_secrets.side_effect = (
             hvac.exceptions.InvalidPath()
         )
-
-    assert client._list_kv2("engine/some/path") == {}
-
-
-def test_list_empty_kv2_engine_returns_empty_list() -> None:
-    """list() on an empty KV v2 engine should return []."""
-    with patch("reconcile.utils.vault.VaultClient.__init__", return_value=None):
-        client = vault.VaultClient()
-        client._client = MagicMock()
-        client._client.secrets.kv.v2.list_secrets.side_effect = (
-            hvac.exceptions.InvalidPath()
-        )
-
-    with patch.object(client, "_get_mount_version_by_secret_path", return_value=2):
-        assert client.list("engine/some/path") == []
+    return client
 
 
-def test_list_all_empty_kv2_engine_returns_empty_list() -> None:
-    """list_all() on an empty KV v2 engine should return []."""
-    with patch("reconcile.utils.vault.VaultClient.__init__", return_value=None):
-        client = vault.VaultClient()
-        client._client = MagicMock()
-        client._client.secrets.kv.v2.list_secrets.side_effect = (
-            hvac.exceptions.InvalidPath()
-        )
-
-    with patch.object(client, "_get_mount_version_by_secret_path", return_value=2):
-        assert client.list_all("engine/some/path") == []
+@pytest.mark.parametrize(
+    "method_name, expected",
+    [
+        ("_list_kv2", {}),
+        ("list", []),
+        ("list_all", []),
+    ],
+)
+def test_empty_kv2_engine(
+    kv2_client_invalid_path: vault.VaultClient,
+    method_name: str,
+    expected: dict | list[str],
+) -> None:
+    with patch.object(
+        kv2_client_invalid_path, "_get_mount_version_by_secret_path", return_value=2
+    ):
+        result = getattr(kv2_client_invalid_path, method_name)("engine/some/path")
+        assert result == expected

--- a/reconcile/utils/vault.py
+++ b/reconcile/utils/vault.py
@@ -405,6 +405,8 @@ class VaultClient:
                 mount_point=mount_point, path=secret_path
             )
             return response
+        except InvalidPath:
+            return {}
         except hvac.exceptions.Forbidden:
             msg = f"permission denied accessing path '{path}'"
             raise PathAccessForbiddenError(msg) from None

--- a/reconcile/utils/vault.py
+++ b/reconcile/utils/vault.py
@@ -417,6 +417,8 @@ class VaultClient:
             if response is None or not isinstance(response, dict):
                 return {}
             return response
+        except InvalidPath:
+            return {}
         except hvac.exceptions.Forbidden:
             msg = f"permission denied accessing path '{path}'"
             raise PathAccessForbiddenError(msg) from None


### PR DESCRIPTION
## Summary

- Catch `hvac.exceptions.InvalidPath` in `VaultClient._list_kv2()` and `_list()` and return an empty dict
- Prevents vault-replication from crashing when a newly created KV v2 engine has no secrets yet
- Triggered by empty `releng-stage/` engine created via app-interface MR !191856

## Test plan

- [x] Parametrized tests for `_list_kv2`, `list`, `list_all` with empty KV v2 engine
- [x] Integration test for `get_policy_secret_list` with empty engine
- [x] All existing vault tests pass
- [x] Linter + mypy clean

Closes: [APPSRE-14594](https://redhat.atlassian.net/browse/APPSRE-14594)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Listing from empty or invalid Vault KV v2 and non-KV-v2 paths now returns empty results instead of raising errors, improving robustness of secret discovery.
* **Tests**
  * Added tests covering empty/invalid Vault engine/listing scenarios to verify listing functions return empty results when paths are absent.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->