### PR TITLE
feat(blackbox-exporter): emit Probe.monitoring.rhobs for COO parallel run

### DIFF
--- a/reconcile/blackbox_exporter_endpoint_monitoring.py
+++ b/reconcile/blackbox_exporter_endpoint_monitoring.py
@@ -16,6 +16,8 @@ QONTRACT_INTEGRATION = "blackbox-exporter-endpoint-monitoring"
 QONTRACT_INTEGRATION_VERSION = make_semver(0, 1, 0)
 
 PROVIDER = "blackbox-exporter"
+COO_NAMESPACE_NAME = "app-sre-observability-per-cluster"
+MANAGED_TYPES = ["Probe.monitoring.coreos.com", "Probe.monitoring.rhobs"]
 
 LOG = logging.getLogger(__name__)
 
@@ -50,6 +52,7 @@ def run(
             thread_pool_size=thread_pool_size,
             internal=internal,
             use_jump_host=use_jump_host,
+            managed_types=MANAGED_TYPES,
         )
     except Exception as e:
         LOG.error(e)
@@ -66,37 +69,62 @@ def get_blackbox_providers() -> list[EndpointMonitoringProvider]:
 
 def build_probe(
     provider: EndpointMonitoringProvider, endpoints: list[Endpoint]
-) -> OpenshiftResource | None:
+) -> list[tuple[OpenshiftResource, dict[str, Any]]]:
     blackbox_exporter = provider.blackboxExporter
-    if blackbox_exporter:
-        prober_url = parse_prober_url(blackbox_exporter.exporterUrl)
-        body: dict[str, Any] = {
-            "apiVersion": "monitoring.coreos.com/v1",
-            "kind": "Probe",
-            "metadata": {
-                "name": provider.name,
-                "namespace": blackbox_exporter.namespace.get("name"),
-                "labels": {"prometheus": "app-sre"},
-            },
-            "spec": {
-                "jobName": provider.name,
-                "interval": provider.checkInterval or "10s",
-                "module": blackbox_exporter.module,
-                "prober": prober_url,
-                "targets": {
-                    "staticConfig": {
-                        "relabelingConfigs": [
-                            {"action": "labeldrop", "regex": "namespace"}
-                        ],
-                        "labels": provider.metric_labels,
-                        "static": [ep.url for ep in endpoints],
-                    }
-                },
-            },
-        }
-        if provider.timeout:
-            body["spec"]["scrapeTimeout"] = provider.timeout
-        return OpenshiftResource(
-            body, QONTRACT_INTEGRATION, QONTRACT_INTEGRATION_VERSION
-        )
-    return None
+    if not blackbox_exporter:
+        return []
+
+    prober_url = parse_prober_url(blackbox_exporter.exporterUrl)
+    spec: dict[str, Any] = {
+        "jobName": provider.name,
+        "interval": provider.checkInterval or "10s",
+        "module": blackbox_exporter.module,
+        "prober": prober_url,
+        "targets": {
+            "staticConfig": {
+                "relabelingConfigs": [{"action": "labeldrop", "regex": "namespace"}],
+                "labels": provider.metric_labels,
+                "static": [ep.url for ep in endpoints],
+            }
+        },
+    }
+    if provider.timeout:
+        spec["scrapeTimeout"] = provider.timeout
+
+    namespace = blackbox_exporter.namespace
+
+    coreos_body: dict[str, Any] = {
+        "apiVersion": "monitoring.coreos.com/v1",
+        "kind": "Probe",
+        "metadata": {
+            "name": provider.name,
+            "namespace": namespace.get("name"),
+            "labels": {"prometheus": "app-sre"},
+        },
+        "spec": spec,
+    }
+    coo_namespace: dict[str, Any] = {**namespace, "name": COO_NAMESPACE_NAME}
+    rhobs_body: dict[str, Any] = {
+        "apiVersion": "monitoring.rhobs/v1",
+        "kind": "Probe",
+        "metadata": {
+            "name": provider.name,
+            "namespace": COO_NAMESPACE_NAME,
+            "labels": {"prometheus": "app-sre"},
+        },
+        "spec": spec,
+    }
+    return [
+        (
+            OpenshiftResource(
+                coreos_body, QONTRACT_INTEGRATION, QONTRACT_INTEGRATION_VERSION
+            ),
+            namespace,
+        ),
+        (
+            OpenshiftResource(
+                rhobs_body, QONTRACT_INTEGRATION, QONTRACT_INTEGRATION_VERSION
+            ),
+            coo_namespace,
+        ),
+    ]

