### PR TITLE
feat: add IMAGE_DIGEST, BUSYBOX_IMAGE_DIGEST, FLUENTD_IMAGE_DIGEST fo…

### DIFF
--- a/helm/qontract-reconcile/templates/template.yaml
+++ b/helm/qontract-reconcile/templates/template.yaml
@@ -821,17 +821,17 @@ parameters:
 - name: BUSYBOX_IMAGE
   value: registry.access.redhat.com/ubi8/ubi-minimal
 - name: BUSYBOX_IMAGE_TAG
-  value: latest
+  value: 8.10-1781701121
 - name: BUSYBOX_IMAGE_DIGEST
-  value: ''
+  value: 'sha256:5d76d0cedabd7d7893b28bec684d7a3412dd8d95d186e7d4b6eeed4ea28c327b'
 - name: BUSYBOX_IMAGE_PULL_POLICY
   value: Always
 - name: FLUENTD_IMAGE
   value: quay.io/redhat-services-prod/app-sre-tenant/fluentd-master/fluentd-master
 - name: FLUENTD_IMAGE_TAG
-  value: latest
+  value: d0d1812
 - name: FLUENTD_IMAGE_DIGEST
-  value: ''
+  value: 'sha256:4868ac49b42f14ff0878216cd2c618413209f634a5c9a6c004e353e1b0805e60'
 - name: FLUENTD_IMAGE_PULL_POLICY
   value: Always
 - name: ENVIRONMENT_NAME

--- a/helm/qontract-reconcile/templates/template.yaml
+++ b/helm/qontract-reconcile/templates/template.yaml
@@ -70,7 +70,7 @@ objects:
               memory: 20Mi
         {{- end }}
         - name: config
-          image: ${BUSYBOX_IMAGE}:${BUSYBOX_IMAGE_TAG}
+          image: ${BUSYBOX_IMAGE}:${BUSYBOX_IMAGE_TAG}@${BUSYBOX_IMAGE_DIGEST}
           imagePullPolicy: ${BUSYBOX_IMAGE_PULL_POLICY}
           resources:
             requests:
@@ -324,7 +324,7 @@ objects:
           {{- else if $integration.imageRef}}
           image: ${IMAGE}:{{$integration.imageRef}}
           {{- else }}
-          image: ${IMAGE}:${IMAGE_TAG}
+          image: ${IMAGE}:${IMAGE_TAG}@${IMAGE_DIGEST}
           {{- end }}
           ports:
             - name: http
@@ -446,16 +446,22 @@ objects:
             value: "${IMAGE}"
           - name: IMAGE_TAG
             value: "${IMAGE_TAG}"
+          - name: IMAGE_DIGEST
+            value: "${IMAGE_DIGEST}"
           - name: BUSYBOX_IMAGE
             value: "${BUSYBOX_IMAGE}"
           - name: BUSYBOX_IMAGE_TAG
             value: "${BUSYBOX_IMAGE_TAG}"
+          - name: BUSYBOX_IMAGE_DIGEST
+            value: "${BUSYBOX_IMAGE_DIGEST}"
           - name: BUSYBOX_IMAGE_PULL_POLICY
             value: "${BUSYBOX_IMAGE_PULL_POLICY}"
           - name: FLUENTD_IMAGE
             value: "${FLUENTD_IMAGE}"
           - name: FLUENTD_IMAGE_TAG
             value: "${FLUENTD_IMAGE_TAG}"
+          - name: FLUENTD_IMAGE_DIGEST
+            value: "${FLUENTD_IMAGE_DIGEST}"
           - name: FLUENTD_IMAGE_PULL_POLICY
             value: "${FLUENTD_IMAGE_PULL_POLICY}"
           - name: CLOUDWATCH_SECRET
@@ -549,7 +555,7 @@ objects:
             readOnly: true
           {{- end }}
         - name: fluentd
-          image: ${FLUENTD_IMAGE}:${FLUENTD_IMAGE_TAG}
+          image: ${FLUENTD_IMAGE}:${FLUENTD_IMAGE_TAG}@${FLUENTD_IMAGE_DIGEST}
           imagePullPolicy: ${FLUENTD_IMAGE_PULL_POLICY}
           env:
           - name: AWS_REGION
@@ -673,7 +679,7 @@ objects:
             serviceAccountName: qontract-reconcile
             containers:
             - name: int
-              image: ${IMAGE}:${IMAGE_TAG}
+              image: ${IMAGE}:${IMAGE_TAG}@${IMAGE_DIGEST}
               env:
               - name: RUN_ONCE
                 value: 'true'
@@ -810,16 +816,22 @@ parameters:
   value: quay.io/app-sre/qontract-reconcile
 - name: IMAGE_TAG
   value: latest
+- name: IMAGE_DIGEST
+  value: ''
 - name: BUSYBOX_IMAGE
   value: registry.access.redhat.com/ubi8/ubi-minimal
 - name: BUSYBOX_IMAGE_TAG
   value: latest
+- name: BUSYBOX_IMAGE_DIGEST
+  value: ''
 - name: BUSYBOX_IMAGE_PULL_POLICY
   value: Always
 - name: FLUENTD_IMAGE
   value: quay.io/redhat-services-prod/app-sre-tenant/fluentd-master/fluentd-master
 - name: FLUENTD_IMAGE_TAG
   value: latest
+- name: FLUENTD_IMAGE_DIGEST
+  value: ''
 - name: FLUENTD_IMAGE_PULL_POLICY
   value: Always
 - name: ENVIRONMENT_NAME

--- a/openshift/qontract-manager-fedramp.yaml
+++ b/openshift/qontract-manager-fedramp.yaml
@@ -376,17 +376,17 @@ parameters:
 - name: BUSYBOX_IMAGE
   value: registry.access.redhat.com/ubi8/ubi-minimal
 - name: BUSYBOX_IMAGE_TAG
-  value: latest
+  value: 8.10-1781701121
 - name: BUSYBOX_IMAGE_DIGEST
-  value: ''
+  value: 'sha256:5d76d0cedabd7d7893b28bec684d7a3412dd8d95d186e7d4b6eeed4ea28c327b'
 - name: BUSYBOX_IMAGE_PULL_POLICY
   value: Always
 - name: FLUENTD_IMAGE
   value: quay.io/redhat-services-prod/app-sre-tenant/fluentd-master/fluentd-master
 - name: FLUENTD_IMAGE_TAG
-  value: latest
+  value: d0d1812
 - name: FLUENTD_IMAGE_DIGEST
-  value: ''
+  value: 'sha256:4868ac49b42f14ff0878216cd2c618413209f634a5c9a6c004e353e1b0805e60'
 - name: FLUENTD_IMAGE_PULL_POLICY
   value: Always
 - name: ENVIRONMENT_NAME

--- a/openshift/qontract-manager-fedramp.yaml
+++ b/openshift/qontract-manager-fedramp.yaml
@@ -31,7 +31,7 @@ objects:
         serviceAccountName: qontract-reconcile
         initContainers:
         - name: config
-          image: ${BUSYBOX_IMAGE}:${BUSYBOX_IMAGE_TAG}
+          image: ${BUSYBOX_IMAGE}:${BUSYBOX_IMAGE_TAG}@${BUSYBOX_IMAGE_DIGEST}
           imagePullPolicy: ${BUSYBOX_IMAGE_PULL_POLICY}
           resources:
             requests:
@@ -216,7 +216,7 @@ objects:
             mountPath: /fluentd/etc/
         containers:
         - name: int
-          image: ${IMAGE}:${IMAGE_TAG}
+          image: ${IMAGE}:${IMAGE_TAG}@${IMAGE_DIGEST}
           ports:
             - name: http
               containerPort: 9090
@@ -271,16 +271,22 @@ objects:
             value: "${IMAGE}"
           - name: IMAGE_TAG
             value: "${IMAGE_TAG}"
+          - name: IMAGE_DIGEST
+            value: "${IMAGE_DIGEST}"
           - name: BUSYBOX_IMAGE
             value: "${BUSYBOX_IMAGE}"
           - name: BUSYBOX_IMAGE_TAG
             value: "${BUSYBOX_IMAGE_TAG}"
+          - name: BUSYBOX_IMAGE_DIGEST
+            value: "${BUSYBOX_IMAGE_DIGEST}"
           - name: BUSYBOX_IMAGE_PULL_POLICY
             value: "${BUSYBOX_IMAGE_PULL_POLICY}"
           - name: FLUENTD_IMAGE
             value: "${FLUENTD_IMAGE}"
           - name: FLUENTD_IMAGE_TAG
             value: "${FLUENTD_IMAGE_TAG}"
+          - name: FLUENTD_IMAGE_DIGEST
+            value: "${FLUENTD_IMAGE_DIGEST}"
           - name: FLUENTD_IMAGE_PULL_POLICY
             value: "${FLUENTD_IMAGE_PULL_POLICY}"
           - name: CLOUDWATCH_SECRET
@@ -307,7 +313,7 @@ objects:
           - name: qontract-reconcile-sa-token
             mountPath: ${KUBE_SA_TOKEN_MOUNT_PATH}
         - name: fluentd
-          image: ${FLUENTD_IMAGE}:${FLUENTD_IMAGE_TAG}
+          image: ${FLUENTD_IMAGE}:${FLUENTD_IMAGE_TAG}@${FLUENTD_IMAGE_DIGEST}
           imagePullPolicy: ${FLUENTD_IMAGE_PULL_POLICY}
           env:
           - name: AWS_REGION
@@ -365,16 +371,22 @@ parameters:
   value: quay.io/app-sre/qontract-reconcile
 - name: IMAGE_TAG
   value: latest
+- name: IMAGE_DIGEST
+  value: ''
 - name: BUSYBOX_IMAGE
   value: registry.access.redhat.com/ubi8/ubi-minimal
 - name: BUSYBOX_IMAGE_TAG
   value: latest
+- name: BUSYBOX_IMAGE_DIGEST
+  value: ''
 - name: BUSYBOX_IMAGE_PULL_POLICY
   value: Always
 - name: FLUENTD_IMAGE
   value: quay.io/redhat-services-prod/app-sre-tenant/fluentd-master/fluentd-master
 - name: FLUENTD_IMAGE_TAG
   value: latest
+- name: FLUENTD_IMAGE_DIGEST
+  value: ''
 - name: FLUENTD_IMAGE_PULL_POLICY
   value: Always
 - name: ENVIRONMENT_NAME

--- a/openshift/qontract-manager.yaml
+++ b/openshift/qontract-manager.yaml
@@ -279,17 +279,17 @@ parameters:
 - name: BUSYBOX_IMAGE
   value: registry.access.redhat.com/ubi8/ubi-minimal
 - name: BUSYBOX_IMAGE_TAG
-  value: latest
+  value: 8.10-1781701121
 - name: BUSYBOX_IMAGE_DIGEST
-  value: ''
+  value: 'sha256:5d76d0cedabd7d7893b28bec684d7a3412dd8d95d186e7d4b6eeed4ea28c327b'
 - name: BUSYBOX_IMAGE_PULL_POLICY
   value: Always
 - name: FLUENTD_IMAGE
   value: quay.io/redhat-services-prod/app-sre-tenant/fluentd-master/fluentd-master
 - name: FLUENTD_IMAGE_TAG
-  value: latest
+  value: d0d1812
 - name: FLUENTD_IMAGE_DIGEST
-  value: ''
+  value: 'sha256:4868ac49b42f14ff0878216cd2c618413209f634a5c9a6c004e353e1b0805e60'
 - name: FLUENTD_IMAGE_PULL_POLICY
   value: Always
 - name: ENVIRONMENT_NAME

--- a/openshift/qontract-manager.yaml
+++ b/openshift/qontract-manager.yaml
@@ -31,7 +31,7 @@ objects:
         serviceAccountName: qontract-reconcile
         initContainers:
         - name: config
-          image: ${BUSYBOX_IMAGE}:${BUSYBOX_IMAGE_TAG}
+          image: ${BUSYBOX_IMAGE}:${BUSYBOX_IMAGE_TAG}@${BUSYBOX_IMAGE_DIGEST}
           imagePullPolicy: ${BUSYBOX_IMAGE_PULL_POLICY}
           resources:
             requests:
@@ -123,7 +123,7 @@ objects:
             mountPath: /fluentd/etc/
         containers:
         - name: int
-          image: ${IMAGE}:${IMAGE_TAG}
+          image: ${IMAGE}:${IMAGE_TAG}@${IMAGE_DIGEST}
           ports:
             - name: http
               containerPort: 9090
@@ -182,16 +182,22 @@ objects:
             value: "${IMAGE}"
           - name: IMAGE_TAG
             value: "${IMAGE_TAG}"
+          - name: IMAGE_DIGEST
+            value: "${IMAGE_DIGEST}"
           - name: BUSYBOX_IMAGE
             value: "${BUSYBOX_IMAGE}"
           - name: BUSYBOX_IMAGE_TAG
             value: "${BUSYBOX_IMAGE_TAG}"
+          - name: BUSYBOX_IMAGE_DIGEST
+            value: "${BUSYBOX_IMAGE_DIGEST}"
           - name: BUSYBOX_IMAGE_PULL_POLICY
             value: "${BUSYBOX_IMAGE_PULL_POLICY}"
           - name: FLUENTD_IMAGE
             value: "${FLUENTD_IMAGE}"
           - name: FLUENTD_IMAGE_TAG
             value: "${FLUENTD_IMAGE_TAG}"
+          - name: FLUENTD_IMAGE_DIGEST
+            value: "${FLUENTD_IMAGE_DIGEST}"
           - name: FLUENTD_IMAGE_PULL_POLICY
             value: "${FLUENTD_IMAGE_PULL_POLICY}"
           - name: CLOUDWATCH_SECRET
@@ -218,7 +224,7 @@ objects:
           - name: qontract-reconcile-sa-token
             mountPath: ${KUBE_SA_TOKEN_MOUNT_PATH}
         - name: fluentd
-          image: ${FLUENTD_IMAGE}:${FLUENTD_IMAGE_TAG}
+          image: ${FLUENTD_IMAGE}:${FLUENTD_IMAGE_TAG}@${FLUENTD_IMAGE_DIGEST}
           imagePullPolicy: ${FLUENTD_IMAGE_PULL_POLICY}
           env:
           - name: AWS_REGION
@@ -268,16 +274,22 @@ parameters:
   value: quay.io/app-sre/qontract-reconcile
 - name: IMAGE_TAG
   value: latest
+- name: IMAGE_DIGEST
+  value: ''
 - name: BUSYBOX_IMAGE
   value: registry.access.redhat.com/ubi8/ubi-minimal
 - name: BUSYBOX_IMAGE_TAG
   value: latest
+- name: BUSYBOX_IMAGE_DIGEST
+  value: ''
 - name: BUSYBOX_IMAGE_PULL_POLICY
   value: Always
 - name: FLUENTD_IMAGE
   value: quay.io/redhat-services-prod/app-sre-tenant/fluentd-master/fluentd-master
 - name: FLUENTD_IMAGE_TAG
   value: latest
