### PR TITLE
Speed up CI tests with pytest-xdist and fix UnleashClient leak

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -102,7 +102,7 @@ helm-test: generate
 	git diff --exit-code helm openshift
 
 unittest: ## Run unit tests
-	uv run pytest --cov=reconcile --cov-report=term-missing --cov-report xml reconcile tools
+	uv run pytest -n auto --dist worksteal --cov=reconcile --cov-report=term-missing --cov-report xml reconcile tools
 
 .PHONY: generate-client
 generate-client:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -99,6 +99,7 @@ dev = [
     "types-requests-oauthlib",
     "types-requests",
     "types-tabulate",
+    "pytest-xdist>=3.8.0",
 ]
 
 # required for qontract_utils

--- a/reconcile/test/utils/unleash/test_unleash_client.py
+++ b/reconcile/test/utils/unleash/test_unleash_client.py
@@ -1,4 +1,4 @@
-from collections.abc import Callable
+from collections.abc import Callable, Generator
 from typing import Any
 from unittest.mock import ANY, MagicMock
 
@@ -17,13 +17,16 @@ from reconcile.utils.unleash.client import (
 )
 
 
-@pytest.fixture
-def reset_client() -> None:
+@pytest.fixture(autouse=True)
+def reset_client() -> Generator:
+    yield
+    if (c := reconcile.utils.unleash.client.client) is not None:
+        c.destroy()
     reconcile.utils.unleash.client.client = None
 
 
 @pytest.fixture
-def mock_unleash_client(mocker: MockerFixture, reset_client: Any) -> MagicMock:
+def mock_unleash_client(mocker: MockerFixture) -> MagicMock:
     return mocker.patch("reconcile.utils.unleash.client.UnleashClient", autospec=True)
 
 
@@ -167,7 +170,6 @@ def test_get_feature_toggle_state(
 
 
 def test_get_feature_toggle_state_with_strategy(
-    reset_client: Any,
     setup_unleash_disable_cluster_strategy: Callable,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -181,7 +183,6 @@ def test_get_feature_toggle_state_with_strategy(
 
 
 def test_get_feature_toggle_state_disabled_with_strategy(
-    reset_client: None,
     setup_unleash_disable_cluster_strategy: Callable,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -194,7 +195,6 @@ def test_get_feature_toggle_state_disabled_with_strategy(
 
 
 def test_get_feature_toggle_state_with_enable_cluster_strategy(
-    reset_client: None,
     setup_unleash_enable_cluster_strategy: Callable,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -726,6 +726,15 @@ wheels = [
 ]
 
 [[package]]
+name = "execnet"
+version = "2.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/bf/89/780e11f9588d9e7128a3f87788354c7946a9cbb1401ad38a48c4db9a4f07/execnet-2.1.2.tar.gz", hash = "sha256:63d83bfdd9a23e35b9c6a3261412324f964c2ec8dcd8d3c6916ee9373e0befcd", size = 166622, upload-time = "2025-11-12T09:56:37.75Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ab/84/02fc1827e8cdded4aa65baef11296a9bbe595c474f0d6d758af082d849fd/execnet-2.1.2-py3-none-any.whl", hash = "sha256:67fba928dd5a544b783f6056f449e5e3931a5c378b128bc18501f7ea79e296ec", size = 40708, upload-time = "2025-11-12T09:56:36.333Z" },
+]
+
+[[package]]
 name = "fast-depends"
 version = "3.0.8"
 source = { registry = "https://pypi.org/simple" }
@@ -1902,6 +1911,19 @@ wheels = [
 ]
 
 [[package]]
+name = "pytest-xdist"
+version = "3.8.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "execnet" },
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/78/b4/439b179d1ff526791eb921115fca8e44e596a13efeda518b9d845a619450/pytest_xdist-3.8.0.tar.gz", hash = "sha256:7e578125ec9bc6050861aa93f2d59f1d8d085595d6551c2c90b6f4fad8d3a9f1", size = 88069, upload-time = "2025-07-01T13:30:59.346Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ca/31/d4e37e9e550c2b92a9cbc2e4d0b7420a27224968580b5a447f420847c975/pytest_xdist-3.8.0-py3-none-any.whl", hash = "sha256:202ca578cfeb7370784a8c33d6d05bc6e13b4f25b5053c30a152269fd10f0b88", size = 46396, upload-time = "2025-07-01T13:30:56.632Z" },
+]
+
+[[package]]
 name = "python-dateutil"
 version = "2.9.0.post0"
 source = { registry = "https://pypi.org/simple" }
@@ -2191,6 +2213,7 @@ dev = [
     { name = "pytest-cov" },
     { name = "pytest-httpserver" },
     { name = "pytest-mock" },
+    { name = "pytest-xdist" },
     { name = "qenerate" },
     { name = "responses" },
     { name = "ruff" },
@@ -2276,6 +2299,7 @@ dev = [
     { name = "pytest-cov", specifier = "==7.1.0" },
     { name = "pytest-httpserver", specifier = "==1.1.5" },
     { name = "pytest-mock", specifier = "==3.15.1" },
+    { name = "pytest-xdist", specifier = ">=3.8.0" },
     { name = "qenerate", specifier = "==0.9.2" },
     { name = "responses", specifier = "==0.26.0" },
     { name = "ruff", specifier = "==0.15.13" },


### PR DESCRIPTION
## Summary

- Add `pytest-xdist` and run tests with `-n auto --dist worksteal` to parallelize across all available CPU cores. Local benchmark: **130s → 68s (~48% faster)**. CI improvement expected from **277s → ~140s**.
- Fix `UnleashClient` background thread leak: the `reset_client` test fixture set the global reference to `None` without calling `destroy()`, leaving background threads that blocked process exit with 3 rounds of connection retry tracebacks after every test run.

## Test plan

- [x] Verified locally: same test results with and without xdist (31 pre-existing failures from missing binaries like `amtool`, `skopeo` — unchanged)
- [x] Unleash tests pass (15/15) and no more leaked tracebacks after pytest exits
- [x] Verify CI pipeline passes with parallel test execution

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test execution performance by enabling parallel test running.
  * Added development dependency to support parallel test infrastructure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->