--- a/reconcile/closedbox_endpoint_monitoring_base.py
+++ b/reconcile/closedbox_endpoint_monitoring_base.py
@@ -111,25 +111,25 @@ def get_endpoints(provider: str) -> dict[EndpointMonitoringProvider, list[Endpoi
 
 
 def fill_desired_state(
-    provider: EndpointMonitoringProvider,
+    namespace: dict[str, Any],
     probe: OpenshiftResource,
     ri: ResourceInventory,
 ) -> None:
-    if provider.namespace:
-        ri.add_desired(
-            cluster=provider.namespace["cluster"]["name"],
-            namespace=provider.namespace["name"],
-            resource_type=probe.kind_and_group,
-            name=probe.name,
-            value=probe,
-        )
+    ri.add_desired(
+        cluster=namespace["cluster"]["name"],
+        namespace=namespace["name"],
+        resource_type=probe.kind_and_group,
+        name=probe.name,
+        value=probe,
+    )
 
 
 @defer
 def run_for_provider(
     provider: str,
     probe_builder: Callable[
-        [EndpointMonitoringProvider, list[Endpoint]], OpenshiftResource | None
+        [EndpointMonitoringProvider, list[Endpoint]],
+        list[tuple[OpenshiftResource, dict[str, Any]]],
     ],
     integration: str,
     integration_version: str,
@@ -137,11 +137,25 @@ def run_for_provider(
     thread_pool_size: int,
     internal: bool,
     use_jump_host: bool,
+    managed_types: list[str] | None = None,
     defer: Callable | None = None,
 ) -> None:
-    # prepare
     desired_endpoints = get_endpoints(provider)
-    namespaces = [p.namespace for p in desired_endpoints if p.namespace]
+
+    # Build all probes upfront to collect their target namespaces
+    provider_probes = {
+        ep_mon_provider: probe_builder(ep_mon_provider, endpoints)
+        for ep_mon_provider, endpoints in desired_endpoints.items()
+    }
+
+    # Deduplicate target namespaces by (cluster, namespace-name)
+    ns_by_key: dict[tuple[str, str], dict[str, Any]] = {}
+    for probes in provider_probes.values():
+        for _, ns in probes:
+            if ns:
+                ns_by_key[ns["cluster"]["name"], ns["name"]] = ns
+
+    namespaces = list(ns_by_key.values())
 
     if namespaces:
         ri, oc_map = ob.fetch_current_state(
@@ -151,16 +165,15 @@ def run_for_provider(
             use_jump_host=use_jump_host,
             integration=integration,
             integration_version=integration_version,
-            override_managed_types=["Probe.monitoring.coreos.com"],
+            override_managed_types=managed_types or ["Probe.monitoring.coreos.com"],
         )
         if defer:
             defer(oc_map.cleanup)
 
-        # reconcile
-        for ep_mon_provider, endpoints in desired_endpoints.items():
-            probe = probe_builder(ep_mon_provider, endpoints)
-            if probe:
-                fill_desired_state(ep_mon_provider, probe, ri)
+        for probes in provider_probes.values():
+            for probe, ns in probes:
+                if ns:
+                    fill_desired_state(ns, probe, ri)
         ob.publish_metrics(ri, integration)
         ob.realize_data(dry_run, oc_map, ri, thread_pool_size, recycle_pods=False)
 

--- a/reconcile/signalfx_endpoint_monitoring.py
+++ b/reconcile/signalfx_endpoint_monitoring.py
@@ -40,10 +40,10 @@ def run(
 
 def build_probe(
     provider: EndpointMonitoringProvider, endpoints: list[Endpoint]
-) -> OpenshiftResource | None:
+) -> list[tuple[OpenshiftResource, dict[str, Any]]]:
     signalfx = provider.signalFx
     if not signalfx:
-        return None
+        return []
     prober_url = parse_prober_url(signalfx.exporterUrl)
     prober_url["path"] += "/" + signalfx.targetFilterLabel
 
@@ -87,4 +87,9 @@ def build_probe(
     }
     if provider.timeout:
         body["spec"]["scrapeTimeout"] = provider.timeout
-    return OpenshiftResource(body, QONTRACT_INTEGRATION, QONTRACT_INTEGRATION_VERSION)
+    return [
+        (
+            OpenshiftResource(body, QONTRACT_INTEGRATION, QONTRACT_INTEGRATION_VERSION),
+            signalfx.namespace,
+        )
+    ]

--- a/reconcile/test/test_closedbox_endpoint_monitoring.py
+++ b/reconcile/test/test_closedbox_endpoint_monitoring.py
@@ -79,8 +79,12 @@ def test_blackbox_exporter_probe_building(mocker: MockerFixture) -> None:
     provider = next(iter(endpoints.keys()))
     provider_endpoints = endpoints.get(provider)
     assert provider_endpoints is not None
-    probe_resource = blackbox_exporter_probe_builder(provider, provider_endpoints)
-    assert probe_resource is not None
+    probes = blackbox_exporter_probe_builder(provider, provider_endpoints)
+    assert len(probes) == 2
+
+    probe_resource, namespace = probes[0]
+    assert probe_resource.body["apiVersion"] == "monitoring.coreos.com/v1"
+    assert namespace["name"] == "openshift-customer-monitoring"
 
     # verify prober url decomposition
     spec = probe_resource.body.get("spec", {})
@@ -102,6 +106,13 @@ def test_blackbox_exporter_probe_building(mocker: MockerFixture) -> None:
     assert "https://test1.url" in spec["targets"]["staticConfig"]["static"]
     assert "https://test2.url" in spec["targets"]["staticConfig"]["static"]
 
+    # verify COO rhobs probe
+    coo_probe, coo_namespace = probes[1]
+    assert coo_probe.body["apiVersion"] == "monitoring.rhobs/v1"
+    assert coo_namespace["name"] == "app-sre-observability-per-cluster"
+    assert coo_namespace["cluster"] == namespace["cluster"]
+    assert coo_probe.body["spec"] == spec
+
 
 def test_signalfx_probe_building(mocker: MockerFixture) -> None:
     ep_query = mocker.patch.object(queries, "get_service_monitoring_endpoints")
@@ -113,8 +124,10 @@ def test_signalfx_probe_building(mocker: MockerFixture) -> None:
     provider = next(iter(endpoints.keys()))
     provider_endpoints = endpoints.get(provider)
     assert provider_endpoints is not None
-    probe_resource = signalfx_probe_builder(provider, provider_endpoints)
-    assert probe_resource is not None
+    probes = signalfx_probe_builder(provider, provider_endpoints)
+    assert len(probes) == 1
+
+    probe_resource, _ = probes[0]
 
     # verify prober url decomposition
     spec = probe_resource.body.get("spec", {})
@@ -153,22 +166,34 @@ def test_signalfx_probe_building(mocker: MockerFixture) -> None:
     } in spec["targets"]["staticConfig"]["relabelingConfigs"]
 
 
-def test_blackbox_exporter_filling_desired_state(mocker: MockerFixture) -> None:
+@pytest.mark.parametrize(
+    "probe_idx,expected_namespace,expected_resource_type",
+    [
+        (0, "openshift-customer-monitoring", "Probe.monitoring.coreos.com"),
+        (1, "app-sre-observability-per-cluster", "Probe.monitoring.rhobs"),
+    ],
+)
+def test_blackbox_exporter_filling_desired_state(
+    mocker: MockerFixture,
+    probe_idx: int,
+    expected_namespace: str,
+    expected_resource_type: str,
+) -> None:
     ep_query = mocker.patch.object(queries, "get_service_monitoring_endpoints")
     ep_query.return_value = get_endpoint_fixtures("test_endpoint.yaml")
     add_desired_mock = mocker.patch.object(ResourceInventory, "add_desired")
 
     endpoints = get_endpoints(BLACKBOX_EXPORTER_PROVIDER)
     provider = next(iter(endpoints.keys()))
-    probe = blackbox_exporter_probe_builder(provider, endpoints[provider])
-    assert probe is not None
-    fill_desired_state(provider, probe, ResourceInventory())
+    probes = blackbox_exporter_probe_builder(provider, endpoints[provider])
+    probe, ns = probes[probe_idx]
+    fill_desired_state(ns, probe, ResourceInventory())
 
     assert add_desired_mock.call_count == 1
     add_desired_mock.assert_called_with(
         cluster="app-sre-stage-01",
-        namespace="openshift-customer-monitoring",
-        resource_type="Probe.monitoring.coreos.com",
+        namespace=expected_namespace,
+        resource_type=expected_resource_type,
         name="blackbox-exporter-http-2xx",
         value=ANY,
     )
@@ -181,9 +206,10 @@ def test_signalfx_filling_desired_state(mocker: MockerFixture) -> None:
 
     endpoints = get_endpoints(SIGNALFX_PROVIDER)
     provider = next(iter(endpoints.keys()))
-    probe = signalfx_probe_builder(provider, endpoints[provider])
-    assert probe is not None
-    fill_desired_state(provider, probe, ResourceInventory())
+    probes = signalfx_probe_builder(provider, endpoints[provider])
+    assert len(probes) > 0
+    probe, ns = probes[0]
+    fill_desired_state(ns, probe, ResourceInventory())
 
     assert add_desired_mock.call_count == 1
     add_desired_mock.assert_called_with(


### PR DESCRIPTION
## Summary

- Extends the blackbox exporter integration to emit `Probe.monitoring.rhobs/v1` into `app-sre-observability-per-cluster` on hub clusters alongside the existing `Probe.monitoring.coreos.com/v1` in `openshift-customer-monitoring` (COO Phase 2 - Step 2.2)
- Refactors `run_for_provider` in the base class so probe builders return `list[tuple[OpenshiftResource, dict]]` — each probe paired with its target namespace — enabling multi-namespace emission without double-connecting to clusters
- `fill_desired_state` now takes an explicit namespace dict instead of deriving it from the provider; signalfx updated to the new return type with no behavioural change

## Diff

```
qontract-reconcile-blackbox-exporter-endpoint-monitoring  | [2026-06-11 10:46:59] [INFO] [DRY-RUN] [openshift_base.py:apply:429] - ['apply', 'privileged=False', 'appsrep09ue1', 'app-sre-observability-per-cluster', 'Probe.monitoring.rhobs', 'blackbox-tls-expiration-critical-fts']
qontract-reconcile-blackbox-exporter-endpoint-monitoring  | [2026-06-11 10:46:59] [INFO] [DRY-RUN] [openshift_base.py:apply:429] - ['apply', 'privileged=False', 'appsrep09ue1', 'app-sre-observability-per-cluster', 'Probe.monitoring.rhobs', 'blackbox-http-2xx-internal-prod-critical']
qontract-reconcile-blackbox-exporter-endpoint-monitoring  | [2026-06-11 10:46:59] [INFO] [DRY-RUN] [openshift_base.py:apply:429] - ['apply', 'privileged=False', 'appsrep11ue1', 'app-sre-observability-per-cluster', 'Probe.monitoring.rhobs', 'blackbox-http-2xx-prod-critical']
qontract-reconcile-blackbox-exporter-endpoint-monitoring  | [2026-06-11 10:46:59] [INFO] [DRY-RUN] [openshift_base.py:apply:429] - ['apply', 'privileged=False', 'appsrep11ue1', 'app-sre-observability-per-cluster', 'Probe.monitoring.rhobs', 'blackbox-http-2xx-stage-warning']
qontract-reconcile-blackbox-exporter-endpoint-monitoring  | [2026-06-11 10:46:59] [INFO] [DRY-RUN] [openshift_base.py:apply:429] - ['apply', 'privileged=False', 'appsrep11ue1', 'app-sre-observability-per-cluster', 'Probe.monitoring.rhobs', 'blackbox-http-2xx-critical-fts']
qontract-reconcile-blackbox-exporter-endpoint-monitoring  | [2026-06-11 10:46:59] [INFO] [DRY-RUN] [openshift_base.py:apply:429] - ['apply', 'privileged=False', 'appsres09ue1', 'app-sre-observability-per-cluster', 'Probe.monitoring.rhobs', 'blackbox-http-2xx-internal-stage-warning']
qontract-reconcile-blackbox-exporter-endpoint-monitoring  | [2026-06-11 10:46:59] [INFO] [DRY-RUN] [openshift_base.py:apply:429] - ['apply', 'privileged=False', 'appsres09ue1', 'app-sre-observability-per-cluster', 'Probe.monitoring.rhobs', 'blackbox-http-2xx-internal-stage-critical']
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Enhancements**
  * Endpoint monitoring now emits multiple probe resources per provider to cover different probe types (including COREOS and RHOBS variants).
  * Blackbox exporter monitoring now produces additional probes targeting cluster observability namespaces.

* **Tests**
  * Updated tests to validate the new multi-probe return shape and desired-state population for each probe/namespace pair.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->