+- name: FLUENTD_IMAGE_DIGEST
+  value: ''
 - name: FLUENTD_IMAGE_PULL_POLICY
   value: Always
 - name: ENVIRONMENT_NAME

--- a/reconcile/test/fixtures/helm/aws_account_shard_disabled.yml
+++ b/reconcile/test/fixtures/helm/aws_account_shard_disabled.yml
@@ -443,17 +443,17 @@ parameters:
 - name: BUSYBOX_IMAGE
   value: registry.access.redhat.com/ubi8/ubi-minimal
 - name: BUSYBOX_IMAGE_TAG
-  value: latest
+  value: 8.10-1781701121
 - name: BUSYBOX_IMAGE_DIGEST
-  value: ''
+  value: 'sha256:5d76d0cedabd7d7893b28bec684d7a3412dd8d95d186e7d4b6eeed4ea28c327b'
 - name: BUSYBOX_IMAGE_PULL_POLICY
   value: Always
 - name: FLUENTD_IMAGE
   value: quay.io/redhat-services-prod/app-sre-tenant/fluentd-master/fluentd-master
 - name: FLUENTD_IMAGE_TAG
-  value: latest
+  value: d0d1812
 - name: FLUENTD_IMAGE_DIGEST
-  value: ''
+  value: 'sha256:4868ac49b42f14ff0878216cd2c618413209f634a5c9a6c004e353e1b0805e60'
 - name: FLUENTD_IMAGE_PULL_POLICY
   value: Always
 - name: ENVIRONMENT_NAME

--- a/reconcile/test/fixtures/helm/aws_account_shard_disabled.yml
+++ b/reconcile/test/fixtures/helm/aws_account_shard_disabled.yml
@@ -31,7 +31,7 @@ objects:
         serviceAccountName: qontract-reconcile
         initContainers:
         - name: config
-          image: ${BUSYBOX_IMAGE}:${BUSYBOX_IMAGE_TAG}
+          image: ${BUSYBOX_IMAGE}:${BUSYBOX_IMAGE_TAG}@${BUSYBOX_IMAGE_DIGEST}
           imagePullPolicy: ${BUSYBOX_IMAGE_PULL_POLICY}
           resources:
             requests:
@@ -100,7 +100,7 @@ objects:
             mountPath: /fluentd/etc/
         containers:
         - name: int
-          image: ${IMAGE}:${IMAGE_TAG}
+          image: ${IMAGE}:${IMAGE_TAG}@${IMAGE_DIGEST}
           ports:
             - name: http
               containerPort: 9090
@@ -167,7 +167,7 @@ objects:
           - name: qontract-reconcile-sa-token
             mountPath: ${KUBE_SA_TOKEN_MOUNT_PATH}
         - name: fluentd
-          image: ${FLUENTD_IMAGE}:${FLUENTD_IMAGE_TAG}
+          image: ${FLUENTD_IMAGE}:${FLUENTD_IMAGE_TAG}@${FLUENTD_IMAGE_DIGEST}
           imagePullPolicy: ${FLUENTD_IMAGE_PULL_POLICY}
           env:
           - name: AWS_REGION
@@ -238,7 +238,7 @@ objects:
         serviceAccountName: qontract-reconcile
         initContainers:
         - name: config
-          image: ${BUSYBOX_IMAGE}:${BUSYBOX_IMAGE_TAG}
+          image: ${BUSYBOX_IMAGE}:${BUSYBOX_IMAGE_TAG}@${BUSYBOX_IMAGE_DIGEST}
           imagePullPolicy: ${BUSYBOX_IMAGE_PULL_POLICY}
           resources:
             requests:
@@ -307,7 +307,7 @@ objects:
             mountPath: /fluentd/etc/
         containers:
         - name: int
-          image: ${IMAGE}:${IMAGE_TAG}
+          image: ${IMAGE}:${IMAGE_TAG}@${IMAGE_DIGEST}
           ports:
             - name: http
               containerPort: 9090
@@ -374,7 +374,7 @@ objects:
           - name: qontract-reconcile-sa-token
             mountPath: ${KUBE_SA_TOKEN_MOUNT_PATH}
         - name: fluentd
-          image: ${FLUENTD_IMAGE}:${FLUENTD_IMAGE_TAG}
+          image: ${FLUENTD_IMAGE}:${FLUENTD_IMAGE_TAG}@${FLUENTD_IMAGE_DIGEST}
           imagePullPolicy: ${FLUENTD_IMAGE_PULL_POLICY}
           env:
           - name: AWS_REGION
@@ -438,16 +438,22 @@ parameters:
   value: quay.io/app-sre/qontract-reconcile
 - name: IMAGE_TAG
   value: latest
+- name: IMAGE_DIGEST
+  value: ''
 - name: BUSYBOX_IMAGE
   value: registry.access.redhat.com/ubi8/ubi-minimal
 - name: BUSYBOX_IMAGE_TAG
   value: latest
+- name: BUSYBOX_IMAGE_DIGEST
+  value: ''
 - name: BUSYBOX_IMAGE_PULL_POLICY
   value: Always
 - name: FLUENTD_IMAGE
   value: quay.io/redhat-services-prod/app-sre-tenant/fluentd-master/fluentd-master
 - name: FLUENTD_IMAGE_TAG
   value: latest
+- name: FLUENTD_IMAGE_DIGEST
+  value: ''
 - name: FLUENTD_IMAGE_PULL_POLICY
   value: Always
 - name: ENVIRONMENT_NAME

--- a/reconcile/test/fixtures/helm/aws_account_shard_spec_override.yml
+++ b/reconcile/test/fixtures/helm/aws_account_shard_spec_override.yml
@@ -443,17 +443,17 @@ parameters:
 - name: BUSYBOX_IMAGE
   value: registry.access.redhat.com/ubi8/ubi-minimal
 - name: BUSYBOX_IMAGE_TAG
-  value: latest
+  value: 8.10-1781701121
 - name: BUSYBOX_IMAGE_DIGEST
-  value: ''
+  value: 'sha256:5d76d0cedabd7d7893b28bec684d7a3412dd8d95d186e7d4b6eeed4ea28c327b'
 - name: BUSYBOX_IMAGE_PULL_POLICY
   value: Always
 - name: FLUENTD_IMAGE
   value: quay.io/redhat-services-prod/app-sre-tenant/fluentd-master/fluentd-master
 - name: FLUENTD_IMAGE_TAG
-  value: latest
+  value: d0d1812
 - name: FLUENTD_IMAGE_DIGEST
-  value: ''
+  value: 'sha256:4868ac49b42f14ff0878216cd2c618413209f634a5c9a6c004e353e1b0805e60'
 - name: FLUENTD_IMAGE_PULL_POLICY
   value: Always
 - name: ENVIRONMENT_NAME

--- a/reconcile/test/fixtures/helm/aws_account_shard_spec_override.yml
+++ b/reconcile/test/fixtures/helm/aws_account_shard_spec_override.yml
@@ -31,7 +31,7 @@ objects:
         serviceAccountName: qontract-reconcile
         initContainers:
         - name: config
-          image: ${BUSYBOX_IMAGE}:${BUSYBOX_IMAGE_TAG}
+          image: ${BUSYBOX_IMAGE}:${BUSYBOX_IMAGE_TAG}@${BUSYBOX_IMAGE_DIGEST}
           imagePullPolicy: ${BUSYBOX_IMAGE_PULL_POLICY}
           resources:
             requests:
@@ -100,7 +100,7 @@ objects:
             mountPath: /fluentd/etc/
         containers:
         - name: int
-          image: ${IMAGE}:${IMAGE_TAG}
+          image: ${IMAGE}:${IMAGE_TAG}@${IMAGE_DIGEST}
           ports:
             - name: http
               containerPort: 9090
@@ -167,7 +167,7 @@ objects:
           - name: qontract-reconcile-sa-token
             mountPath: ${KUBE_SA_TOKEN_MOUNT_PATH}
         - name: fluentd
-          image: ${FLUENTD_IMAGE}:${FLUENTD_IMAGE_TAG}
+          image: ${FLUENTD_IMAGE}:${FLUENTD_IMAGE_TAG}@${FLUENTD_IMAGE_DIGEST}
           imagePullPolicy: ${FLUENTD_IMAGE_PULL_POLICY}
           env:
           - name: AWS_REGION
@@ -238,7 +238,7 @@ objects:
         serviceAccountName: qontract-reconcile
         initContainers:
         - name: config
-          image: ${BUSYBOX_IMAGE}:${BUSYBOX_IMAGE_TAG}
+          image: ${BUSYBOX_IMAGE}:${BUSYBOX_IMAGE_TAG}@${BUSYBOX_IMAGE_DIGEST}
           imagePullPolicy: ${BUSYBOX_IMAGE_PULL_POLICY}
           resources:
             requests:
@@ -374,7 +374,7 @@ objects:
           - name: qontract-reconcile-sa-token
             mountPath: ${KUBE_SA_TOKEN_MOUNT_PATH}
         - name: fluentd
-          image: ${FLUENTD_IMAGE}:${FLUENTD_IMAGE_TAG}
+          image: ${FLUENTD_IMAGE}:${FLUENTD_IMAGE_TAG}@${FLUENTD_IMAGE_DIGEST}
           imagePullPolicy: ${FLUENTD_IMAGE_PULL_POLICY}
           env:
           - name: AWS_REGION
@@ -438,16 +438,22 @@ parameters:
   value: quay.io/app-sre/qontract-reconcile
 - name: IMAGE_TAG
   value: latest
+- name: IMAGE_DIGEST
+  value: ''
 - name: BUSYBOX_IMAGE
   value: registry.access.redhat.com/ubi8/ubi-minimal
 - name: BUSYBOX_IMAGE_TAG
   value: latest
+- name: BUSYBOX_IMAGE_DIGEST
+  value: ''
 - name: BUSYBOX_IMAGE_PULL_POLICY
   value: Always
 - name: FLUENTD_IMAGE
   value: quay.io/redhat-services-prod/app-sre-tenant/fluentd-master/fluentd-master
 - name: FLUENTD_IMAGE_TAG
   value: latest
+- name: FLUENTD_IMAGE_DIGEST
+  value: ''
 - name: FLUENTD_IMAGE_PULL_POLICY
   value: Always
 - name: ENVIRONMENT_NAME

--- a/reconcile/test/fixtures/helm/aws_account_shards.yml
+++ b/reconcile/test/fixtures/helm/aws_account_shards.yml
@@ -443,17 +443,17 @@ parameters:
 - name: BUSYBOX_IMAGE
   value: registry.access.redhat.com/ubi8/ubi-minimal
 - name: BUSYBOX_IMAGE_TAG
-  value: latest
+  value: 8.10-1781701121
 - name: BUSYBOX_IMAGE_DIGEST
-  value: ''
+  value: 'sha256:5d76d0cedabd7d7893b28bec684d7a3412dd8d95d186e7d4b6eeed4ea28c327b'
 - name: BUSYBOX_IMAGE_PULL_POLICY
   value: Always
 - name: FLUENTD_IMAGE
   value: quay.io/redhat-services-prod/app-sre-tenant/fluentd-master/fluentd-master
 - name: FLUENTD_IMAGE_TAG
-  value: latest
+  value: d0d1812
 - name: FLUENTD_IMAGE_DIGEST
-  value: ''
+  value: 'sha256:4868ac49b42f14ff0878216cd2c618413209f634a5c9a6c004e353e1b0805e60'
 - name: FLUENTD_IMAGE_PULL_POLICY
   value: Always
 - name: ENVIRONMENT_NAME

--- a/reconcile/test/fixtures/helm/aws_account_shards.yml
+++ b/reconcile/test/fixtures/helm/aws_account_shards.yml
@@ -31,7 +31,7 @@ objects:
         serviceAccountName: qontract-reconcile
         initContainers:
         - name: config
-          image: ${BUSYBOX_IMAGE}:${BUSYBOX_IMAGE_TAG}
+          image: ${BUSYBOX_IMAGE}:${BUSYBOX_IMAGE_TAG}@${BUSYBOX_IMAGE_DIGEST}
           imagePullPolicy: ${BUSYBOX_IMAGE_PULL_POLICY}
           resources:
             requests:
@@ -100,7 +100,7 @@ objects:
             mountPath: /fluentd/etc/
         containers:
         - name: int
-          image: ${IMAGE}:${IMAGE_TAG}
+          image: ${IMAGE}:${IMAGE_TAG}@${IMAGE_DIGEST}
           ports:
             - name: http
               containerPort: 9090
@@ -167,7 +167,7 @@ objects:
           - name: qontract-reconcile-sa-token
             mountPath: ${KUBE_SA_TOKEN_MOUNT_PATH}
         - name: fluentd
-          image: ${FLUENTD_IMAGE}:${FLUENTD_IMAGE_TAG}
+          image: ${FLUENTD_IMAGE}:${FLUENTD_IMAGE_TAG}@${FLUENTD_IMAGE_DIGEST}
           imagePullPolicy: ${FLUENTD_IMAGE_PULL_POLICY}
           env:
           - name: AWS_REGION
@@ -238,7 +238,7 @@ objects:
         serviceAccountName: qontract-reconcile
         initContainers:
         - name: config
-          image: ${BUSYBOX_IMAGE}:${BUSYBOX_IMAGE_TAG}
+          image: ${BUSYBOX_IMAGE}:${BUSYBOX_IMAGE_TAG}@${BUSYBOX_IMAGE_DIGEST}
           imagePullPolicy: ${BUSYBOX_IMAGE_PULL_POLICY}
           resources:
             requests:
@@ -307,7 +307,7 @@ objects:
             mountPath: /fluentd/etc/
         containers:
         - name: int
-          image: ${IMAGE}:${IMAGE_TAG}
+          image: ${IMAGE}:${IMAGE_TAG}@${IMAGE_DIGEST}
           ports:
             - name: http
               containerPort: 9090
@@ -374,7 +374,7 @@ objects:
           - name: qontract-reconcile-sa-token
             mountPath: ${KUBE_SA_TOKEN_MOUNT_PATH}
         - name: fluentd
-          image: ${FLUENTD_IMAGE}:${FLUENTD_IMAGE_TAG}
+          image: ${FLUENTD_IMAGE}:${FLUENTD_IMAGE_TAG}@${FLUENTD_IMAGE_DIGEST}
           imagePullPolicy: ${FLUENTD_IMAGE_PULL_POLICY}
           env:
           - name: AWS_REGION
@@ -438,16 +438,22 @@ parameters:
   value: quay.io/app-sre/qontract-reconcile
 - name: IMAGE_TAG
   value: latest
+- name: IMAGE_DIGEST
+  value: ''
 - name: BUSYBOX_IMAGE
   value: registry.access.redhat.com/ubi8/ubi-minimal
 - name: BUSYBOX_IMAGE_TAG
   value: latest
