### PR TITLE
Removed top-k rebasing algorithm

### DIFF
--- a/reconcile/gitlab_housekeeping.py
+++ b/reconcile/gitlab_housekeeping.py
@@ -147,7 +147,6 @@ merge_batch_size_histogram = Histogram(
 class RebaseStrategy(StrEnum):
     ACTIVE_CAP = "active-cap"
     ACTIVE_CAP_MULTI_MERGE = "active-cap-multi-merge"
-    TOP_K = "top-k"
     OLD_BURST = "old-burst"
 
 
@@ -631,7 +630,6 @@ def rebase_merge_requests(
     dispatch = {
         RebaseStrategy.ACTIVE_CAP: _rebase_merge_requests_active_cap,
         RebaseStrategy.ACTIVE_CAP_MULTI_MERGE: _rebase_merge_requests_active_cap,
-        RebaseStrategy.TOP_K: _rebase_merge_requests_top_k,
         RebaseStrategy.OLD_BURST: _rebase_merge_requests_old_burst,
     }
 
@@ -879,43 +877,6 @@ def _check_post_merge_ci(gl: GitLabApi, lead: ProjectMergeRequest) -> bool:
             break
         return pipeline.status != PipelineStatus.FAILED
     return True
-
-
-def _rebase_merge_requests_top_k(
-    dry_run: bool,
-    gl: GitLabApi,
-    rebase_limit: int,
-    state: State,
-    pipeline_timeout: int | None = None,
-    wait_for_pipeline: bool = False,
-    users_allowed_to_label: Iterable[str] | None = None,
-) -> None:
-    """Top-k strategy: only evaluate the first rebase_limit MRs in priority
-    order.  The queue is already sorted by priority, so slicing to K
-    guarantees at most K MRs are rebased across all runs.
-    Error MRs are filtered before slicing so they don't consume slots."""
-    merge_requests = [
-        item["mr"]
-        for item in get_merge_requests(
-            dry_run=dry_run,
-            gl=gl,
-            state=state,
-            users_allowed_to_label=users_allowed_to_label,
-        )
-        if not item["error"]
-    ][:rebase_limit]
-
-    for mr in merge_requests:
-        if is_rebased(mr, gl):
-            continue
-
-        pipelines = gl.get_merge_request_pipelines(mr)
-        _cancel_timed_out_pipelines(dry_run, gl, mr, pipelines, pipeline_timeout)
-
-        if _should_skip_for_running_pipeline(pipelines, wait_for_pipeline):
-            continue
-
-        _try_rebase(dry_run, gl, mr)
 
 
 def _rebase_merge_requests_active_cap(

--- a/reconcile/test/test_gitlab_housekeeping.py
+++ b/reconcile/test/test_gitlab_housekeeping.py
@@ -895,38 +895,11 @@ def test_rebase_stale_success_pipeline_does_not_block_rebase(
     assert merge_requests[1].rebase.call_count == 1
 
 
-# --- rebase_merge_requests top-K strategy tests ---
-
-
-def test_top_k_only_considers_first_k_mrs(
-    mocker: MockerFixture, gitlab_api: Mock, state: Mock
-) -> None:
-    """Top-K slices the queue to first K MRs; MRs beyond K are never rebased."""
-    merge_requests = [_make_rebase_mr(i) for i in range(1, 6)]
-
-    _call_rebase(
-        mocker,
-        gitlab_api,
-        state,
-        merge_requests,
-        rebase_limit=2,
-        strategy=RebaseStrategy.TOP_K,
-    )
-
-    assert merge_requests[0].rebase.call_count == 1
-    assert merge_requests[1].rebase.call_count == 1
-    assert merge_requests[2].rebase.call_count == 0
-    assert merge_requests[3].rebase.call_count == 0
-    assert merge_requests[4].rebase.call_count == 0
-
-
 @pytest.mark.parametrize(
     ("error_label", "strategy"),
     [
         ("merge-error", RebaseStrategy.ACTIVE_CAP),
         ("pipeline-error", RebaseStrategy.ACTIVE_CAP),
-        ("merge-error", RebaseStrategy.TOP_K),
-        ("pipeline-error", RebaseStrategy.TOP_K),
         ("merge-error", RebaseStrategy.OLD_BURST),
         ("pipeline-error", RebaseStrategy.OLD_BURST),
     ],
@@ -1002,7 +975,6 @@ def test_get_rebase_strategy_toggle_enabled_unknown_variant(
     ("variant_value", "expected_strategy"),
     [
         ("active-cap", RebaseStrategy.ACTIVE_CAP),
-        ("top-k", RebaseStrategy.TOP_K),
         ("old-burst", RebaseStrategy.OLD_BURST),
     ],
 )


### PR DESCRIPTION
GLHK is getting out of hand: clean up is necessary. 

## Summary
Remove the unused `top-k` rebase strategy from gitlab-housekeeping. 

## Changes
- Remove `TOP_K` from the `RebaseStrategy` enum
- Remove `_rebase_merge_requests_top_k` function
- Remove the `TOP_K` dispatch entry in `rebase_merge_requests`
- Remove associated test coverage (`test_top_k_only_considers_first_k_mrs` and parametrized entries)

TODO: Remove top-k variant in Unleash after merge

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed the top-k rebase strategy option from the system. Configurations targeting this strategy will automatically fall back to the default rebase behavior, maintaining operational continuity.
  * Updated test coverage to validate rebase strategy selection and fallback mechanisms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->