### PR TITLE
Include bot-authored and self-serviceable MR's with ERROR_LABELS to review queue 

### DIFF
--- a/tools/qontract_cli.py
+++ b/tools/qontract_cli.py
@@ -2387,7 +2387,7 @@ def app_interface_review_queue(ctx: click.Context) -> None:
                 continue
             if "stale" in labels:
                 continue
-            if SAAS_FILE_UPDATE in labels:
+            if SAAS_FILE_UPDATE in labels and not has_error_label:
                 continue
             if HOLD in labels:
                 continue
@@ -2395,6 +2395,7 @@ def app_interface_review_queue(ctx: click.Context) -> None:
                 SELF_SERVICEABLE in labels
                 and SHOW_SELF_SERVICEABLE_IN_REVIEW_QUEUE not in labels
                 and AVS not in labels
+                and not has_error_label
             ):
                 continue
 
@@ -2414,7 +2415,9 @@ def app_interface_review_queue(ctx: click.Context) -> None:
 
             author = mr.author["username"]
             app_sre_team_members = {u.username for u in gl.get_app_sre_group_users()}
-            if author in app_sre_team_members:
+            if author in app_sre_team_members and not (
+                good_to_merge and has_error_label
+            ):
                 continue
 
             is_assigned_by_app_sre = gl.is_assigned_by_team(mr, app_sre_team_members)