+- name: BUSYBOX_IMAGE_DIGEST
+  value: ''
 - name: BUSYBOX_IMAGE_PULL_POLICY
   value: Always
 - name: FLUENTD_IMAGE
   value: quay.io/redhat-services-prod/app-sre-tenant/fluentd-master/fluentd-master
 - name: FLUENTD_IMAGE_TAG
   value: latest
+- name: FLUENTD_IMAGE_DIGEST
+  value: ''
 - name: FLUENTD_IMAGE_PULL_POLICY
   value: Always
 - name: ENVIRONMENT_NAME

--- a/reconcile/test/fixtures/helm/basic.yml
+++ b/reconcile/test/fixtures/helm/basic.yml
@@ -31,7 +31,7 @@ objects:
         serviceAccountName: qontract-reconcile
         initContainers:
         - name: config
-          image: ${BUSYBOX_IMAGE}:${BUSYBOX_IMAGE_TAG}
+          image: ${BUSYBOX_IMAGE}:${BUSYBOX_IMAGE_TAG}@${BUSYBOX_IMAGE_DIGEST}
           imagePullPolicy: ${BUSYBOX_IMAGE_PULL_POLICY}
           resources:
             requests:
@@ -100,7 +100,7 @@ objects:
             mountPath: /fluentd/etc/
         containers:
         - name: int
-          image: ${IMAGE}:${IMAGE_TAG}
+          image: ${IMAGE}:${IMAGE_TAG}@${IMAGE_DIGEST}
           ports:
             - name: http
               containerPort: 9090
@@ -165,7 +165,7 @@ objects:
           - name: qontract-reconcile-sa-token
             mountPath: ${KUBE_SA_TOKEN_MOUNT_PATH}
         - name: fluentd
-          image: ${FLUENTD_IMAGE}:${FLUENTD_IMAGE_TAG}
+          image: ${FLUENTD_IMAGE}:${FLUENTD_IMAGE_TAG}@${FLUENTD_IMAGE_DIGEST}
           imagePullPolicy: ${FLUENTD_IMAGE_PULL_POLICY}
           env:
           - name: AWS_REGION
@@ -229,16 +229,22 @@ parameters:
   value: quay.io/app-sre/qontract-reconcile
 - name: IMAGE_TAG
   value: latest
+- name: IMAGE_DIGEST
+  value: ''
 - name: BUSYBOX_IMAGE
   value: registry.access.redhat.com/ubi8/ubi-minimal
 - name: BUSYBOX_IMAGE_TAG
   value: latest
+- name: BUSYBOX_IMAGE_DIGEST
+  value: ''
 - name: BUSYBOX_IMAGE_PULL_POLICY
   value: Always
 - name: FLUENTD_IMAGE
   value: quay.io/redhat-services-prod/app-sre-tenant/fluentd-master/fluentd-master
 - name: FLUENTD_IMAGE_TAG
   value: latest
+- name: FLUENTD_IMAGE_DIGEST
+  value: ''
 - name: FLUENTD_IMAGE_PULL_POLICY
   value: Always
 - name: ENVIRONMENT_NAME

--- a/reconcile/test/fixtures/helm/basic.yml
+++ b/reconcile/test/fixtures/helm/basic.yml
@@ -234,17 +234,17 @@ parameters:
 - name: BUSYBOX_IMAGE
   value: registry.access.redhat.com/ubi8/ubi-minimal
 - name: BUSYBOX_IMAGE_TAG
-  value: latest
+  value: 8.10-1781701121
 - name: BUSYBOX_IMAGE_DIGEST
-  value: ''
+  value: 'sha256:5d76d0cedabd7d7893b28bec684d7a3412dd8d95d186e7d4b6eeed4ea28c327b'
 - name: BUSYBOX_IMAGE_PULL_POLICY
   value: Always
 - name: FLUENTD_IMAGE
   value: quay.io/redhat-services-prod/app-sre-tenant/fluentd-master/fluentd-master
 - name: FLUENTD_IMAGE_TAG
-  value: latest
+  value: d0d1812
 - name: FLUENTD_IMAGE_DIGEST
-  value: ''
+  value: 'sha256:4868ac49b42f14ff0878216cd2c618413209f634a5c9a6c004e353e1b0805e60'
 - name: FLUENTD_IMAGE_PULL_POLICY
   value: Always
 - name: ENVIRONMENT_NAME

--- a/reconcile/test/fixtures/helm/cache.yml
+++ b/reconcile/test/fixtures/helm/cache.yml
@@ -245,17 +245,17 @@ parameters:
 - name: BUSYBOX_IMAGE
   value: registry.access.redhat.com/ubi8/ubi-minimal
 - name: BUSYBOX_IMAGE_TAG
-  value: latest
+  value: 8.10-1781701121
 - name: BUSYBOX_IMAGE_DIGEST
-  value: ''
+  value: 'sha256:5d76d0cedabd7d7893b28bec684d7a3412dd8d95d186e7d4b6eeed4ea28c327b'
 - name: BUSYBOX_IMAGE_PULL_POLICY
   value: Always
 - name: FLUENTD_IMAGE
   value: quay.io/redhat-services-prod/app-sre-tenant/fluentd-master/fluentd-master
 - name: FLUENTD_IMAGE_TAG
-  value: latest
+  value: d0d1812
 - name: FLUENTD_IMAGE_DIGEST
-  value: ''
+  value: 'sha256:4868ac49b42f14ff0878216cd2c618413209f634a5c9a6c004e353e1b0805e60'
 - name: FLUENTD_IMAGE_PULL_POLICY
   value: Always
 - name: ENVIRONMENT_NAME

--- a/reconcile/test/fixtures/helm/cache.yml
+++ b/reconcile/test/fixtures/helm/cache.yml
@@ -40,7 +40,7 @@ objects:
         serviceAccountName: qontract-reconcile
         initContainers:
         - name: config
-          image: ${BUSYBOX_IMAGE}:${BUSYBOX_IMAGE_TAG}
+          image: ${BUSYBOX_IMAGE}:${BUSYBOX_IMAGE_TAG}@${BUSYBOX_IMAGE_DIGEST}
           imagePullPolicy: ${BUSYBOX_IMAGE_PULL_POLICY}
           resources:
             requests:
@@ -109,7 +109,7 @@ objects:
             mountPath: /fluentd/etc/
         containers:
         - name: int
-          image: ${IMAGE}:${IMAGE_TAG}
+          image: ${IMAGE}:${IMAGE_TAG}@${IMAGE_DIGEST}
           ports:
             - name: http
               containerPort: 9090
@@ -176,7 +176,7 @@ objects:
           - name: qontract-reconcile-sa-token
             mountPath: ${KUBE_SA_TOKEN_MOUNT_PATH}
         - name: fluentd
-          image: ${FLUENTD_IMAGE}:${FLUENTD_IMAGE_TAG}
+          image: ${FLUENTD_IMAGE}:${FLUENTD_IMAGE_TAG}@${FLUENTD_IMAGE_DIGEST}
           imagePullPolicy: ${FLUENTD_IMAGE_PULL_POLICY}
           env:
           - name: AWS_REGION
@@ -240,16 +240,22 @@ parameters:
   value: quay.io/app-sre/qontract-reconcile
 - name: IMAGE_TAG
   value: latest
+- name: IMAGE_DIGEST
+  value: ''
 - name: BUSYBOX_IMAGE
   value: registry.access.redhat.com/ubi8/ubi-minimal
 - name: BUSYBOX_IMAGE_TAG
   value: latest
+- name: BUSYBOX_IMAGE_DIGEST
+  value: ''
 - name: BUSYBOX_IMAGE_PULL_POLICY
   value: Always
 - name: FLUENTD_IMAGE
   value: quay.io/redhat-services-prod/app-sre-tenant/fluentd-master/fluentd-master
 - name: FLUENTD_IMAGE_TAG
   value: latest
+- name: FLUENTD_IMAGE_DIGEST
+  value: ''
 - name: FLUENTD_IMAGE_PULL_POLICY
   value: Always
 - name: ENVIRONMENT_NAME

--- a/reconcile/test/fixtures/helm/cache_storage_vars.yml
+++ b/reconcile/test/fixtures/helm/cache_storage_vars.yml
@@ -245,17 +245,17 @@ parameters:
 - name: BUSYBOX_IMAGE
   value: registry.access.redhat.com/ubi8/ubi-minimal
 - name: BUSYBOX_IMAGE_TAG
-  value: latest
+  value: 8.10-1781701121
 - name: BUSYBOX_IMAGE_DIGEST
-  value: ''
+  value: 'sha256:5d76d0cedabd7d7893b28bec684d7a3412dd8d95d186e7d4b6eeed4ea28c327b'
 - name: BUSYBOX_IMAGE_PULL_POLICY
   value: Always
 - name: FLUENTD_IMAGE
   value: quay.io/redhat-services-prod/app-sre-tenant/fluentd-master/fluentd-master
 - name: FLUENTD_IMAGE_TAG
-  value: latest
+  value: d0d1812
 - name: FLUENTD_IMAGE_DIGEST
-  value: ''
+  value: 'sha256:4868ac49b42f14ff0878216cd2c618413209f634a5c9a6c004e353e1b0805e60'
 - name: FLUENTD_IMAGE_PULL_POLICY
   value: Always
 - name: ENVIRONMENT_NAME

--- a/reconcile/test/fixtures/helm/cache_storage_vars.yml
+++ b/reconcile/test/fixtures/helm/cache_storage_vars.yml
@@ -40,7 +40,7 @@ objects:
         serviceAccountName: qontract-reconcile
         initContainers:
         - name: config
-          image: ${BUSYBOX_IMAGE}:${BUSYBOX_IMAGE_TAG}
+          image: ${BUSYBOX_IMAGE}:${BUSYBOX_IMAGE_TAG}@${BUSYBOX_IMAGE_DIGEST}
           imagePullPolicy: ${BUSYBOX_IMAGE_PULL_POLICY}
           resources:
             requests:
@@ -109,7 +109,7 @@ objects:
             mountPath: /fluentd/etc/
         containers:
         - name: int
-          image: ${IMAGE}:${IMAGE_TAG}
+          image: ${IMAGE}:${IMAGE_TAG}@${IMAGE_DIGEST}
           ports:
             - name: http
               containerPort: 9090
@@ -176,7 +176,7 @@ objects:
           - name: qontract-reconcile-sa-token
             mountPath: ${KUBE_SA_TOKEN_MOUNT_PATH}
         - name: fluentd
-          image: ${FLUENTD_IMAGE}:${FLUENTD_IMAGE_TAG}
+          image: ${FLUENTD_IMAGE}:${FLUENTD_IMAGE_TAG}@${FLUENTD_IMAGE_DIGEST}
           imagePullPolicy: ${FLUENTD_IMAGE_PULL_POLICY}
           env:
           - name: AWS_REGION
@@ -240,16 +240,22 @@ parameters:
   value: quay.io/app-sre/qontract-reconcile
 - name: IMAGE_TAG
   value: latest
+- name: IMAGE_DIGEST
+  value: ''
 - name: BUSYBOX_IMAGE
   value: registry.access.redhat.com/ubi8/ubi-minimal
 - name: BUSYBOX_IMAGE_TAG
   value: latest
+- name: BUSYBOX_IMAGE_DIGEST
+  value: ''
 - name: BUSYBOX_IMAGE_PULL_POLICY
   value: Always
 - name: FLUENTD_IMAGE
   value: quay.io/redhat-services-prod/app-sre-tenant/fluentd-master/fluentd-master
 - name: FLUENTD_IMAGE_TAG
   value: latest
+- name: FLUENTD_IMAGE_DIGEST
+  value: ''
 - name: FLUENTD_IMAGE_PULL_POLICY
   value: Always
 - name: ENVIRONMENT_NAME

--- a/reconcile/test/fixtures/helm/command.yml
+++ b/reconcile/test/fixtures/helm/command.yml
@@ -236,17 +236,17 @@ parameters:
 - name: BUSYBOX_IMAGE
   value: registry.access.redhat.com/ubi8/ubi-minimal
 - name: BUSYBOX_IMAGE_TAG
-  value: latest
+  value: 8.10-1781701121
 - name: BUSYBOX_IMAGE_DIGEST
-  value: ''
+  value: 'sha256:5d76d0cedabd7d7893b28bec684d7a3412dd8d95d186e7d4b6eeed4ea28c327b'
 - name: BUSYBOX_IMAGE_PULL_POLICY
   value: Always
 - name: FLUENTD_IMAGE
   value: quay.io/redhat-services-prod/app-sre-tenant/fluentd-master/fluentd-master
 - name: FLUENTD_IMAGE_TAG
-  value: latest
+  value: d0d1812
 - name: FLUENTD_IMAGE_DIGEST
-  value: ''
+  value: 'sha256:4868ac49b42f14ff0878216cd2c618413209f634a5c9a6c004e353e1b0805e60'
 - name: FLUENTD_IMAGE_PULL_POLICY
   value: Always
 - name: ENVIRONMENT_NAME

--- a/reconcile/test/fixtures/helm/command.yml
+++ b/reconcile/test/fixtures/helm/command.yml
@@ -31,7 +31,7 @@ objects:
         serviceAccountName: qontract-reconcile
         initContainers:
         - name: config
-          image: ${BUSYBOX_IMAGE}:${BUSYBOX_IMAGE_TAG}
+          image: ${BUSYBOX_IMAGE}:${BUSYBOX_IMAGE_TAG}@${BUSYBOX_IMAGE_DIGEST}
           imagePullPolicy: ${BUSYBOX_IMAGE_PULL_POLICY}
           resources:
             requests:
@@ -100,7 +100,7 @@ objects:
             mountPath: /fluentd/etc/
         containers:
         - name: int
-          image: ${IMAGE}:${IMAGE_TAG}
+          image: ${IMAGE}:${IMAGE_TAG}@${IMAGE_DIGEST}
           ports:
             - name: http
               containerPort: 9090
@@ -167,7 +167,7 @@ objects:
           - name: qontract-reconcile-sa-token
             mountPath: ${KUBE_SA_TOKEN_MOUNT_PATH}
         - name: fluentd
-          image: ${FLUENTD_IMAGE}:${FLUENTD_IMAGE_TAG}
+          image: ${FLUENTD_IMAGE}:${FLUENTD_IMAGE_TAG}@${FLUENTD_IMAGE_DIGEST}
           imagePullPolicy: ${FLUENTD_IMAGE_PULL_POLICY}
           env:
           - name: AWS_REGION
@@ -231,16 +231,22 @@ parameters:
   value: quay.io/app-sre/qontract-reconcile
 - name: IMAGE_TAG
   value: latest
+- name: IMAGE_DIGEST
+  value: ''
 - name: BUSYBOX_IMAGE
   value: registry.access.redhat.com/ubi8/ubi-minimal
 - name: BUSYBOX_IMAGE_TAG
   value: latest
