### PR TITLE
fix(prometheus-rule): remove stale monitoring.rhobs.io from override_managed_types

### DIFF
--- a/reconcile/openshift_resources_base.py
+++ b/reconcile/openshift_resources_base.py
@@ -883,7 +883,6 @@ def canonicalize_namespaces(
             elif providers[0] == "prometheus-rule":
                 override = [
                     "PrometheusRule.monitoring.coreos.com",
-                    "PrometheusRule.monitoring.rhobs.io",
                     "PrometheusRule.monitoring.rhobs",
                 ]
 

--- a/reconcile/test/test_openshift_resources_base.py
+++ b/reconcile/test/test_openshift_resources_base.py
@@ -111,7 +111,6 @@ def test_prometheus_rule(
     _, override = canonicalize_namespaces(namespaces, ["prometheus-rule"])
     assert override == [
         "PrometheusRule.monitoring.coreos.com",
-        "PrometheusRule.monitoring.rhobs.io",
         "PrometheusRule.monitoring.rhobs",
     ]
 


### PR DESCRIPTION
## Summary

- Removes `PrometheusRule.monitoring.rhobs.io` from the `override_managed_types` list in `canonicalize_namespaces`
- No resource in app-interface uses `apiVersion: monitoring.rhobs.io/v1` — all COO-based PrometheusRules use `monitoring.rhobs/v1`
- Keeping the stale `.io` variant caused a `WARNING` log for every cluster on every integration run since no cluster has that CRD installed (~100+ noisy warnings per run)
- `PrometheusRule.monitoring.rhobs` (without `.io`) was already added in #5567 and remains

## Test plan

- [ ] `test_prometheus_rule` updated and passing
- [ ] Dry-run of `openshift-prometheus-rules` no longer emits `cluster has no API resource PrometheusRule.monitoring.rhobs.io` warnings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the Prometheus Rule namespace type override mapping to use the correct identifier.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->