### PR TITLE
fix(saasherder): preserve check_in on successful re-deployments of same ref

### DIFF
--- a/reconcile/utils/saasherder/saasherder.py
+++ b/reconcile/utils/saasherder/saasherder.py
@@ -2237,11 +2237,16 @@ class SaasHerder:
                 for channel in promotion.publish:
                     # make sure we keep some attributes on re-deployments of same ref
                     has_succeeded_once = success
+                    # pre_check_sha_exists=False: _commits_by_channel is never
+                    # populated in the saasherder flow (only SAPM calls
+                    # cache_commit_shas_from_s3), so the default True would
+                    # always short-circuit to None and lose the old check_in.
                     current_state = self._promotion_state.get_promotion_data(
                         sha=promotion.commit_sha,
                         channel=channel,
                         target_uid=promotion.saas_target_uid,
                         use_cache=True,
+                        pre_check_sha_exists=False,
                     )
                     if current_state and current_state.has_succeeded_once:
                         has_succeeded_once = True


### PR DESCRIPTION
## Summary

- `publish_promotions` reads the prior S3 state before writing, so it can preserve the old `check_in` timestamp on successful re-deployments of the same ref (preventing soak-day accumulation from collapsing).
- However, `get_promotion_data` defaults to `pre_check_sha_exists=True`, which gates the S3 read on `_commits_by_channel` — a dict populated by `cache_commit_shas_from_s3()`.
- `cache_commit_shas_from_s3()` is **never called** in the saasherder/openshift-saas-deploy flow (only SAPM calls it), so `_commits_by_channel` is always empty and the guard always short-circuits to `None`.
- Result: `current_state` is always `None`, the preservation condition is never reached, and `check_in` is reset to `now` on every publish — making the fix from #4577 effectively dead code.

Fix: pass `pre_check_sha_exists=False` on the `get_promotion_data` call in `publish_promotions` so it skips the empty cache check and reads directly from S3.

Confirmed via S3 version history: two consecutive successful deploys of the same sha/config-hash both wrote fresh `check_in` timestamps instead of preserving the original.

Fixes: APPSRE-14585

## Test plan

- [ ] Existing saasherder unit tests pass
- [ ] Verify in staging that re-deployment of the same ref no longer resets `check_in` in S3