+- name: BUSYBOX_IMAGE_DIGEST
+  value: ''
 - name: BUSYBOX_IMAGE_PULL_POLICY
   value: Always
 - name: FLUENTD_IMAGE
   value: quay.io/redhat-services-prod/app-sre-tenant/fluentd-master/fluentd-master
 - name: FLUENTD_IMAGE_TAG
   value: latest
+- name: FLUENTD_IMAGE_DIGEST
+  value: ''
 - name: FLUENTD_IMAGE_PULL_POLICY
   value: Always
 - name: ENVIRONMENT_NAME

--- a/reconcile/test/fixtures/helm/concurrency_policy.yml
+++ b/reconcile/test/fixtures/helm/concurrency_policy.yml
@@ -25,7 +25,7 @@ objects:
             serviceAccountName: qontract-reconcile
             containers:
             - name: int
-              image: ${IMAGE}:${IMAGE_TAG}
+              image: ${IMAGE}:${IMAGE_TAG}@${IMAGE_DIGEST}
               env:
               - name: RUN_ONCE
                 value: 'true'
@@ -93,16 +93,22 @@ parameters:
   value: quay.io/app-sre/qontract-reconcile
 - name: IMAGE_TAG
   value: latest
+- name: IMAGE_DIGEST
+  value: ''
 - name: BUSYBOX_IMAGE
   value: registry.access.redhat.com/ubi8/ubi-minimal
 - name: BUSYBOX_IMAGE_TAG
   value: latest
+- name: BUSYBOX_IMAGE_DIGEST
+  value: ''
 - name: BUSYBOX_IMAGE_PULL_POLICY
   value: Always
 - name: FLUENTD_IMAGE
   value: quay.io/redhat-services-prod/app-sre-tenant/fluentd-master/fluentd-master
 - name: FLUENTD_IMAGE_TAG
   value: latest
+- name: FLUENTD_IMAGE_DIGEST
+  value: ''
 - name: FLUENTD_IMAGE_PULL_POLICY
   value: Always
 - name: ENVIRONMENT_NAME

--- a/reconcile/test/fixtures/helm/concurrency_policy.yml
+++ b/reconcile/test/fixtures/helm/concurrency_policy.yml
@@ -98,17 +98,17 @@ parameters:
 - name: BUSYBOX_IMAGE
   value: registry.access.redhat.com/ubi8/ubi-minimal
 - name: BUSYBOX_IMAGE_TAG
-  value: latest
+  value: 8.10-1781701121
 - name: BUSYBOX_IMAGE_DIGEST
-  value: ''
+  value: 'sha256:5d76d0cedabd7d7893b28bec684d7a3412dd8d95d186e7d4b6eeed4ea28c327b'
 - name: BUSYBOX_IMAGE_PULL_POLICY
   value: Always
 - name: FLUENTD_IMAGE
   value: quay.io/redhat-services-prod/app-sre-tenant/fluentd-master/fluentd-master
 - name: FLUENTD_IMAGE_TAG
-  value: latest
+  value: d0d1812
 - name: FLUENTD_IMAGE_DIGEST
-  value: ''
+  value: 'sha256:4868ac49b42f14ff0878216cd2c618413209f634a5c9a6c004e353e1b0805e60'
 - name: FLUENTD_IMAGE_PULL_POLICY
   value: Always
 - name: ENVIRONMENT_NAME

--- a/reconcile/test/fixtures/helm/cron.yml
+++ b/reconcile/test/fixtures/helm/cron.yml
@@ -25,7 +25,7 @@ objects:
             serviceAccountName: qontract-reconcile
             containers:
             - name: int
-              image: ${IMAGE}:${IMAGE_TAG}
+              image: ${IMAGE}:${IMAGE_TAG}@${IMAGE_DIGEST}
               env:
               - name: RUN_ONCE
                 value: 'true'
@@ -93,16 +93,22 @@ parameters:
   value: quay.io/app-sre/qontract-reconcile
 - name: IMAGE_TAG
   value: latest
+- name: IMAGE_DIGEST
+  value: ''
 - name: BUSYBOX_IMAGE
   value: registry.access.redhat.com/ubi8/ubi-minimal
 - name: BUSYBOX_IMAGE_TAG
   value: latest
+- name: BUSYBOX_IMAGE_DIGEST
+  value: ''
 - name: BUSYBOX_IMAGE_PULL_POLICY
   value: Always
 - name: FLUENTD_IMAGE
   value: quay.io/redhat-services-prod/app-sre-tenant/fluentd-master/fluentd-master
 - name: FLUENTD_IMAGE_TAG
   value: latest
+- name: FLUENTD_IMAGE_DIGEST
+  value: ''
 - name: FLUENTD_IMAGE_PULL_POLICY
   value: Always
 - name: ENVIRONMENT_NAME

--- a/reconcile/test/fixtures/helm/cron.yml
+++ b/reconcile/test/fixtures/helm/cron.yml
@@ -98,17 +98,17 @@ parameters:
 - name: BUSYBOX_IMAGE
   value: registry.access.redhat.com/ubi8/ubi-minimal
 - name: BUSYBOX_IMAGE_TAG
-  value: latest
+  value: 8.10-1781701121
 - name: BUSYBOX_IMAGE_DIGEST
-  value: ''
+  value: 'sha256:5d76d0cedabd7d7893b28bec684d7a3412dd8d95d186e7d4b6eeed4ea28c327b'
 - name: BUSYBOX_IMAGE_PULL_POLICY
   value: Always
 - name: FLUENTD_IMAGE
   value: quay.io/redhat-services-prod/app-sre-tenant/fluentd-master/fluentd-master
 - name: FLUENTD_IMAGE_TAG
-  value: latest
+  value: d0d1812
 - name: FLUENTD_IMAGE_DIGEST
-  value: ''
+  value: 'sha256:4868ac49b42f14ff0878216cd2c618413209f634a5c9a6c004e353e1b0805e60'
 - name: FLUENTD_IMAGE_PULL_POLICY
   value: Always
 - name: ENVIRONMENT_NAME

--- a/reconcile/test/fixtures/helm/dashdotdb.yml
+++ b/reconcile/test/fixtures/helm/dashdotdb.yml
@@ -103,17 +103,17 @@ parameters:
 - name: BUSYBOX_IMAGE
   value: registry.access.redhat.com/ubi8/ubi-minimal
 - name: BUSYBOX_IMAGE_TAG
-  value: latest
+  value: 8.10-1781701121
 - name: BUSYBOX_IMAGE_DIGEST
-  value: ''
+  value: 'sha256:5d76d0cedabd7d7893b28bec684d7a3412dd8d95d186e7d4b6eeed4ea28c327b'
 - name: BUSYBOX_IMAGE_PULL_POLICY
   value: Always
 - name: FLUENTD_IMAGE
   value: quay.io/redhat-services-prod/app-sre-tenant/fluentd-master/fluentd-master
 - name: FLUENTD_IMAGE_TAG
-  value: latest
+  value: d0d1812
 - name: FLUENTD_IMAGE_DIGEST
-  value: ''
+  value: 'sha256:4868ac49b42f14ff0878216cd2c618413209f634a5c9a6c004e353e1b0805e60'
 - name: FLUENTD_IMAGE_PULL_POLICY
   value: Always
 - name: ENVIRONMENT_NAME

--- a/reconcile/test/fixtures/helm/dashdotdb.yml
+++ b/reconcile/test/fixtures/helm/dashdotdb.yml
@@ -25,7 +25,7 @@ objects:
             serviceAccountName: qontract-reconcile
             containers:
             - name: int
-              image: ${IMAGE}:${IMAGE_TAG}
+              image: ${IMAGE}:${IMAGE_TAG}@${IMAGE_DIGEST}
               env:
               - name: RUN_ONCE
                 value: 'true'
@@ -98,16 +98,22 @@ parameters:
   value: quay.io/app-sre/qontract-reconcile
 - name: IMAGE_TAG
   value: latest
+- name: IMAGE_DIGEST
+  value: ''
 - name: BUSYBOX_IMAGE
   value: registry.access.redhat.com/ubi8/ubi-minimal
 - name: BUSYBOX_IMAGE_TAG
   value: latest
+- name: BUSYBOX_IMAGE_DIGEST
+  value: ''
 - name: BUSYBOX_IMAGE_PULL_POLICY
   value: Always
 - name: FLUENTD_IMAGE
   value: quay.io/redhat-services-prod/app-sre-tenant/fluentd-master/fluentd-master
 - name: FLUENTD_IMAGE_TAG
   value: latest
+- name: FLUENTD_IMAGE_DIGEST
+  value: ''
 - name: FLUENTD_IMAGE_PULL_POLICY
   value: Always
 - name: ENVIRONMENT_NAME

--- a/reconcile/test/fixtures/helm/disable_unleash.yml
+++ b/reconcile/test/fixtures/helm/disable_unleash.yml
@@ -222,17 +222,17 @@ parameters:
 - name: BUSYBOX_IMAGE
   value: registry.access.redhat.com/ubi8/ubi-minimal
 - name: BUSYBOX_IMAGE_TAG
-  value: latest
+  value: 8.10-1781701121
 - name: BUSYBOX_IMAGE_DIGEST
-  value: ''
+  value: 'sha256:5d76d0cedabd7d7893b28bec684d7a3412dd8d95d186e7d4b6eeed4ea28c327b'
 - name: BUSYBOX_IMAGE_PULL_POLICY
   value: Always
 - name: FLUENTD_IMAGE
   value: quay.io/redhat-services-prod/app-sre-tenant/fluentd-master/fluentd-master
 - name: FLUENTD_IMAGE_TAG
-  value: latest
+  value: d0d1812
 - name: FLUENTD_IMAGE_DIGEST
-  value: ''
+  value: 'sha256:4868ac49b42f14ff0878216cd2c618413209f634a5c9a6c004e353e1b0805e60'
 - name: FLUENTD_IMAGE_PULL_POLICY
   value: Always
 - name: ENVIRONMENT_NAME

--- a/reconcile/test/fixtures/helm/disable_unleash.yml
+++ b/reconcile/test/fixtures/helm/disable_unleash.yml
@@ -31,7 +31,7 @@ objects:
         serviceAccountName: qontract-reconcile
         initContainers:
         - name: config
-          image: ${BUSYBOX_IMAGE}:${BUSYBOX_IMAGE_TAG}
+          image: ${BUSYBOX_IMAGE}:${BUSYBOX_IMAGE_TAG}@${BUSYBOX_IMAGE_DIGEST}
           imagePullPolicy: ${BUSYBOX_IMAGE_PULL_POLICY}
           resources:
             requests:
@@ -100,7 +100,7 @@ objects:
             mountPath: /fluentd/etc/
         containers:
         - name: int
-          image: ${IMAGE}:${IMAGE_TAG}
+          image: ${IMAGE}:${IMAGE_TAG}@${IMAGE_DIGEST}
           ports:
             - name: http
               containerPort: 9090
@@ -153,7 +153,7 @@ objects:
           - name: qontract-reconcile-sa-token
             mountPath: ${KUBE_SA_TOKEN_MOUNT_PATH}
         - name: fluentd
-          image: ${FLUENTD_IMAGE}:${FLUENTD_IMAGE_TAG}
+          image: ${FLUENTD_IMAGE}:${FLUENTD_IMAGE_TAG}@${FLUENTD_IMAGE_DIGEST}
           imagePullPolicy: ${FLUENTD_IMAGE_PULL_POLICY}
           env:
           - name: AWS_REGION
@@ -217,16 +217,22 @@ parameters:
   value: quay.io/app-sre/qontract-reconcile
 - name: IMAGE_TAG
   value: latest
+- name: IMAGE_DIGEST
+  value: ''
 - name: BUSYBOX_IMAGE
   value: registry.access.redhat.com/ubi8/ubi-minimal
 - name: BUSYBOX_IMAGE_TAG
   value: latest
+- name: BUSYBOX_IMAGE_DIGEST
+  value: ''
 - name: BUSYBOX_IMAGE_PULL_POLICY
   value: Always
 - name: FLUENTD_IMAGE
   value: quay.io/redhat-services-prod/app-sre-tenant/fluentd-master/fluentd-master
 - name: FLUENTD_IMAGE_TAG
   value: latest
+- name: FLUENTD_IMAGE_DIGEST
+  value: ''
 - name: FLUENTD_IMAGE_PULL_POLICY
   value: Always
 - name: ENVIRONMENT_NAME

--- a/reconcile/test/fixtures/helm/enable_google_chat.yml
+++ b/reconcile/test/fixtures/helm/enable_google_chat.yml
@@ -277,17 +277,17 @@ parameters:
 - name: BUSYBOX_IMAGE
   value: registry.access.redhat.com/ubi8/ubi-minimal
 - name: BUSYBOX_IMAGE_TAG
-  value: latest
+  value: 8.10-1781701121
 - name: BUSYBOX_IMAGE_DIGEST
-  value: ''
+  value: 'sha256:5d76d0cedabd7d7893b28bec684d7a3412dd8d95d186e7d4b6eeed4ea28c327b'
 - name: BUSYBOX_IMAGE_PULL_POLICY
   value: Always
 - name: FLUENTD_IMAGE
   value: quay.io/redhat-services-prod/app-sre-tenant/fluentd-master/fluentd-master
 - name: FLUENTD_IMAGE_TAG
-  value: latest
+  value: d0d1812
 - name: FLUENTD_IMAGE_DIGEST
-  value: ''
+  value: 'sha256:4868ac49b42f14ff0878216cd2c618413209f634a5c9a6c004e353e1b0805e60'
 - name: FLUENTD_IMAGE_PULL_POLICY
   value: Always
 - name: ENVIRONMENT_NAME

--- a/reconcile/test/fixtures/helm/enable_google_chat.yml
+++ b/reconcile/test/fixtures/helm/enable_google_chat.yml
@@ -31,7 +31,7 @@ objects:
         serviceAccountName: qontract-reconcile
         initContainers:
         - name: config
-          image: ${BUSYBOX_IMAGE}:${BUSYBOX_IMAGE_TAG}
+          image: ${BUSYBOX_IMAGE}:${BUSYBOX_IMAGE_TAG}@${BUSYBOX_IMAGE_DIGEST}
           imagePullPolicy: ${BUSYBOX_IMAGE_PULL_POLICY}
           resources:
             requests:
@@ -137,7 +137,7 @@ objects:
             mountPath: /fluentd/etc/
         containers:
         - name: int
-          image: ${IMAGE}:${IMAGE_TAG}
+          image: ${IMAGE}:${IMAGE_TAG}@${IMAGE_DIGEST}
           ports:
             - name: http
               containerPort: 9090
@@ -204,7 +204,7 @@ objects:
           - name: qontract-reconcile-sa-token
             mountPath: ${KUBE_SA_TOKEN_MOUNT_PATH}
         - name: fluentd
-          image: ${FLUENTD_IMAGE}:${FLUENTD_IMAGE_TAG}
+          image: ${FLUENTD_IMAGE}:${FLUENTD_IMAGE_TAG}@${FLUENTD_IMAGE_DIGEST}
           imagePullPolicy: ${FLUENTD_IMAGE_PULL_POLICY}
           env:
           - name: AWS_REGION
