### PR TITLE
skip_ci on group formation

### DIFF
--- a/reconcile/gitlab_housekeeping.py
+++ b/reconcile/gitlab_housekeeping.py
@@ -746,7 +746,7 @@ def apply_omm_pending(
         if not dry_run:
             gl.add_label_to_merge_request(mr, OMM_PENDING)
             try:
-                mr.rebase(skip_ci=False)
+                mr.rebase(skip_ci=True)
             except gitlab.exceptions.GitlabMRRebaseError:
                 logging.warning([
                     "omm-group",

--- a/reconcile/test/test_gitlab_housekeeping.py
+++ b/reconcile/test/test_gitlab_housekeeping.py
@@ -1947,7 +1947,7 @@ def test_multi_merge_two_non_overlapping_tenants(
 
     mr1.merge.assert_called_once()
     mr2.merge.assert_not_called()
-    mr2.rebase.assert_called_once_with(skip_ci=False)
+    mr2.rebase.assert_called_once_with(skip_ci=True)
 
 
 def test_multi_merge_overlapping_tenants_serialized(


### PR DESCRIPTION
Changed `skip_ci=False` to `skip_ci=True` so CI's get skipped on group formation (already skips CI's within the group)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated automated merge request rebasing to skip continuous integration execution in specific scenarios for improved efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->