### PR TITLE
Kinesis: Add shard_level_metrics attribute

### DIFF
--- a/reconcile/utils/terrascript_aws_client.py
+++ b/reconcile/utils/terrascript_aws_client.py
@@ -4086,6 +4086,10 @@ class TerrascriptClient:
         if kinesis_values["encryption_type"] == "KMS":
             kinesis_values["kms_key_id"] = common_values.get("kms_key_id")
 
+        shard_level_metrics = common_values.get("shard_level_metrics")
+        if shard_level_metrics is not None:
+            kinesis_values["shard_level_metrics"] = shard_level_metrics
+
         # get region and set provider if required
         region = common_values.get("region") or self.default_regions.get(account)
         assert region  # make mypy happy


### PR DESCRIPTION
## Summary
- Add support for `shard_level_metrics` attribute on Kinesis streams in terrascript

## Requires
- https://github.com/app-sre/qontract-schemas/pull/1019

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added shard-level metrics support for Kinesis streams in Terraform integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->