@@ -272,16 +272,22 @@ parameters:
   value: quay.io/app-sre/qontract-reconcile
 - name: IMAGE_TAG
   value: latest
+- name: IMAGE_DIGEST
+  value: ''
 - name: BUSYBOX_IMAGE
   value: registry.access.redhat.com/ubi8/ubi-minimal
 - name: BUSYBOX_IMAGE_TAG
   value: latest
+- name: BUSYBOX_IMAGE_DIGEST
+  value: ''
 - name: BUSYBOX_IMAGE_PULL_POLICY
   value: Always
 - name: FLUENTD_IMAGE
   value: quay.io/redhat-services-prod/app-sre-tenant/fluentd-master/fluentd-master
 - name: FLUENTD_IMAGE_TAG
   value: latest
+- name: FLUENTD_IMAGE_DIGEST
+  value: ''
 - name: FLUENTD_IMAGE_PULL_POLICY
   value: Always
 - name: ENVIRONMENT_NAME

--- a/reconcile/test/fixtures/helm/enable_pushgateway.yml
+++ b/reconcile/test/fixtures/helm/enable_pushgateway.yml
@@ -25,7 +25,7 @@ objects:
             serviceAccountName: qontract-reconcile
             containers:
             - name: int
-              image: ${IMAGE}:${IMAGE_TAG}
+              image: ${IMAGE}:${IMAGE_TAG}@${IMAGE_DIGEST}
               env:
               - name: RUN_ONCE
                 value: 'true'
@@ -110,16 +110,22 @@ parameters:
   value: quay.io/app-sre/qontract-reconcile
 - name: IMAGE_TAG
   value: latest
+- name: IMAGE_DIGEST
+  value: ''
 - name: BUSYBOX_IMAGE
   value: registry.access.redhat.com/ubi8/ubi-minimal
 - name: BUSYBOX_IMAGE_TAG
   value: latest
+- name: BUSYBOX_IMAGE_DIGEST
+  value: ''
 - name: BUSYBOX_IMAGE_PULL_POLICY
   value: Always
 - name: FLUENTD_IMAGE
   value: quay.io/redhat-services-prod/app-sre-tenant/fluentd-master/fluentd-master
 - name: FLUENTD_IMAGE_TAG
   value: latest
+- name: FLUENTD_IMAGE_DIGEST
+  value: ''
 - name: FLUENTD_IMAGE_PULL_POLICY
   value: Always
 - name: ENVIRONMENT_NAME

--- a/reconcile/test/fixtures/helm/enable_pushgateway.yml
+++ b/reconcile/test/fixtures/helm/enable_pushgateway.yml
@@ -115,17 +115,17 @@ parameters:
 - name: BUSYBOX_IMAGE
   value: registry.access.redhat.com/ubi8/ubi-minimal
 - name: BUSYBOX_IMAGE_TAG
-  value: latest
+  value: 8.10-1781701121
 - name: BUSYBOX_IMAGE_DIGEST
-  value: ''
+  value: 'sha256:5d76d0cedabd7d7893b28bec684d7a3412dd8d95d186e7d4b6eeed4ea28c327b'
 - name: BUSYBOX_IMAGE_PULL_POLICY
   value: Always
 - name: FLUENTD_IMAGE
   value: quay.io/redhat-services-prod/app-sre-tenant/fluentd-master/fluentd-master
 - name: FLUENTD_IMAGE_TAG
-  value: latest
+  value: d0d1812
 - name: FLUENTD_IMAGE_DIGEST
-  value: ''
+  value: 'sha256:4868ac49b42f14ff0878216cd2c618413209f634a5c9a6c004e353e1b0805e60'
 - name: FLUENTD_IMAGE_PULL_POLICY
   value: Always
 - name: ENVIRONMENT_NAME

--- a/reconcile/test/fixtures/helm/environment_aware.yml
+++ b/reconcile/test/fixtures/helm/environment_aware.yml
@@ -266,17 +266,17 @@ parameters:
 - name: BUSYBOX_IMAGE
   value: registry.access.redhat.com/ubi8/ubi-minimal
 - name: BUSYBOX_IMAGE_TAG
-  value: latest
+  value: 8.10-1781701121
 - name: BUSYBOX_IMAGE_DIGEST
-  value: ''
+  value: 'sha256:5d76d0cedabd7d7893b28bec684d7a3412dd8d95d186e7d4b6eeed4ea28c327b'
 - name: BUSYBOX_IMAGE_PULL_POLICY
   value: Always
 - name: FLUENTD_IMAGE
   value: quay.io/redhat-services-prod/app-sre-tenant/fluentd-master/fluentd-master
 - name: FLUENTD_IMAGE_TAG
-  value: latest
+  value: d0d1812
 - name: FLUENTD_IMAGE_DIGEST
-  value: ''
+  value: 'sha256:4868ac49b42f14ff0878216cd2c618413209f634a5c9a6c004e353e1b0805e60'
 - name: FLUENTD_IMAGE_PULL_POLICY
   value: Always
 - name: ENVIRONMENT_NAME

--- a/reconcile/test/fixtures/helm/environment_aware.yml
+++ b/reconcile/test/fixtures/helm/environment_aware.yml
@@ -31,7 +31,7 @@ objects:
         serviceAccountName: qontract-reconcile
         initContainers:
         - name: config
-          image: ${BUSYBOX_IMAGE}:${BUSYBOX_IMAGE_TAG}
+          image: ${BUSYBOX_IMAGE}:${BUSYBOX_IMAGE_TAG}@${BUSYBOX_IMAGE_DIGEST}
           imagePullPolicy: ${BUSYBOX_IMAGE_PULL_POLICY}
           resources:
             requests:
@@ -100,7 +100,7 @@ objects:
             mountPath: /fluentd/etc/
         containers:
         - name: int
-          image: ${IMAGE}:${IMAGE_TAG}
+          image: ${IMAGE}:${IMAGE_TAG}@${IMAGE_DIGEST}
           ports:
             - name: http
               containerPort: 9090
@@ -155,16 +155,22 @@ objects:
             value: "${IMAGE}"
           - name: IMAGE_TAG
             value: "${IMAGE_TAG}"
+          - name: IMAGE_DIGEST
+            value: "${IMAGE_DIGEST}"
           - name: BUSYBOX_IMAGE
             value: "${BUSYBOX_IMAGE}"
           - name: BUSYBOX_IMAGE_TAG
             value: "${BUSYBOX_IMAGE_TAG}"
+          - name: BUSYBOX_IMAGE_DIGEST
+            value: "${BUSYBOX_IMAGE_DIGEST}"
           - name: BUSYBOX_IMAGE_PULL_POLICY
             value: "${BUSYBOX_IMAGE_PULL_POLICY}"
           - name: FLUENTD_IMAGE
             value: "${FLUENTD_IMAGE}"
           - name: FLUENTD_IMAGE_TAG
             value: "${FLUENTD_IMAGE_TAG}"
+          - name: FLUENTD_IMAGE_DIGEST
+            value: "${FLUENTD_IMAGE_DIGEST}"
           - name: FLUENTD_IMAGE_PULL_POLICY
             value: "${FLUENTD_IMAGE_PULL_POLICY}"
           - name: CLOUDWATCH_SECRET
@@ -191,7 +197,7 @@ objects:
           - name: qontract-reconcile-sa-token
             mountPath: ${KUBE_SA_TOKEN_MOUNT_PATH}
         - name: fluentd
-          image: ${FLUENTD_IMAGE}:${FLUENTD_IMAGE_TAG}
+          image: ${FLUENTD_IMAGE}:${FLUENTD_IMAGE_TAG}@${FLUENTD_IMAGE_DIGEST}
           imagePullPolicy: ${FLUENTD_IMAGE_PULL_POLICY}
           env:
           - name: AWS_REGION
@@ -255,16 +261,22 @@ parameters:
   value: quay.io/app-sre/qontract-reconcile
 - name: IMAGE_TAG
   value: latest
+- name: IMAGE_DIGEST
+  value: ''
 - name: BUSYBOX_IMAGE
   value: registry.access.redhat.com/ubi8/ubi-minimal
 - name: BUSYBOX_IMAGE_TAG
   value: latest
+- name: BUSYBOX_IMAGE_DIGEST
+  value: ''
 - name: BUSYBOX_IMAGE_PULL_POLICY
   value: Always
 - name: FLUENTD_IMAGE
   value: quay.io/redhat-services-prod/app-sre-tenant/fluentd-master/fluentd-master
 - name: FLUENTD_IMAGE_TAG
   value: latest
+- name: FLUENTD_IMAGE_DIGEST
+  value: ''
 - name: FLUENTD_IMAGE_PULL_POLICY
   value: Always
 - name: ENVIRONMENT_NAME

--- a/reconcile/test/fixtures/helm/exclude_service.yml
+++ b/reconcile/test/fixtures/helm/exclude_service.yml
@@ -220,17 +220,17 @@ parameters:
 - name: BUSYBOX_IMAGE
   value: registry.access.redhat.com/ubi8/ubi-minimal
 - name: BUSYBOX_IMAGE_TAG
-  value: latest
+  value: 8.10-1781701121
 - name: BUSYBOX_IMAGE_DIGEST
-  value: ''
+  value: 'sha256:5d76d0cedabd7d7893b28bec684d7a3412dd8d95d186e7d4b6eeed4ea28c327b'
 - name: BUSYBOX_IMAGE_PULL_POLICY
   value: Always
 - name: FLUENTD_IMAGE
   value: quay.io/redhat-services-prod/app-sre-tenant/fluentd-master/fluentd-master
 - name: FLUENTD_IMAGE_TAG
-  value: latest
+  value: d0d1812
 - name: FLUENTD_IMAGE_DIGEST
-  value: ''
+  value: 'sha256:4868ac49b42f14ff0878216cd2c618413209f634a5c9a6c004e353e1b0805e60'
 - name: FLUENTD_IMAGE_PULL_POLICY
   value: Always
 - name: ENVIRONMENT_NAME

--- a/reconcile/test/fixtures/helm/exclude_service.yml
+++ b/reconcile/test/fixtures/helm/exclude_service.yml
@@ -31,7 +31,7 @@ objects:
         serviceAccountName: qontract-reconcile
         initContainers:
         - name: config
-          image: ${BUSYBOX_IMAGE}:${BUSYBOX_IMAGE_TAG}
+          image: ${BUSYBOX_IMAGE}:${BUSYBOX_IMAGE_TAG}@${BUSYBOX_IMAGE_DIGEST}
           imagePullPolicy: ${BUSYBOX_IMAGE_PULL_POLICY}
           resources:
             requests:
@@ -100,7 +100,7 @@ objects:
             mountPath: /fluentd/etc/
         containers:
         - name: int
-          image: ${IMAGE}:${IMAGE_TAG}
+          image: ${IMAGE}:${IMAGE_TAG}@${IMAGE_DIGEST}
           ports:
             - name: http
               containerPort: 9090
@@ -165,7 +165,7 @@ objects:
           - name: qontract-reconcile-sa-token
             mountPath: ${KUBE_SA_TOKEN_MOUNT_PATH}
         - name: fluentd
-          image: ${FLUENTD_IMAGE}:${FLUENTD_IMAGE_TAG}
+          image: ${FLUENTD_IMAGE}:${FLUENTD_IMAGE_TAG}@${FLUENTD_IMAGE_DIGEST}
           imagePullPolicy: ${FLUENTD_IMAGE_PULL_POLICY}
           env:
           - name: AWS_REGION
@@ -215,16 +215,22 @@ parameters:
   value: quay.io/app-sre/qontract-reconcile
 - name: IMAGE_TAG
   value: latest
+- name: IMAGE_DIGEST
+  value: ''
 - name: BUSYBOX_IMAGE
   value: registry.access.redhat.com/ubi8/ubi-minimal
 - name: BUSYBOX_IMAGE_TAG
   value: latest
+- name: BUSYBOX_IMAGE_DIGEST
+  value: ''
 - name: BUSYBOX_IMAGE_PULL_POLICY
   value: Always
 - name: FLUENTD_IMAGE
   value: quay.io/redhat-services-prod/app-sre-tenant/fluentd-master/fluentd-master
 - name: FLUENTD_IMAGE_TAG
   value: latest
+- name: FLUENTD_IMAGE_DIGEST
+  value: ''
 - name: FLUENTD_IMAGE_PULL_POLICY
   value: Always
 - name: ENVIRONMENT_NAME

--- a/reconcile/test/fixtures/helm/extra_args.yml
+++ b/reconcile/test/fixtures/helm/extra_args.yml
@@ -236,17 +236,17 @@ parameters:
 - name: BUSYBOX_IMAGE
   value: registry.access.redhat.com/ubi8/ubi-minimal
 - name: BUSYBOX_IMAGE_TAG
-  value: latest
+  value: 8.10-1781701121
 - name: BUSYBOX_IMAGE_DIGEST
-  value: ''
+  value: 'sha256:5d76d0cedabd7d7893b28bec684d7a3412dd8d95d186e7d4b6eeed4ea28c327b'
 - name: BUSYBOX_IMAGE_PULL_POLICY
   value: Always
 - name: FLUENTD_IMAGE
   value: quay.io/redhat-services-prod/app-sre-tenant/fluentd-master/fluentd-master
 - name: FLUENTD_IMAGE_TAG
-  value: latest
+  value: d0d1812
 - name: FLUENTD_IMAGE_DIGEST
-  value: ''
+  value: 'sha256:4868ac49b42f14ff0878216cd2c618413209f634a5c9a6c004e353e1b0805e60'
 - name: FLUENTD_IMAGE_PULL_POLICY
   value: Always
 - name: ENVIRONMENT_NAME

--- a/reconcile/test/fixtures/helm/extra_args.yml
+++ b/reconcile/test/fixtures/helm/extra_args.yml
@@ -31,7 +31,7 @@ objects:
         serviceAccountName: qontract-reconcile
         initContainers:
         - name: config
-          image: ${BUSYBOX_IMAGE}:${BUSYBOX_IMAGE_TAG}
+          image: ${BUSYBOX_IMAGE}:${BUSYBOX_IMAGE_TAG}@${BUSYBOX_IMAGE_DIGEST}
           imagePullPolicy: ${BUSYBOX_IMAGE_PULL_POLICY}
           resources:
             requests:
@@ -100,7 +100,7 @@ objects:
             mountPath: /fluentd/etc/
         containers:
         - name: int
-          image: ${IMAGE}:${IMAGE_TAG}
+          image: ${IMAGE}:${IMAGE_TAG}@${IMAGE_DIGEST}
           ports:
             - name: http
               containerPort: 9090
@@ -167,7 +167,7 @@ objects:
           - name: qontract-reconcile-sa-token
             mountPath: ${KUBE_SA_TOKEN_MOUNT_PATH}
         - name: fluentd
