### PR TITLE
Adaptive close fix

### DIFF
--- a/reconcile/gitlab_housekeeping.py
+++ b/reconcile/gitlab_housekeeping.py
@@ -1130,7 +1130,7 @@ def _process_omm_group(
 
         # skip_ci=True rebase causes GitLab to create a "skipped" pipeline;
         # filter these out so the real (pre-rebase) pipeline drives decisions.
-        pipelines = [p for p in pipelines if p.status != "skipped"]
+        pipelines = [p for p in pipelines if p.status != PipelineStatus.SKIPPED]
 
         if not pipelines:
             if is_rebased(mr, gl):
@@ -1248,7 +1248,13 @@ def _process_omm_group(
             any_active = True
             continue
 
-        logging.info(["omm-group", "unhandled-status-not-rebased", gl.project.name, mr.iid, latest_status])
+        logging.info([
+            "omm-group",
+            "unhandled-status-not-rebased",
+            gl.project.name,
+            mr.iid,
+            latest_status,
+        ])
 
     if not any_active:
         logging.info(["omm-group", "adaptive-close", gl.project.name])

--- a/reconcile/gitlab_housekeeping.py
+++ b/reconcile/gitlab_housekeeping.py
@@ -1128,7 +1128,19 @@ def _process_omm_group(
                     pipelines=timed_out,
                 )
 
+        # skip_ci=True rebase causes GitLab to create a "skipped" pipeline;
+        # filter these out so the real (pre-rebase) pipeline drives decisions.
+        pipelines = [p for p in pipelines if p.status != "skipped"]
+
         if not pipelines:
+            if is_rebased(mr, gl):
+                logging.info([
+                    "omm-group",
+                    "no-pipelines-rebased",
+                    gl.project.name,
+                    mr.iid,
+                ])
+                any_active = True
             continue
 
         latest_status = pipelines[0].status
@@ -1149,6 +1161,15 @@ def _process_omm_group(
         if is_rebased(mr, gl):
             if latest_status != PipelineStatus.SUCCESS:
                 if latest_status in {PipelineStatus.RUNNING, PipelineStatus.PENDING}:
+                    any_active = True
+                else:
+                    logging.info([
+                        "omm-group",
+                        "unhandled-status-rebased",
+                        gl.project.name,
+                        mr.iid,
+                        latest_status,
+                    ])
                     any_active = True
                 continue
 
@@ -1226,6 +1247,8 @@ def _process_omm_group(
         if latest_status in {PipelineStatus.RUNNING, PipelineStatus.PENDING}:
             any_active = True
             continue
+
+        logging.info(["omm-group", "unhandled-status-not-rebased", gl.project.name, mr.iid, latest_status])
 
     if not any_active:
         logging.info(["omm-group", "adaptive-close", gl.project.name])

--- a/reconcile/gitlab_housekeeping.py
+++ b/reconcile/gitlab_housekeeping.py
@@ -1160,9 +1160,10 @@ def _process_omm_group(
 
         if is_rebased(mr, gl):
             if latest_status != PipelineStatus.SUCCESS:
-                if latest_status in {PipelineStatus.RUNNING, PipelineStatus.PENDING}:
-                    any_active = True
-                else:
+                if latest_status not in {
+                    PipelineStatus.RUNNING,
+                    PipelineStatus.PENDING,
+                }:
                     logging.info([
                         "omm-group",
                         "unhandled-status-rebased",
@@ -1170,7 +1171,7 @@ def _process_omm_group(
                         mr.iid,
                         latest_status,
                     ])
-                    any_active = True
+                any_active = True
                 continue
 
             if merges >= merge_limit:

--- a/reconcile/test/test_gitlab_housekeeping.py
+++ b/reconcile/test/test_gitlab_housekeeping.py
@@ -2624,3 +2624,160 @@ def test_multi_merge_disabled_single_merge_on_rebase(
     mr1.merge.assert_called_once()
     mr2.merge.assert_not_called()
     mr2.rebase.assert_not_called()
+
+
+# --- OMM skipped pipeline handling tests ---
+
+
+def _skipped_pipeline() -> Mock:
+    return create_autospec(ProjectMergeRequestPipeline, status="skipped")
+
+
+@pytest.mark.parametrize(
+    "merge_sha, squash_sha",
+    [("abc123", None), (None, "abc123")],
+    ids=["merge-commit", "squash-commit"],
+)
+def test_omm_group_skipped_pipeline_filtered_merges_on_pre_rebase_success(
+    mocker: MockerFixture,
+    merge_sha: str | None,
+    squash_sha: str | None,
+) -> None:
+    """After skip-ci rebase, GitLab creates a 'skipped' pipeline. The code
+    should filter it out and use the pre-rebase SUCCESS pipeline to merge."""
+    _setup_omm_group_mocks(mocker)
+    mocker.patch(
+        "reconcile.gitlab_housekeeping.is_rebased",
+        return_value=True,
+    )
+    mocker.patch(
+        "reconcile.gitlab_housekeeping.clear_omm_group",
+    )
+
+    lead = create_autospec(ProjectMergeRequest)
+    lead.merge_commit_sha = merge_sha
+    lead.squash_commit_sha = squash_sha
+    lead.target_branch = "master"
+
+    mr = _make_merge_mr(11, ["approved", "tenant-bar", "omm-pending"])
+
+    mocker.patch(
+        "reconcile.gitlab_housekeeping.get_omm_pending_mrs",
+        return_value=[mr],
+    )
+
+    mocked_gl = _make_omm_gl(head_sha="abc123")
+    mocked_gl.get_merge_request_pipelines.return_value = [
+        _skipped_pipeline(),
+        _success_pipeline(),
+    ]
+
+    merges = gl_h._process_omm_group(
+        dry_run=False,
+        gl=mocked_gl,
+        lead=lead,
+        app_sre_usernames=set(),
+    )
+
+    assert merges == 1
+    mr.merge.assert_called_once()
+
+
+@pytest.mark.parametrize(
+    "merge_sha, squash_sha",
+    [("abc123", None), (None, "abc123")],
+    ids=["merge-commit", "squash-commit"],
+)
+def test_omm_group_all_skipped_pipelines_rebased_stays_active(
+    mocker: MockerFixture,
+    merge_sha: str | None,
+    squash_sha: str | None,
+) -> None:
+    """When all pipelines are 'skipped' and the MR is rebased, the group
+    should stay active (any_active=True) rather than triggering adaptive-close."""
+    _setup_omm_group_mocks(mocker)
+    mocker.patch(
+        "reconcile.gitlab_housekeeping.is_rebased",
+        return_value=True,
+    )
+    clear_mock = mocker.patch(
+        "reconcile.gitlab_housekeeping.clear_omm_group",
+    )
+
+    lead = create_autospec(ProjectMergeRequest)
+    lead.merge_commit_sha = merge_sha
+    lead.squash_commit_sha = squash_sha
+    lead.target_branch = "master"
+
+    mr = _make_merge_mr(11, ["approved", "tenant-bar", "omm-pending"])
+
+    mocker.patch(
+        "reconcile.gitlab_housekeeping.get_omm_pending_mrs",
+        return_value=[mr],
+    )
+
+    mocked_gl = _make_omm_gl(head_sha="abc123")
+    mocked_gl.get_merge_request_pipelines.return_value = [_skipped_pipeline()]
+
+    merges = gl_h._process_omm_group(
+        dry_run=False,
+        gl=mocked_gl,
+        lead=lead,
+        app_sre_usernames=set(),
+    )
+
+    assert merges == 0
+    mr.merge.assert_not_called()
+    clear_mock.assert_not_called()
+
+
+def _canceled_pipeline() -> Mock:
+    return create_autospec(ProjectMergeRequestPipeline, status="canceled")
+
+
+@pytest.mark.parametrize(
+    "merge_sha, squash_sha",
+    [("abc123", None), (None, "abc123")],
+    ids=["merge-commit", "squash-commit"],
+)
+def test_omm_group_unhandled_status_rebased_stays_active(
+    mocker: MockerFixture,
+    merge_sha: str | None,
+    squash_sha: str | None,
+) -> None:
+    """An unexpected pipeline status (e.g. 'canceled') on a rebased MR
+    should keep the group active rather than triggering adaptive-close."""
+    _setup_omm_group_mocks(mocker)
+    mocker.patch(
+        "reconcile.gitlab_housekeeping.is_rebased",
+        return_value=True,
+    )
+    clear_mock = mocker.patch(
+        "reconcile.gitlab_housekeeping.clear_omm_group",
+    )
+
+    lead = create_autospec(ProjectMergeRequest)
+    lead.merge_commit_sha = merge_sha
+    lead.squash_commit_sha = squash_sha
+    lead.target_branch = "master"
+
+    mr = _make_merge_mr(11, ["approved", "tenant-bar", "omm-pending"])
+
+    mocker.patch(
+        "reconcile.gitlab_housekeeping.get_omm_pending_mrs",
+        return_value=[mr],
+    )
+
+    mocked_gl = _make_omm_gl(head_sha="abc123")
+    mocked_gl.get_merge_request_pipelines.return_value = [_canceled_pipeline()]
+
+    merges = gl_h._process_omm_group(
+        dry_run=False,
+        gl=mocked_gl,
+        lead=lead,
+        app_sre_usernames=set(),
+    )
+
+    assert merges == 0
+    mr.merge.assert_not_called()
+    clear_mock.assert_not_called()


### PR DESCRIPTION
## Problem

When `_process_omm_group` rebases an MR with `skip_ci=True`, GitLab creates a synthetic pipeline with `status: skipped`. On the next reconcile loop, this `skipped` pipeline appeared as the latest pipeline, and no existing branch handled it — so `any_active` was never set, causing premature `adaptive-close` of the OMM group.

This was the root cause of OMM being reverted to `active-cap` after testing.

## Changes

**Primary fix** — filter out `skipped` pipelines before any status logic, so the real pre-rebase `SUCCESS` pipeline drives merge decisions.

**Defensive empty-pipeline handling** — after filtering, if `pipelines` is now empty but the MR is rebased, mark it as active and wait for the next loop. Previously an empty pipeline list silently skipped the MR without setting
`any_active`.

**Catch-all for rebased MRs with unexpected statuses** — if an MR is rebased but has a pipeline status that isn't `SUCCESS`, `RUNNING`, or `PENDING` (e.g. `canceled`, `manual`), keep the group active rather than letting it fall through to `adaptive-close`. Logs `omm-group unhandled-status-rebased` for observability.

**Diagnostic logging** — added `omm-group unhandled-status-not-rebased` for MRs that hit none of the known status branches and are not rebased, making it easier to trace future `adaptive-close` events.

## Tests

3 new test cases covering:

- `skipped` pipeline filtered, pre-rebase `SUCCESS` pipeline drives merge
- All pipelines filtered out + MR is rebased → group stays active
- Unexpected status (`canceled`) on rebased MR → group stays active

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved pipeline state evaluation to filter skipped pipelines and better handle edge cases.
  * Enhanced detection and logging of pipeline status conditions in pending member workflows.

* **Tests**
  * Added test coverage for skipped pipeline filtering scenarios.
  * Added test coverage for unhandled pipeline status cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->