### PR TITLE
chore(dockerfile): bump qontract-reconcile-base to 1.6.0-1

### DIFF
--- a/dockerfiles/Dockerfile
+++ b/dockerfiles/Dockerfile
@@ -28,7 +28,7 @@ RUN UV_DYNAMIC_VERSIONING_BYPASS="0.0.0" uv sync --frozen --no-group dev
 ###############################################################################
 # STAGE 2 - dev-image
 ###############################################################################
-FROM quay.io/redhat-services-prod/app-sre-tenant/container-images-master/qontract-reconcile-base-master:1.5.2-1@sha256:feb8c631c26c0d9ad1ec24903baf0afc20028bd98b0826625ca5389e8ffc6676 AS dev-image
+FROM quay.io/redhat-services-prod/app-sre-tenant/container-images-master/qontract-reconcile-base-master:1.6.0-1@sha256:5e308a422841a2ad80b82c0601cd4765fd3b52f65661ff361a15b18a6ff3fbc2 AS dev-image
 COPY --from=ghcr.io/astral-sh/uv:0.11.13@sha256:841c8e6fe30a8b07b4478d12d0c608cba6de66102d29d65d1cc423af86051563 /uv /bin/uv
 
 ENV \
@@ -59,7 +59,7 @@ ENTRYPOINT ["/work/dev/run.sh"]
 ###############################################################################
 # STAGE 3 - prod-image-pre-test
 ###############################################################################
-FROM quay.io/redhat-services-prod/app-sre-tenant/container-images-master/qontract-reconcile-base-master:1.5.2-1@sha256:feb8c631c26c0d9ad1ec24903baf0afc20028bd98b0826625ca5389e8ffc6676 AS prod-image-pre-test
+FROM quay.io/redhat-services-prod/app-sre-tenant/container-images-master/qontract-reconcile-base-master:1.6.0-1@sha256:5e308a422841a2ad80b82c0601cd4765fd3b52f65661ff361a15b18a6ff3fbc2 AS prod-image-pre-test
 
 # Tini
 ENV TINI_VERSION=v0.19.0

--- a/reconcile/prometheus_rules_tester/integration.py
+++ b/reconcile/prometheus_rules_tester/integration.py
@@ -45,7 +45,7 @@ NAMESPACE_NAMES = frozenset([
     "openshift-customer-monitoring",
     "app-sre-observability-per-cluster",
 ])
-DEFAULT_PROMTOOL_VERSION = "3.2.1"
+DEFAULT_PROMTOOL_VERSION = "3.9.1"
 
 
 class TestContent(BaseModel):

--- a/reconcile/utils/promtool.py
+++ b/reconcile/utils/promtool.py
@@ -10,7 +10,7 @@ import yaml
 from reconcile.utils.defer import defer
 from reconcile.utils.structs import CommandExecutionResult
 
-PROMTOOL_VERSION = ["2.55.1", "3.2.1"]
+PROMTOOL_VERSION = ["2.55.1", "3.9.1"]
 PROMTOOL_VERSION_REGEX = r"^promtool,\sversion\s([\d]+\.[\d]+\.[\d]+).+$"
 
 


### PR DESCRIPTION
## Summary

- Bump `qontract-reconcile-base` from `1.5.2-1` to `1.6.0-1` (stages dev-image and prod-image-pre-test)
- Update `DEFAULT_PROMTOOL_VERSION` from `3.2.1` to `3.9.1`
- Update `PROMTOOL_VERSION` list from `["2.55.1", "3.2.1"]` to `["2.55.1", "3.9.1"]`

The new base image adds promtool 3.9.1 and removes the unused 3.2.1 (Python 3.12/UBI9 — not the 2.x.x Python 3.14 series).

Depends on: https://github.com/app-sre/container-images/pull/308

## Test plan

- [ ] Konflux build passes with new base image
- [ ] `promtool-3.9.1` invoked correctly by `prometheus_rules_tester` integration
- [ ] Existing 2.55.1 tests unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the container base image used for development and pre-test builds.
* **Chores**
  * Upgraded Prometheus rule testing tooling to Promtool 3.9.1 (default and supported version).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->