-          image: ${FLUENTD_IMAGE}:${FLUENTD_IMAGE_TAG}
+          image: ${FLUENTD_IMAGE}:${FLUENTD_IMAGE_TAG}@${FLUENTD_IMAGE_DIGEST}
           imagePullPolicy: ${FLUENTD_IMAGE_PULL_POLICY}
           env:
           - name: AWS_REGION
@@ -231,16 +231,22 @@ parameters:
   value: quay.io/app-sre/qontract-reconcile
 - name: IMAGE_TAG
   value: latest
+- name: IMAGE_DIGEST
+  value: ''
 - name: BUSYBOX_IMAGE
   value: registry.access.redhat.com/ubi8/ubi-minimal
 - name: BUSYBOX_IMAGE_TAG
   value: latest
+- name: BUSYBOX_IMAGE_DIGEST
+  value: ''
 - name: BUSYBOX_IMAGE_PULL_POLICY
   value: Always
 - name: FLUENTD_IMAGE
   value: quay.io/redhat-services-prod/app-sre-tenant/fluentd-master/fluentd-master
 - name: FLUENTD_IMAGE_TAG
   value: latest
+- name: FLUENTD_IMAGE_DIGEST
+  value: ''
 - name: FLUENTD_IMAGE_PULL_POLICY
   value: Always
 - name: ENVIRONMENT_NAME

--- a/reconcile/test/fixtures/helm/extra_env.yml
+++ b/reconcile/test/fixtures/helm/extra_env.yml
@@ -31,7 +31,7 @@ objects:
         serviceAccountName: qontract-reconcile
         initContainers:
         - name: config
-          image: ${BUSYBOX_IMAGE}:${BUSYBOX_IMAGE_TAG}
+          image: ${BUSYBOX_IMAGE}:${BUSYBOX_IMAGE_TAG}@${BUSYBOX_IMAGE_DIGEST}
           imagePullPolicy: ${BUSYBOX_IMAGE_PULL_POLICY}
           resources:
             requests:
@@ -100,7 +100,7 @@ objects:
             mountPath: /fluentd/etc/
         containers:
         - name: int
-          image: ${IMAGE}:${IMAGE_TAG}
+          image: ${IMAGE}:${IMAGE_TAG}@${IMAGE_DIGEST}
           ports:
             - name: http
               containerPort: 9090
@@ -172,7 +172,7 @@ objects:
           - name: qontract-reconcile-sa-token
             mountPath: ${KUBE_SA_TOKEN_MOUNT_PATH}
         - name: fluentd
-          image: ${FLUENTD_IMAGE}:${FLUENTD_IMAGE_TAG}
+          image: ${FLUENTD_IMAGE}:${FLUENTD_IMAGE_TAG}@${FLUENTD_IMAGE_DIGEST}
           imagePullPolicy: ${FLUENTD_IMAGE_PULL_POLICY}
           env:
           - name: AWS_REGION
@@ -236,16 +236,22 @@ parameters:
   value: quay.io/app-sre/qontract-reconcile
 - name: IMAGE_TAG
   value: latest
+- name: IMAGE_DIGEST
+  value: ''
 - name: BUSYBOX_IMAGE
   value: registry.access.redhat.com/ubi8/ubi-minimal
 - name: BUSYBOX_IMAGE_TAG
   value: latest
+- name: BUSYBOX_IMAGE_DIGEST
+  value: ''
 - name: BUSYBOX_IMAGE_PULL_POLICY
   value: Always
 - name: FLUENTD_IMAGE
   value: quay.io/redhat-services-prod/app-sre-tenant/fluentd-master/fluentd-master
 - name: FLUENTD_IMAGE_TAG
   value: latest
+- name: FLUENTD_IMAGE_DIGEST
+  value: ''
 - name: FLUENTD_IMAGE_PULL_POLICY
   value: Always
 - name: ENVIRONMENT_NAME

--- a/reconcile/test/fixtures/helm/extra_env.yml
+++ b/reconcile/test/fixtures/helm/extra_env.yml
@@ -241,17 +241,17 @@ parameters:
 - name: BUSYBOX_IMAGE
   value: registry.access.redhat.com/ubi8/ubi-minimal
 - name: BUSYBOX_IMAGE_TAG
-  value: latest
+  value: 8.10-1781701121
 - name: BUSYBOX_IMAGE_DIGEST
-  value: ''
+  value: 'sha256:5d76d0cedabd7d7893b28bec684d7a3412dd8d95d186e7d4b6eeed4ea28c327b'
 - name: BUSYBOX_IMAGE_PULL_POLICY
   value: Always
 - name: FLUENTD_IMAGE
   value: quay.io/redhat-services-prod/app-sre-tenant/fluentd-master/fluentd-master
 - name: FLUENTD_IMAGE_TAG
-  value: latest
+  value: d0d1812
 - name: FLUENTD_IMAGE_DIGEST
-  value: ''
+  value: 'sha256:4868ac49b42f14ff0878216cd2c618413209f634a5c9a6c004e353e1b0805e60'
 - name: FLUENTD_IMAGE_PULL_POLICY
   value: Always
 - name: ENVIRONMENT_NAME

--- a/reconcile/test/fixtures/helm/failure_history.yml
+++ b/reconcile/test/fixtures/helm/failure_history.yml
@@ -25,7 +25,7 @@ objects:
             serviceAccountName: qontract-reconcile
             containers:
             - name: int
-              image: ${IMAGE}:${IMAGE_TAG}
+              image: ${IMAGE}:${IMAGE_TAG}@${IMAGE_DIGEST}
               env:
               - name: RUN_ONCE
                 value: 'true'
@@ -93,16 +93,22 @@ parameters:
   value: quay.io/app-sre/qontract-reconcile
 - name: IMAGE_TAG
   value: latest
+- name: IMAGE_DIGEST
+  value: ''
 - name: BUSYBOX_IMAGE
   value: registry.access.redhat.com/ubi8/ubi-minimal
 - name: BUSYBOX_IMAGE_TAG
   value: latest
+- name: BUSYBOX_IMAGE_DIGEST
+  value: ''
 - name: BUSYBOX_IMAGE_PULL_POLICY
   value: Always
 - name: FLUENTD_IMAGE
   value: quay.io/redhat-services-prod/app-sre-tenant/fluentd-master/fluentd-master
 - name: FLUENTD_IMAGE_TAG
   value: latest
+- name: FLUENTD_IMAGE_DIGEST
+  value: ''
 - name: FLUENTD_IMAGE_PULL_POLICY
   value: Always
 - name: ENVIRONMENT_NAME

--- a/reconcile/test/fixtures/helm/failure_history.yml
+++ b/reconcile/test/fixtures/helm/failure_history.yml
@@ -98,17 +98,17 @@ parameters:
 - name: BUSYBOX_IMAGE
   value: registry.access.redhat.com/ubi8/ubi-minimal
 - name: BUSYBOX_IMAGE_TAG
-  value: latest
+  value: 8.10-1781701121
 - name: BUSYBOX_IMAGE_DIGEST
-  value: ''
+  value: 'sha256:5d76d0cedabd7d7893b28bec684d7a3412dd8d95d186e7d4b6eeed4ea28c327b'
 - name: BUSYBOX_IMAGE_PULL_POLICY
   value: Always
 - name: FLUENTD_IMAGE
   value: quay.io/redhat-services-prod/app-sre-tenant/fluentd-master/fluentd-master
 - name: FLUENTD_IMAGE_TAG
-  value: latest
+  value: d0d1812
 - name: FLUENTD_IMAGE_DIGEST
-  value: ''
+  value: 'sha256:4868ac49b42f14ff0878216cd2c618413209f634a5c9a6c004e353e1b0805e60'
 - name: FLUENTD_IMAGE_PULL_POLICY
   value: Always
 - name: ENVIRONMENT_NAME

--- a/reconcile/test/fixtures/helm/integrations_manager.yml
+++ b/reconcile/test/fixtures/helm/integrations_manager.yml
@@ -242,17 +242,17 @@ parameters:
 - name: BUSYBOX_IMAGE
   value: registry.access.redhat.com/ubi8/ubi-minimal
 - name: BUSYBOX_IMAGE_TAG
-  value: latest
+  value: 8.10-1781701121
 - name: BUSYBOX_IMAGE_DIGEST
-  value: ''
+  value: 'sha256:5d76d0cedabd7d7893b28bec684d7a3412dd8d95d186e7d4b6eeed4ea28c327b'
 - name: BUSYBOX_IMAGE_PULL_POLICY
   value: Always
 - name: FLUENTD_IMAGE
   value: quay.io/redhat-services-prod/app-sre-tenant/fluentd-master/fluentd-master
 - name: FLUENTD_IMAGE_TAG
-  value: latest
+  value: d0d1812
 - name: FLUENTD_IMAGE_DIGEST
-  value: ''
+  value: 'sha256:4868ac49b42f14ff0878216cd2c618413209f634a5c9a6c004e353e1b0805e60'
 - name: FLUENTD_IMAGE_PULL_POLICY
   value: Always
 - name: ENVIRONMENT_NAME

--- a/reconcile/test/fixtures/helm/integrations_manager.yml
+++ b/reconcile/test/fixtures/helm/integrations_manager.yml
@@ -31,7 +31,7 @@ objects:
         serviceAccountName: qontract-reconcile
         initContainers:
         - name: config
-          image: ${BUSYBOX_IMAGE}:${BUSYBOX_IMAGE_TAG}
+          image: ${BUSYBOX_IMAGE}:${BUSYBOX_IMAGE_TAG}@${BUSYBOX_IMAGE_DIGEST}
           imagePullPolicy: ${BUSYBOX_IMAGE_PULL_POLICY}
           resources:
             requests:
@@ -100,7 +100,7 @@ objects:
             mountPath: /fluentd/etc/
         containers:
         - name: int
-          image: ${IMAGE}:${IMAGE_TAG}
+          image: ${IMAGE}:${IMAGE_TAG}@${IMAGE_DIGEST}
           ports:
             - name: http
               containerPort: 9090
@@ -173,7 +173,7 @@ objects:
           - name: qontract-reconcile-sa-token
             mountPath: ${KUBE_SA_TOKEN_MOUNT_PATH}
         - name: fluentd
-          image: ${FLUENTD_IMAGE}:${FLUENTD_IMAGE_TAG}
+          image: ${FLUENTD_IMAGE}:${FLUENTD_IMAGE_TAG}@${FLUENTD_IMAGE_DIGEST}
           imagePullPolicy: ${FLUENTD_IMAGE_PULL_POLICY}
           env:
           - name: AWS_REGION
@@ -237,16 +237,22 @@ parameters:
   value: quay.io/app-sre/qontract-reconcile
 - name: IMAGE_TAG
   value: latest
+- name: IMAGE_DIGEST
+  value: ''
 - name: BUSYBOX_IMAGE
   value: registry.access.redhat.com/ubi8/ubi-minimal
 - name: BUSYBOX_IMAGE_TAG
   value: latest
+- name: BUSYBOX_IMAGE_DIGEST
+  value: ''
 - name: BUSYBOX_IMAGE_PULL_POLICY
   value: Always
 - name: FLUENTD_IMAGE
   value: quay.io/redhat-services-prod/app-sre-tenant/fluentd-master/fluentd-master
 - name: FLUENTD_IMAGE_TAG
   value: latest
+- name: FLUENTD_IMAGE_DIGEST
+  value: ''
 - name: FLUENTD_IMAGE_PULL_POLICY
   value: Always
 - name: ENVIRONMENT_NAME

--- a/reconcile/test/fixtures/helm/internal_certificates.yml
+++ b/reconcile/test/fixtures/helm/internal_certificates.yml
@@ -47,7 +47,7 @@ objects:
             limits:
               memory: 20Mi
         - name: config
-          image: ${BUSYBOX_IMAGE}:${BUSYBOX_IMAGE_TAG}
+          image: ${BUSYBOX_IMAGE}:${BUSYBOX_IMAGE_TAG}@${BUSYBOX_IMAGE_DIGEST}
           imagePullPolicy: ${BUSYBOX_IMAGE_PULL_POLICY}
           resources:
             requests:
@@ -116,7 +116,7 @@ objects:
             mountPath: /fluentd/etc/
         containers:
         - name: int
-          image: ${IMAGE}:${IMAGE_TAG}
+          image: ${IMAGE}:${IMAGE_TAG}@${IMAGE_DIGEST}
           ports:
             - name: http
               containerPort: 9090
@@ -183,7 +183,7 @@ objects:
           - name: qontract-reconcile-sa-token
             mountPath: ${KUBE_SA_TOKEN_MOUNT_PATH}
         - name: fluentd
-          image: ${FLUENTD_IMAGE}:${FLUENTD_IMAGE_TAG}
+          image: ${FLUENTD_IMAGE}:${FLUENTD_IMAGE_TAG}@${FLUENTD_IMAGE_DIGEST}
           imagePullPolicy: ${FLUENTD_IMAGE_PULL_POLICY}
           env:
           - name: AWS_REGION
@@ -249,16 +249,22 @@ parameters:
   value: quay.io/app-sre/qontract-reconcile
 - name: IMAGE_TAG
   value: latest
+- name: IMAGE_DIGEST
+  value: ''
 - name: BUSYBOX_IMAGE
   value: registry.access.redhat.com/ubi8/ubi-minimal
 - name: BUSYBOX_IMAGE_TAG
   value: latest
+- name: BUSYBOX_IMAGE_DIGEST
+  value: ''
 - name: BUSYBOX_IMAGE_PULL_POLICY
   value: Always
 - name: FLUENTD_IMAGE
   value: quay.io/redhat-services-prod/app-sre-tenant/fluentd-master/fluentd-master
 - name: FLUENTD_IMAGE_TAG
   value: latest
+- name: FLUENTD_IMAGE_DIGEST
+  value: ''
 - name: FLUENTD_IMAGE_PULL_POLICY
   value: Always
 - name: ENVIRONMENT_NAME

--- a/reconcile/test/fixtures/helm/internal_certificates.yml
+++ b/reconcile/test/fixtures/helm/internal_certificates.yml
@@ -254,17 +254,17 @@ parameters:
 - name: BUSYBOX_IMAGE
   value: registry.access.redhat.com/ubi8/ubi-minimal
 - name: BUSYBOX_IMAGE_TAG
-  value: latest
+  value: 8.10-1781701121
 - name: BUSYBOX_IMAGE_DIGEST
-  value: ''
+  value: 'sha256:5d76d0cedabd7d7893b28bec684d7a3412dd8d95d186e7d4b6eeed4ea28c327b'
 - name: BUSYBOX_IMAGE_PULL_POLICY
   value: Always
 - name: FLUENTD_IMAGE
   value: quay.io/redhat-services-prod/app-sre-tenant/fluentd-master/fluentd-master
 - name: FLUENTD_IMAGE_TAG
-  value: latest
+  value: d0d1812
 - name: FLUENTD_IMAGE_DIGEST
