### PR TITLE
Exclude bot/hold MRs from review queue

### DIFF
--- a/tools/qontract_cli.py
+++ b/tools/qontract_cli.py
@@ -152,6 +152,7 @@ from reconcile.utils.keycloak import (
 )
 from reconcile.utils.mr.labels import (
     AVS,
+    HOLD,
     SAAS_FILE_UPDATE,
     SELF_SERVICEABLE,
     SHOW_SELF_SERVICEABLE_IN_REVIEW_QUEUE,
@@ -2387,6 +2388,8 @@ def app_interface_review_queue(ctx: click.Context) -> None:
             if "stale" in labels:
                 continue
             if SAAS_FILE_UPDATE in labels:
+                continue
+            if HOLD in labels:
                 continue
             if (
                 SELF_SERVICEABLE in labels

--- a/tools/test/test_qontract_cli.py
+++ b/tools/test/test_qontract_cli.py
@@ -6,7 +6,7 @@ from gitlab.const import PipelineStatus
 from pytest_mock import MockerFixture
 
 from reconcile.utils.early_exit_cache import CacheHeadResult, CacheKey, CacheStatus
-from reconcile.utils.mr.labels import LGTM, PIPELINE_ERROR
+from reconcile.utils.mr.labels import HOLD, LGTM, PIPELINE_ERROR
 from tools import qontract_cli
 
 
@@ -494,3 +494,18 @@ def test_review_queue_excludes_pipeline_error_without_approval(
     )
     assert result.exit_code == 0
     assert "MR 3" not in result.output
+
+
+def test_review_queue_excludes_bot_hold(
+    mock_review_queue_gl: Mock,
+) -> None:
+    mock_review_queue_gl.get_merge_requests.return_value = [_mock_mr(4, [HOLD])]
+
+    runner = CliRunner()
+    result = runner.invoke(
+        qontract_cli.get,
+        ["app-interface-review-queue"],
+        obj={"options": {"output": "table", "sort": True}},
+    )
+    assert result.exit_code == 0
+    assert "MR 4" not in result.output


### PR DESCRIPTION
## Summary
- MRs with the `bot/hold` label are now filtered out of the `app-interface-review-queue` CLI output
- Matches existing filtering behavior for `stale` and `saas-file-update` labels
- Adds unit test for the new filter

## Test plan
- [x] Unit test `test_review_queue_excludes_bot_hold` passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for the HOLD label to exclude merge requests from the review queue, allowing better control over which MRs appear in the queue alongside existing exclusion criteria.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->