### PR TITLE
fix(qontract-api): fix OPA sidecar connection exhaustion and enable decision logging

### DIFF
--- a/openshift/qontract-api.yaml
+++ b/openshift/qontract-api.yaml
@@ -156,6 +156,7 @@ objects:
                 - --log-level=info
                 - --disable-telemetry
                 - --addr=0.0.0.0:8181
+                - --set=decision_logs.console=true
                 - --watch
                 - /authz
                 - /policies

--- a/qontract_api/qontract_api/main.py
+++ b/qontract_api/qontract_api/main.py
@@ -69,7 +69,6 @@ async def lifespan(_app: FastAPI) -> AsyncGenerator[None, None]:
     if settings.opa.enabled:
         opa_http_client = httpx.AsyncClient(
             timeout=settings.opa.timeout,
-            limits=httpx.Limits(max_keepalive_connections=5, max_connections=10),
         )
         _app.state.opa_client = OPAClient(
             host=settings.opa.host,


### PR DESCRIPTION
## Summary
- Remove `httpx.Limits(max_keepalive_connections=5, max_connections=10)` from the OPA HTTP client — pool exhaustion caused `ReadError` under load (12+ concurrent requests). httpx defaults to unlimited connections, appropriate for a local sidecar.
- Enable `decision_logs.console=true` on the OPA sidecar so decisions are logged with full input (`request_id`, `username`, `obj`, `params`) and result to stdout.

## Test plan
- [ ] Verify no more `ReadError` exceptions in qontract-api logs under load
- [ ] Verify OPA decision logs appear in pod stdout with `request_id` and decision details

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Configuration**
  * Updated the OPA sidecar container within the deployment to output decision logs directly to the console, improving visibility into policy decisions and enabling easier monitoring.

* **Refactor**
  * Simplified OPA HTTP client connection pooling configuration to rely on framework defaults instead of explicitly specified limits, reducing configuration overhead while maintaining performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->