-  value: ''
+  value: 'sha256:4868ac49b42f14ff0878216cd2c618413209f634a5c9a6c004e353e1b0805e60'
 - name: FLUENTD_IMAGE_PULL_POLICY
   value: Always
 - name: ENVIRONMENT_NAME

--- a/reconcile/test/fixtures/helm/logs_slack.yml
+++ b/reconcile/test/fixtures/helm/logs_slack.yml
@@ -257,17 +257,17 @@ parameters:
 - name: BUSYBOX_IMAGE
   value: registry.access.redhat.com/ubi8/ubi-minimal
 - name: BUSYBOX_IMAGE_TAG
-  value: latest
+  value: 8.10-1781701121
 - name: BUSYBOX_IMAGE_DIGEST
-  value: ''
+  value: 'sha256:5d76d0cedabd7d7893b28bec684d7a3412dd8d95d186e7d4b6eeed4ea28c327b'
 - name: BUSYBOX_IMAGE_PULL_POLICY
   value: Always
 - name: FLUENTD_IMAGE
   value: quay.io/redhat-services-prod/app-sre-tenant/fluentd-master/fluentd-master
 - name: FLUENTD_IMAGE_TAG
-  value: latest
+  value: d0d1812
 - name: FLUENTD_IMAGE_DIGEST
-  value: ''
+  value: 'sha256:4868ac49b42f14ff0878216cd2c618413209f634a5c9a6c004e353e1b0805e60'
 - name: FLUENTD_IMAGE_PULL_POLICY
   value: Always
 - name: ENVIRONMENT_NAME

--- a/reconcile/test/fixtures/helm/logs_slack.yml
+++ b/reconcile/test/fixtures/helm/logs_slack.yml
@@ -31,7 +31,7 @@ objects:
         serviceAccountName: qontract-reconcile
         initContainers:
         - name: config
-          image: ${BUSYBOX_IMAGE}:${BUSYBOX_IMAGE_TAG}
+          image: ${BUSYBOX_IMAGE}:${BUSYBOX_IMAGE_TAG}@${BUSYBOX_IMAGE_DIGEST}
           imagePullPolicy: ${BUSYBOX_IMAGE_PULL_POLICY}
           resources:
             requests:
@@ -123,7 +123,7 @@ objects:
             mountPath: /fluentd/etc/
         containers:
         - name: int
-          image: ${IMAGE}:${IMAGE_TAG}
+          image: ${IMAGE}:${IMAGE_TAG}@${IMAGE_DIGEST}
           ports:
             - name: http
               containerPort: 9090
@@ -188,7 +188,7 @@ objects:
           - name: qontract-reconcile-sa-token
             mountPath: ${KUBE_SA_TOKEN_MOUNT_PATH}
         - name: fluentd
-          image: ${FLUENTD_IMAGE}:${FLUENTD_IMAGE_TAG}
+          image: ${FLUENTD_IMAGE}:${FLUENTD_IMAGE_TAG}@${FLUENTD_IMAGE_DIGEST}
           imagePullPolicy: ${FLUENTD_IMAGE_PULL_POLICY}
           env:
           - name: AWS_REGION
@@ -252,16 +252,22 @@ parameters:
   value: quay.io/app-sre/qontract-reconcile
 - name: IMAGE_TAG
   value: latest
+- name: IMAGE_DIGEST
+  value: ''
 - name: BUSYBOX_IMAGE
   value: registry.access.redhat.com/ubi8/ubi-minimal
 - name: BUSYBOX_IMAGE_TAG
   value: latest
+- name: BUSYBOX_IMAGE_DIGEST
+  value: ''
 - name: BUSYBOX_IMAGE_PULL_POLICY
   value: Always
 - name: FLUENTD_IMAGE
   value: quay.io/redhat-services-prod/app-sre-tenant/fluentd-master/fluentd-master
 - name: FLUENTD_IMAGE_TAG
   value: latest
+- name: FLUENTD_IMAGE_DIGEST
+  value: ''
 - name: FLUENTD_IMAGE_PULL_POLICY
   value: Always
 - name: ENVIRONMENT_NAME

--- a/reconcile/test/fixtures/helm/restart_policy.yml
+++ b/reconcile/test/fixtures/helm/restart_policy.yml
@@ -25,7 +25,7 @@ objects:
             serviceAccountName: qontract-reconcile
             containers:
             - name: int
-              image: ${IMAGE}:${IMAGE_TAG}
+              image: ${IMAGE}:${IMAGE_TAG}@${IMAGE_DIGEST}
               env:
               - name: RUN_ONCE
                 value: 'true'
@@ -93,16 +93,22 @@ parameters:
   value: quay.io/app-sre/qontract-reconcile
 - name: IMAGE_TAG
   value: latest
+- name: IMAGE_DIGEST
+  value: ''
 - name: BUSYBOX_IMAGE
   value: registry.access.redhat.com/ubi8/ubi-minimal
 - name: BUSYBOX_IMAGE_TAG
   value: latest
+- name: BUSYBOX_IMAGE_DIGEST
+  value: ''
 - name: BUSYBOX_IMAGE_PULL_POLICY
   value: Always
 - name: FLUENTD_IMAGE
   value: quay.io/redhat-services-prod/app-sre-tenant/fluentd-master/fluentd-master
 - name: FLUENTD_IMAGE_TAG
   value: latest
+- name: FLUENTD_IMAGE_DIGEST
+  value: ''
 - name: FLUENTD_IMAGE_PULL_POLICY
   value: Always
 - name: ENVIRONMENT_NAME

--- a/reconcile/test/fixtures/helm/restart_policy.yml
+++ b/reconcile/test/fixtures/helm/restart_policy.yml
@@ -98,17 +98,17 @@ parameters:
 - name: BUSYBOX_IMAGE
   value: registry.access.redhat.com/ubi8/ubi-minimal
 - name: BUSYBOX_IMAGE_TAG
-  value: latest
+  value: 8.10-1781701121
 - name: BUSYBOX_IMAGE_DIGEST
-  value: ''
+  value: 'sha256:5d76d0cedabd7d7893b28bec684d7a3412dd8d95d186e7d4b6eeed4ea28c327b'
 - name: BUSYBOX_IMAGE_PULL_POLICY
   value: Always
 - name: FLUENTD_IMAGE
   value: quay.io/redhat-services-prod/app-sre-tenant/fluentd-master/fluentd-master
 - name: FLUENTD_IMAGE_TAG
-  value: latest
+  value: d0d1812
 - name: FLUENTD_IMAGE_DIGEST
-  value: ''
+  value: 'sha256:4868ac49b42f14ff0878216cd2c618413209f634a5c9a6c004e353e1b0805e60'
 - name: FLUENTD_IMAGE_PULL_POLICY
   value: Always
 - name: ENVIRONMENT_NAME

--- a/reconcile/test/fixtures/helm/shards.yml
+++ b/reconcile/test/fixtures/helm/shards.yml
@@ -439,17 +439,17 @@ parameters:
 - name: BUSYBOX_IMAGE
   value: registry.access.redhat.com/ubi8/ubi-minimal
 - name: BUSYBOX_IMAGE_TAG
-  value: latest
+  value: 8.10-1781701121
 - name: BUSYBOX_IMAGE_DIGEST
-  value: ''
+  value: 'sha256:5d76d0cedabd7d7893b28bec684d7a3412dd8d95d186e7d4b6eeed4ea28c327b'
 - name: BUSYBOX_IMAGE_PULL_POLICY
   value: Always
 - name: FLUENTD_IMAGE
   value: quay.io/redhat-services-prod/app-sre-tenant/fluentd-master/fluentd-master
 - name: FLUENTD_IMAGE_TAG
-  value: latest
+  value: d0d1812
 - name: FLUENTD_IMAGE_DIGEST
-  value: ''
+  value: 'sha256:4868ac49b42f14ff0878216cd2c618413209f634a5c9a6c004e353e1b0805e60'
 - name: FLUENTD_IMAGE_PULL_POLICY
   value: Always
 - name: ENVIRONMENT_NAME

--- a/reconcile/test/fixtures/helm/shards.yml
+++ b/reconcile/test/fixtures/helm/shards.yml
@@ -31,7 +31,7 @@ objects:
         serviceAccountName: qontract-reconcile
         initContainers:
         - name: config
-          image: ${BUSYBOX_IMAGE}:${BUSYBOX_IMAGE_TAG}
+          image: ${BUSYBOX_IMAGE}:${BUSYBOX_IMAGE_TAG}@${BUSYBOX_IMAGE_DIGEST}
           imagePullPolicy: ${BUSYBOX_IMAGE_PULL_POLICY}
           resources:
             requests:
@@ -100,7 +100,7 @@ objects:
             mountPath: /fluentd/etc/
         containers:
         - name: int
-          image: ${IMAGE}:${IMAGE_TAG}
+          image: ${IMAGE}:${IMAGE_TAG}@${IMAGE_DIGEST}
           ports:
             - name: http
               containerPort: 9090
@@ -165,7 +165,7 @@ objects:
           - name: qontract-reconcile-sa-token
             mountPath: ${KUBE_SA_TOKEN_MOUNT_PATH}
         - name: fluentd
-          image: ${FLUENTD_IMAGE}:${FLUENTD_IMAGE_TAG}
+          image: ${FLUENTD_IMAGE}:${FLUENTD_IMAGE_TAG}@${FLUENTD_IMAGE_DIGEST}
           imagePullPolicy: ${FLUENTD_IMAGE_PULL_POLICY}
           env:
           - name: AWS_REGION
@@ -236,7 +236,7 @@ objects:
         serviceAccountName: qontract-reconcile
         initContainers:
         - name: config
-          image: ${BUSYBOX_IMAGE}:${BUSYBOX_IMAGE_TAG}
+          image: ${BUSYBOX_IMAGE}:${BUSYBOX_IMAGE_TAG}@${BUSYBOX_IMAGE_DIGEST}
           imagePullPolicy: ${BUSYBOX_IMAGE_PULL_POLICY}
           resources:
             requests:
@@ -305,7 +305,7 @@ objects:
             mountPath: /fluentd/etc/
         containers:
         - name: int
-          image: ${IMAGE}:${IMAGE_TAG}
+          image: ${IMAGE}:${IMAGE_TAG}@${IMAGE_DIGEST}
           ports:
             - name: http
               containerPort: 9090
@@ -370,7 +370,7 @@ objects:
           - name: qontract-reconcile-sa-token
             mountPath: ${KUBE_SA_TOKEN_MOUNT_PATH}
         - name: fluentd
-          image: ${FLUENTD_IMAGE}:${FLUENTD_IMAGE_TAG}
+          image: ${FLUENTD_IMAGE}:${FLUENTD_IMAGE_TAG}@${FLUENTD_IMAGE_DIGEST}
           imagePullPolicy: ${FLUENTD_IMAGE_PULL_POLICY}
           env:
           - name: AWS_REGION
@@ -434,16 +434,22 @@ parameters:
   value: quay.io/app-sre/qontract-reconcile
 - name: IMAGE_TAG
   value: latest
+- name: IMAGE_DIGEST
+  value: ''
 - name: BUSYBOX_IMAGE
   value: registry.access.redhat.com/ubi8/ubi-minimal
 - name: BUSYBOX_IMAGE_TAG
   value: latest
+- name: BUSYBOX_IMAGE_DIGEST
+  value: ''
 - name: BUSYBOX_IMAGE_PULL_POLICY
   value: Always
 - name: FLUENTD_IMAGE
   value: quay.io/redhat-services-prod/app-sre-tenant/fluentd-master/fluentd-master
 - name: FLUENTD_IMAGE_TAG
   value: latest
+- name: FLUENTD_IMAGE_DIGEST
+  value: ''
 - name: FLUENTD_IMAGE_PULL_POLICY
   value: Always
 - name: ENVIRONMENT_NAME

--- a/reconcile/test/fixtures/helm/sleep_duration.yml
+++ b/reconcile/test/fixtures/helm/sleep_duration.yml
@@ -31,7 +31,7 @@ objects:
         serviceAccountName: qontract-reconcile
         initContainers:
         - name: config
-          image: ${BUSYBOX_IMAGE}:${BUSYBOX_IMAGE_TAG}
+          image: ${BUSYBOX_IMAGE}:${BUSYBOX_IMAGE_TAG}@${BUSYBOX_IMAGE_DIGEST}
           imagePullPolicy: ${BUSYBOX_IMAGE_PULL_POLICY}
           resources:
             requests:
@@ -100,7 +100,7 @@ objects:
             mountPath: /fluentd/etc/
         containers:
         - name: int
-          image: ${IMAGE}:${IMAGE_TAG}
+          image: ${IMAGE}:${IMAGE_TAG}@${IMAGE_DIGEST}
           ports:
             - name: http
               containerPort: 9090
@@ -165,7 +165,7 @@ objects:
           - name: qontract-reconcile-sa-token
             mountPath: ${KUBE_SA_TOKEN_MOUNT_PATH}
         - name: fluentd
-          image: ${FLUENTD_IMAGE}:${FLUENTD_IMAGE_TAG}
+          image: ${FLUENTD_IMAGE}:${FLUENTD_IMAGE_TAG}@${FLUENTD_IMAGE_DIGEST}
           imagePullPolicy: ${FLUENTD_IMAGE_PULL_POLICY}
           env:
           - name: AWS_REGION
@@ -229,16 +229,22 @@ parameters:
   value: quay.io/app-sre/qontract-reconcile
 - name: IMAGE_TAG
   value: latest
+- name: IMAGE_DIGEST
+  value: ''
 - name: BUSYBOX_IMAGE
   value: registry.access.redhat.com/ubi8/ubi-minimal
 - name: BUSYBOX_IMAGE_TAG
   value: latest
+- name: BUSYBOX_IMAGE_DIGEST
+  value: ''
 - name: BUSYBOX_IMAGE_PULL_POLICY
   value: Always
 - name: FLUENTD_IMAGE
   value: quay.io/redhat-services-prod/app-sre-tenant/fluentd-master/fluentd-master
 - name: FLUENTD_IMAGE_TAG
   value: latest
+- name: FLUENTD_IMAGE_DIGEST
+  value: ''
 - name: FLUENTD_IMAGE_PULL_POLICY
   value: Always
 - name: ENVIRONMENT_NAME

--- a/reconcile/test/fixtures/helm/sleep_duration.yml
+++ b/reconcile/test/fixtures/helm/sleep_duration.yml
@@ -234,17 +234,17 @@ parameters:
 - name: BUSYBOX_IMAGE
   value: registry.access.redhat.com/ubi8/ubi-minimal
 - name: BUSYBOX_IMAGE_TAG
-  value: latest
+  value: 8.10-1781701121
 - name: BUSYBOX_IMAGE_DIGEST