--- a/tools/test/test_qontract_cli.py
+++ b/tools/test/test_qontract_cli.py
@@ -496,6 +496,7 @@ def test_review_queue_excludes_pipeline_error_without_approval(
     assert "MR 3" not in result.output
 
 
+
 def test_review_queue_excludes_bot_hold(
     mock_review_queue_gl: Mock,
 ) -> None:

--- a/tools/test/test_qontract_cli.py
+++ b/tools/test/test_qontract_cli.py
@@ -6,7 +6,13 @@ from gitlab.const import PipelineStatus
 from pytest_mock import MockerFixture
 
 from reconcile.utils.early_exit_cache import CacheHeadResult, CacheKey, CacheStatus
-from reconcile.utils.mr.labels import HOLD, LGTM, PIPELINE_ERROR
+from reconcile.utils.mr.labels import (
+    HOLD,
+    LGTM,
+    PIPELINE_ERROR,
+    SAAS_FILE_UPDATE,
+    SELF_SERVICEABLE,
+)
 from tools import qontract_cli
 
 
@@ -496,7 +502,6 @@ def test_review_queue_excludes_pipeline_error_without_approval(
     assert "MR 3" not in result.output
 
 
-
 def test_review_queue_excludes_bot_hold(
     mock_review_queue_gl: Mock,
 ) -> None:
@@ -510,3 +515,86 @@ def test_review_queue_excludes_bot_hold(
     )
     assert result.exit_code == 0
     assert "MR 4" not in result.output
+
+
+def test_review_queue_includes_self_serviceable_mr_with_pipeline_error(
+    mock_review_queue_gl: Mock,
+) -> None:
+    mock_review_queue_gl.get_merge_requests.return_value = [
+        _mock_mr(4, [LGTM, PIPELINE_ERROR, SELF_SERVICEABLE])
+    ]
+    mock_review_queue_gl.get_merge_request_pipelines.return_value = [
+        Mock(status=PipelineStatus.FAILED)
+    ]
+
+    runner = CliRunner()
+    result = runner.invoke(
+        qontract_cli.get,
+        ["app-interface-review-queue"],
+        obj={"options": {"output": "table", "sort": True}},
+    )
+    assert result.exit_code == 0
+    assert "MR 4" in result.output
+
+
+def test_review_queue_includes_saas_file_update_mr_with_pipeline_error(
+    mock_review_queue_gl: Mock,
+) -> None:
+    mock_review_queue_gl.get_merge_requests.return_value = [
+        _mock_mr(5, [LGTM, PIPELINE_ERROR, SAAS_FILE_UPDATE])
+    ]
+    mock_review_queue_gl.get_merge_request_pipelines.return_value = [
+        Mock(status=PipelineStatus.FAILED)
+    ]
+
+    runner = CliRunner()
+    result = runner.invoke(
+        qontract_cli.get,
+        ["app-interface-review-queue"],
+        obj={"options": {"output": "table", "sort": True}},
+    )
+    assert result.exit_code == 0
+    assert "MR 5" in result.output
+
+
+def test_review_queue_excludes_self_serviceable_mr_without_error(
+    mock_review_queue_gl: Mock,
+) -> None:
+    mock_review_queue_gl.get_merge_requests.return_value = [
+        _mock_mr(6, [SELF_SERVICEABLE])
+    ]
+    mock_review_queue_gl.get_merge_request_pipelines.return_value = [
+        Mock(status=PipelineStatus.SUCCESS)
+    ]
+
+    runner = CliRunner()
+    result = runner.invoke(
+        qontract_cli.get,
+        ["app-interface-review-queue"],
+        obj={"options": {"output": "table", "sort": True}},
+    )
+    assert result.exit_code == 0
+    assert "MR 6" not in result.output
+
+
+def test_review_queue_includes_bot_authored_self_serviceable_mr_with_pipeline_error(
+    mock_review_queue_gl: Mock,
+) -> None:
+    mr = _mock_mr(7, [LGTM, PIPELINE_ERROR, SELF_SERVICEABLE])
+    mr.author = {"username": "app-sre-bot"}
+    mock_review_queue_gl.get_merge_requests.return_value = [mr]
+    mock_review_queue_gl.get_merge_request_pipelines.return_value = [
+        Mock(status=PipelineStatus.FAILED)
+    ]
+    mock_review_queue_gl.get_app_sre_group_users.return_value = [
+        Mock(username="app-sre-bot")
+    ]
+
+    runner = CliRunner()
+    result = runner.invoke(
+        qontract_cli.get,
+        ["app-interface-review-queue"],
+        obj={"options": {"output": "table", "sort": True}},
+    )
+    assert result.exit_code == 0
+    assert "MR 7" in result.output


### PR DESCRIPTION
## Summary
This is a follow up to [this MR](https://github.com/app-sre/qontract-reconcile/pull/5605) which introduced the initial `has_error_label` bypass for the pipeline-status and `is_last_action_by_app_sre` filters. This PR closes the remaining gaps:

- **Self-serviceable / saas-file-update MRs**: Previously unconditionally filtered out. Now bypass those filters when they carry an error label + approval.
- **Bot-authored MRs**: Previously caught by the `author in app_sre_team_members` filter. Now bypass it when the MR is approved with an error label — since bot-authored self-serviceable MRs (e.g. saas-file-updates) are tenant-owned changes where nobody is actively watching for pipeline failures.

## Context

[Slack Thread ](https://redhat-internal.slack.com/archives/C098G63A9JQ/p1780383584718759)
[APPSRE-14402](https://issues.redhat.com/browse/APPSRE-14402)


Self-serviceable MRs authored by `app-sre-bot` that have `pipeline-error` have no visibility in review queue — AppSRE has no signal since these MRs are excluded from the review queue. The IC should see them so they can either nudge the tenant or investigate.

## What changed

- `tools/qontract_cli.py`: Added `and not has_error_label` to the `SAAS_FILE_UPDATE` and `SELF_SERVICEABLE` skip conditions; added `and not (good_to_merge and has_error_label)` to the author filter.

## Flooding risk

The only filters relaxed are: saas-file-update/self-serviceable skip, pipeline-success requirement, AppSRE-authored skip, and last-action-by-AppSRE skip — all bypassed only when approved + error-label is true. 

Created by Claude

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Review queue filtering updated so merge requests labeled as having pipeline errors are not excluded by SAAS-file-update or self-serviceable rules; AppSRE-authored MRs are allowed through when they are ready to merge and show an error.

* **Tests**
  * Added tests covering inclusion/exclusion of MRs across pipeline status, error labels, self-serviceable flag, and bot-authored cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->