-  value: ''
+  value: 'sha256:5d76d0cedabd7d7893b28bec684d7a3412dd8d95d186e7d4b6eeed4ea28c327b'
 - name: BUSYBOX_IMAGE_PULL_POLICY
   value: Always
 - name: FLUENTD_IMAGE
   value: quay.io/redhat-services-prod/app-sre-tenant/fluentd-master/fluentd-master
 - name: FLUENTD_IMAGE_TAG
-  value: latest
+  value: d0d1812
 - name: FLUENTD_IMAGE_DIGEST
-  value: ''
+  value: 'sha256:4868ac49b42f14ff0878216cd2c618413209f634a5c9a6c004e353e1b0805e60'
 - name: FLUENTD_IMAGE_PULL_POLICY
   value: Always
 - name: ENVIRONMENT_NAME

--- a/reconcile/test/fixtures/helm/state.yml
+++ b/reconcile/test/fixtures/helm/state.yml
@@ -272,17 +272,17 @@ parameters:
 - name: BUSYBOX_IMAGE
   value: registry.access.redhat.com/ubi8/ubi-minimal
 - name: BUSYBOX_IMAGE_TAG
-  value: latest
+  value: 8.10-1781701121
 - name: BUSYBOX_IMAGE_DIGEST
-  value: ''
+  value: 'sha256:5d76d0cedabd7d7893b28bec684d7a3412dd8d95d186e7d4b6eeed4ea28c327b'
 - name: BUSYBOX_IMAGE_PULL_POLICY
   value: Always
 - name: FLUENTD_IMAGE
   value: quay.io/redhat-services-prod/app-sre-tenant/fluentd-master/fluentd-master
 - name: FLUENTD_IMAGE_TAG
-  value: latest
+  value: d0d1812
 - name: FLUENTD_IMAGE_DIGEST
-  value: ''
+  value: 'sha256:4868ac49b42f14ff0878216cd2c618413209f634a5c9a6c004e353e1b0805e60'
 - name: FLUENTD_IMAGE_PULL_POLICY
   value: Always
 - name: ENVIRONMENT_NAME

--- a/reconcile/test/fixtures/helm/state.yml
+++ b/reconcile/test/fixtures/helm/state.yml
@@ -31,7 +31,7 @@ objects:
         serviceAccountName: qontract-reconcile
         initContainers:
         - name: config
-          image: ${BUSYBOX_IMAGE}:${BUSYBOX_IMAGE_TAG}
+          image: ${BUSYBOX_IMAGE}:${BUSYBOX_IMAGE_TAG}@${BUSYBOX_IMAGE_DIGEST}
           imagePullPolicy: ${BUSYBOX_IMAGE_PULL_POLICY}
           resources:
             requests:
@@ -100,7 +100,7 @@ objects:
             mountPath: /fluentd/etc/
         containers:
         - name: int
-          image: ${IMAGE}:${IMAGE_TAG}
+          image: ${IMAGE}:${IMAGE_TAG}@${IMAGE_DIGEST}
           ports:
             - name: http
               containerPort: 9090
@@ -191,7 +191,7 @@ objects:
             mountPath: /var/run/secrets/openshift/serviceaccount
             readOnly: true
         - name: fluentd
-          image: ${FLUENTD_IMAGE}:${FLUENTD_IMAGE_TAG}
+          image: ${FLUENTD_IMAGE}:${FLUENTD_IMAGE_TAG}@${FLUENTD_IMAGE_DIGEST}
           imagePullPolicy: ${FLUENTD_IMAGE_PULL_POLICY}
           env:
           - name: AWS_REGION
@@ -267,16 +267,22 @@ parameters:
   value: quay.io/app-sre/qontract-reconcile
 - name: IMAGE_TAG
   value: latest
+- name: IMAGE_DIGEST
+  value: ''
 - name: BUSYBOX_IMAGE
   value: registry.access.redhat.com/ubi8/ubi-minimal
 - name: BUSYBOX_IMAGE_TAG
   value: latest
+- name: BUSYBOX_IMAGE_DIGEST
+  value: ''
 - name: BUSYBOX_IMAGE_PULL_POLICY
   value: Always
 - name: FLUENTD_IMAGE
   value: quay.io/redhat-services-prod/app-sre-tenant/fluentd-master/fluentd-master
 - name: FLUENTD_IMAGE_TAG
   value: latest
+- name: FLUENTD_IMAGE_DIGEST
+  value: ''
 - name: FLUENTD_IMAGE_PULL_POLICY
   value: Always
 - name: ENVIRONMENT_NAME

--- a/reconcile/test/fixtures/helm/storage.yml
+++ b/reconcile/test/fixtures/helm/storage.yml
@@ -31,7 +31,7 @@ objects:
         serviceAccountName: qontract-reconcile
         initContainers:
         - name: config
-          image: ${BUSYBOX_IMAGE}:${BUSYBOX_IMAGE_TAG}
+          image: ${BUSYBOX_IMAGE}:${BUSYBOX_IMAGE_TAG}@${BUSYBOX_IMAGE_DIGEST}
           imagePullPolicy: ${BUSYBOX_IMAGE_PULL_POLICY}
           resources:
             requests:
@@ -100,7 +100,7 @@ objects:
             mountPath: /fluentd/etc/
         containers:
         - name: int
-          image: ${IMAGE}:${IMAGE_TAG}
+          image: ${IMAGE}:${IMAGE_TAG}@${IMAGE_DIGEST}
           ports:
             - name: http
               containerPort: 9090
@@ -165,7 +165,7 @@ objects:
           - name: qontract-reconcile-sa-token
             mountPath: ${KUBE_SA_TOKEN_MOUNT_PATH}
         - name: fluentd
-          image: ${FLUENTD_IMAGE}:${FLUENTD_IMAGE_TAG}
+          image: ${FLUENTD_IMAGE}:${FLUENTD_IMAGE_TAG}@${FLUENTD_IMAGE_DIGEST}
           imagePullPolicy: ${FLUENTD_IMAGE_PULL_POLICY}
           env:
           - name: AWS_REGION
@@ -229,16 +229,22 @@ parameters:
   value: quay.io/app-sre/qontract-reconcile
 - name: IMAGE_TAG
   value: latest
+- name: IMAGE_DIGEST
+  value: ''
 - name: BUSYBOX_IMAGE
   value: registry.access.redhat.com/ubi8/ubi-minimal
 - name: BUSYBOX_IMAGE_TAG
   value: latest
+- name: BUSYBOX_IMAGE_DIGEST
+  value: ''
 - name: BUSYBOX_IMAGE_PULL_POLICY
   value: Always
 - name: FLUENTD_IMAGE
   value: quay.io/redhat-services-prod/app-sre-tenant/fluentd-master/fluentd-master
 - name: FLUENTD_IMAGE_TAG
   value: latest
+- name: FLUENTD_IMAGE_DIGEST
+  value: ''
 - name: FLUENTD_IMAGE_PULL_POLICY
   value: Always
 - name: ENVIRONMENT_NAME

--- a/reconcile/test/fixtures/helm/storage.yml
+++ b/reconcile/test/fixtures/helm/storage.yml
@@ -234,17 +234,17 @@ parameters:
 - name: BUSYBOX_IMAGE
   value: registry.access.redhat.com/ubi8/ubi-minimal
 - name: BUSYBOX_IMAGE_TAG
-  value: latest
+  value: 8.10-1781701121
 - name: BUSYBOX_IMAGE_DIGEST
-  value: ''
+  value: 'sha256:5d76d0cedabd7d7893b28bec684d7a3412dd8d95d186e7d4b6eeed4ea28c327b'
 - name: BUSYBOX_IMAGE_PULL_POLICY
   value: Always
 - name: FLUENTD_IMAGE
   value: quay.io/redhat-services-prod/app-sre-tenant/fluentd-master/fluentd-master
 - name: FLUENTD_IMAGE_TAG
-  value: latest
+  value: d0d1812
 - name: FLUENTD_IMAGE_DIGEST
-  value: ''
+  value: 'sha256:4868ac49b42f14ff0878216cd2c618413209f634a5c9a6c004e353e1b0805e60'
 - name: FLUENTD_IMAGE_PULL_POLICY
   value: Always
 - name: ENVIRONMENT_NAME

--- a/reconcile/test/fixtures/helm/success_history.yml
+++ b/reconcile/test/fixtures/helm/success_history.yml
@@ -25,7 +25,7 @@ objects:
             serviceAccountName: qontract-reconcile
             containers:
             - name: int
-              image: ${IMAGE}:${IMAGE_TAG}
+              image: ${IMAGE}:${IMAGE_TAG}@${IMAGE_DIGEST}
               env:
               - name: RUN_ONCE
                 value: 'true'
@@ -93,16 +93,22 @@ parameters:
   value: quay.io/app-sre/qontract-reconcile
 - name: IMAGE_TAG
   value: latest
+- name: IMAGE_DIGEST
+  value: ''
 - name: BUSYBOX_IMAGE
   value: registry.access.redhat.com/ubi8/ubi-minimal
 - name: BUSYBOX_IMAGE_TAG
   value: latest
+- name: BUSYBOX_IMAGE_DIGEST
+  value: ''
 - name: BUSYBOX_IMAGE_PULL_POLICY
   value: Always
 - name: FLUENTD_IMAGE
   value: quay.io/redhat-services-prod/app-sre-tenant/fluentd-master/fluentd-master
 - name: FLUENTD_IMAGE_TAG
   value: latest
+- name: FLUENTD_IMAGE_DIGEST
+  value: ''
 - name: FLUENTD_IMAGE_PULL_POLICY
   value: Always
 - name: ENVIRONMENT_NAME

--- a/reconcile/test/fixtures/helm/success_history.yml
+++ b/reconcile/test/fixtures/helm/success_history.yml
@@ -98,17 +98,17 @@ parameters:
 - name: BUSYBOX_IMAGE
   value: registry.access.redhat.com/ubi8/ubi-minimal
 - name: BUSYBOX_IMAGE_TAG
-  value: latest
+  value: 8.10-1781701121
 - name: BUSYBOX_IMAGE_DIGEST
-  value: ''
+  value: 'sha256:5d76d0cedabd7d7893b28bec684d7a3412dd8d95d186e7d4b6eeed4ea28c327b'
 - name: BUSYBOX_IMAGE_PULL_POLICY
   value: Always
 - name: FLUENTD_IMAGE
   value: quay.io/redhat-services-prod/app-sre-tenant/fluentd-master/fluentd-master
 - name: FLUENTD_IMAGE_TAG
-  value: latest
+  value: d0d1812
 - name: FLUENTD_IMAGE_DIGEST
-  value: ''
+  value: 'sha256:4868ac49b42f14ff0878216cd2c618413209f634a5c9a6c004e353e1b0805e60'
 - name: FLUENTD_IMAGE_PULL_POLICY
   value: Always
 - name: ENVIRONMENT_NAME

--- a/reconcile/test/fixtures/helm/trigger.yml
+++ b/reconcile/test/fixtures/helm/trigger.yml
@@ -31,7 +31,7 @@ objects:
         serviceAccountName: qontract-reconcile
         initContainers:
         - name: config
-          image: ${BUSYBOX_IMAGE}:${BUSYBOX_IMAGE_TAG}
+          image: ${BUSYBOX_IMAGE}:${BUSYBOX_IMAGE_TAG}@${BUSYBOX_IMAGE_DIGEST}
           imagePullPolicy: ${BUSYBOX_IMAGE_PULL_POLICY}
           resources:
             requests:
@@ -100,7 +100,7 @@ objects:
             mountPath: /fluentd/etc/
         containers:
         - name: int
-          image: ${IMAGE}:${IMAGE_TAG}
+          image: ${IMAGE}:${IMAGE_TAG}@${IMAGE_DIGEST}
           ports:
             - name: http
               containerPort: 9090
@@ -165,7 +165,7 @@ objects:
           - name: qontract-reconcile-sa-token
             mountPath: ${KUBE_SA_TOKEN_MOUNT_PATH}
         - name: fluentd
-          image: ${FLUENTD_IMAGE}:${FLUENTD_IMAGE_TAG}
+          image: ${FLUENTD_IMAGE}:${FLUENTD_IMAGE_TAG}@${FLUENTD_IMAGE_DIGEST}
           imagePullPolicy: ${FLUENTD_IMAGE_PULL_POLICY}
           env:
           - name: AWS_REGION
@@ -229,16 +229,22 @@ parameters:
   value: quay.io/app-sre/qontract-reconcile
 - name: IMAGE_TAG
   value: latest
+- name: IMAGE_DIGEST
+  value: ''
 - name: BUSYBOX_IMAGE
   value: registry.access.redhat.com/ubi8/ubi-minimal
 - name: BUSYBOX_IMAGE_TAG
   value: latest
+- name: BUSYBOX_IMAGE_DIGEST
+  value: ''
 - name: BUSYBOX_IMAGE_PULL_POLICY
   value: Always
 - name: FLUENTD_IMAGE
   value: quay.io/redhat-services-prod/app-sre-tenant/fluentd-master/fluentd-master
 - name: FLUENTD_IMAGE_TAG
   value: latest
+- name: FLUENTD_IMAGE_DIGEST
+  value: ''
 - name: FLUENTD_IMAGE_PULL_POLICY
   value: Always
 - name: ENVIRONMENT_NAME

--- a/reconcile/test/fixtures/helm/trigger.yml
+++ b/reconcile/test/fixtures/helm/trigger.yml
@@ -234,17 +234,17 @@ parameters:
 - name: BUSYBOX_IMAGE
   value: registry.access.redhat.com/ubi8/ubi-minimal
 - name: BUSYBOX_IMAGE_TAG
-  value: latest
+  value: 8.10-1781701121
 - name: BUSYBOX_IMAGE_DIGEST
-  value: ''
+  value: 'sha256:5d76d0cedabd7d7893b28bec684d7a3412dd8d95d186e7d4b6eeed4ea28c327b'
 - name: BUSYBOX_IMAGE_PULL_POLICY
   value: Always
 - name: FLUENTD_IMAGE
   value: quay.io/redhat-services-prod/app-sre-tenant/fluentd-master/fluentd-master
 - name: FLUENTD_IMAGE_TAG
-  value: latest
+  value: d0d1812
 - name: FLUENTD_IMAGE_DIGEST
-  value: ''
+  value: 'sha256:4868ac49b42f14ff0878216cd2c618413209f634a5c9a6c004e353e1b0805e60'
 - name: FLUENTD_IMAGE_PULL_POLICY
   value: Always
 - name: ENVIRONMENT_NAME


### PR DESCRIPTION
…r digest pinning (step 2)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added digest-pinning for Helm and OpenShift reconciliation workloads via new template parameters: `IMAGE_DIGEST`, `BUSYBOX_IMAGE_DIGEST`, and `FLUENTD_IMAGE_DIGEST`.
  * Updated generated Deployments, init containers, fluentd sidecars, CronJobs, and sharded variants to use immutable `image: ...@sha256...` references (with an optional digest for the main image).
  * Updated default BusyBox and fluentd tags from `latest` to pinned versions for more consistent rollouts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->