### PR TITLE
chore(lint): move type-only imports into TYPE_CHECKING blocks (TC001/TC002/TC003)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -258,6 +258,11 @@ allow-star-arg-any = true
 
 [tool.ruff.lint.flake8-type-checking]
 runtime-evaluated-base-classes = ["pydantic.BaseModel"]
+runtime-evaluated-decorators = [
+    "dataclasses.dataclass",
+    "pydantic.dataclasses.dataclass",
+    "pydantic.validate_call",
+]
 
 [tool.ruff.lint.isort]
 known-first-party = ["reconcile", "tools"]

--- a/qontract_api/pyproject.toml
+++ b/qontract_api/pyproject.toml
@@ -123,6 +123,14 @@ ignore = [
     "S106",    # Possible hardcoded password (test fixtures use hardcoded values)
     "SLF001",  # Private member access (testing internal state)
 ]
+[tool.ruff.lint.flake8-type-checking]
+runtime-evaluated-base-classes = ["pydantic.BaseModel"]
+runtime-evaluated-decorators = [
+    "dataclasses.dataclass",
+    "pydantic.dataclasses.dataclass",
+    "pydantic.validate_call",
+]
+
 [tool.ruff.lint.isort]
 known-first-party = ["qontract_api"]
 

--- a/qontract_utils/pyproject.toml
+++ b/qontract_utils/pyproject.toml
@@ -121,6 +121,14 @@ ignore = [
     "SLF001",  # Private member access (testing internal state)
 ]
 
+[tool.ruff.lint.flake8-type-checking]
+runtime-evaluated-base-classes = ["pydantic.BaseModel"]
+runtime-evaluated-decorators = [
+    "dataclasses.dataclass",
+    "pydantic.dataclasses.dataclass",
+    "pydantic.validate_call",
+]
+
 [tool.ruff.lint.isort]
 split-on-trailing-comma = false
 

--- a/reconcile/aus/advanced_upgrade_service.py
+++ b/reconcile/aus/advanced_upgrade_service.py
@@ -1,7 +1,9 @@
+from __future__ import annotations
+
 import logging
 from collections import defaultdict
 from datetime import timedelta
-from typing import Annotated, Optional
+from typing import Annotated
 
 from pydantic import (
     BaseModel,
@@ -115,7 +117,7 @@ class AdvancedUpgradeServiceIntegration(OCMClusterUpgradeSchedulerOrgIntegration
                 )
         return envs_org_upgrade_specs
 
-    def init_version_data_network(self) -> dict["OrgRef", "VersionDataInheritance"]:
+    def init_version_data_network(self) -> dict[OrgRef, VersionDataInheritance]:
         # collect all version data labels from all OCM environments ...
         org_to_env: dict[str, OCMEnvironment] = {}
         labels_by_org: dict[str, list[OCMOrganizationLabel]] = defaultdict(list)
@@ -139,7 +141,7 @@ class AdvancedUpgradeServiceIntegration(OCMClusterUpgradeSchedulerOrgIntegration
     def _build_ocm_env_upgrade_specs(
         self,
         ocm_env: OCMEnvironment,
-        inheritance_network: dict["OrgRef", "VersionDataInheritance"],
+        inheritance_network: dict[OrgRef, VersionDataInheritance],
     ) -> dict[str, OrganizationUpgradeSpec]:
         organizations = {
             org.org_id: org for org in self.get_orgs_for_environment(ocm_env)
@@ -250,7 +252,7 @@ def _build_org_upgrade_specs_for_ocm_env(
     orgs: dict[str, AUSOCMOrganization],
     clusters_by_org: dict[str, list[ClusterDetails]],
     labels_by_org: dict[str, LabelContainer],
-    inheritance_network: dict[str, "VersionDataInheritance"],
+    inheritance_network: dict[str, VersionDataInheritance],
     cluster_health_providers: dict[str, ClusterHealthProvider],
     node_pool_specs_by_org_cluster: dict[str, dict[str, list[NodePoolSpec]]],
 ) -> dict[str, OrganizationUpgradeSpec]:
@@ -333,7 +335,7 @@ def _build_org_upgrade_spec(
     org: AUSOCMOrganization,
     clusters: list[ClusterDetails],
     org_labels: LabelContainer,
-    version_data_inheritance: Optional["VersionDataInheritance"],
+    version_data_inheritance: VersionDataInheritance | None,
     cluster_health_provider: AUSClusterHealthCheckProvider,
     node_pool_specs_by_cluster_id: dict[str, list[NodePoolSpec]],
 ) -> OrganizationUpgradeSpec:

--- a/reconcile/aus/advanced_upgrade_service.py
+++ b/reconcile/aus/advanced_upgrade_service.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import logging
 from collections import defaultdict
 from datetime import timedelta
-from typing import Annotated
+from typing import TYPE_CHECKING, Annotated
 
 from pydantic import (
     BaseModel,
@@ -39,13 +39,11 @@ from reconcile.gql_definitions.fragments.aus_organization import (
 from reconcile.gql_definitions.fragments.minimal_ocm_organization import (
     MinimalOCMOrganization,
 )
-from reconcile.gql_definitions.fragments.ocm_environment import OCMEnvironment
 from reconcile.gql_definitions.fragments.upgrade_policy import (
     ClusterUpgradePolicyConditionsV1,
     ClusterUpgradePolicyV1,
 )
 from reconcile.utils import metrics
-from reconcile.utils.clusterhealth.providerbase import ClusterHealthProvider
 from reconcile.utils.models import (
     CSV,
     cron_validator,
@@ -78,6 +76,10 @@ from reconcile.utils.ocm_base_client import (
     init_ocm_base_client,
 )
 from reconcile.utils.semver_helper import make_semver
+
+if TYPE_CHECKING:
+    from reconcile.gql_definitions.fragments.ocm_environment import OCMEnvironment
+    from reconcile.utils.clusterhealth.providerbase import ClusterHealthProvider
 
 QONTRACT_INTEGRATION = "advanced-upgrade-scheduler"
 QONTRACT_INTEGRATION_VERSION = make_semver(0, 1, 0)

--- a/reconcile/aus/base.py
+++ b/reconcile/aus/base.py
@@ -7,7 +7,6 @@ from abc import (
     abstractmethod,
 )
 from collections import defaultdict
-from collections.abc import Callable, Sequence
 from datetime import (
     datetime,
     timedelta,
@@ -63,15 +62,9 @@ from reconcile.gql_definitions.common.ocm_env_telemeter import (
 from reconcile.gql_definitions.common.ocm_environments import (
     query as ocm_environment_query,
 )
-from reconcile.gql_definitions.fragments.aus_organization import AUSOCMOrganization
-from reconcile.gql_definitions.fragments.ocm_environment import OCMEnvironment
-from reconcile.gql_definitions.fragments.upgrade_policy import ClusterUpgradePolicyV1
 from reconcile.utils import (
     gql,
     metrics,
-)
-from reconcile.utils.clusterhealth.providerbase import (
-    ClusterHealthProvider,
 )
 from reconcile.utils.clusterhealth.telemeter import (
     TELEMETER_SOURCE,
@@ -103,7 +96,6 @@ from reconcile.utils.ocm.upgrades import (
     get_version_agreement,
     get_version_gates,
 )
-from reconcile.utils.ocm_base_client import OCMBaseClient
 from reconcile.utils.prometheus import (
     init_prometheus_http_querier_from_prometheus_instance,
 )
@@ -111,7 +103,6 @@ from reconcile.utils.runtime.integration import (
     PydanticRunParams,
     QontractReconcileIntegration,
 )
-from reconcile.utils.secret_reader import SecretReaderBase
 from reconcile.utils.semver_helper import (
     get_version_prefix,
     parse_semver,
@@ -120,7 +111,20 @@ from reconcile.utils.semver_helper import (
 from reconcile.utils.state import init_state
 
 if TYPE_CHECKING:
+    from collections.abc import Callable, Sequence
+
     from semver import VersionInfo
+
+    from reconcile.gql_definitions.fragments.aus_organization import AUSOCMOrganization
+    from reconcile.gql_definitions.fragments.ocm_environment import OCMEnvironment
+    from reconcile.gql_definitions.fragments.upgrade_policy import (
+        ClusterUpgradePolicyV1,
+    )
+    from reconcile.utils.clusterhealth.providerbase import (
+        ClusterHealthProvider,
+    )
+    from reconcile.utils.ocm_base_client import OCMBaseClient
+    from reconcile.utils.secret_reader import SecretReaderBase
 
 MIN_DELTA_MINUTES = 6
 

--- a/reconcile/aus/base.py
+++ b/reconcile/aus/base.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import logging
 import sys
 from abc import (
@@ -11,6 +13,7 @@ from datetime import (
     timedelta,
 )
 from typing import (
+    TYPE_CHECKING,
     Protocol,
     cast,
 )
@@ -18,7 +21,6 @@ from typing import (
 from croniter import croniter
 from pydantic import BaseModel
 from requests.exceptions import HTTPError
-from semver import VersionInfo
 
 from reconcile.aus.aus_sts_gate_handler import (
     AUS_VERSION_GATE_APPROVALS_LABEL,
@@ -116,6 +118,9 @@ from reconcile.utils.semver_helper import (
     sort_versions,
 )
 from reconcile.utils.state import init_state
+
+if TYPE_CHECKING:
+    from semver import VersionInfo
 
 MIN_DELTA_MINUTES = 6
 
@@ -233,8 +238,8 @@ class AdvancedUpgradeSchedulerBaseIntegration(
         self,
         org_upgrade_spec: OrganizationUpgradeSpec,
         version_data: VersionData,
-        current_state: Sequence["AbstractUpgradePolicy"],
-        metrics_builder: "RemainingSoakDayMetricsBuilder",
+        current_state: Sequence[AbstractUpgradePolicy],
+        metrics_builder: RemainingSoakDayMetricsBuilder,
     ) -> None:
         current_cluster_upgrade_policies = {
             p.cluster.external_id: p for p in current_state

--- a/reconcile/aus/cluster_version_data.py
+++ b/reconcile/aus/cluster_version_data.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from collections.abc import Iterable
 from datetime import datetime
 from typing import (
@@ -50,7 +52,7 @@ class Stats(BaseModel):
     min_version_per_workload: dict[str, str] = Field(default_factory=dict)
     inherited: Optional["Stats"] = None
 
-    def inherit(self, added: "Stats") -> None:
+    def inherit(self, added: Stats) -> None:
         """adds the provided stats to our inherited data
         If we already have inherited data, we will merge the stats data:
         compute new minimums and add missing data
@@ -145,7 +147,7 @@ class VersionData(BaseModel):
                 min_version_per_workload=min_version_per_workload,
             )
 
-    def aggregate(self, added: "VersionData", added_scope: str) -> None:
+    def aggregate(self, added: VersionData, added_scope: str) -> None:
         """aggregate an other version data with this one.
         this adds new value and merges the ones we we already have
         """

--- a/reconcile/aus/cluster_version_data.py
+++ b/reconcile/aus/cluster_version_data.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 
-from collections.abc import Iterable
 from datetime import datetime
 from typing import (
+    TYPE_CHECKING,
     Any,
     Optional,
 )
@@ -12,9 +12,13 @@ from pydantic import (
     Field,
 )
 
-from reconcile.aus.models import OrganizationUpgradeSpec
 from reconcile.utils.semver_helper import parse_semver
-from reconcile.utils.state import State
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
+
+    from reconcile.aus.models import OrganizationUpgradeSpec
+    from reconcile.utils.state import State
 
 
 class WorkloadHistory(BaseModel):

--- a/reconcile/aus/healthchecks.py
+++ b/reconcile/aus/healthchecks.py
@@ -1,9 +1,12 @@
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 from pydantic import BaseModel
 
-from reconcile.gql_definitions.fragments.aus_organization import AUSOCMOrganization
-from reconcile.utils.clusterhealth.providerbase import ClusterHealthProvider
+if TYPE_CHECKING:
+    from reconcile.gql_definitions.fragments.aus_organization import AUSOCMOrganization
+    from reconcile.utils.clusterhealth.providerbase import ClusterHealthProvider
 
 
 class AUSHealthError(BaseModel):

--- a/reconcile/aus/healthchecks.py
+++ b/reconcile/aus/healthchecks.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from pydantic import BaseModel
 
 from reconcile.gql_definitions.fragments.aus_organization import AUSOCMOrganization
@@ -39,7 +41,7 @@ class AUSClusterHealthCheckProvider:
 
     def add_provider(
         self, name: str, provider: ClusterHealthProvider, enforce: bool
-    ) -> "AUSClusterHealthCheckProvider":
+    ) -> AUSClusterHealthCheckProvider:
         self.providers[name] = (provider, enforce)
         return self
 

--- a/reconcile/automated_actions/config/integration.py
+++ b/reconcile/automated_actions/config/integration.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import logging
 from collections.abc import (
     Callable,
@@ -89,7 +91,7 @@ class AutomatedActionsConfigIntegration(
 
     def get_automated_actions_instances(
         self, query_func: Callable
-    ) -> Generator[AutomatedActionsInstanceV1, None, None]:
+    ) -> Generator[AutomatedActionsInstanceV1]:
         """Return all automated actions."""
         data = instance_query(query_func, variables={})
         for instance in data.automated_actions_instances_v1 or []:
@@ -109,7 +111,7 @@ class AutomatedActionsConfigIntegration(
 
     def filter_actions(
         self, actions: Iterable[AutomatedActionV1]
-    ) -> Generator[AutomatedActionV1, None, None]:
+    ) -> Generator[AutomatedActionV1]:
         """Filter out expired roles and arguments (cluster.namespace) with disabled integrations."""
         for action in actions:
             match action:

--- a/reconcile/automated_actions/config/integration.py
+++ b/reconcile/automated_actions/config/integration.py
@@ -1,12 +1,7 @@
 from __future__ import annotations
 
 import logging
-from collections.abc import (
-    Callable,
-    Generator,
-    Iterable,
-)
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import yaml
 from kubernetes.client import (
@@ -34,7 +29,6 @@ from reconcile.gql_definitions.automated_actions.instance import query as instan
 from reconcile.utils import expiration, gql
 from reconcile.utils.defer import defer
 from reconcile.utils.disabled_integrations import integration_is_enabled
-from reconcile.utils.oc import OCCli
 from reconcile.utils.oc_map import init_oc_map_from_namespaces
 from reconcile.utils.openshift_resource import OpenshiftResource, ResourceInventory
 from reconcile.utils.runtime.integration import (
@@ -42,6 +36,15 @@ from reconcile.utils.runtime.integration import (
     QontractReconcileIntegration,
 )
 from reconcile.utils.semver_helper import make_semver
+
+if TYPE_CHECKING:
+    from collections.abc import (
+        Callable,
+        Generator,
+        Iterable,
+    )
+
+    from reconcile.utils.oc import OCCli
 
 QONTRACT_INTEGRATION = "automated-actions-config"
 QONTRACT_INTEGRATION_VERSION = make_semver(0, 1, 1)

--- a/reconcile/aws_account_manager/integration.py
+++ b/reconcile/aws_account_manager/integration.py
@@ -1,9 +1,10 @@
+from __future__ import annotations
+
 from collections.abc import Callable, Iterable
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import jinja2
 from qontract_utils.aws_api_typed.api import AWSApi, AWSStaticCredentials
-from qontract_utils.aws_api_typed.iam import AWSAccessKey
 
 from reconcile.aws_account_manager.merge_request_manager import MergeRequestManager
 from reconcile.aws_account_manager.metrics import (
@@ -36,6 +37,9 @@ from reconcile.utils.semver_helper import make_semver
 from reconcile.utils.state import init_state
 from reconcile.utils.unleash import get_feature_toggle_state
 from reconcile.utils.vcs import VCS
+
+if TYPE_CHECKING:
+    from qontract_utils.aws_api_typed.iam import AWSAccessKey
 
 QONTRACT_INTEGRATION = "aws-account-manager"
 QONTRACT_INTEGRATION_VERSION = make_semver(1, 0, 0)

--- a/reconcile/aws_account_manager/integration.py
+++ b/reconcile/aws_account_manager/integration.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-from collections.abc import Callable, Iterable
 from typing import TYPE_CHECKING, Any
 
 import jinja2
@@ -39,6 +38,8 @@ from reconcile.utils.unleash import get_feature_toggle_state
 from reconcile.utils.vcs import VCS
 
 if TYPE_CHECKING:
+    from collections.abc import Callable, Iterable
+
     from qontract_utils.aws_api_typed.iam import AWSAccessKey
 
 QONTRACT_INTEGRATION = "aws-account-manager"

--- a/reconcile/aws_account_manager/reconciler.py
+++ b/reconcile/aws_account_manager/reconciler.py
@@ -1,14 +1,11 @@
+from __future__ import annotations
+
 import logging
 from collections.abc import Iterable
 from textwrap import dedent
-from typing import Any, Protocol
+from typing import TYPE_CHECKING, Any, Protocol
 
 from qontract_utils.aws_api_typed.account import OptStatus
-from qontract_utils.aws_api_typed.api import AWSApi
-from qontract_utils.aws_api_typed.iam import (
-    AWSAccessKey,
-)
-from qontract_utils.aws_api_typed.organization import AwsOrganizationOU
 from qontract_utils.aws_api_typed.service_quotas import (
     AWSResourceAlreadyExistsError,
 )
@@ -16,6 +13,13 @@ from qontract_utils.aws_api_typed.support import SupportPlan
 
 from reconcile.aws_account_manager.utils import state_key
 from reconcile.utils.state import AbortStateTransactionError, State
+
+if TYPE_CHECKING:
+    from qontract_utils.aws_api_typed.api import AWSApi
+    from qontract_utils.aws_api_typed.iam import (
+        AWSAccessKey,
+    )
+    from qontract_utils.aws_api_typed.organization import AwsOrganizationOU
 
 TASK_CREATE_ACCOUNT = "create-account"
 TASK_DESCRIBE_ACCOUNT = "describe-account"

--- a/reconcile/aws_account_manager/reconciler.py
+++ b/reconcile/aws_account_manager/reconciler.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import logging
-from collections.abc import Iterable
 from textwrap import dedent
 from typing import TYPE_CHECKING, Any, Protocol
 
@@ -15,6 +14,8 @@ from reconcile.aws_account_manager.utils import state_key
 from reconcile.utils.state import AbortStateTransactionError, State
 
 if TYPE_CHECKING:
+    from collections.abc import Iterable
+
     from qontract_utils.aws_api_typed.api import AWSApi
     from qontract_utils.aws_api_typed.iam import (
         AWSAccessKey,

--- a/reconcile/change_owners/change_log_tracking.py
+++ b/reconcile/change_owners/change_log_tracking.py
@@ -1,11 +1,11 @@
+from __future__ import annotations
+
 import json
 import logging
 from collections import defaultdict
 from collections.abc import Callable
+from typing import TYPE_CHECKING
 
-from gitlab.v4.objects import (
-    ProjectCommit,
-)
 from pydantic import BaseModel
 
 from reconcile.change_owners.bundle import (
@@ -32,6 +32,11 @@ from reconcile.utils.runtime.integration import (
     QontractReconcileIntegration,
 )
 from reconcile.utils.state import init_state
+
+if TYPE_CHECKING:
+    from gitlab.v4.objects import (
+        ProjectCommit,
+    )
 
 QONTRACT_INTEGRATION = "change-log-tracking"
 BUNDLE_DIFFS_OBJ = "bundle-diffs.json"

--- a/reconcile/change_owners/change_log_tracking.py
+++ b/reconcile/change_owners/change_log_tracking.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import json
 import logging
 from collections import defaultdict
-from collections.abc import Callable
 from typing import TYPE_CHECKING
 
 from pydantic import BaseModel
@@ -34,6 +33,8 @@ from reconcile.utils.runtime.integration import (
 from reconcile.utils.state import init_state
 
 if TYPE_CHECKING:
+    from collections.abc import Callable
+
     from gitlab.v4.objects import (
         ProjectCommit,
     )

--- a/reconcile/change_owners/change_owners.py
+++ b/reconcile/change_owners/change_owners.py
@@ -1,8 +1,9 @@
+from __future__ import annotations
+
 import logging
 import sys
 import traceback
-
-from gitlab.v4.objects import ProjectMergeRequest
+from typing import TYPE_CHECKING
 
 from reconcile import queries
 from reconcile.change_owners.approver import GqlApproverResolver
@@ -48,6 +49,9 @@ from reconcile.utils.mr.labels import (
 )
 from reconcile.utils.output import format_table
 from reconcile.utils.semver_helper import make_semver
+
+if TYPE_CHECKING:
+    from gitlab.v4.objects import ProjectMergeRequest
 
 QONTRACT_INTEGRATION = "change-owners"
 QONTRACT_INTEGRATION_VERSION = make_semver(0, 1, 0)

--- a/reconcile/change_owners/change_types.py
+++ b/reconcile/change_owners/change_types.py
@@ -27,16 +27,11 @@ import jinja2.meta
 import jsonpath_ng
 import networkx
 
-from reconcile.change_owners.approver import (
-    Approver,
-    ApproverReachability,
-)
 from reconcile.change_owners.bundle import (
     BundleFileType,
     FileDiffResolver,
     FileRef,
 )
-from reconcile.change_owners.diff import Diff
 from reconcile.gql_definitions.change_owners.queries.change_types import (
     ChangeTypeChangeDetectorChangeTypeProviderV1,
     ChangeTypeChangeDetectorJsonPathProviderV1,
@@ -51,6 +46,12 @@ from reconcile.utils.jsonpath import (
 
 if TYPE_CHECKING:
     from pydantic import Json
+
+    from reconcile.change_owners.approver import (
+        Approver,
+        ApproverReachability,
+    )
+    from reconcile.change_owners.diff import Diff
 
 
 class ChangeTypePriority(Enum):

--- a/reconcile/change_owners/change_types.py
+++ b/reconcile/change_owners/change_types.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from abc import (
     ABC,
     abstractmethod,
@@ -16,15 +18,14 @@ from dataclasses import (
 )
 from enum import Enum
 from typing import (
+    TYPE_CHECKING,
     Any,
-    Optional,
 )
 
 import jinja2
 import jinja2.meta
 import jsonpath_ng
 import networkx
-from pydantic import Json
 
 from reconcile.change_owners.approver import (
     Approver,
@@ -47,6 +48,9 @@ from reconcile.utils.jsonpath import (
     remove_prefix_from_path,
     sortable_jsonpath_string_repr,
 )
+
+if TYPE_CHECKING:
+    from pydantic import Json
 
 
 class ChangeTypePriority(Enum):
@@ -73,17 +77,17 @@ def parent_of_jsonpath(path: jsonpath_ng.JSONPath) -> jsonpath_ng.JSONPath | Non
 @dataclass
 class DiffCoverage:
     diff: Diff
-    coverage: list["ChangeTypeContext"]
+    coverage: list[ChangeTypeContext]
 
     # if a diff is split into smaller diffs, they are stored here
     # please notice that the splits are DiffCoverages objects themselves which
     # can have splits on their own. DiffCoverage objects form a tree-like structure
-    _split_into: list["DiffCoverage"] = field(default_factory=list)
+    _split_into: list[DiffCoverage] = field(default_factory=list)
 
-    parent: Optional["DiffCoverage"] = None
+    parent: DiffCoverage | None = None
 
     @property
-    def diff_fragments(self) -> Sequence["DiffCoverage"]:
+    def diff_fragments(self) -> Sequence[DiffCoverage]:
         return self._split_into
 
     @property
@@ -160,8 +164,8 @@ class DiffCoverage:
         ) and str(path) != str(self.diff.path)
 
     def split(
-        self, path: jsonpath_ng.JSONPath, ctx: "ChangeTypeContext"
-    ) -> Optional["DiffCoverage"]:
+        self, path: jsonpath_ng.JSONPath, ctx: ChangeTypeContext
+    ) -> DiffCoverage | None:
         """
         create a new DiffCoverage object that coveres the given path
         this function also manages the split tree structure in _split_into
@@ -202,12 +206,12 @@ class DiffCoverage:
 
         return None
 
-    def add_covering_context(self, ctx: "ChangeTypeContext") -> None:
+    def add_covering_context(self, ctx: ChangeTypeContext) -> None:
         self.coverage.append(ctx)
         for s in self._split_into:
             s.add_covering_context(ctx)
 
-    def fine_grained_diff_coverages(self) -> dict[str, "DiffCoverage"]:
+    def fine_grained_diff_coverages(self) -> dict[str, DiffCoverage]:
         coverages = {}
         for s in self._split_into:
             coverages.update(s.fine_grained_diff_coverages())
@@ -251,7 +255,7 @@ class PathExpression:
         else:
             self.parsed_jsonpath = parse_jsonpath(jsonpath_expression)
 
-    def jsonpath_for_context(self, ctx: "ChangeTypeContext") -> jsonpath_ng.JSONPath:
+    def jsonpath_for_context(self, ctx: ChangeTypeContext) -> jsonpath_ng.JSONPath:
         if self.parsed_jsonpath:
             return self.parsed_jsonpath
 
@@ -366,14 +370,14 @@ class ContextExpansion:
     """
 
     context: OwnershipContext
-    change_type: "ChangeTypeProcessor"
+    change_type: ChangeTypeProcessor
     file_diff_resolver: FileDiffResolver
 
     def expand_from_file_ref(
         self,
         file_ref: FileRef,
         expansion_trail: AbstractSet[tuple[str, FileRef]],
-    ) -> list["ResolvedContext"]:
+    ) -> list[ResolvedContext]:
         old_data, new_data = self.file_diff_resolver.lookup_file_diff(file_ref)
         return self.expand(
             FileChange(
@@ -388,7 +392,7 @@ class ContextExpansion:
         self,
         change: FileChange,
         expansion_trail: AbstractSet[tuple[str, FileRef]],
-    ) -> list["ResolvedContext"]:
+    ) -> list[ResolvedContext]:
         """
         Find context based on the `self.context`, lookup the file diff for
         that new context and expose everything as a new `ResolvedContext` with
@@ -423,7 +427,7 @@ class ResolvedContext:
 
     owned_file_ref: FileRef
     context_file_ref: FileRef
-    change_type: "ChangeTypeProcessor"
+    change_type: ChangeTypeProcessor
 
 
 @dataclass
@@ -620,7 +624,7 @@ class ChangeTypeProcessor:
         return contexts
 
     def allowed_changed_paths(
-        self, file_ref: FileRef, file_content: Any, ctx: "ChangeTypeContext"
+        self, file_ref: FileRef, file_content: Any, ctx: ChangeTypeContext
     ) -> list[jsonpath_ng.JSONPath]:
         """
         find all paths within the provide file_content, that are covered by this
@@ -644,7 +648,7 @@ class ChangeTypeProcessor:
         file_type: BundleFileType,
         file_schema: str | None,
         file_content: Any,
-        ctx: "ChangeTypeContext",
+        ctx: ChangeTypeContext,
     ) -> list[jsonpath_ng.JSONPath]:
         paths = []
         if (
@@ -683,7 +687,7 @@ class ChangeTypeProcessor:
     def add_context_expansion(self, context_expansion: ContextExpansion) -> None:
         self._context_expansions.append(context_expansion)
 
-    def inherit_from(self, other: "ChangeTypeProcessor") -> None:
+    def inherit_from(self, other: ChangeTypeProcessor) -> None:
         for detector in other.change_detectors:
             self.add_change_detector(detector)
         other._heritage = self.lineage.union(other._heritage)

--- a/reconcile/change_owners/change_types.py
+++ b/reconcile/change_owners/change_types.py
@@ -18,7 +18,6 @@ from dataclasses import (
 )
 from enum import Enum
 from typing import (
-    TYPE_CHECKING,
     Any,
 )
 
@@ -26,12 +25,18 @@ import jinja2
 import jinja2.meta
 import jsonpath_ng
 import networkx
+from pydantic import Json
 
+from reconcile.change_owners.approver import (
+    Approver,
+    ApproverReachability,
+)
 from reconcile.change_owners.bundle import (
     BundleFileType,
     FileDiffResolver,
     FileRef,
 )
+from reconcile.change_owners.diff import Diff
 from reconcile.gql_definitions.change_owners.queries.change_types import (
     ChangeTypeChangeDetectorChangeTypeProviderV1,
     ChangeTypeChangeDetectorJsonPathProviderV1,
@@ -43,15 +48,6 @@ from reconcile.utils.jsonpath import (
     remove_prefix_from_path,
     sortable_jsonpath_string_repr,
 )
-
-if TYPE_CHECKING:
-    from pydantic import Json
-
-    from reconcile.change_owners.approver import (
-        Approver,
-        ApproverReachability,
-    )
-    from reconcile.change_owners.diff import Diff
 
 
 class ChangeTypePriority(Enum):

--- a/reconcile/change_owners/decision.py
+++ b/reconcile/change_owners/decision.py
@@ -1,20 +1,23 @@
 from __future__ import annotations
 
 from collections import defaultdict
-from collections.abc import Iterable
 from dataclasses import dataclass
 from enum import Enum
 from operator import attrgetter
+from typing import TYPE_CHECKING
 
-from reconcile.change_owners.approver import (
-    Approver,
-    ApproverReachability,
-)
-from reconcile.change_owners.bundle import FileRef
-from reconcile.change_owners.change_types import ChangeTypeContext, DiffCoverage
-from reconcile.change_owners.changes import BundleFileChange
-from reconcile.change_owners.diff import Diff
-from reconcile.utils.gitlab_api import Comment
+if TYPE_CHECKING:
+    from collections.abc import Iterable
+
+    from reconcile.change_owners.approver import (
+        Approver,
+        ApproverReachability,
+    )
+    from reconcile.change_owners.bundle import FileRef
+    from reconcile.change_owners.change_types import ChangeTypeContext, DiffCoverage
+    from reconcile.change_owners.changes import BundleFileChange
+    from reconcile.change_owners.diff import Diff
+    from reconcile.utils.gitlab_api import Comment
 
 
 class DecisionCommand(Enum):

--- a/reconcile/change_owners/decision.py
+++ b/reconcile/change_owners/decision.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from collections import defaultdict
 from collections.abc import Iterable
 from dataclasses import dataclass
@@ -82,12 +84,12 @@ class ChangeDecision:
 
     def apply_decision(
         self, ctx: ChangeTypeContext, decision_cmd: DecisionCommand
-    ) -> "ChangeDecision":
+    ) -> ChangeDecision:
         return self.apply_context_decision(ctx.context, decision_cmd)
 
     def apply_context_decision(
         self, context: str, decision_cmd: DecisionCommand
-    ) -> "ChangeDecision":
+    ) -> ChangeDecision:
         if decision_cmd == DecisionCommand.APPROVED:
             self.approve[context] = True
         elif decision_cmd == DecisionCommand.CANCEL_APPROVED:

--- a/reconcile/change_owners/decision.py
+++ b/reconcile/change_owners/decision.py
@@ -6,17 +6,19 @@ from enum import Enum
 from operator import attrgetter
 from typing import TYPE_CHECKING
 
+from reconcile.change_owners.approver import (
+    Approver,
+    ApproverReachability,
+)
+from reconcile.change_owners.bundle import FileRef
+from reconcile.change_owners.change_types import ChangeTypeContext
+from reconcile.change_owners.diff import Diff
+
 if TYPE_CHECKING:
     from collections.abc import Iterable
 
-    from reconcile.change_owners.approver import (
-        Approver,
-        ApproverReachability,
-    )
-    from reconcile.change_owners.bundle import FileRef
-    from reconcile.change_owners.change_types import ChangeTypeContext, DiffCoverage
+    from reconcile.change_owners.change_types import DiffCoverage
     from reconcile.change_owners.changes import BundleFileChange
-    from reconcile.change_owners.diff import Diff
     from reconcile.utils.gitlab_api import Comment
 
 

--- a/reconcile/change_owners/diff.py
+++ b/reconcile/change_owners/diff.py
@@ -1,17 +1,21 @@
+from __future__ import annotations
+
 import copy
 from dataclasses import dataclass
 from enum import Enum
 from functools import reduce
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import jsonpath_ng
 from deepdiff import DeepDiff
 from deepdiff.helper import CannotCompare
-from deepdiff.model import DiffLevel
 from deepdiff.path import parse_path
 
 from reconcile.utils.json import json_dumps
 from reconcile.utils.jsonpath import parse_jsonpath
+
+if TYPE_CHECKING:
+    from deepdiff.model import DiffLevel
 
 
 class DiffType(Enum):
@@ -31,7 +35,7 @@ class Diff:
     old: Any | None
     new: Any | None
 
-    def create_subdiff(self, sub_path: jsonpath_ng.JSONPath) -> "Diff":
+    def create_subdiff(self, sub_path: jsonpath_ng.JSONPath) -> Diff:
         if sub_path == self.path:
             # no need to subdiff ... this is the same path
             return self

--- a/reconcile/change_owners/self_service_roles.py
+++ b/reconcile/change_owners/self_service_roles.py
@@ -1,13 +1,13 @@
 from collections import defaultdict
 
 from reconcile.change_owners.approver import (
+    Approver,
     ApproverReachability,
     GitlabGroupApproverReachability,
     SlackGroupApproverReachability,
 )
 from reconcile.change_owners.bundle import BundleFileType
 from reconcile.change_owners.change_types import (
-    Approver,
     ChangeTypeContext,
     ChangeTypeProcessor,
     FileChange,

--- a/reconcile/change_owners/tester.py
+++ b/reconcile/change_owners/tester.py
@@ -1,10 +1,11 @@
+from __future__ import annotations
+
 import os
 import sys
 from collections.abc import Generator
 from dataclasses import dataclass
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
-import jsonpath_ng
 import pygments
 import pygments.lexers
 import yaml
@@ -28,6 +29,9 @@ from reconcile.change_owners.self_service_roles import (
 from reconcile.gql_definitions.change_owners.queries import self_service_roles
 from reconcile.gql_definitions.change_owners.queries.self_service_roles import RoleV1
 from reconcile.utils import gql
+
+if TYPE_CHECKING:
+    import jsonpath_ng
 
 
 def test_change_type_in_context(
@@ -205,7 +209,7 @@ class SelfServiceableHighlighter(Filter):
         Filter.__init__(self)
         self.self_serviceable_marker = self_serviceable_marker
 
-    def filter(self, _: Any, stream: Any) -> Generator[tuple[Any, Any], None, None]:
+    def filter(self, _: Any, stream: Any) -> Generator[tuple[Any, Any]]:
         for ttype, value in stream:
             if value != self.self_serviceable_marker:
                 ttype = Name

--- a/reconcile/change_owners/tester.py
+++ b/reconcile/change_owners/tester.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import os
 import sys
-from collections.abc import Generator
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
@@ -27,11 +26,16 @@ from reconcile.change_owners.self_service_roles import (
     change_type_contexts_for_self_service_roles,
 )
 from reconcile.gql_definitions.change_owners.queries import self_service_roles
-from reconcile.gql_definitions.change_owners.queries.self_service_roles import RoleV1
 from reconcile.utils import gql
 
 if TYPE_CHECKING:
+    from collections.abc import Generator
+
     import jsonpath_ng
+
+    from reconcile.gql_definitions.change_owners.queries.self_service_roles import (
+        RoleV1,
+    )
 
 
 def test_change_type_in_context(

--- a/reconcile/checkpoint.py
+++ b/reconcile/checkpoint.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 """Performs an SRE checkpoint.
 
 The checks are defined in
@@ -18,15 +20,17 @@ from functools import (
 )
 from http import HTTPStatus
 from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import requests
 from jinja2 import Template
-from jira import Issue
 
 from reconcile.utils.constants import PROJ_ROOT
 from reconcile.utils.jira_client import JiraClient
 from reconcile.utils.secret_reader import SecretReaderBase
+
+if TYPE_CHECKING:
+    from jira import Issue
 
 DEFAULT_CHECKPOINT_LABELS = ("sre-checkpoint",)
 

--- a/reconcile/checkpoint.py
+++ b/reconcile/checkpoint.py
@@ -9,17 +9,11 @@ https://gitlab.cee.redhat.com/app-sre/contract/-/blob/master/content/process/sre
 
 import logging
 import re
-from collections.abc import (
-    Callable,
-    Iterable,
-    Mapping,
-)
 from functools import (
     lru_cache,
     partial,
 )
 from http import HTTPStatus
-from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 import requests
@@ -27,10 +21,18 @@ from jinja2 import Template
 
 from reconcile.utils.constants import PROJ_ROOT
 from reconcile.utils.jira_client import JiraClient
-from reconcile.utils.secret_reader import SecretReaderBase
 
 if TYPE_CHECKING:
+    from collections.abc import (
+        Callable,
+        Iterable,
+        Mapping,
+    )
+    from pathlib import Path
+
     from jira import Issue
+
+    from reconcile.utils.secret_reader import SecretReaderBase
 
 DEFAULT_CHECKPOINT_LABELS = ("sre-checkpoint",)
 

--- a/reconcile/external_resources/model.py
+++ b/reconcile/external_resources/model.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import hashlib
 from collections.abc import ItemsView, Iterable, Iterator, MutableMapping
 from enum import StrEnum
@@ -44,7 +46,7 @@ from reconcile.utils.json import json_dumps
 
 
 class ExternalResourceOrphanedResourcesError(Exception):
-    def __init__(self, orphans: Iterable["ExternalResourceKey"]) -> None:
+    def __init__(self, orphans: Iterable[ExternalResourceKey]) -> None:
         msg = [
             "There are orphaned resources in the configuration. ",
             "To delete ERv2 managed external resources, set the 'delete: true' attribute.\n",
@@ -83,7 +85,7 @@ class ExternalResourceKey(BaseModel, frozen=True):
     identifier: str
 
     @staticmethod
-    def from_spec(spec: ExternalResourceSpec) -> "ExternalResourceKey":
+    def from_spec(spec: ExternalResourceSpec) -> ExternalResourceKey:
         return ExternalResourceKey(
             provision_provider=spec.provision_provider,
             provisioner_name=spec.provisioner_name,
@@ -257,7 +259,7 @@ class Resources(BaseModel, frozen=True):
     limits: ResourcesSpec = ResourcesSpec()
 
     @staticmethod
-    def from_deploy_resources_fields(fields: DeployResourcesFields) -> "Resources":
+    def from_deploy_resources_fields(fields: DeployResourcesFields) -> Resources:
         """Create Resource obect from GQL DeployResourcesFields.
 
         DeployResourceFields can not be used directly as it not hashable."""
@@ -296,7 +298,7 @@ class ExternalResourceModuleConfiguration(BaseModel, frozen=True):
         module: ExternalResourcesModuleV1,
         spec: ExternalResourceSpec,
         settings: ExternalResourcesSettingsV1,
-    ) -> "ExternalResourceModuleConfiguration":
+    ) -> ExternalResourceModuleConfiguration:
         """Resolve the module configuration for a given ExternalResourceSpec.
         Priority:
         1.- Module_overrides from the spec

--- a/reconcile/external_resources/model.py
+++ b/reconcile/external_resources/model.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import hashlib
 from collections.abc import ItemsView, Iterable, Iterator, MutableMapping
 from enum import StrEnum
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from pydantic import BaseModel, Field
 
@@ -11,9 +11,6 @@ from reconcile.external_resources.meta import (
     FLAG_DELETE_RESOURCE,
     FLAG_RESOURCE_MANAGED_BY_ERV2,
     MODULE_OVERRIDES,
-)
-from reconcile.gql_definitions.external_resources.external_resources_modules import (
-    ExternalResourcesModuleV1,
 )
 from reconcile.gql_definitions.external_resources.external_resources_namespaces import (
     NamespaceTerraformProviderResourceAWSV1,
@@ -31,18 +28,25 @@ from reconcile.gql_definitions.external_resources.external_resources_namespaces 
     NamespaceTerraformResourceVpcEndpointV1,
     NamespaceV1,
 )
-from reconcile.gql_definitions.external_resources.external_resources_settings import (
-    ExternalResourcesSettingsV1,
-)
 from reconcile.gql_definitions.external_resources.fragments.external_resources_module_overrides import (
     ExternalResourcesModuleOverrides,
 )
-from reconcile.gql_definitions.fragments.deploy_resources import DeployResourcesFields
 from reconcile.utils.exceptions import FetchResourceError
 from reconcile.utils.external_resource_spec import (
     ExternalResourceSpec,
 )
 from reconcile.utils.json import json_dumps
+
+if TYPE_CHECKING:
+    from reconcile.gql_definitions.external_resources.external_resources_modules import (
+        ExternalResourcesModuleV1,
+    )
+    from reconcile.gql_definitions.external_resources.external_resources_settings import (
+        ExternalResourcesSettingsV1,
+    )
+    from reconcile.gql_definitions.fragments.deploy_resources import (
+        DeployResourcesFields,
+    )
 
 
 class ExternalResourceOrphanedResourcesError(Exception):

--- a/reconcile/external_resources/state.py
+++ b/reconcile/external_resources/state.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import json
 import logging
-from collections.abc import Mapping
 from datetime import datetime
 from enum import StrEnum
 from hashlib import sha256
@@ -23,6 +22,8 @@ from reconcile.utils.datetime_util import to_utc_microseconds_iso_format, utc_no
 from reconcile.utils.json import json_dumps
 
 if TYPE_CHECKING:
+    from collections.abc import Mapping
+
     from qontract_utils.aws_api_typed.api import AWSApi
 
 DATE_FORMAT = "%Y-%m-%dT%H:%M:%SZ"

--- a/reconcile/external_resources/state.py
+++ b/reconcile/external_resources/state.py
@@ -1,13 +1,14 @@
+from __future__ import annotations
+
 import json
 import logging
 from collections.abc import Mapping
 from datetime import datetime
 from enum import StrEnum
 from hashlib import sha256
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from pydantic import BaseModel
-from qontract_utils.aws_api_typed.api import AWSApi
 
 from reconcile.external_resources.model import (
     ExternalResourceKey,
@@ -20,6 +21,9 @@ from reconcile.external_resources.model import (
 )
 from reconcile.utils.datetime_util import to_utc_microseconds_iso_format, utc_now
 from reconcile.utils.json import json_dumps
+
+if TYPE_CHECKING:
+    from qontract_utils.aws_api_typed.api import AWSApi
 
 DATE_FORMAT = "%Y-%m-%dT%H:%M:%SZ"
 

--- a/reconcile/github_org.py
+++ b/reconcile/github_org.py
@@ -1,12 +1,12 @@
+from __future__ import annotations
+
 import logging
 import os
 from collections.abc import Callable, Iterable, KeysView
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from github import Github
 from github.GithubObject import NotSet  # type: ignore
-from github.Organization import Organization
-from github.Team import Team
 from sretoolbox.utils import retry
 
 from reconcile import (
@@ -23,6 +23,10 @@ from reconcile.utils.aggregated_list import (
 )
 from reconcile.utils.raw_github_api import RawGithubApi
 from reconcile.utils.secret_reader import SecretReader
+
+if TYPE_CHECKING:
+    from github.Organization import Organization
+    from github.Team import Team
 
 GH_BASE_URL = os.environ.get("GITHUB_API", "https://api.github.com")
 

--- a/reconcile/github_org.py
+++ b/reconcile/github_org.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import logging
 import os
-from collections.abc import Callable, Iterable, KeysView
 from typing import TYPE_CHECKING, Any
 
 from github import Github
@@ -25,6 +24,8 @@ from reconcile.utils.raw_github_api import RawGithubApi
 from reconcile.utils.secret_reader import SecretReader
 
 if TYPE_CHECKING:
+    from collections.abc import Callable, Iterable, KeysView
+
     from github.Organization import Organization
     from github.Team import Team
 

--- a/reconcile/gitlab_housekeeping.py
+++ b/reconcile/gitlab_housekeeping.py
@@ -1,12 +1,6 @@
 from __future__ import annotations
 
 import logging
-from collections.abc import (
-    Iterable,
-)
-from collections.abc import (
-    Set as AbstractSet,
-)
 from contextlib import suppress
 from dataclasses import dataclass
 from datetime import (
@@ -59,6 +53,13 @@ from reconcile.utils.state import State, init_state
 from reconcile.utils.unleash import get_feature_variant
 
 if TYPE_CHECKING:
+    from collections.abc import (
+        Iterable,
+    )
+    from collections.abc import (
+        Set as AbstractSet,
+    )
+
     from gitlab.v4.objects import (
         ProjectCommit,
         ProjectIssue,

--- a/reconcile/gitlab_housekeeping.py
+++ b/reconcile/gitlab_housekeeping.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import logging
 from collections.abc import (
     Iterable,
@@ -13,16 +15,10 @@ from datetime import (
 )
 from enum import StrEnum
 from operator import itemgetter
-from typing import Any, cast
+from typing import TYPE_CHECKING, Any, cast
 
 import gitlab
 from gitlab.const import PipelineStatus
-from gitlab.v4.objects import (
-    ProjectCommit,
-    ProjectIssue,
-    ProjectMergeRequest,
-    ProjectMergeRequestPipeline,
-)
 from prometheus_client import (
     Counter,
     Gauge,
@@ -61,6 +57,14 @@ from reconcile.utils.mr.labels import (
 from reconcile.utils.sharding import is_in_shard
 from reconcile.utils.state import State, init_state
 from reconcile.utils.unleash import get_feature_variant
+
+if TYPE_CHECKING:
+    from gitlab.v4.objects import (
+        ProjectCommit,
+        ProjectIssue,
+        ProjectMergeRequest,
+        ProjectMergeRequestPipeline,
+    )
 
 MERGE_LABELS_PRIORITY = [
     prioritized_approval_label(p.value) for p in ChangeTypePriority

--- a/reconcile/gitlab_owners.py
+++ b/reconcile/gitlab_owners.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import logging
-from collections.abc import Callable, Mapping
 from typing import TYPE_CHECKING, Any
 
 from sretoolbox.utils import threaded
@@ -18,6 +17,8 @@ from reconcile.utils.mr.labels import APPROVED
 from reconcile.utils.repo_owners import RepoOwners
 
 if TYPE_CHECKING:
+    from collections.abc import Callable, Mapping
+
     from gitlab.v4.objects import ProjectMergeRequest
 
 QONTRACT_INTEGRATION = "gitlab-owners"

--- a/reconcile/gitlab_owners.py
+++ b/reconcile/gitlab_owners.py
@@ -1,8 +1,9 @@
+from __future__ import annotations
+
 import logging
 from collections.abc import Callable, Mapping
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
-from gitlab.v4.objects import ProjectMergeRequest
 from sretoolbox.utils import threaded
 
 from reconcile import queries
@@ -15,6 +16,9 @@ from reconcile.utils.gitlab_api import (
 )
 from reconcile.utils.mr.labels import APPROVED
 from reconcile.utils.repo_owners import RepoOwners
+
+if TYPE_CHECKING:
+    from gitlab.v4.objects import ProjectMergeRequest
 
 QONTRACT_INTEGRATION = "gitlab-owners"
 

--- a/reconcile/openshift_namespace_labels.py
+++ b/reconcile/openshift_namespace_labels.py
@@ -2,19 +2,13 @@ from __future__ import annotations
 
 import logging
 import sys
-from collections.abc import (
-    Callable,
-    Generator,
-    Sequence,
-)
 from threading import Lock
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from kubernetes.client.exceptions import ApiException
 from sretoolbox.utils import threaded
 
 import reconcile.openshift_base as ob
-from reconcile.gql_definitions.common.namespaces import NamespaceV1
 from reconcile.typed_queries.app_interface_vault_settings import (
     get_app_interface_vault_settings,
 )
@@ -36,6 +30,15 @@ from reconcile.utils.state import (
     State,
     init_state,
 )
+
+if TYPE_CHECKING:
+    from collections.abc import (
+        Callable,
+        Generator,
+        Sequence,
+    )
+
+    from reconcile.gql_definitions.common.namespaces import NamespaceV1
 
 _LOG = logging.getLogger(__name__)
 

--- a/reconcile/openshift_namespace_labels.py
+++ b/reconcile/openshift_namespace_labels.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import logging
 import sys
 from collections.abc import (
@@ -87,7 +89,7 @@ class LabelInventory:
         """Checks if any cluster / namespace has any error registered"""
         return any(e[2] for e in self.iter_errors())
 
-    def iter_errors(self) -> Generator[tuple[str, str, list[str]], None, None]:
+    def iter_errors(self) -> Generator[tuple[str, str, list[str]]]:
         """yields (cluster, namespace, errors) items"""
         for cluster, namespaces in self._errors.items():
             for namespace, errors in namespaces.items():
@@ -126,7 +128,7 @@ class LabelInventory:
         with self._lock:
             self._inv.get(cluster, {}).pop(namespace, None)
 
-    def __iter__(self) -> Generator[tuple[str, str, Types], None, None]:
+    def __iter__(self) -> Generator[tuple[str, str, Types]]:
         """Makes the inventory iterable by yielding (cluster, namespace, types)
         items. Types here is a Dict of {type: labelsOrKeys}"""
         for cluster, namespaces in self._inv.items():

--- a/reconcile/saas_auto_promotions_manager/merge_request_manager/mr_parser.py
+++ b/reconcile/saas_auto_promotions_manager/merge_request_manager/mr_parser.py
@@ -1,8 +1,9 @@
+from __future__ import annotations
+
 import logging
 import re
 from collections.abc import Iterable
-
-from gitlab.v4.objects import ProjectMergeRequest
+from typing import TYPE_CHECKING
 
 from reconcile.saas_auto_promotions_manager.merge_request_manager.open_merge_requests import (
     MRKind,
@@ -19,6 +20,9 @@ from reconcile.saas_auto_promotions_manager.merge_request_manager.renderer impor
     VERSION_REF,
 )
 from reconcile.utils.vcs import VCS, MRCheckStatus
+
+if TYPE_CHECKING:
+    from gitlab.v4.objects import ProjectMergeRequest
 
 ITEM_SEPARATOR = ","
 

--- a/reconcile/saas_auto_promotions_manager/merge_request_manager/mr_parser.py
+++ b/reconcile/saas_auto_promotions_manager/merge_request_manager/mr_parser.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import logging
 import re
-from collections.abc import Iterable
 from typing import TYPE_CHECKING
 
 from reconcile.saas_auto_promotions_manager.merge_request_manager.open_merge_requests import (
@@ -22,6 +21,8 @@ from reconcile.saas_auto_promotions_manager.merge_request_manager.renderer impor
 from reconcile.utils.vcs import VCS, MRCheckStatus
 
 if TYPE_CHECKING:
+    from collections.abc import Iterable
+
     from gitlab.v4.objects import ProjectMergeRequest
 
 ITEM_SEPARATOR = ","

--- a/reconcile/saas_auto_promotions_manager/merge_request_manager/open_merge_requests.py
+++ b/reconcile/saas_auto_promotions_manager/merge_request_manager/open_merge_requests.py
@@ -1,7 +1,11 @@
+from __future__ import annotations
+
 from dataclasses import dataclass
 from enum import Enum
+from typing import TYPE_CHECKING
 
-from gitlab.v4.objects import ProjectMergeRequest
+if TYPE_CHECKING:
+    from gitlab.v4.objects import ProjectMergeRequest
 
 
 class MRKind(Enum):

--- a/reconcile/saas_auto_promotions_manager/merge_request_manager/open_merge_requests.py
+++ b/reconcile/saas_auto_promotions_manager/merge_request_manager/open_merge_requests.py
@@ -2,10 +2,8 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from enum import Enum
-from typing import TYPE_CHECKING
 
-if TYPE_CHECKING:
-    from gitlab.v4.objects import ProjectMergeRequest
+from gitlab.v4.objects import ProjectMergeRequest
 
 
 class MRKind(Enum):

--- a/reconcile/saas_auto_promotions_manager/subscriber.py
+++ b/reconcile/saas_auto_promotions_manager/subscriber.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import hashlib
 import logging
 from collections.abc import Iterable
@@ -271,7 +273,7 @@ class Subscriber:
                 )
 
     @staticmethod
-    def combined_content_hash(subscribers: Iterable["Subscriber"]) -> str:
+    def combined_content_hash(subscribers: Iterable[Subscriber]) -> str:
         """
         Get a deterministic content hash for the attributes of a collection
         of subscribers. The order of subscribers must not matter for the hash.

--- a/reconcile/saas_auto_promotions_manager/subscriber.py
+++ b/reconcile/saas_auto_promotions_manager/subscriber.py
@@ -2,21 +2,25 @@ from __future__ import annotations
 
 import hashlib
 import logging
-from collections.abc import Iterable
 from dataclasses import dataclass
 from datetime import timedelta
+from typing import TYPE_CHECKING
 
 from croniter import croniter
 
-from reconcile.gql_definitions.fragments.saas_target_namespace import (
-    SaasTargetNamespace,
-)
-from reconcile.saas_auto_promotions_manager.publisher import (
-    DeploymentInfo,
-    Publisher,
-)
 from reconcile.utils.datetime_util import utc_now
-from reconcile.utils.slo_document_manager import SLODocumentManager
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
+
+    from reconcile.gql_definitions.fragments.saas_target_namespace import (
+        SaasTargetNamespace,
+    )
+    from reconcile.saas_auto_promotions_manager.publisher import (
+        DeploymentInfo,
+        Publisher,
+    )
+    from reconcile.utils.slo_document_manager import SLODocumentManager
 
 CONTENT_HASH_LENGTH = 32
 

--- a/reconcile/saas_auto_promotions_manager/subscriber.py
+++ b/reconcile/saas_auto_promotions_manager/subscriber.py
@@ -8,6 +8,9 @@ from typing import TYPE_CHECKING
 
 from croniter import croniter
 
+from reconcile.saas_auto_promotions_manager.publisher import (
+    Publisher,
+)
 from reconcile.utils.datetime_util import utc_now
 
 if TYPE_CHECKING:
@@ -18,7 +21,6 @@ if TYPE_CHECKING:
     )
     from reconcile.saas_auto_promotions_manager.publisher import (
         DeploymentInfo,
-        Publisher,
     )
     from reconcile.utils.slo_document_manager import SLODocumentManager
 

--- a/reconcile/terraform_tgw_attachments.py
+++ b/reconcile/terraform_tgw_attachments.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import logging
 from collections.abc import (
     Callable,
@@ -154,7 +156,7 @@ def _build_desired_state_items(
     awsapi: AWSApi,
     tgw_account_names: list[str],
     account_name: str | None = None,
-) -> Generator[DesiredStateItem | None, Any, None]:
+) -> Generator[DesiredStateItem | None, Any]:
     for cluster_info in clusters:
         ocm = ocm_map.get(cluster_info.name) if ocm_map and cluster_info.ocm else None
         for peer_connection in cluster_info.peering.connections:  # type: ignore[union-attr]
@@ -176,7 +178,7 @@ def _build_desired_state_tgw_connection(
     cluster_info: ClusterV1,
     ocm: OCM | None,
     awsapi: AWSApi,
-) -> Generator[DesiredStateItem | None, Any, None]:
+) -> Generator[DesiredStateItem | None, Any]:
     cluster_name = cluster_info.name
     cluster_region = cluster_info.spec.region if cluster_info.spec is not None else ""
     cluster_cidr_block = (

--- a/reconcile/terraform_tgw_attachments.py
+++ b/reconcile/terraform_tgw_attachments.py
@@ -1,13 +1,8 @@
 from __future__ import annotations
 
 import logging
-from collections.abc import (
-    Callable,
-    Generator,
-    Iterable,
-    Mapping,
-)
 from typing import (
+    TYPE_CHECKING,
     Any,
     TypedDict,
     cast,
@@ -15,9 +10,6 @@ from typing import (
 
 from pydantic import BaseModel
 
-from reconcile.gql_definitions.common.app_interface_vault_settings import (
-    AppInterfaceSettingsV1,
-)
 from reconcile.gql_definitions.common.clusters_with_peering import (
     ClusterPeeringConnectionAccountTGWV1,
     ClusterPeeringConnectionAccountV1,
@@ -57,6 +49,18 @@ from reconcile.utils.semver_helper import make_semver
 from reconcile.utils.terraform_client import TerraformClient as Terraform
 from reconcile.utils.terrascript_aws_client import TerrascriptClient as Terrascript
 from reconcile.utils.unleash import get_feature_toggle_state
+
+if TYPE_CHECKING:
+    from collections.abc import (
+        Callable,
+        Generator,
+        Iterable,
+        Mapping,
+    )
+
+    from reconcile.gql_definitions.common.app_interface_vault_settings import (
+        AppInterfaceSettingsV1,
+    )
 
 QONTRACT_INTEGRATION = "terraform_tgw_attachments"
 QONTRACT_INTEGRATION_VERSION = make_semver(0, 1, 0)

--- a/reconcile/test/automated_actions/config/test_automated_actions_config_integration.py
+++ b/reconcile/test/automated_actions/config/test_automated_actions_config_integration.py
@@ -1,7 +1,9 @@
+from __future__ import annotations
+
 from collections.abc import Callable
+from typing import TYPE_CHECKING
 
 import pytest
-from pytest_mock import MockerFixture
 
 from reconcile.automated_actions.config.integration import (
     AutomatedActionRoles,
@@ -20,6 +22,9 @@ from reconcile.gql_definitions.automated_actions.instance import (
 )
 from reconcile.utils.oc import OCCli
 from reconcile.utils.openshift_resource import ResourceInventory
+
+if TYPE_CHECKING:
+    from pytest_mock import MockerFixture
 
 
 def test_automated_actions_config_get_early_exit_desired_state(

--- a/reconcile/test/automated_actions/config/test_automated_actions_config_integration.py
+++ b/reconcile/test/automated_actions/config/test_automated_actions_config_integration.py
@@ -1,15 +1,9 @@
 from __future__ import annotations
 
-from collections.abc import Callable
 from typing import TYPE_CHECKING
 
 import pytest
 
-from reconcile.automated_actions.config.integration import (
-    AutomatedActionRoles,
-    AutomatedActionsConfigIntegration,
-    AutomatedActionsUser,
-)
 from reconcile.gql_definitions.automated_actions.instance import (
     AutomatedActionOpenshiftWorkloadRestartArgumentV1,
     AutomatedActionOpenshiftWorkloadRestartArgumentV1_NamespaceV1,
@@ -24,7 +18,15 @@ from reconcile.utils.oc import OCCli
 from reconcile.utils.openshift_resource import ResourceInventory
 
 if TYPE_CHECKING:
+    from collections.abc import Callable
+
     from pytest_mock import MockerFixture
+
+    from reconcile.automated_actions.config.integration import (
+        AutomatedActionRoles,
+        AutomatedActionsConfigIntegration,
+        AutomatedActionsUser,
+    )
 
 
 def test_automated_actions_config_get_early_exit_desired_state(

--- a/reconcile/test/aws_account_manager/conftest.py
+++ b/reconcile/test/aws_account_manager/conftest.py
@@ -1,9 +1,10 @@
+from __future__ import annotations
+
 from collections.abc import Callable, Mapping
-from typing import Any
+from typing import TYPE_CHECKING, Any
 from unittest.mock import MagicMock
 
 import pytest
-from pytest_mock import MockerFixture
 from qontract_utils.aws_api_typed.api import AWSApi
 
 from reconcile.aws_account_manager.integration import (
@@ -19,6 +20,9 @@ from reconcile.gql_definitions.aws_account_manager.aws_accounts import (
 from reconcile.gql_definitions.fragments.aws_account_managed import AWSAccountManaged
 from reconcile.test.fixtures import Fixtures
 from reconcile.utils.state import State
+
+if TYPE_CHECKING:
+    from pytest_mock import MockerFixture
 
 
 @pytest.fixture

--- a/reconcile/test/aws_account_manager/conftest.py
+++ b/reconcile/test/aws_account_manager/conftest.py
@@ -1,8 +1,6 @@
 from __future__ import annotations
 
-from collections.abc import Callable, Mapping
 from typing import TYPE_CHECKING, Any
-from unittest.mock import MagicMock
 
 import pytest
 from qontract_utils.aws_api_typed.api import AWSApi
@@ -17,12 +15,18 @@ from reconcile.gql_definitions.aws_account_manager.aws_accounts import (
     AWSAccountRequestV1,
     AWSAccountV1,
 )
-from reconcile.gql_definitions.fragments.aws_account_managed import AWSAccountManaged
 from reconcile.test.fixtures import Fixtures
 from reconcile.utils.state import State
 
 if TYPE_CHECKING:
+    from collections.abc import Callable, Mapping
+    from unittest.mock import MagicMock
+
     from pytest_mock import MockerFixture
+
+    from reconcile.gql_definitions.fragments.aws_account_managed import (
+        AWSAccountManaged,
+    )
 
 
 @pytest.fixture

--- a/reconcile/test/aws_account_manager/test_aws_account_manager_integration.py
+++ b/reconcile/test/aws_account_manager/test_aws_account_manager_integration.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import datetime
-from collections.abc import Callable, Mapping
 from textwrap import dedent
 from typing import TYPE_CHECKING, Any
 from unittest.mock import ANY, MagicMock
@@ -10,7 +9,6 @@ import pytest
 from qontract_utils.aws_api_typed.iam import AWSAccessKey
 
 from reconcile.aws_account_manager import integration
-from reconcile.aws_account_manager.integration import AwsAccountMgmtIntegration
 from reconcile.gql_definitions.aws_account_manager.aws_accounts import (
     AWSAccountRequestV1,
     AWSAccountV1,
@@ -22,7 +20,11 @@ from reconcile.gql_definitions.fragments.aws_account_managed import (
 )
 
 if TYPE_CHECKING:
+    from collections.abc import Callable, Mapping
+
     from pytest_mock import MockerFixture
+
+    from reconcile.aws_account_manager.integration import AwsAccountMgmtIntegration
 
 
 def test_aws_account_manager_utils_integration_early_exit(

--- a/reconcile/test/aws_account_manager/test_aws_account_manager_integration.py
+++ b/reconcile/test/aws_account_manager/test_aws_account_manager_integration.py
@@ -1,11 +1,12 @@
+from __future__ import annotations
+
 import datetime
 from collections.abc import Callable, Mapping
 from textwrap import dedent
-from typing import Any
+from typing import TYPE_CHECKING, Any
 from unittest.mock import ANY, MagicMock
 
 import pytest
-from pytest_mock import MockerFixture
 from qontract_utils.aws_api_typed.iam import AWSAccessKey
 
 from reconcile.aws_account_manager import integration
@@ -19,6 +20,9 @@ from reconcile.gql_definitions.fragments.aws_account_managed import (
     AWSContactV1,
     AWSQuotaV1,
 )
+
+if TYPE_CHECKING:
+    from pytest_mock import MockerFixture
 
 
 def test_aws_account_manager_utils_integration_early_exit(

--- a/reconcile/test/aws_account_manager/test_aws_account_manager_reconciler.py
+++ b/reconcile/test/aws_account_manager/test_aws_account_manager_reconciler.py
@@ -51,7 +51,7 @@ from reconcile.utils.state import State
 
 
 @pytest.fixture
-def s3_client(monkeypatch: pytest.MonkeyPatch) -> Generator[S3Client, None, None]:
+def s3_client(monkeypatch: pytest.MonkeyPatch) -> Generator[S3Client]:
     monkeypatch.setenv("AWS_ACCESS_KEY_ID", "testing")
     monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", "testing")
     monkeypatch.setenv("AWS_SECURITY_TOKEN", "testing")

--- a/reconcile/test/aws_saml_idp/test_aws_saml_idp_integration.py
+++ b/reconcile/test/aws_saml_idp/test_aws_saml_idp_integration.py
@@ -1,12 +1,13 @@
 from __future__ import annotations
 
-from collections.abc import Callable
 from typing import TYPE_CHECKING
 
 from reconcile.aws_saml_idp.integration import AwsSamlIdpIntegration, SamlIdpConfig
 from reconcile.gql_definitions.aws_saml_idp.aws_accounts import AWSAccountV1
 
 if TYPE_CHECKING:
+    from collections.abc import Callable
+
     from pytest_httpserver import HTTPServer
 
 

--- a/reconcile/test/aws_saml_idp/test_aws_saml_idp_integration.py
+++ b/reconcile/test/aws_saml_idp/test_aws_saml_idp_integration.py
@@ -1,9 +1,13 @@
-from collections.abc import Callable
+from __future__ import annotations
 
-from pytest_httpserver import HTTPServer
+from collections.abc import Callable
+from typing import TYPE_CHECKING
 
 from reconcile.aws_saml_idp.integration import AwsSamlIdpIntegration, SamlIdpConfig
 from reconcile.gql_definitions.aws_saml_idp.aws_accounts import AWSAccountV1
+
+if TYPE_CHECKING:
+    from pytest_httpserver import HTTPServer
 
 
 def test_aws_saml_idp_get_early_exit_desired_state(

--- a/reconcile/test/aws_saml_roles/test_aws_saml_roles_integration.py
+++ b/reconcile/test/aws_saml_roles/test_aws_saml_roles_integration.py
@@ -1,7 +1,9 @@
+from __future__ import annotations
+
 from collections.abc import Callable
+from typing import TYPE_CHECKING
 
 import pytest
-from pytest_mock import MockerFixture
 
 from reconcile.aws_saml_roles.integration import (
     AwsRole,
@@ -9,6 +11,9 @@ from reconcile.aws_saml_roles.integration import (
 )
 from reconcile.gql_definitions.aws_saml_roles.aws_accounts import AWSAccountV1
 from reconcile.utils.terrascript_aws_client import TerrascriptClient
+
+if TYPE_CHECKING:
+    from pytest_mock import MockerFixture
 
 
 def test_aws_saml_roles_get_early_exit_desired_state(

--- a/reconcile/test/aws_saml_roles/test_aws_saml_roles_integration.py
+++ b/reconcile/test/aws_saml_roles/test_aws_saml_roles_integration.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-from collections.abc import Callable
 from typing import TYPE_CHECKING
 
 import pytest
@@ -13,6 +12,8 @@ from reconcile.gql_definitions.aws_saml_roles.aws_accounts import AWSAccountV1
 from reconcile.utils.terrascript_aws_client import TerrascriptClient
 
 if TYPE_CHECKING:
+    from collections.abc import Callable
+
     from pytest_mock import MockerFixture
 
 

--- a/reconcile/test/aws_version_sync/merge_request_manager/test_avs_merge_request_manager.py
+++ b/reconcile/test/aws_version_sync/merge_request_manager/test_avs_merge_request_manager.py
@@ -1,9 +1,5 @@
 from __future__ import annotations
 
-from collections.abc import (
-    Callable,
-    Iterable,
-)
 from typing import TYPE_CHECKING
 from unittest.mock import (
     ANY,
@@ -33,6 +29,11 @@ from reconcile.utils.mr.labels import AUTO_MERGE
 from reconcile.utils.vcs import VCS
 
 if TYPE_CHECKING:
+    from collections.abc import (
+        Callable,
+        Iterable,
+    )
+
     from pytest_mock import MockerFixture
 
 

--- a/reconcile/test/aws_version_sync/merge_request_manager/test_avs_merge_request_manager.py
+++ b/reconcile/test/aws_version_sync/merge_request_manager/test_avs_merge_request_manager.py
@@ -1,7 +1,10 @@
+from __future__ import annotations
+
 from collections.abc import (
     Callable,
     Iterable,
 )
+from typing import TYPE_CHECKING
 from unittest.mock import (
     ANY,
     MagicMock,
@@ -10,7 +13,6 @@ from unittest.mock import (
 
 import pytest
 from gitlab.v4.objects import ProjectMergeRequest
-from pytest_mock import MockerFixture
 
 from reconcile.aws_version_sync.merge_request_manager.merge_request import (
     AVS_LABEL,
@@ -29,6 +31,9 @@ from reconcile.utils.merge_request_manager.parser import (
 )
 from reconcile.utils.mr.labels import AUTO_MERGE
 from reconcile.utils.vcs import VCS
+
+if TYPE_CHECKING:
+    from pytest_mock import MockerFixture
 
 
 def test_avsmr(mocker: MockerFixture) -> None:

--- a/reconcile/test/aws_version_sync/test_avs_integration.py
+++ b/reconcile/test/aws_version_sync/test_avs_integration.py
@@ -1,10 +1,6 @@
 from __future__ import annotations
 
 import random
-from collections.abc import (
-    Callable,
-    Sequence,
-)
 from textwrap import dedent
 from typing import TYPE_CHECKING, Any
 
@@ -21,16 +17,22 @@ from reconcile.aws_version_sync.merge_request_manager.merge_request_manager impo
     MrData,
 )
 from reconcile.aws_version_sync.utils import prom_get
-from reconcile.gql_definitions.aws_version_sync.clusters import (
-    ClusterV1 as AWSResourceExporterClusterV1,
-)
 from reconcile.gql_definitions.aws_version_sync.namespaces import NamespaceV1
-from reconcile.test.fixtures import Fixtures
 from reconcile.utils.gql import GqlApi
-from reconcile.utils.secret_reader import SecretReader
 
 if TYPE_CHECKING:
+    from collections.abc import (
+        Callable,
+        Sequence,
+    )
+
     from pytest_mock import MockerFixture
+
+    from reconcile.gql_definitions.aws_version_sync.clusters import (
+        ClusterV1 as AWSResourceExporterClusterV1,
+    )
+    from reconcile.test.fixtures import Fixtures
+    from reconcile.utils.secret_reader import SecretReader
 
 
 @pytest.fixture

--- a/reconcile/test/aws_version_sync/test_avs_integration.py
+++ b/reconcile/test/aws_version_sync/test_avs_integration.py
@@ -1,13 +1,14 @@
+from __future__ import annotations
+
 import random
 from collections.abc import (
     Callable,
     Sequence,
 )
 from textwrap import dedent
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import pytest
-from pytest_mock import MockerFixture
 
 from reconcile.aws_version_sync.integration import (
     AVSIntegration,
@@ -27,6 +28,9 @@ from reconcile.gql_definitions.aws_version_sync.namespaces import NamespaceV1
 from reconcile.test.fixtures import Fixtures
 from reconcile.utils.gql import GqlApi
 from reconcile.utils.secret_reader import SecretReader
+
+if TYPE_CHECKING:
+    from pytest_mock import MockerFixture
 
 
 @pytest.fixture

--- a/reconcile/test/aws_version_sync/test_utils.py
+++ b/reconcile/test/aws_version_sync/test_utils.py
@@ -1,11 +1,12 @@
+from __future__ import annotations
+
 from collections.abc import (
     Iterable,
     Mapping,
 )
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import pytest
-from pytest_httpserver import HTTPServer
 
 from reconcile.aws_version_sync.utils import (
     get_values,
@@ -13,6 +14,9 @@ from reconcile.aws_version_sync.utils import (
     prom_get,
     uniquify,
 )
+
+if TYPE_CHECKING:
+    from pytest_httpserver import HTTPServer
 
 
 def test_prom_get(httpserver: HTTPServer) -> None:

--- a/reconcile/test/aws_version_sync/test_utils.py
+++ b/reconcile/test/aws_version_sync/test_utils.py
@@ -1,9 +1,5 @@
 from __future__ import annotations
 
-from collections.abc import (
-    Iterable,
-    Mapping,
-)
 from typing import TYPE_CHECKING, Any
 
 import pytest
@@ -16,6 +12,11 @@ from reconcile.aws_version_sync.utils import (
 )
 
 if TYPE_CHECKING:
+    from collections.abc import (
+        Iterable,
+        Mapping,
+    )
+
     from pytest_httpserver import HTTPServer
 
 

--- a/reconcile/test/change_owners/fixtures.py
+++ b/reconcile/test/change_owners/fixtures.py
@@ -1,10 +1,11 @@
+from __future__ import annotations
+
 import copy
 import hashlib
 import json
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import jsonpath_ng.ext
-from pydantic import Json
 from pydantic.dataclasses import dataclass
 
 from reconcile.change_owners.bundle import (
@@ -48,6 +49,9 @@ from reconcile.gql_definitions.change_owners.queries.self_service_roles import (
     UserV1,
 )
 
+if TYPE_CHECKING:
+    from pydantic import Json
+
 
 def _sha256_sum(content: dict[str, Any]) -> str:
     m = hashlib.sha256()
@@ -74,7 +78,7 @@ class QontractServerBundleDiffDataBuilder:
         new_content: dict[str, Any] | None,
         old_sha_override: str | None = None,
         new_sha_override: str | None = None,
-    ) -> "QontractServerBundleDiffDataBuilder":
+    ) -> QontractServerBundleDiffDataBuilder:
         old = copy.deepcopy(old_content)
         if old:
             old[DATAFILE_SHA256SUM_FIELD_NAME] = old_sha_override or _sha256_sum(old)
@@ -98,7 +102,7 @@ class QontractServerBundleDiffDataBuilder:
         schema: str | None = None,
         old_backrefs: list[QontractServerResourcefileBackref] | None = None,
         new_backrefs: list[QontractServerResourcefileBackref] | None = None,
-    ) -> "QontractServerBundleDiffDataBuilder":
+    ) -> QontractServerBundleDiffDataBuilder:
         entry = QontractServerResourcefileDiff(resourcepath=path)
         if old_content:
             entry.old = QontractServerResourcefileDiffState(**{
@@ -398,14 +402,14 @@ class MockFileDiffResolver:
 
     def register_raw_diff(
         self, path: str, old: dict[str, Any] | None, new: dict[str, Any] | None
-    ) -> "MockFileDiffResolver":
+    ) -> MockFileDiffResolver:
         self.file_diffs[path] = (old, new)
         return self
 
     def register_bundle_change(
         self,
         bundle_change: BundleFileChange,
-    ) -> "MockFileDiffResolver":
+    ) -> MockFileDiffResolver:
         return self.register_raw_diff(
             bundle_change.fileref.path, bundle_change.old, bundle_change.new
         )

--- a/reconcile/test/change_owners/test_change_log_tracking.py
+++ b/reconcile/test/change_owners/test_change_log_tracking.py
@@ -1,5 +1,7 @@
+from __future__ import annotations
+
 from collections.abc import Callable
-from typing import Any
+from typing import TYPE_CHECKING, Any
 from unittest.mock import call, create_autospec
 
 import pytest
@@ -8,7 +10,6 @@ from gitlab.v4.objects import (
     ProjectCommit,
     ProjectCommitManager,
 )
-from pytest_mock import MockerFixture
 
 from reconcile.change_owners.change_log_tracking import (
     BUNDLE_DIFFS_OBJ,
@@ -23,6 +24,9 @@ from reconcile.gql_definitions.change_owners.queries.change_types import (
 )
 from reconcile.gql_definitions.common.apps import AppV1
 from reconcile.utils.gql import GqlApi
+
+if TYPE_CHECKING:
+    from pytest_mock import MockerFixture
 
 APP_PATH = "/services/a/app.yml"
 MERGED_AT = "2024-01-01T00:00:00Z"

--- a/reconcile/test/change_owners/test_change_log_tracking.py
+++ b/reconcile/test/change_owners/test_change_log_tracking.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-from collections.abc import Callable
 from typing import TYPE_CHECKING, Any
 from unittest.mock import call, create_autospec
 
@@ -22,11 +21,14 @@ from reconcile.change_owners.change_log_tracking import (
 from reconcile.gql_definitions.change_owners.queries.change_types import (
     ChangeTypesQueryData,
 )
-from reconcile.gql_definitions.common.apps import AppV1
-from reconcile.utils.gql import GqlApi
 
 if TYPE_CHECKING:
+    from collections.abc import Callable
+
     from pytest_mock import MockerFixture
+
+    from reconcile.gql_definitions.common.apps import AppV1
+    from reconcile.utils.gql import GqlApi
 
 APP_PATH = "/services/a/app.yml"
 MERGED_AT = "2024-01-01T00:00:00Z"

--- a/reconcile/test/change_owners/test_change_type_admission.py
+++ b/reconcile/test/change_owners/test_change_type_admission.py
@@ -1,7 +1,8 @@
-from typing import cast
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, cast
 
 import pytest
-from pytest_mock import MockerFixture
 
 from reconcile.change_owners.approver import Approver
 from reconcile.change_owners.bundle import BundleFileType, FileRef
@@ -15,6 +16,9 @@ from reconcile.gql_definitions.change_owners.queries.change_types import ChangeT
 from reconcile.test.change_owners.fixtures import (
     change_type_to_processor,
 )
+
+if TYPE_CHECKING:
+    from pytest_mock import MockerFixture
 
 
 @pytest.fixture

--- a/reconcile/test/change_owners/test_change_type_admission.py
+++ b/reconcile/test/change_owners/test_change_type_admission.py
@@ -11,14 +11,17 @@ from reconcile.change_owners.change_types import (
     ChangeTypeContext,
     DiffCoverage,
 )
-from reconcile.change_owners.changes import BundleFileChange
-from reconcile.gql_definitions.change_owners.queries.change_types import ChangeTypeV1
 from reconcile.test.change_owners.fixtures import (
     change_type_to_processor,
 )
 
 if TYPE_CHECKING:
     from pytest_mock import MockerFixture
+
+    from reconcile.change_owners.changes import BundleFileChange
+    from reconcile.gql_definitions.change_owners.queries.change_types import (
+        ChangeTypeV1,
+    )
 
 
 @pytest.fixture

--- a/reconcile/test/change_owners/test_change_type_bundle.py
+++ b/reconcile/test/change_owners/test_change_type_bundle.py
@@ -1,7 +1,8 @@
-from typing import Any
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
 
 import pytest
-from pytest_mock.plugin import MockerFixture
 
 from reconcile.change_owners import bundle
 from reconcile.change_owners.bundle import (
@@ -9,6 +10,9 @@ from reconcile.change_owners.bundle import (
     FileRef,
     QontractServerFileDiffResolver,
 )
+
+if TYPE_CHECKING:
+    from pytest_mock.plugin import MockerFixture
 
 
 @pytest.mark.parametrize(

--- a/reconcile/test/change_owners/test_change_type_coverage.py
+++ b/reconcile/test/change_owners/test_change_type_coverage.py
@@ -1,8 +1,8 @@
 import jsonpath_ng
 import pytest
 
+from reconcile.change_owners.approver import Approver
 from reconcile.change_owners.change_types import (
-    Approver,
     ChangeTypeContext,
     DiffCoverage,
 )

--- a/reconcile/test/change_owners/test_change_type_decision.py
+++ b/reconcile/test/change_owners/test_change_type_decision.py
@@ -1,9 +1,7 @@
 import pytest
 
-from reconcile.change_owners.change_types import (
-    Approver,
-    ChangeTypeContext,
-)
+from reconcile.change_owners.approver import Approver
+from reconcile.change_owners.change_types import ChangeTypeContext
 from reconcile.change_owners.changes import BundleFileChange
 from reconcile.change_owners.decision import (
     Decision,

--- a/reconcile/test/cluster_auth_rhidp/conftest.py
+++ b/reconcile/test/cluster_auth_rhidp/conftest.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-from collections.abc import Callable, Iterable, Mapping, Sequence
 from typing import TYPE_CHECKING, Any
 
 import pytest
@@ -22,10 +21,13 @@ from reconcile.utils.ocm.base import (
 )
 from reconcile.utils.ocm.label_sources import ClusterRef, LabelState
 from reconcile.utils.ocm_base_client import OCMBaseClient
-from reconcile.utils.secret_reader import SecretReader
 
 if TYPE_CHECKING:
+    from collections.abc import Callable, Iterable, Mapping, Sequence
+
     from pytest_mock import MockerFixture
+
+    from reconcile.utils.secret_reader import SecretReader
 
 
 @pytest.fixture

--- a/reconcile/test/cluster_auth_rhidp/conftest.py
+++ b/reconcile/test/cluster_auth_rhidp/conftest.py
@@ -1,8 +1,9 @@
+from __future__ import annotations
+
 from collections.abc import Callable, Iterable, Mapping, Sequence
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import pytest
-from pytest_mock import MockerFixture
 
 from reconcile.cluster_auth_rhidp.integration import (
     ClusterAuthRhidpIntegration,
@@ -22,6 +23,9 @@ from reconcile.utils.ocm.base import (
 from reconcile.utils.ocm.label_sources import ClusterRef, LabelState
 from reconcile.utils.ocm_base_client import OCMBaseClient
 from reconcile.utils.secret_reader import SecretReader
+
+if TYPE_CHECKING:
+    from pytest_mock import MockerFixture
 
 
 @pytest.fixture

--- a/reconcile/test/cluster_auth_rhidp/test_cluster_auth_rhidp_integration.py
+++ b/reconcile/test/cluster_auth_rhidp/test_cluster_auth_rhidp_integration.py
@@ -1,12 +1,14 @@
+from __future__ import annotations
+
 from collections.abc import (
     Callable,
     Iterable,
     Sequence,
 )
+from typing import TYPE_CHECKING
 from unittest.mock import call
 
 import pytest
-from pytest_mock import MockerFixture
 
 from reconcile.cluster_auth_rhidp.integration import (
     ClusterAuthRhidpIntegration,
@@ -17,6 +19,9 @@ from reconcile.gql_definitions.fragments.ocm_environment import OCMEnvironment
 from reconcile.utils.ocm.base import ClusterDetails
 from reconcile.utils.ocm.label_sources import LabelState
 from reconcile.utils.ocm_base_client import OCMBaseClient
+
+if TYPE_CHECKING:
+    from pytest_mock import MockerFixture
 
 
 def test_cluster_auth_rhidp_early_exit(

--- a/reconcile/test/cluster_auth_rhidp/test_cluster_auth_rhidp_integration.py
+++ b/reconcile/test/cluster_auth_rhidp/test_cluster_auth_rhidp_integration.py
@@ -1,27 +1,29 @@
 from __future__ import annotations
 
-from collections.abc import (
-    Callable,
-    Iterable,
-    Sequence,
-)
 from typing import TYPE_CHECKING
 from unittest.mock import call
 
 import pytest
 
-from reconcile.cluster_auth_rhidp.integration import (
-    ClusterAuthRhidpIntegration,
-    OcmApis,
-)
 from reconcile.gql_definitions.cluster_auth_rhidp.clusters import ClusterV1
-from reconcile.gql_definitions.fragments.ocm_environment import OCMEnvironment
-from reconcile.utils.ocm.base import ClusterDetails
-from reconcile.utils.ocm.label_sources import LabelState
-from reconcile.utils.ocm_base_client import OCMBaseClient
 
 if TYPE_CHECKING:
+    from collections.abc import (
+        Callable,
+        Iterable,
+        Sequence,
+    )
+
     from pytest_mock import MockerFixture
+
+    from reconcile.cluster_auth_rhidp.integration import (
+        ClusterAuthRhidpIntegration,
+        OcmApis,
+    )
+    from reconcile.gql_definitions.fragments.ocm_environment import OCMEnvironment
+    from reconcile.utils.ocm.base import ClusterDetails
+    from reconcile.utils.ocm.label_sources import LabelState
+    from reconcile.utils.ocm_base_client import OCMBaseClient
 
 
 def test_cluster_auth_rhidp_early_exit(

--- a/reconcile/test/conftest.py
+++ b/reconcile/test/conftest.py
@@ -16,7 +16,6 @@ import pytest
 from pydantic import BaseModel, ValidationError
 
 from reconcile.gql_definitions.fragments.vault_secret import VaultSecret
-from reconcile.test.fixtures import Fixtures
 from reconcile.utils.gql import GqlApi
 from reconcile.utils.models import data_default_none
 from reconcile.utils.state import State
@@ -24,6 +23,8 @@ from reconcile.utils.state import State
 if TYPE_CHECKING:
     from pytest_httpserver import HTTPServer
     from pytest_mock import MockerFixture
+
+    from reconcile.test.fixtures import Fixtures
 
 
 @pytest.fixture

--- a/reconcile/test/conftest.py
+++ b/reconcile/test/conftest.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import time
 from collections.abc import (
     Callable,
@@ -7,13 +9,11 @@ from collections.abc import (
     MutableMapping,
 )
 from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
 from unittest.mock import MagicMock, create_autospec
 
 import pytest
 from pydantic import BaseModel, ValidationError
-from pytest_httpserver import HTTPServer
-from pytest_mock import MockerFixture
 
 from reconcile.gql_definitions.fragments.vault_secret import VaultSecret
 from reconcile.test.fixtures import Fixtures
@@ -21,9 +21,13 @@ from reconcile.utils.gql import GqlApi
 from reconcile.utils.models import data_default_none
 from reconcile.utils.state import State
 
+if TYPE_CHECKING:
+    from pytest_httpserver import HTTPServer
+    from pytest_mock import MockerFixture
+
 
 @pytest.fixture
-def patch_sleep(mocker: MockerFixture) -> Generator[MagicMock, None, None]:
+def patch_sleep(mocker: MockerFixture) -> Generator[MagicMock]:
     yield mocker.patch.object(time, "sleep")
 
 

--- a/reconcile/test/endpoints_discovery/conftest.py
+++ b/reconcile/test/endpoints_discovery/conftest.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-from collections.abc import Callable, Mapping
 from copy import deepcopy
 from typing import TYPE_CHECKING, Any
 
@@ -12,11 +11,14 @@ from reconcile.endpoints_discovery.integration import (
 )
 from reconcile.gql_definitions.endpoints_discovery.apps import AppV1
 from reconcile.test.fixtures import Fixtures
-from reconcile.utils.oc import OCNative
-from reconcile.utils.oc_map import OCMap
 
 if TYPE_CHECKING:
+    from collections.abc import Callable, Mapping
+
     from pytest_mock import MockerFixture
+
+    from reconcile.utils.oc import OCNative
+    from reconcile.utils.oc_map import OCMap
 
 
 @pytest.fixture

--- a/reconcile/test/endpoints_discovery/conftest.py
+++ b/reconcile/test/endpoints_discovery/conftest.py
@@ -1,9 +1,10 @@
+from __future__ import annotations
+
 from collections.abc import Callable, Mapping
 from copy import deepcopy
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import pytest
-from pytest_mock import MockerFixture
 
 from reconcile.endpoints_discovery.integration import (
     EndpointsDiscoveryIntegration,
@@ -13,6 +14,9 @@ from reconcile.gql_definitions.endpoints_discovery.apps import AppV1
 from reconcile.test.fixtures import Fixtures
 from reconcile.utils.oc import OCNative
 from reconcile.utils.oc_map import OCMap
+
+if TYPE_CHECKING:
+    from pytest_mock import MockerFixture
 
 
 @pytest.fixture

--- a/reconcile/test/endpoints_discovery/test_endpoints_discovery_integration.py
+++ b/reconcile/test/endpoints_discovery/test_endpoints_discovery_integration.py
@@ -1,7 +1,8 @@
+from __future__ import annotations
+
 from collections.abc import Callable, Sequence
 from textwrap import dedent
-
-from pytest_mock import MockerFixture
+from typing import TYPE_CHECKING
 
 from reconcile.endpoints_discovery.integration import (
     EndpointsDiscoveryIntegration,
@@ -13,6 +14,9 @@ from reconcile.endpoints_discovery.integration import (
 from reconcile.endpoints_discovery.merge_request_manager import App, Endpoint
 from reconcile.gql_definitions.endpoints_discovery.apps import AppEndPointsV1, AppV1
 from reconcile.utils.oc_map import OCMap
+
+if TYPE_CHECKING:
+    from pytest_mock import MockerFixture
 
 TEMPLATE = """
 ---

--- a/reconcile/test/endpoints_discovery/test_endpoints_discovery_integration.py
+++ b/reconcile/test/endpoints_discovery/test_endpoints_discovery_integration.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-from collections.abc import Callable, Sequence
 from textwrap import dedent
 from typing import TYPE_CHECKING
 
@@ -13,10 +12,13 @@ from reconcile.endpoints_discovery.integration import (
 )
 from reconcile.endpoints_discovery.merge_request_manager import App, Endpoint
 from reconcile.gql_definitions.endpoints_discovery.apps import AppEndPointsV1, AppV1
-from reconcile.utils.oc_map import OCMap
 
 if TYPE_CHECKING:
+    from collections.abc import Callable, Sequence
+
     from pytest_mock import MockerFixture
+
+    from reconcile.utils.oc_map import OCMap
 
 TEMPLATE = """
 ---

--- a/reconcile/test/endpoints_discovery/test_endpoints_discovery_merge_request_manager.py
+++ b/reconcile/test/endpoints_discovery/test_endpoints_discovery_merge_request_manager.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-from collections.abc import Callable, Iterable
 from random import shuffle
 from typing import TYPE_CHECKING
 from unittest.mock import ANY, MagicMock, create_autospec
@@ -26,6 +25,8 @@ from reconcile.utils.mr.labels import AUTO_MERGE
 from reconcile.utils.vcs import VCS
 
 if TYPE_CHECKING:
+    from collections.abc import Callable, Iterable
+
     from pytest_mock import MockerFixture
 
 

--- a/reconcile/test/endpoints_discovery/test_endpoints_discovery_merge_request_manager.py
+++ b/reconcile/test/endpoints_discovery/test_endpoints_discovery_merge_request_manager.py
@@ -1,11 +1,13 @@
+from __future__ import annotations
+
 from collections.abc import Callable, Iterable
 from random import shuffle
+from typing import TYPE_CHECKING
 from unittest.mock import ANY, MagicMock, create_autospec
 
 import pytest
 from gitlab.exceptions import GitlabGetError
 from gitlab.v4.objects import ProjectMergeRequest
-from pytest_mock import MockerFixture
 
 from reconcile.endpoints_discovery.merge_request import (
     LABEL,
@@ -22,6 +24,9 @@ from reconcile.endpoints_discovery.merge_request_manager import (
 from reconcile.utils.gitlab_api import GitLabApi
 from reconcile.utils.mr.labels import AUTO_MERGE
 from reconcile.utils.vcs import VCS
+
+if TYPE_CHECKING:
+    from pytest_mock import MockerFixture
 
 
 @pytest.fixture()

--- a/reconcile/test/external_resources/test_manager.py
+++ b/reconcile/test/external_resources/test_manager.py
@@ -26,12 +26,13 @@ from reconcile.external_resources.state import (
     ExternalResourcesStateDynamoDB,
     ExternalResourceState,
 )
-from reconcile.gql_definitions.external_resources.external_resources_settings import (
-    ExternalResourcesSettingsV1,
-)
 
 if TYPE_CHECKING:
     from pytest_mock import MockerFixture
+
+    from reconcile.gql_definitions.external_resources.external_resources_settings import (
+        ExternalResourcesSettingsV1,
+    )
 
 
 @fixture

--- a/reconcile/test/external_resources/test_manager.py
+++ b/reconcile/test/external_resources/test_manager.py
@@ -1,10 +1,11 @@
+from __future__ import annotations
+
 from datetime import UTC, datetime
-from typing import cast
+from typing import TYPE_CHECKING, cast
 from unittest.mock import Mock
 
 import pytest
 from pytest import fixture
-from pytest_mock import MockerFixture
 
 from reconcile.external_resources.manager import (
     ExternalResourceDryRunsValidator,
@@ -28,6 +29,9 @@ from reconcile.external_resources.state import (
 from reconcile.gql_definitions.external_resources.external_resources_settings import (
     ExternalResourcesSettingsV1,
 )
+
+if TYPE_CHECKING:
+    from pytest_mock import MockerFixture
 
 
 @fixture

--- a/reconcile/test/external_resources/test_module_configuration.py
+++ b/reconcile/test/external_resources/test_module_configuration.py
@@ -3,6 +3,8 @@ import pytest
 from reconcile.external_resources.model import (
     ExternalResourceModuleConfiguration,
     ExternalResourceModuleConfigurationError,
+)
+from reconcile.gql_definitions.external_resources.external_resources_settings import (
     ExternalResourcesSettingsV1,
 )
 from reconcile.gql_definitions.external_resources.external_resources_modules import (

--- a/reconcile/test/external_resources/test_module_configuration.py
+++ b/reconcile/test/external_resources/test_module_configuration.py
@@ -4,11 +4,11 @@ from reconcile.external_resources.model import (
     ExternalResourceModuleConfiguration,
     ExternalResourceModuleConfigurationError,
 )
-from reconcile.gql_definitions.external_resources.external_resources_settings import (
-    ExternalResourcesSettingsV1,
-)
 from reconcile.gql_definitions.external_resources.external_resources_modules import (
     ExternalResourcesModuleV1,
+)
+from reconcile.gql_definitions.external_resources.external_resources_settings import (
+    ExternalResourcesSettingsV1,
 )
 from reconcile.gql_definitions.external_resources.fragments.external_resources_module_overrides import (
     ExternalResourcesModuleOverrides,

--- a/reconcile/test/external_resources/test_outputs_formatter.py
+++ b/reconcile/test/external_resources/test_outputs_formatter.py
@@ -1,10 +1,14 @@
+from __future__ import annotations
+
 import base64
 import json
-
-from pytest_mock import MockerFixture
+from typing import TYPE_CHECKING
 
 from reconcile.external_resources.secrets_sync import OutputSecretsFormatter
 from reconcile.utils.secret_reader import SecretReaderBase
+
+if TYPE_CHECKING:
+    from pytest_mock import MockerFixture
 
 
 def test_outputs(mocker: MockerFixture) -> None:

--- a/reconcile/test/external_resources/test_rds_factory.py
+++ b/reconcile/test/external_resources/test_rds_factory.py
@@ -1,9 +1,10 @@
+from __future__ import annotations
+
 from collections.abc import Mapping
-from typing import Any
+from typing import TYPE_CHECKING, Any
 from unittest.mock import Mock, create_autospec
 
 import pytest
-from pytest_mock import MockerFixture
 
 from reconcile.external_resources.aws import AWSRdsFactory
 from reconcile.external_resources.model import (
@@ -15,6 +16,9 @@ from reconcile.utils.external_resource_spec import (
     ExternalResourceSpec,
 )
 from reconcile.utils.external_resources import ResourceValueResolver
+
+if TYPE_CHECKING:
+    from pytest_mock import MockerFixture
 
 
 @pytest.fixture

--- a/reconcile/test/external_resources/test_rds_factory.py
+++ b/reconcile/test/external_resources/test_rds_factory.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-from collections.abc import Mapping
 from typing import TYPE_CHECKING, Any
 from unittest.mock import Mock, create_autospec
 
@@ -18,6 +17,8 @@ from reconcile.utils.external_resource_spec import (
 from reconcile.utils.external_resources import ResourceValueResolver
 
 if TYPE_CHECKING:
+    from collections.abc import Mapping
+
     from pytest_mock import MockerFixture
 
 

--- a/reconcile/test/glitchtip/conftest.py
+++ b/reconcile/test/glitchtip/conftest.py
@@ -1,15 +1,19 @@
+from __future__ import annotations
+
 from collections.abc import Callable
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import pytest
-from pytest_httpserver import HTTPServer
-from pytest_mock import MockerFixture
 
 from reconcile.test.fixtures import Fixtures
 from reconcile.utils.glitchtip import GlitchtipClient
 from reconcile.utils.oc import OCNative
 from reconcile.utils.oc_map import OCMap
 from reconcile.utils.rest_api_base import BearerTokenAuth
+
+if TYPE_CHECKING:
+    from pytest_httpserver import HTTPServer
+    from pytest_mock import MockerFixture
 
 
 @pytest.fixture

--- a/reconcile/test/glitchtip/conftest.py
+++ b/reconcile/test/glitchtip/conftest.py
@@ -1,19 +1,21 @@
 from __future__ import annotations
 
-from collections.abc import Callable
 from typing import TYPE_CHECKING, Any
 
 import pytest
 
 from reconcile.test.fixtures import Fixtures
 from reconcile.utils.glitchtip import GlitchtipClient
-from reconcile.utils.oc import OCNative
-from reconcile.utils.oc_map import OCMap
 from reconcile.utils.rest_api_base import BearerTokenAuth
 
 if TYPE_CHECKING:
+    from collections.abc import Callable
+
     from pytest_httpserver import HTTPServer
     from pytest_mock import MockerFixture
+
+    from reconcile.utils.oc import OCNative
+    from reconcile.utils.oc_map import OCMap
 
 
 @pytest.fixture

--- a/reconcile/test/glitchtip/test_utils_glitchtip_models.py
+++ b/reconcile/test/glitchtip/test_utils_glitchtip_models.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from collections.abc import Mapping
 
 import pytest
@@ -25,7 +27,7 @@ from reconcile.utils.glitchtip.models import (
 )
 @pytest.mark.parametrize("model", [Organization, Project, Team])
 def test_model_slugs(
-    model: type[Organization] | type[Project] | type[Team], name: str, slug: str
+    model: type[Organization | Project | Team], name: str, slug: str
 ) -> None:
     assert model(name=name).slug == slug
 

--- a/reconcile/test/glitchtip/test_utils_glitchtip_models.py
+++ b/reconcile/test/glitchtip/test_utils_glitchtip_models.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from collections.abc import Mapping
+from typing import TYPE_CHECKING
 
 import pytest
 
@@ -13,6 +13,9 @@ from reconcile.utils.glitchtip.models import (
     ProjectAlert,
     slugify,
 )
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping
 
 
 @pytest.mark.parametrize(

--- a/reconcile/test/ldap_groups/conftest.py
+++ b/reconcile/test/ldap_groups/conftest.py
@@ -1,12 +1,6 @@
 from __future__ import annotations
 
-from collections.abc import (
-    Callable,
-    Iterable,
-    Mapping,
-)
 from typing import TYPE_CHECKING, Any
-from unittest.mock import Mock
 
 import pytest
 
@@ -24,6 +18,13 @@ from reconcile.utils.internal_groups.models import (
 )
 
 if TYPE_CHECKING:
+    from collections.abc import (
+        Callable,
+        Iterable,
+        Mapping,
+    )
+    from unittest.mock import Mock
+
     from pytest_mock import MockerFixture
 
 

--- a/reconcile/test/ldap_groups/conftest.py
+++ b/reconcile/test/ldap_groups/conftest.py
@@ -1,13 +1,14 @@
+from __future__ import annotations
+
 from collections.abc import (
     Callable,
     Iterable,
     Mapping,
 )
-from typing import Any
+from typing import TYPE_CHECKING, Any
 from unittest.mock import Mock
 
 import pytest
-from pytest_mock import MockerFixture
 
 from reconcile.gql_definitions.ldap_groups.roles import RoleV1
 from reconcile.ldap_groups.integration import (
@@ -21,6 +22,9 @@ from reconcile.utils.internal_groups.models import (
     EntityType,
     Group,
 )
+
+if TYPE_CHECKING:
+    from pytest_mock import MockerFixture
 
 
 @pytest.fixture

--- a/reconcile/test/ldap_users/conftest.py
+++ b/reconcile/test/ldap_users/conftest.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-from collections.abc import Callable, Mapping
 from typing import TYPE_CHECKING, Any
 
 import pytest
@@ -12,6 +11,8 @@ from reconcile.test.fixtures import Fixtures
 from reconcile.typed_queries.users_with_paths import get_users_with_paths
 
 if TYPE_CHECKING:
+    from collections.abc import Callable, Mapping
+
     from pytest_mock import MockerFixture, MockType
 
 

--- a/reconcile/test/ldap_users/conftest.py
+++ b/reconcile/test/ldap_users/conftest.py
@@ -1,14 +1,18 @@
+from __future__ import annotations
+
 from collections.abc import Callable, Mapping
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import pytest
-from pytest_mock import MockerFixture, MockType
 
 from reconcile import ldap_users, mr_client_gateway
 from reconcile.gql_definitions.common.ldap_settings import LdapSettingsV1
 from reconcile.gql_definitions.common.users_with_paths import UserV1
 from reconcile.test.fixtures import Fixtures
 from reconcile.typed_queries.users_with_paths import get_users_with_paths
+
+if TYPE_CHECKING:
+    from pytest_mock import MockerFixture, MockType
 
 
 @pytest.fixture

--- a/reconcile/test/ldap_users/test_ldap_users.py
+++ b/reconcile/test/ldap_users/test_ldap_users.py
@@ -4,11 +4,12 @@ from typing import TYPE_CHECKING
 from unittest.mock import call
 
 from reconcile import ldap_users
-from reconcile.gql_definitions.common.users_with_paths import UserV1
 from reconcile.utils.mr.user_maintenance import PathSpec, PathTypes
 
 if TYPE_CHECKING:
     from pytest_mock import MockType
+
+    from reconcile.gql_definitions.common.users_with_paths import UserV1
 
 
 def test_transform_users_paths(users_with_paths: list[UserV1]) -> None:

--- a/reconcile/test/ldap_users/test_ldap_users.py
+++ b/reconcile/test/ldap_users/test_ldap_users.py
@@ -1,10 +1,14 @@
-from unittest.mock import call
+from __future__ import annotations
 
-from pytest_mock import MockType
+from typing import TYPE_CHECKING
+from unittest.mock import call
 
 from reconcile import ldap_users
 from reconcile.gql_definitions.common.users_with_paths import UserV1
 from reconcile.utils.mr.user_maintenance import PathSpec, PathTypes
+
+if TYPE_CHECKING:
+    from pytest_mock import MockType
 
 
 def test_transform_users_paths(users_with_paths: list[UserV1]) -> None:

--- a/reconcile/test/ldap_users_api/test_integration.py
+++ b/reconcile/test/ldap_users_api/test_integration.py
@@ -233,7 +233,7 @@ def _vcs_instances() -> list[Vcs]:
 
 
 @pytest.fixture
-def integration() -> Generator[LdapUsersApiIntegration, None, None]:
+def integration() -> Generator[LdapUsersApiIntegration]:
     """Create integration instance with mocked base class properties."""
     inst = LdapUsersApiIntegration(
         LdapUsersApiIntegrationParams(

--- a/reconcile/test/ocm/aus/conftest.py
+++ b/reconcile/test/ocm/aus/conftest.py
@@ -1,14 +1,18 @@
-from typing import Any
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
 from unittest.mock import Mock
 
 import pytest
-from pytest_mock import MockerFixture
 
 from reconcile.aus.cluster_version_data import VersionData
 from reconcile.aus.version_gates import ocp_gate_handler
 from reconcile.gql_definitions.fragments.ocm_environment import OCMEnvironment
 from reconcile.gql_definitions.fragments.vault_secret import VaultSecret
 from reconcile.utils.ocm.base import OCMVersionGate
+
+if TYPE_CHECKING:
+    from pytest_mock import MockerFixture
 
 
 @pytest.fixture

--- a/reconcile/test/ocm/aus/conftest.py
+++ b/reconcile/test/ocm/aus/conftest.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any
-from unittest.mock import Mock
 
 import pytest
 
@@ -12,6 +11,8 @@ from reconcile.gql_definitions.fragments.vault_secret import VaultSecret
 from reconcile.utils.ocm.base import OCMVersionGate
 
 if TYPE_CHECKING:
+    from unittest.mock import Mock
+
     from pytest_mock import MockerFixture
 
 

--- a/reconcile/test/ocm/aus/test_advanced_upgrade_service.py
+++ b/reconcile/test/ocm/aus/test_advanced_upgrade_service.py
@@ -1,8 +1,9 @@
-from typing import Any
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
 
 import pytest
 from pydantic import ValidationError
-from pytest_mock import MockerFixture
 
 from reconcile.aus import advanced_upgrade_service
 from reconcile.aus.advanced_upgrade_service import (
@@ -54,6 +55,9 @@ from reconcile.utils.ocm.labels import subscription_label_filter
 from reconcile.utils.ocm.search_filters import Filter
 from reconcile.utils.ocm.sre_capability_labels import build_labelset
 from reconcile.utils.ocm_base_client import OCMBaseClient
+
+if TYPE_CHECKING:
+    from pytest_mock import MockerFixture
 
 ORG_ID = "org-id"
 

--- a/reconcile/test/ocm/aus/test_advanced_upgrade_service.py
+++ b/reconcile/test/ocm/aus/test_advanced_upgrade_service.py
@@ -31,8 +31,6 @@ from reconcile.aus.models import (
 )
 from reconcile.gql_definitions.common.ocm_env_telemeter import OCMEnvTelemeterQueryData
 from reconcile.gql_definitions.common.ocm_environments import OCMEnvironmentsQueryData
-from reconcile.gql_definitions.fragments.aus_organization import AUSOCMOrganization
-from reconcile.gql_definitions.fragments.ocm_environment import OCMEnvironment
 from reconcile.gql_definitions.fragments.upgrade_policy import (
     ClusterUpgradePolicyConditionsV1,
     ClusterUpgradePolicyV1,
@@ -54,10 +52,13 @@ from reconcile.utils.ocm.base import (
 from reconcile.utils.ocm.labels import subscription_label_filter
 from reconcile.utils.ocm.search_filters import Filter
 from reconcile.utils.ocm.sre_capability_labels import build_labelset
-from reconcile.utils.ocm_base_client import OCMBaseClient
 
 if TYPE_CHECKING:
     from pytest_mock import MockerFixture
+
+    from reconcile.gql_definitions.fragments.aus_organization import AUSOCMOrganization
+    from reconcile.gql_definitions.fragments.ocm_environment import OCMEnvironment
+    from reconcile.utils.ocm_base_client import OCMBaseClient
 
 ORG_ID = "org-id"
 

--- a/reconcile/test/ocm/aus/test_base.py
+++ b/reconcile/test/ocm/aus/test_base.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-from collections.abc import Callable
 from datetime import (
     UTC,
     datetime,
@@ -48,12 +47,15 @@ from reconcile.utils.ocm.base import (
     OCMClusterAWSSettings,
     build_label_container,
 )
-from reconcile.utils.ocm.clusters import OCMCluster
-from reconcile.utils.ocm_base_client import OCMBaseClient
-from reconcile.utils.secret_reader import SecretReaderBase
 
 if TYPE_CHECKING:
+    from collections.abc import Callable
+
     from pytest_mock import MockerFixture
+
+    from reconcile.utils.ocm.clusters import OCMCluster
+    from reconcile.utils.ocm_base_client import OCMBaseClient
+    from reconcile.utils.secret_reader import SecretReaderBase
 
 
 @pytest.fixture

--- a/reconcile/test/ocm/aus/test_base.py
+++ b/reconcile/test/ocm/aus/test_base.py
@@ -1,14 +1,15 @@
+from __future__ import annotations
+
 from collections.abc import Callable
 from datetime import (
     UTC,
     datetime,
     timedelta,
 )
-from typing import Any
+from typing import TYPE_CHECKING, Any
 from unittest.mock import ANY, create_autospec
 
 import pytest
-from pytest_mock import MockerFixture
 
 from reconcile.aus import base
 from reconcile.aus.base import (
@@ -50,6 +51,9 @@ from reconcile.utils.ocm.base import (
 from reconcile.utils.ocm.clusters import OCMCluster
 from reconcile.utils.ocm_base_client import OCMBaseClient
 from reconcile.utils.secret_reader import SecretReaderBase
+
+if TYPE_CHECKING:
+    from pytest_mock import MockerFixture
 
 
 @pytest.fixture

--- a/reconcile/test/ocm/aus/test_calculate_diff.py
+++ b/reconcile/test/ocm/aus/test_calculate_diff.py
@@ -1,10 +1,11 @@
+from __future__ import annotations
+
 from collections import defaultdict
 from datetime import UTC, datetime
-from typing import Any
+from typing import TYPE_CHECKING, Any
 from unittest.mock import Mock
 
 import pytest
-from pytest_mock import MockerFixture
 
 from reconcile.aus import base
 from reconcile.aus.base import (
@@ -31,6 +32,9 @@ from reconcile.test.ocm.fixtures import build_label, build_ocm_cluster
 from reconcile.utils.ocm.base import OCMVersionGate, build_label_container
 from reconcile.utils.ocm.clusters import OCMCluster
 from reconcile.utils.ocm_base_client import OCMBaseClient
+
+if TYPE_CHECKING:
+    from pytest_mock import MockerFixture
 
 
 @pytest.fixture

--- a/reconcile/test/ocm/aus/test_calculate_diff.py
+++ b/reconcile/test/ocm/aus/test_calculate_diff.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 from collections import defaultdict
 from datetime import UTC, datetime
 from typing import TYPE_CHECKING, Any
-from unittest.mock import Mock
 
 import pytest
 
@@ -30,11 +29,14 @@ from reconcile.test.ocm.aus.fixtures import (
 )
 from reconcile.test.ocm.fixtures import build_label, build_ocm_cluster
 from reconcile.utils.ocm.base import OCMVersionGate, build_label_container
-from reconcile.utils.ocm.clusters import OCMCluster
-from reconcile.utils.ocm_base_client import OCMBaseClient
 
 if TYPE_CHECKING:
+    from unittest.mock import Mock
+
     from pytest_mock import MockerFixture
+
+    from reconcile.utils.ocm.clusters import OCMCluster
+    from reconcile.utils.ocm_base_client import OCMBaseClient
 
 
 @pytest.fixture

--- a/reconcile/test/ocm/aus/test_expose_metrics.py
+++ b/reconcile/test/ocm/aus/test_expose_metrics.py
@@ -1,10 +1,11 @@
+from __future__ import annotations
+
 from datetime import (
     UTC,
     datetime,
     timedelta,
 )
-
-from pytest_mock import MockFixture
+from typing import TYPE_CHECKING
 
 from reconcile.aus.advanced_upgrade_service import AdvancedUpgradeServiceIntegration
 from reconcile.aus.base import (
@@ -29,6 +30,9 @@ from reconcile.test.ocm.aus.fixtures import (
     build_upgrade_policy,
 )
 from reconcile.test.ocm.fixtures import build_ocm_cluster
+
+if TYPE_CHECKING:
+    from pytest_mock import MockFixture
 
 
 def test_remaining_soak_day_metric_values_for_cluster_skip_early_ready() -> None:

--- a/reconcile/test/ocm/aus/test_ocm_upgrade_scheduler_org.py
+++ b/reconcile/test/ocm/aus/test_ocm_upgrade_scheduler_org.py
@@ -1,6 +1,6 @@
-from typing import Any
+from __future__ import annotations
 
-from pytest_mock import MockerFixture
+from typing import TYPE_CHECKING, Any
 
 from reconcile.aus.base import AdvancedUpgradeSchedulerBaseIntegrationParams
 from reconcile.aus.healthchecks import AUSClusterHealth
@@ -27,6 +27,9 @@ from reconcile.test.ocm.aus.fixtures import (
 )
 from reconcile.test.ocm.fixtures import build_cluster_details
 from reconcile.utils.ocm.base import ClusterDetails
+
+if TYPE_CHECKING:
+    from pytest_mock import MockerFixture
 
 ORG_ID = "org-id"
 

--- a/reconcile/test/ocm/aus/test_ocm_upgrade_scheduler_org.py
+++ b/reconcile/test/ocm/aus/test_ocm_upgrade_scheduler_org.py
@@ -16,20 +16,21 @@ from reconcile.aus.ocm_upgrade_scheduler_org import (
     OCMClusterUpgradeSchedulerOrgIntegration,
 )
 from reconcile.gql_definitions.common.ocm_env_telemeter import OCMEnvTelemeterQueryData
-from reconcile.gql_definitions.fragments.aus_organization import (
-    AUSOCMOrganization,
-)
-from reconcile.gql_definitions.fragments.ocm_environment import OCMEnvironment
 from reconcile.test.ocm.aus.fixtures import (
     build_addon_upgrade_spec,
     build_organization,
     build_upgrade_policy_cluster,
 )
 from reconcile.test.ocm.fixtures import build_cluster_details
-from reconcile.utils.ocm.base import ClusterDetails
 
 if TYPE_CHECKING:
     from pytest_mock import MockerFixture
+
+    from reconcile.gql_definitions.fragments.aus_organization import (
+        AUSOCMOrganization,
+    )
+    from reconcile.gql_definitions.fragments.ocm_environment import OCMEnvironment
+    from reconcile.utils.ocm.base import ClusterDetails
 
 ORG_ID = "org-id"
 

--- a/reconcile/test/ocm/aus/test_version_data.py
+++ b/reconcile/test/ocm/aus/test_version_data.py
@@ -1,8 +1,10 @@
+from __future__ import annotations
+
 import datetime
+from typing import TYPE_CHECKING
 from unittest.mock import Mock
 
 import pytest
-from pytest_mock import MockerFixture
 
 from reconcile.aus import base
 from reconcile.aus.base import get_version_data_map
@@ -17,6 +19,9 @@ from reconcile.test.ocm.aus.fixtures import (
     build_upgrade_policy,
 )
 from reconcile.test.ocm.fixtures import build_ocm_cluster
+
+if TYPE_CHECKING:
+    from pytest_mock import MockerFixture
 
 #
 # tests for reading version data and inheriting from other orgs

--- a/reconcile/test/ocm/aus/test_version_data.py
+++ b/reconcile/test/ocm/aus/test_version_data.py
@@ -2,14 +2,11 @@ from __future__ import annotations
 
 import datetime
 from typing import TYPE_CHECKING
-from unittest.mock import Mock
 
 import pytest
 
 from reconcile.aus import base
 from reconcile.aus.base import get_version_data_map
-from reconcile.aus.cluster_version_data import VersionData
-from reconcile.aus.healthchecks import AUSClusterHealth
 from reconcile.test.ocm.aus.fixtures import (
     build_cluster_health,
     build_healthy_cluster_health,
@@ -21,7 +18,12 @@ from reconcile.test.ocm.aus.fixtures import (
 from reconcile.test.ocm.fixtures import build_ocm_cluster
 
 if TYPE_CHECKING:
+    from unittest.mock import Mock
+
     from pytest_mock import MockerFixture
+
+    from reconcile.aus.cluster_version_data import VersionData
+    from reconcile.aus.healthchecks import AUSClusterHealth
 
 #
 # tests for reading version data and inheriting from other orgs

--- a/reconcile/test/ocm/aus/test_version_gate_approver.py
+++ b/reconcile/test/ocm/aus/test_version_gate_approver.py
@@ -1,7 +1,9 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
 from unittest.mock import MagicMock
 
 import pytest
-from pytest_mock import MockerFixture
 
 from reconcile.aus import version_gate_approver
 from reconcile.aus.advanced_upgrade_service import aus_label_key
@@ -28,6 +30,9 @@ from reconcile.utils.ocm.base import (
     build_label_container,
 )
 from reconcile.utils.ocm_base_client import OCMBaseClient
+
+if TYPE_CHECKING:
+    from pytest_mock import MockerFixture
 
 
 @pytest.fixture

--- a/reconcile/test/ocm/aus/test_version_gate_approver.py
+++ b/reconcile/test/ocm/aus/test_version_gate_approver.py
@@ -29,10 +29,11 @@ from reconcile.utils.ocm.base import (
     OCMVersionGate,
     build_label_container,
 )
-from reconcile.utils.ocm_base_client import OCMBaseClient
 
 if TYPE_CHECKING:
     from pytest_mock import MockerFixture
+
+    from reconcile.utils.ocm_base_client import OCMBaseClient
 
 
 @pytest.fixture

--- a/reconcile/test/ocm/conftest.py
+++ b/reconcile/test/ocm/conftest.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-from collections.abc import Callable
 from typing import TYPE_CHECKING, Any
 from urllib.parse import urlparse
 
@@ -13,6 +12,8 @@ from reconcile.utils.ocm import OCM
 from reconcile.utils.ocm_base_client import OCMBaseClient
 
 if TYPE_CHECKING:
+    from collections.abc import Callable
+
     from pytest_httpserver import HTTPServer
     from werkzeug import Request, Response
 

--- a/reconcile/test/ocm/conftest.py
+++ b/reconcile/test/ocm/conftest.py
@@ -1,16 +1,20 @@
+from __future__ import annotations
+
 from collections.abc import Callable
-from typing import Any
+from typing import TYPE_CHECKING, Any
 from urllib.parse import urlparse
 
 import pytest
-from pytest_httpserver import HTTPServer
-from werkzeug import Request, Response
 
 from reconcile.test.fixtures import Fixtures
 from reconcile.test.ocm.fixtures import OcmUrl
 from reconcile.utils.json import json_dumps, pydantic_encoder
 from reconcile.utils.ocm import OCM
 from reconcile.utils.ocm_base_client import OCMBaseClient
+
+if TYPE_CHECKING:
+    from pytest_httpserver import HTTPServer
+    from werkzeug import Request, Response
 
 
 @pytest.fixture

--- a/reconcile/test/ocm/fixtures.py
+++ b/reconcile/test/ocm/fixtures.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import json
 from abc import (
     ABC,
@@ -50,7 +52,7 @@ class OcmUrl(BaseModel):
     method: str = "POST"
     responses: list[Any] = Field(default_factory=list)
 
-    def add_list_response(self, items: list[Any], kind: str | None = None) -> "OcmUrl":
+    def add_list_response(self, items: list[Any], kind: str | None = None) -> OcmUrl:
         self.responses.append({
             "kind": f"{kind}List" if kind else "List",
             "items": items,
@@ -65,7 +67,7 @@ class OcmUrl(BaseModel):
         id: str,
         resources: list[Any],
         kind: str | None = None,
-    ) -> "OcmUrl":
+    ) -> OcmUrl:
         self.responses.append({
             "kind": f"{kind}",
             "id": f"{id}",
@@ -75,7 +77,7 @@ class OcmUrl(BaseModel):
 
     def add_paginated_get_response(
         self, page: int, size: int, total: int, items: Iterable[Mapping], kind: str
-    ) -> "OcmUrl":
+    ) -> OcmUrl:
         self.responses.append({
             "kind": kind,
             "page": page,

--- a/reconcile/test/ocm/fixtures.py
+++ b/reconcile/test/ocm/fixtures.py
@@ -5,8 +5,7 @@ from abc import (
     ABC,
     abstractmethod,
 )
-from collections.abc import Iterable, Mapping
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from pydantic import (
     BaseModel,
@@ -32,6 +31,9 @@ from reconcile.utils.ocm.labels import (
     OCMLabel,
     OCMOrganizationLabel,
 )
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable, Mapping
 
 
 class OcmResponse(BaseModel, ABC):

--- a/reconcile/test/ocm/oum/test_oum_base.py
+++ b/reconcile/test/ocm/oum/test_oum_base.py
@@ -1,7 +1,9 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
 from unittest.mock import MagicMock
 
 import pytest
-from pytest_mock import MockerFixture
 
 from reconcile.gql_definitions.fragments.ocm_environment import OCMEnvironment
 from reconcile.oum import base
@@ -45,6 +47,9 @@ from reconcile.utils.ocm.base import (
     OCMClusterUserList,
 )
 from reconcile.utils.ocm_base_client import OCMBaseClient
+
+if TYPE_CHECKING:
+    from pytest_mock import MockerFixture
 
 
 def build_ocm_cluster_group(

--- a/reconcile/test/ocm/oum/test_oum_base.py
+++ b/reconcile/test/ocm/oum/test_oum_base.py
@@ -1,11 +1,9 @@
 from __future__ import annotations
 
 from typing import TYPE_CHECKING
-from unittest.mock import MagicMock
 
 import pytest
 
-from reconcile.gql_definitions.fragments.ocm_environment import OCMEnvironment
 from reconcile.oum import base
 from reconcile.oum.base import (
     OCMUserManagementIntegration,
@@ -46,10 +44,14 @@ from reconcile.utils.ocm.base import (
     OCMClusterUser,
     OCMClusterUserList,
 )
-from reconcile.utils.ocm_base_client import OCMBaseClient
 
 if TYPE_CHECKING:
+    from unittest.mock import MagicMock
+
     from pytest_mock import MockerFixture
+
+    from reconcile.gql_definitions.fragments.ocm_environment import OCMEnvironment
+    from reconcile.utils.ocm_base_client import OCMBaseClient
 
 
 def build_ocm_cluster_group(

--- a/reconcile/test/ocm/oum/test_oum_providers.py
+++ b/reconcile/test/ocm/oum/test_oum_providers.py
@@ -1,9 +1,15 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 import pytest
-from pytest_mock import MockerFixture
 from qontract_utils.ldap_api import LdapApi
 from qontract_utils.ldap_api.models import LdapGroup, LdapUser
 
 from reconcile.oum.providers import LdapGroupMemberProvider
+
+if TYPE_CHECKING:
+    from pytest_mock import MockerFixture
 
 
 @pytest.fixture

--- a/reconcile/test/ocm/oum/test_oum_standalone.py
+++ b/reconcile/test/ocm/oum/test_oum_standalone.py
@@ -1,5 +1,8 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 import pytest
-from pytest_mock import MockerFixture
 
 from reconcile.oum import standalone
 from reconcile.oum.base import OCMUserManagementIntegrationParams
@@ -20,6 +23,9 @@ from reconcile.utils.ocm.cluster_groups import OCMClusterGroupId
 from reconcile.utils.ocm.labels import build_container_for_prefix
 from reconcile.utils.ocm.search_filters import Filter
 from reconcile.utils.ocm_base_client import OCMBaseClient
+
+if TYPE_CHECKING:
+    from pytest_mock import MockerFixture
 
 #
 # test labelset

--- a/reconcile/test/ocm/oum/test_oum_standalone.py
+++ b/reconcile/test/ocm/oum/test_oum_standalone.py
@@ -22,10 +22,11 @@ from reconcile.utils.ocm.base import (
 from reconcile.utils.ocm.cluster_groups import OCMClusterGroupId
 from reconcile.utils.ocm.labels import build_container_for_prefix
 from reconcile.utils.ocm.search_filters import Filter
-from reconcile.utils.ocm_base_client import OCMBaseClient
 
 if TYPE_CHECKING:
     from pytest_mock import MockerFixture
+
+    from reconcile.utils.ocm_base_client import OCMBaseClient
 
 #
 # test labelset

--- a/reconcile/test/ocm/test_utils_ocm_base.py
+++ b/reconcile/test/ocm/test_utils_ocm_base.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-from collections.abc import Callable
 from typing import TYPE_CHECKING
 
 import pytest
@@ -10,6 +9,8 @@ from reconcile.test.ocm.test_utils_ocm_get_json import build_paged_ocm_response
 from reconcile.utils.ocm_base_client import OCMBaseClient
 
 if TYPE_CHECKING:
+    from collections.abc import Callable
+
     from werkzeug import Request
 
 

--- a/reconcile/test/ocm/test_utils_ocm_base.py
+++ b/reconcile/test/ocm/test_utils_ocm_base.py
@@ -1,11 +1,16 @@
+from __future__ import annotations
+
 from collections.abc import Callable
+from typing import TYPE_CHECKING
 
 import pytest
-from werkzeug import Request
 
 from reconcile.test.ocm.fixtures import OcmUrl
 from reconcile.test.ocm.test_utils_ocm_get_json import build_paged_ocm_response
 from reconcile.utils.ocm_base_client import OCMBaseClient
+
+if TYPE_CHECKING:
+    from werkzeug import Request
 
 
 @pytest.fixture

--- a/reconcile/test/ocm/test_utils_ocm_cluster_groups.py
+++ b/reconcile/test/ocm/test_utils_ocm_cluster_groups.py
@@ -1,6 +1,7 @@
-from collections.abc import Callable
+from __future__ import annotations
 
-from werkzeug import Request
+from collections.abc import Callable
+from typing import TYPE_CHECKING
 
 from reconcile.test.ocm.fixtures import OcmUrl
 from reconcile.utils.ocm.base import (
@@ -18,6 +19,9 @@ from reconcile.utils.ocm.cluster_groups import (
     get_cluster_groups,
 )
 from reconcile.utils.ocm_base_client import OCMBaseClient
+
+if TYPE_CHECKING:
+    from werkzeug import Request
 
 
 def build_ocm_cluster_group(

--- a/reconcile/test/ocm/test_utils_ocm_cluster_groups.py
+++ b/reconcile/test/ocm/test_utils_ocm_cluster_groups.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-from collections.abc import Callable
 from typing import TYPE_CHECKING
 
 from reconcile.test.ocm.fixtures import OcmUrl
@@ -18,10 +17,13 @@ from reconcile.utils.ocm.cluster_groups import (
     delete_user_from_cluster_group,
     get_cluster_groups,
 )
-from reconcile.utils.ocm_base_client import OCMBaseClient
 
 if TYPE_CHECKING:
+    from collections.abc import Callable
+
     from werkzeug import Request
+
+    from reconcile.utils.ocm_base_client import OCMBaseClient
 
 
 def build_ocm_cluster_group(

--- a/reconcile/test/ocm/test_utils_ocm_clusters.py
+++ b/reconcile/test/ocm/test_utils_ocm_clusters.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-from collections.abc import Callable
 from typing import TYPE_CHECKING
 
 from reconcile.test.ocm.fixtures import (
@@ -37,14 +36,17 @@ from reconcile.utils.ocm.clusters import (
 )
 from reconcile.utils.ocm.labels import label_filter
 from reconcile.utils.ocm.search_filters import Filter
-from reconcile.utils.ocm_base_client import OCMBaseClient
 
 if TYPE_CHECKING:
+    from collections.abc import Callable
+
     from pytest_httpserver import HTTPServer
     from pytest_mock import (
         MockerFixture,
         MockFixture,
     )
+
+    from reconcile.utils.ocm_base_client import OCMBaseClient
 
 
 def build_cluster_details(

--- a/reconcile/test/ocm/test_utils_ocm_clusters.py
+++ b/reconcile/test/ocm/test_utils_ocm_clusters.py
@@ -1,10 +1,7 @@
-from collections.abc import Callable
+from __future__ import annotations
 
-from pytest_httpserver import HTTPServer
-from pytest_mock import (
-    MockerFixture,
-    MockFixture,
-)
+from collections.abc import Callable
+from typing import TYPE_CHECKING
 
 from reconcile.test.ocm.fixtures import (
     OcmUrl,
@@ -41,6 +38,13 @@ from reconcile.utils.ocm.clusters import (
 from reconcile.utils.ocm.labels import label_filter
 from reconcile.utils.ocm.search_filters import Filter
 from reconcile.utils.ocm_base_client import OCMBaseClient
+
+if TYPE_CHECKING:
+    from pytest_httpserver import HTTPServer
+    from pytest_mock import (
+        MockerFixture,
+        MockFixture,
+    )
 
 
 def build_cluster_details(

--- a/reconcile/test/ocm/test_utils_ocm_get_json.py
+++ b/reconcile/test/ocm/test_utils_ocm_get_json.py
@@ -1,11 +1,15 @@
+from __future__ import annotations
+
 from collections.abc import Callable
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import pytest
-from werkzeug import Request
 
 from reconcile.test.ocm.fixtures import OcmUrl
 from reconcile.utils.ocm import OCM
+
+if TYPE_CHECKING:
+    from werkzeug import Request
 
 
 def buid_ocm_item_page(page: int, items: list[Any], total: int) -> dict[str, Any]:

--- a/reconcile/test/ocm/test_utils_ocm_get_json.py
+++ b/reconcile/test/ocm/test_utils_ocm_get_json.py
@@ -1,15 +1,17 @@
 from __future__ import annotations
 
-from collections.abc import Callable
 from typing import TYPE_CHECKING, Any
 
 import pytest
 
 from reconcile.test.ocm.fixtures import OcmUrl
-from reconcile.utils.ocm import OCM
 
 if TYPE_CHECKING:
+    from collections.abc import Callable
+
     from werkzeug import Request
+
+    from reconcile.utils.ocm import OCM
 
 
 def buid_ocm_item_page(page: int, items: list[Any], total: int) -> dict[str, Any]:

--- a/reconcile/test/ocm/test_utils_ocm_identity_providers.py
+++ b/reconcile/test/ocm/test_utils_ocm_identity_providers.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-from collections.abc import Callable
 from typing import TYPE_CHECKING
 
 from reconcile.test.ocm.fixtures import (
@@ -19,10 +18,13 @@ from reconcile.utils.ocm.identity_providers import (
     get_identity_providers,
     update_identity_provider,
 )
-from reconcile.utils.ocm_base_client import OCMBaseClient
 
 if TYPE_CHECKING:
+    from collections.abc import Callable
+
     from werkzeug import Request
+
+    from reconcile.utils.ocm_base_client import OCMBaseClient
 
 IDP_OIDC = OCMOIdentityProviderOidc(
     href="/api/foobar/1",

--- a/reconcile/test/ocm/test_utils_ocm_identity_providers.py
+++ b/reconcile/test/ocm/test_utils_ocm_identity_providers.py
@@ -1,6 +1,7 @@
-from collections.abc import Callable
+from __future__ import annotations
 
-from werkzeug import Request
+from collections.abc import Callable
+from typing import TYPE_CHECKING
 
 from reconcile.test.ocm.fixtures import (
     OcmUrl,
@@ -19,6 +20,9 @@ from reconcile.utils.ocm.identity_providers import (
     update_identity_provider,
 )
 from reconcile.utils.ocm_base_client import OCMBaseClient
+
+if TYPE_CHECKING:
+    from werkzeug import Request
 
 IDP_OIDC = OCMOIdentityProviderOidc(
     href="/api/foobar/1",

--- a/reconcile/test/ocm/test_utils_ocm_labels.py
+++ b/reconcile/test/ocm/test_utils_ocm_labels.py
@@ -1,8 +1,9 @@
+from __future__ import annotations
+
 from collections.abc import Callable
+from typing import TYPE_CHECKING
 
 import pytest
-from pytest_mock import MockerFixture
-from werkzeug import Request
 
 from reconcile.test.ocm.fixtures import (
     OcmUrl,
@@ -29,6 +30,10 @@ from reconcile.utils.ocm.labels import (
 )
 from reconcile.utils.ocm.search_filters import Filter
 from reconcile.utils.ocm_base_client import OCMBaseClient
+
+if TYPE_CHECKING:
+    from pytest_mock import MockerFixture
+    from werkzeug import Request
 
 
 def build_organization_label(key: str, value: str, org_id: str) -> OCMOrganizationLabel:

--- a/reconcile/test/ocm/test_utils_ocm_labels.py
+++ b/reconcile/test/ocm/test_utils_ocm_labels.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-from collections.abc import Callable
 from typing import TYPE_CHECKING
 
 import pytest
@@ -29,11 +28,14 @@ from reconcile.utils.ocm.labels import (
     update_ocm_label,
 )
 from reconcile.utils.ocm.search_filters import Filter
-from reconcile.utils.ocm_base_client import OCMBaseClient
 
 if TYPE_CHECKING:
+    from collections.abc import Callable
+
     from pytest_mock import MockerFixture
     from werkzeug import Request
+
+    from reconcile.utils.ocm_base_client import OCMBaseClient
 
 
 def build_organization_label(key: str, value: str, org_id: str) -> OCMOrganizationLabel:

--- a/reconcile/test/ocm/test_utils_ocm_manifest.py
+++ b/reconcile/test/ocm/test_utils_ocm_manifest.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-from collections.abc import Callable
 from typing import TYPE_CHECKING, Any
 
 from reconcile.test.ocm.fixtures import OcmUrl
@@ -9,11 +8,14 @@ from reconcile.utils.ocm.manifests import (
     create_manifest,
     patch_manifest,
 )
-from reconcile.utils.ocm_base_client import OCMBaseClient
 
 if TYPE_CHECKING:
+    from collections.abc import Callable
+
     from pytest_mock import MockerFixture
     from werkzeug import Request
+
+    from reconcile.utils.ocm_base_client import OCMBaseClient
 
 
 def build_manifest(cluster_id: str, manifest_id: str) -> dict[str, Any]:

--- a/reconcile/test/ocm/test_utils_ocm_manifest.py
+++ b/reconcile/test/ocm/test_utils_ocm_manifest.py
@@ -1,8 +1,7 @@
-from collections.abc import Callable
-from typing import Any
+from __future__ import annotations
 
-from pytest_mock import MockerFixture
-from werkzeug import Request
+from collections.abc import Callable
+from typing import TYPE_CHECKING, Any
 
 from reconcile.test.ocm.fixtures import OcmUrl
 from reconcile.utils.ocm import manifests
@@ -11,6 +10,10 @@ from reconcile.utils.ocm.manifests import (
     patch_manifest,
 )
 from reconcile.utils.ocm_base_client import OCMBaseClient
+
+if TYPE_CHECKING:
+    from pytest_mock import MockerFixture
+    from werkzeug import Request
 
 
 def build_manifest(cluster_id: str, manifest_id: str) -> dict[str, Any]:

--- a/reconcile/test/ocm/test_utils_ocm_search_filters.py
+++ b/reconcile/test/ocm/test_utils_ocm_search_filters.py
@@ -1,16 +1,21 @@
+from __future__ import annotations
+
 from datetime import (
     UTC,
     datetime,
 )
+from typing import TYPE_CHECKING
 
 import pytest
-from pytest_mock import MockerFixture
 
 from reconcile.utils.ocm.search_filters import (
     Filter,
     InvalidChunkRequestError,
     InvalidFilterError,
 )
+
+if TYPE_CHECKING:
+    from pytest_mock import MockerFixture
 
 #
 # eq and is_in

--- a/reconcile/test/ocm/test_utils_ocm_service_log.py
+++ b/reconcile/test/ocm/test_utils_ocm_service_log.py
@@ -1,13 +1,14 @@
+from __future__ import annotations
+
 from collections.abc import Callable
 from datetime import (
     UTC,
     datetime,
     timedelta,
 )
+from typing import TYPE_CHECKING
 
 import pytest
-from pytest_mock import MockerFixture
-from werkzeug import Request
 
 from reconcile.test.ocm.fixtures import OcmUrl
 from reconcile.utils.ocm import service_log
@@ -27,6 +28,10 @@ from reconcile.utils.ocm.service_log import (
     get_service_logs_for_cluster_uuid,
 )
 from reconcile.utils.ocm_base_client import OCMBaseClient
+
+if TYPE_CHECKING:
+    from pytest_mock import MockerFixture
+    from werkzeug import Request
 
 
 def build_service_log(

--- a/reconcile/test/ocm/test_utils_ocm_service_log.py
+++ b/reconcile/test/ocm/test_utils_ocm_service_log.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-from collections.abc import Callable
 from datetime import (
     UTC,
     datetime,
@@ -27,11 +26,14 @@ from reconcile.utils.ocm.service_log import (
     create_service_log,
     get_service_logs_for_cluster_uuid,
 )
-from reconcile.utils.ocm_base_client import OCMBaseClient
 
 if TYPE_CHECKING:
+    from collections.abc import Callable
+
     from pytest_mock import MockerFixture
     from werkzeug import Request
+
+    from reconcile.utils.ocm_base_client import OCMBaseClient
 
 
 def build_service_log(

--- a/reconcile/test/ocm/test_utils_ocm_status_board.py
+++ b/reconcile/test/ocm/test_utils_ocm_status_board.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-from collections.abc import Callable
 from typing import TYPE_CHECKING, Any
 
 import pytest
@@ -21,6 +20,8 @@ from reconcile.utils.ocm.status_board import (
 )
 
 if TYPE_CHECKING:
+    from collections.abc import Callable
+
     from pytest_mock import MockFixture
 
 

--- a/reconcile/test/ocm/test_utils_ocm_status_board.py
+++ b/reconcile/test/ocm/test_utils_ocm_status_board.py
@@ -1,8 +1,9 @@
+from __future__ import annotations
+
 from collections.abc import Callable
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import pytest
-from pytest_mock import MockFixture
 
 from reconcile.utils.ocm.status_board import (
     METADATA_MANAGED_BY_KEY,
@@ -18,6 +19,9 @@ from reconcile.utils.ocm.status_board import (
     get_product_applications,
     update_service,
 )
+
+if TYPE_CHECKING:
+    from pytest_mock import MockFixture
 
 
 @pytest.fixture

--- a/reconcile/test/ocm/test_utils_ocm_syncset.py
+++ b/reconcile/test/ocm/test_utils_ocm_syncset.py
@@ -1,8 +1,7 @@
-from collections.abc import Callable
-from typing import Any
+from __future__ import annotations
 
-from pytest_mock import MockerFixture
-from werkzeug import Request
+from collections.abc import Callable
+from typing import TYPE_CHECKING, Any
 
 from reconcile.test.ocm.fixtures import OcmUrl
 from reconcile.utils.ocm import syncsets
@@ -11,6 +10,10 @@ from reconcile.utils.ocm.syncsets import (
     patch_syncset,
 )
 from reconcile.utils.ocm_base_client import OCMBaseClient
+
+if TYPE_CHECKING:
+    from pytest_mock import MockerFixture
+    from werkzeug import Request
 
 
 def build_syncset(cluster_id: str, syncset_id: str) -> dict[str, Any]:

--- a/reconcile/test/ocm/test_utils_ocm_syncset.py
+++ b/reconcile/test/ocm/test_utils_ocm_syncset.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-from collections.abc import Callable
 from typing import TYPE_CHECKING, Any
 
 from reconcile.test.ocm.fixtures import OcmUrl
@@ -9,11 +8,14 @@ from reconcile.utils.ocm.syncsets import (
     create_syncset,
     patch_syncset,
 )
-from reconcile.utils.ocm_base_client import OCMBaseClient
 
 if TYPE_CHECKING:
+    from collections.abc import Callable
+
     from pytest_mock import MockerFixture
     from werkzeug import Request
+
+    from reconcile.utils.ocm_base_client import OCMBaseClient
 
 
 def build_syncset(cluster_id: str, syncset_id: str) -> dict[str, Any]:

--- a/reconcile/test/ocm_labels/conftest.py
+++ b/reconcile/test/ocm_labels/conftest.py
@@ -1,12 +1,13 @@
+from __future__ import annotations
+
 from collections.abc import (
     Callable,
     Mapping,
     Sequence,
 )
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import pytest
-from pytest_mock import MockerFixture
 
 from reconcile.gql_definitions.fragments.ocm_environment import OCMEnvironment
 from reconcile.gql_definitions.ocm_labels.clusters import ClusterV1
@@ -31,6 +32,9 @@ from reconcile.utils.ocm.label_sources import (
 )
 from reconcile.utils.ocm_base_client import OCMBaseClient
 from reconcile.utils.secret_reader import SecretReader
+
+if TYPE_CHECKING:
+    from pytest_mock import MockerFixture
 
 
 @pytest.fixture

--- a/reconcile/test/ocm_labels/conftest.py
+++ b/reconcile/test/ocm_labels/conftest.py
@@ -1,10 +1,5 @@
 from __future__ import annotations
 
-from collections.abc import (
-    Callable,
-    Mapping,
-    Sequence,
-)
 from typing import TYPE_CHECKING, Any
 
 import pytest
@@ -31,10 +26,17 @@ from reconcile.utils.ocm.label_sources import (
     LabelState,
 )
 from reconcile.utils.ocm_base_client import OCMBaseClient
-from reconcile.utils.secret_reader import SecretReader
 
 if TYPE_CHECKING:
+    from collections.abc import (
+        Callable,
+        Mapping,
+        Sequence,
+    )
+
     from pytest_mock import MockerFixture
+
+    from reconcile.utils.secret_reader import SecretReader
 
 
 @pytest.fixture

--- a/reconcile/test/ocm_labels/test_ocm_labels_integration.py
+++ b/reconcile/test/ocm_labels/test_ocm_labels_integration.py
@@ -1,31 +1,33 @@
 from __future__ import annotations
 
-from collections.abc import (
-    Callable,
-    Iterable,
-    Sequence,
-)
 from typing import TYPE_CHECKING, Any
 from unittest.mock import call
 
 import pytest
 
-from reconcile.gql_definitions.fragments.ocm_environment import OCMEnvironment
 from reconcile.gql_definitions.ocm_labels.clusters import ClusterV1
 from reconcile.ocm_labels.integration import (
     ClusterSubscriptionLabelSource,
     OcmLabelsIntegration,
     init_cluster_subscription_label_source,
 )
-from reconcile.utils.ocm.base import ClusterDetails
 from reconcile.utils.ocm.label_sources import (
     LabelSource,
     LabelState,
 )
-from reconcile.utils.ocm_base_client import OCMBaseClient
 
 if TYPE_CHECKING:
+    from collections.abc import (
+        Callable,
+        Iterable,
+        Sequence,
+    )
+
     from pytest_mock import MockerFixture
+
+    from reconcile.gql_definitions.fragments.ocm_environment import OCMEnvironment
+    from reconcile.utils.ocm.base import ClusterDetails
+    from reconcile.utils.ocm_base_client import OCMBaseClient
 
 
 class StaticLabelSource(LabelSource):

--- a/reconcile/test/ocm_labels/test_ocm_labels_integration.py
+++ b/reconcile/test/ocm_labels/test_ocm_labels_integration.py
@@ -1,13 +1,14 @@
+from __future__ import annotations
+
 from collections.abc import (
     Callable,
     Iterable,
     Sequence,
 )
-from typing import Any
+from typing import TYPE_CHECKING, Any
 from unittest.mock import call
 
 import pytest
-from pytest_mock import MockerFixture
 
 from reconcile.gql_definitions.fragments.ocm_environment import OCMEnvironment
 from reconcile.gql_definitions.ocm_labels.clusters import ClusterV1
@@ -22,6 +23,9 @@ from reconcile.utils.ocm.label_sources import (
     LabelState,
 )
 from reconcile.utils.ocm_base_client import OCMBaseClient
+
+if TYPE_CHECKING:
+    from pytest_mock import MockerFixture
 
 
 class StaticLabelSource(LabelSource):

--- a/reconcile/test/openshift_bindings/test_models.py
+++ b/reconcile/test/openshift_bindings/test_models.py
@@ -1,6 +1,9 @@
+from __future__ import annotations
+
 """Tests for reconcile.openshift_bindings.models module."""
 
-from pytest_mock import MockerFixture
+
+from typing import TYPE_CHECKING
 
 from reconcile.gql_definitions.common.app_interface_clusterrole import (
     AccessV1 as ClusterAccessV1,
@@ -31,6 +34,9 @@ from reconcile.openshift_bindings.models import (
     get_usernames_from_users,
 )
 from reconcile.openshift_bindings.utils import is_valid_namespace
+
+if TYPE_CHECKING:
+    from pytest_mock import MockerFixture
 
 
 class TestIsValidNamespace:

--- a/reconcile/test/openshift_bindings/test_openshift_clusterrolebindings.py
+++ b/reconcile/test/openshift_bindings/test_openshift_clusterrolebindings.py
@@ -1,6 +1,9 @@
+from __future__ import annotations
+
 """Tests for reconcile.openshift_bindings.openshift_clusterrolebindings module."""
 
-from pytest_mock import MockerFixture
+
+from typing import TYPE_CHECKING
 
 from reconcile.gql_definitions.common.app_interface_clusterrole import (
     AccessV1 as ClusterAccessV1,
@@ -30,6 +33,9 @@ from reconcile.openshift_bindings.openshift_clusterrolebindings import (
 from reconcile.test.openshift_bindings.conftest import MockOCMap, MockQueryCluster
 from reconcile.utils.openshift_resource import OpenshiftResource as OR
 from reconcile.utils.openshift_resource import ResourceInventory
+
+if TYPE_CHECKING:
+    from pytest_mock import MockerFixture
 
 
 def get_app_interface_test_cluster_roles() -> list[ClusterRoleV1]:

--- a/reconcile/test/openshift_bindings/test_openshift_rolebindings.py
+++ b/reconcile/test/openshift_bindings/test_openshift_rolebindings.py
@@ -1,7 +1,10 @@
+from __future__ import annotations
+
 """Tests for reconcile.openshift_bindings.openshift_rolebindings module."""
 
+from typing import TYPE_CHECKING
+
 import pytest
-from pytest_mock import MockerFixture
 
 from reconcile.gql_definitions.common.app_interface_roles import (
     AccessV1,
@@ -21,6 +24,9 @@ from reconcile.openshift_bindings.openshift_rolebindings import (
 )
 from reconcile.utils.openshift_resource import OpenshiftResource as OR
 from reconcile.utils.openshift_resource import ResourceInventory
+
+if TYPE_CHECKING:
+    from pytest_mock import MockerFixture
 
 
 def get_app_interface_test_roles() -> list[RoleV1]:

--- a/reconcile/test/rhidp/conftest.py
+++ b/reconcile/test/rhidp/conftest.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-from collections.abc import Callable
 from typing import TYPE_CHECKING
 
 import pytest
@@ -10,6 +9,8 @@ from reconcile.test.fixtures import Fixtures
 from reconcile.utils.ocm_base_client import OCMBaseClient
 
 if TYPE_CHECKING:
+    from collections.abc import Callable
+
     from pytest_mock import MockerFixture
 
 

--- a/reconcile/test/rhidp/conftest.py
+++ b/reconcile/test/rhidp/conftest.py
@@ -1,11 +1,16 @@
+from __future__ import annotations
+
 from collections.abc import Callable
+from typing import TYPE_CHECKING
 
 import pytest
-from pytest_mock import MockerFixture
 
 from reconcile.rhidp.common import Cluster
 from reconcile.test.fixtures import Fixtures
 from reconcile.utils.ocm_base_client import OCMBaseClient
+
+if TYPE_CHECKING:
+    from pytest_mock import MockerFixture
 
 
 @pytest.fixture

--- a/reconcile/test/rhidp/test_common.py
+++ b/reconcile/test/rhidp/test_common.py
@@ -1,11 +1,13 @@
+from __future__ import annotations
+
 from collections.abc import Iterable
+from typing import TYPE_CHECKING
 from unittest.mock import (
     Mock,
     call,
 )
 
 import pytest
-from pytest_mock import MockerFixture
 
 from reconcile.gql_definitions.fragments.vault_secret import VaultSecret
 from reconcile.rhidp import common
@@ -26,6 +28,9 @@ from reconcile.test.ocm.fixtures import (
 )
 from reconcile.utils.metrics import MetricsContainer
 from reconcile.utils.ocm.base import build_label_container
+
+if TYPE_CHECKING:
+    from pytest_mock import MockerFixture
 
 VI = "vault-input-path"
 ORG = "org_id"

--- a/reconcile/test/rhidp/test_common.py
+++ b/reconcile/test/rhidp/test_common.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-from collections.abc import Iterable
 from typing import TYPE_CHECKING
 from unittest.mock import (
     Mock,
@@ -30,6 +29,8 @@ from reconcile.utils.metrics import MetricsContainer
 from reconcile.utils.ocm.base import build_label_container
 
 if TYPE_CHECKING:
+    from collections.abc import Iterable
+
     from pytest_mock import MockerFixture
 
 VI = "vault-input-path"

--- a/reconcile/test/rhidp/test_ocm_oidc_idp_base.py
+++ b/reconcile/test/rhidp/test_ocm_oidc_idp_base.py
@@ -1,8 +1,10 @@
+from __future__ import annotations
+
 from collections.abc import Sequence
+from typing import TYPE_CHECKING
 from unittest.mock import Mock
 
 import pytest
-from pytest_mock import MockerFixture
 
 from reconcile.rhidp.common import (
     Cluster,
@@ -22,6 +24,9 @@ from reconcile.utils.ocm.base import (
     OCMOIdentityProviderOidcOpenIdClaims,
 )
 from reconcile.utils.ocm_base_client import OCMBaseClient
+
+if TYPE_CHECKING:
+    from pytest_mock import MockerFixture
 
 IDP_OIDC = OCMOIdentityProviderOidc(
     name="oidc-auth",

--- a/reconcile/test/rhidp/test_ocm_oidc_idp_base.py
+++ b/reconcile/test/rhidp/test_ocm_oidc_idp_base.py
@@ -1,8 +1,6 @@
 from __future__ import annotations
 
-from collections.abc import Sequence
 from typing import TYPE_CHECKING
-from unittest.mock import Mock
 
 import pytest
 
@@ -23,10 +21,14 @@ from reconcile.utils.ocm.base import (
     OCMOIdentityProviderOidcOpenId,
     OCMOIdentityProviderOidcOpenIdClaims,
 )
-from reconcile.utils.ocm_base_client import OCMBaseClient
 
 if TYPE_CHECKING:
+    from collections.abc import Sequence
+    from unittest.mock import Mock
+
     from pytest_mock import MockerFixture
+
+    from reconcile.utils.ocm_base_client import OCMBaseClient
 
 IDP_OIDC = OCMOIdentityProviderOidc(
     name="oidc-auth",

--- a/reconcile/test/rhidp/test_sso_client_base.py
+++ b/reconcile/test/rhidp/test_sso_client_base.py
@@ -1,13 +1,10 @@
 from __future__ import annotations
 
-from collections.abc import Sequence
 from typing import TYPE_CHECKING
-from unittest.mock import Mock
 
 import pytest
 
 from reconcile.gql_definitions.fragments.vault_secret import VaultSecret
-from reconcile.rhidp.common import Cluster
 from reconcile.rhidp.sso_client.base import (
     act,
     console_url_to_oauth_url,
@@ -23,7 +20,12 @@ from reconcile.utils.keycloak import (
 )
 
 if TYPE_CHECKING:
+    from collections.abc import Sequence
+    from unittest.mock import Mock
+
     from pytest_mock import MockerFixture
+
+    from reconcile.rhidp.common import Cluster
 
 
 @pytest.mark.parametrize(

--- a/reconcile/test/rhidp/test_sso_client_base.py
+++ b/reconcile/test/rhidp/test_sso_client_base.py
@@ -1,8 +1,10 @@
+from __future__ import annotations
+
 from collections.abc import Sequence
+from typing import TYPE_CHECKING
 from unittest.mock import Mock
 
 import pytest
-from pytest_mock import MockerFixture
 
 from reconcile.gql_definitions.fragments.vault_secret import VaultSecret
 from reconcile.rhidp.common import Cluster
@@ -19,6 +21,9 @@ from reconcile.utils.keycloak import (
     KeycloakMap,
     SSOClient,
 )
+
+if TYPE_CHECKING:
+    from pytest_mock import MockerFixture
 
 
 @pytest.mark.parametrize(

--- a/reconcile/test/runtime/test_utils_desired_state_diff.py
+++ b/reconcile/test/runtime/test_utils_desired_state_diff.py
@@ -11,10 +11,6 @@ from reconcile.change_owners.diff import (
     Diff,
     DiffType,
 )
-from reconcile.test.runtime.fixtures import (
-    ShardableTestIntegration,
-    SimpleTestIntegration,
-)
 from reconcile.utils.runtime import desired_state_diff
 from reconcile.utils.runtime.desired_state_diff import (
     DiffDetectionFailureError,
@@ -26,6 +22,11 @@ from reconcile.utils.runtime.integration import DesiredStateShardConfig
 
 if TYPE_CHECKING:
     from pytest_mock.plugin import MockerFixture
+
+    from reconcile.test.runtime.fixtures import (
+        ShardableTestIntegration,
+        SimpleTestIntegration,
+    )
 
 #
 # build desired state diff

--- a/reconcile/test/runtime/test_utils_desired_state_diff.py
+++ b/reconcile/test/runtime/test_utils_desired_state_diff.py
@@ -1,9 +1,10 @@
+from __future__ import annotations
+
 from time import sleep
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import jsonpath_ng
 import pytest
-from pytest_mock.plugin import MockerFixture
 
 from reconcile.change_owners.diff import (
     IDENTIFIER_FIELD_NAME,
@@ -22,6 +23,9 @@ from reconcile.utils.runtime.desired_state_diff import (
     extract_diffs_with_timeout,
 )
 from reconcile.utils.runtime.integration import DesiredStateShardConfig
+
+if TYPE_CHECKING:
+    from pytest_mock.plugin import MockerFixture
 
 #
 # build desired state diff

--- a/reconcile/test/runtime/test_utils_runtime_runner.py
+++ b/reconcile/test/runtime/test_utils_runtime_runner.py
@@ -1,10 +1,11 @@
+from __future__ import annotations
+
 import sys
 from dataclasses import dataclass
-from typing import Any
+from typing import TYPE_CHECKING, Any
 from unittest.mock import MagicMock
 
 import pytest
-from pytest_mock.plugin import MockerFixture
 
 from reconcile.test.runtime.fixtures import (
     ShardableTestIntegration,
@@ -22,6 +23,9 @@ from reconcile.utils.runtime.runner import (
     get_desired_state_diff,
     run_integration_cfg,
 )
+
+if TYPE_CHECKING:
+    from pytest_mock.plugin import MockerFixture
 
 
 @dataclass

--- a/reconcile/test/saas_auto_promotions_manager/merge_request_manager/merge_request_manager/test_mr_parser.py
+++ b/reconcile/test/saas_auto_promotions_manager/merge_request_manager/merge_request_manager/test_mr_parser.py
@@ -1,9 +1,5 @@
 from __future__ import annotations
 
-from collections.abc import (
-    Callable,
-    Mapping,
-)
 from typing import TYPE_CHECKING
 from unittest.mock import call
 
@@ -25,7 +21,6 @@ from reconcile.saas_auto_promotions_manager.merge_request_manager.renderer impor
     SAPM_VERSION,
     VERSION_REF,
 )
-from reconcile.utils.vcs import VCS
 
 from .data_keys import (
     DESCRIPTION,
@@ -35,7 +30,14 @@ from .data_keys import (
 )
 
 if TYPE_CHECKING:
+    from collections.abc import (
+        Callable,
+        Mapping,
+    )
+
     from gitlab.v4.objects import ProjectMergeRequest
+
+    from reconcile.utils.vcs import VCS
 
 
 def test_valid_parsing(

--- a/reconcile/test/saas_auto_promotions_manager/merge_request_manager/merge_request_manager/test_mr_parser.py
+++ b/reconcile/test/saas_auto_promotions_manager/merge_request_manager/merge_request_manager/test_mr_parser.py
@@ -1,10 +1,11 @@
+from __future__ import annotations
+
 from collections.abc import (
     Callable,
     Mapping,
 )
+from typing import TYPE_CHECKING
 from unittest.mock import call
-
-from gitlab.v4.objects import ProjectMergeRequest
 
 from reconcile.saas_auto_promotions_manager.merge_request_manager.merge_request_manager_v2 import (
     SAPM_LABEL,
@@ -32,6 +33,9 @@ from .data_keys import (
     LABELS,
     OPEN_MERGE_REQUESTS,
 )
+
+if TYPE_CHECKING:
+    from gitlab.v4.objects import ProjectMergeRequest
 
 
 def test_valid_parsing(

--- a/reconcile/test/saas_auto_promotions_manager/subscriber/test_slo_gatekeeping.py
+++ b/reconcile/test/saas_auto_promotions_manager/subscriber/test_slo_gatekeeping.py
@@ -1,9 +1,5 @@
 from __future__ import annotations
 
-from collections.abc import (
-    Callable,
-    Mapping,
-)
 from typing import TYPE_CHECKING, Any
 from unittest.mock import create_autospec
 
@@ -11,13 +7,19 @@ from reconcile.gql_definitions.fragments.saas_slo_document import (
     SLODocumentSLOSLOParametersV1,
     SLODocumentSLOV1,
 )
-from reconcile.saas_auto_promotions_manager.subscriber import (
-    Subscriber,
-)
 from reconcile.utils.slo_document_manager import SLODetails, SLODocumentManager
 
 if TYPE_CHECKING:
+    from collections.abc import (
+        Callable,
+        Mapping,
+    )
+
     from pytest_mock import MockerFixture
+
+    from reconcile.saas_auto_promotions_manager.subscriber import (
+        Subscriber,
+    )
 
 
 def test_slo_gatekeeping_no_slos_breached(

--- a/reconcile/test/saas_auto_promotions_manager/subscriber/test_slo_gatekeeping.py
+++ b/reconcile/test/saas_auto_promotions_manager/subscriber/test_slo_gatekeeping.py
@@ -1,11 +1,11 @@
+from __future__ import annotations
+
 from collections.abc import (
     Callable,
     Mapping,
 )
-from typing import Any
+from typing import TYPE_CHECKING, Any
 from unittest.mock import create_autospec
-
-from pytest_mock import MockerFixture
 
 from reconcile.gql_definitions.fragments.saas_slo_document import (
     SLODocumentSLOSLOParametersV1,
@@ -15,6 +15,9 @@ from reconcile.saas_auto_promotions_manager.subscriber import (
     Subscriber,
 )
 from reconcile.utils.slo_document_manager import SLODetails, SLODocumentManager
+
+if TYPE_CHECKING:
+    from pytest_mock import MockerFixture
 
 
 def test_slo_gatekeeping_no_slos_breached(

--- a/reconcile/test/skupper_network/conftest.py
+++ b/reconcile/test/skupper_network/conftest.py
@@ -1,23 +1,25 @@
 from __future__ import annotations
 
-from collections.abc import (
-    Callable,
-    MutableMapping,
-)
 from typing import TYPE_CHECKING, Any
-from unittest.mock import MagicMock
 
 import pytest
 
 from reconcile.gql_definitions.skupper_network.skupper_networks import SkupperNetworkV1
 from reconcile.skupper_network import integration as intg
-from reconcile.skupper_network.models import SkupperSite
 from reconcile.test.fixtures import Fixtures
-from reconcile.utils.oc import OCNative
-from reconcile.utils.oc_map import OCMap
 
 if TYPE_CHECKING:
+    from collections.abc import (
+        Callable,
+        MutableMapping,
+    )
+    from unittest.mock import MagicMock
+
     from pytest_mock import MockerFixture
+
+    from reconcile.skupper_network.models import SkupperSite
+    from reconcile.utils.oc import OCNative
+    from reconcile.utils.oc_map import OCMap
 
 
 @pytest.fixture

--- a/reconcile/test/skupper_network/conftest.py
+++ b/reconcile/test/skupper_network/conftest.py
@@ -1,12 +1,13 @@
+from __future__ import annotations
+
 from collections.abc import (
     Callable,
     MutableMapping,
 )
-from typing import Any
+from typing import TYPE_CHECKING, Any
 from unittest.mock import MagicMock
 
 import pytest
-from pytest_mock import MockerFixture
 
 from reconcile.gql_definitions.skupper_network.skupper_networks import SkupperNetworkV1
 from reconcile.skupper_network import integration as intg
@@ -14,6 +15,9 @@ from reconcile.skupper_network.models import SkupperSite
 from reconcile.test.fixtures import Fixtures
 from reconcile.utils.oc import OCNative
 from reconcile.utils.oc_map import OCMap
+
+if TYPE_CHECKING:
+    from pytest_mock import MockerFixture
 
 
 @pytest.fixture

--- a/reconcile/test/skupper_network/test_skupper_network_reconciler.py
+++ b/reconcile/test/skupper_network/test_skupper_network_reconciler.py
@@ -11,11 +11,12 @@ from unittest.mock import (
 import pytest
 
 from reconcile.skupper_network import reconciler
-from reconcile.skupper_network.models import SkupperSite
-from reconcile.utils.oc_map import OCMap
 
 if TYPE_CHECKING:
     from pytest_mock import MockerFixture
+
+    from reconcile.skupper_network.models import SkupperSite
+    from reconcile.utils.oc_map import OCMap
 
 
 @pytest.mark.parametrize("dry_run", [True, False])

--- a/reconcile/test/skupper_network/test_skupper_network_reconciler.py
+++ b/reconcile/test/skupper_network/test_skupper_network_reconciler.py
@@ -1,5 +1,7 @@
+from __future__ import annotations
+
 import copy
-from typing import Any
+from typing import TYPE_CHECKING, Any
 from unittest.mock import (
     ANY,
     MagicMock,
@@ -7,11 +9,13 @@ from unittest.mock import (
 )
 
 import pytest
-from pytest_mock import MockerFixture
 
 from reconcile.skupper_network import reconciler
 from reconcile.skupper_network.models import SkupperSite
 from reconcile.utils.oc_map import OCMap
+
+if TYPE_CHECKING:
+    from pytest_mock import MockerFixture
 
 
 @pytest.mark.parametrize("dry_run", [True, False])

--- a/reconcile/test/statuspage/test_statuspage_atlassian.py
+++ b/reconcile/test/statuspage/test_statuspage_atlassian.py
@@ -4,12 +4,13 @@ from typing import TYPE_CHECKING
 
 import pytest
 
-from reconcile.statuspage.atlassian import AtlassianStatusPageProvider
 from reconcile.statuspage.page import StatusComponent
 from reconcile.statuspage.status import ManualStatusProvider
 
 if TYPE_CHECKING:
     from pytest_mock import MockerFixture
+
+    from reconcile.statuspage.atlassian import AtlassianStatusPageProvider
 
 """
 About the `atlassian_page` fixture:

--- a/reconcile/test/statuspage/test_statuspage_atlassian.py
+++ b/reconcile/test/statuspage/test_statuspage_atlassian.py
@@ -1,9 +1,15 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 import pytest
-from pytest_mock import MockerFixture
 
 from reconcile.statuspage.atlassian import AtlassianStatusPageProvider
 from reconcile.statuspage.page import StatusComponent
 from reconcile.statuspage.status import ManualStatusProvider
+
+if TYPE_CHECKING:
+    from pytest_mock import MockerFixture
 
 """
 About the `atlassian_page` fixture:

--- a/reconcile/test/templating/conftest.py
+++ b/reconcile/test/templating/conftest.py
@@ -1,13 +1,17 @@
+from __future__ import annotations
+
 from collections.abc import Callable
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import pytest
-from pytest_mock import MockerFixture
 from qontract_utils.ruamel import create_ruamel_instance, yaml
 
 from reconcile.gql_definitions.templating.templates import TemplateV1
 from reconcile.test.fixtures import Fixtures
 from reconcile.utils.secret_reader import SecretReader
+
+if TYPE_CHECKING:
+    from pytest_mock import MockerFixture
 
 
 @pytest.fixture

--- a/reconcile/test/templating/conftest.py
+++ b/reconcile/test/templating/conftest.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-from collections.abc import Callable
 from typing import TYPE_CHECKING, Any
 
 import pytest
@@ -8,10 +7,13 @@ from qontract_utils.ruamel import create_ruamel_instance, yaml
 
 from reconcile.gql_definitions.templating.templates import TemplateV1
 from reconcile.test.fixtures import Fixtures
-from reconcile.utils.secret_reader import SecretReader
 
 if TYPE_CHECKING:
+    from collections.abc import Callable
+
     from pytest_mock import MockerFixture
+
+    from reconcile.utils.secret_reader import SecretReader
 
 
 @pytest.fixture

--- a/reconcile/test/templating/lib/test_tr_merge_request_manager.py
+++ b/reconcile/test/templating/lib/test_tr_merge_request_manager.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 from typing import TYPE_CHECKING
-from unittest.mock import Mock
 
 import pytest
 
@@ -19,6 +18,8 @@ from reconcile.utils.merge_request_manager.merge_request_manager import OpenMerg
 from reconcile.utils.vcs import VCS
 
 if TYPE_CHECKING:
+    from unittest.mock import Mock
+
     from pytest_mock import MockerFixture
 
 

--- a/reconcile/test/templating/lib/test_tr_merge_request_manager.py
+++ b/reconcile/test/templating/lib/test_tr_merge_request_manager.py
@@ -1,7 +1,9 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
 from unittest.mock import Mock
 
 import pytest
-from pytest_mock import MockerFixture
 
 from reconcile.templating.lib.merge_request_manager import (
     MergeRequestManager,
@@ -15,6 +17,9 @@ from reconcile.templating.lib.model import TemplateOutput, TemplateResult
 from reconcile.utils.gitlab_api import GitLabApi
 from reconcile.utils.merge_request_manager.merge_request_manager import OpenMergeRequest
 from reconcile.utils.vcs import VCS
+
+if TYPE_CHECKING:
+    from pytest_mock import MockerFixture
 
 
 @pytest.fixture

--- a/reconcile/test/templating/test_renderer.py
+++ b/reconcile/test/templating/test_renderer.py
@@ -1,12 +1,13 @@
+from __future__ import annotations
+
 import os
 from collections.abc import Callable
 from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
 from unittest.mock import ANY, MagicMock, call
 
 import pytest
 from gitlab import GitlabGetError
-from pytest_mock import MockerFixture
 from qontract_utils.ruamel import create_ruamel_instance, yaml
 
 from reconcile.gql_definitions.templating.template_collection import (
@@ -31,6 +32,9 @@ from reconcile.templating.renderer import (
 from reconcile.utils.jinja2.utils import Jinja2TemplateError
 from reconcile.utils.secret_reader import SecretReader
 from reconcile.utils.vcs import VCS
+
+if TYPE_CHECKING:
+    from pytest_mock import MockerFixture
 
 
 @pytest.fixture

--- a/reconcile/test/templating/test_renderer.py
+++ b/reconcile/test/templating/test_renderer.py
@@ -1,8 +1,6 @@
 from __future__ import annotations
 
 import os
-from collections.abc import Callable
-from pathlib import Path
 from typing import TYPE_CHECKING, Any
 from unittest.mock import ANY, MagicMock, call
 
@@ -30,11 +28,15 @@ from reconcile.templating.renderer import (
     unpack_static_variables,
 )
 from reconcile.utils.jinja2.utils import Jinja2TemplateError
-from reconcile.utils.secret_reader import SecretReader
 from reconcile.utils.vcs import VCS
 
 if TYPE_CHECKING:
+    from collections.abc import Callable
+    from pathlib import Path
+
     from pytest_mock import MockerFixture
+
+    from reconcile.utils.secret_reader import SecretReader
 
 
 @pytest.fixture

--- a/reconcile/test/templating/test_validator.py
+++ b/reconcile/test/templating/test_validator.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-from collections.abc import Callable
 from typing import TYPE_CHECKING
 
 import pytest
@@ -9,6 +8,8 @@ from reconcile.gql_definitions.templating.templates import TemplateTestV1, Templ
 from reconcile.templating.validator import TemplateValidatorIntegration
 
 if TYPE_CHECKING:
+    from collections.abc import Callable
+
     from qontract_utils.ruamel import yaml
 
 

--- a/reconcile/test/templating/test_validator.py
+++ b/reconcile/test/templating/test_validator.py
@@ -1,10 +1,15 @@
+from __future__ import annotations
+
 from collections.abc import Callable
+from typing import TYPE_CHECKING
 
 import pytest
-from qontract_utils.ruamel import yaml
 
 from reconcile.gql_definitions.templating.templates import TemplateTestV1, TemplateV1
 from reconcile.templating.validator import TemplateValidatorIntegration
+
+if TYPE_CHECKING:
+    from qontract_utils.ruamel import yaml
 
 
 @pytest.fixture

--- a/reconcile/test/terraform_init/conftest.py
+++ b/reconcile/test/terraform_init/conftest.py
@@ -1,8 +1,6 @@
 from __future__ import annotations
 
-from collections.abc import Callable, Mapping
 from typing import TYPE_CHECKING, Any
-from unittest.mock import MagicMock
 
 import pytest
 from qontract_utils.aws_api_typed.api import AWSApi
@@ -19,6 +17,9 @@ from reconcile.terraform_init.merge_request_manager import MergeRequestManager
 from reconcile.test.fixtures import Fixtures
 
 if TYPE_CHECKING:
+    from collections.abc import Callable, Mapping
+    from unittest.mock import MagicMock
+
     from pytest_mock import MockerFixture
 
 

--- a/reconcile/test/terraform_init/conftest.py
+++ b/reconcile/test/terraform_init/conftest.py
@@ -1,9 +1,10 @@
+from __future__ import annotations
+
 from collections.abc import Callable, Mapping
-from typing import Any
+from typing import TYPE_CHECKING, Any
 from unittest.mock import MagicMock
 
 import pytest
-from pytest_mock import MockerFixture
 from qontract_utils.aws_api_typed.api import AWSApi
 
 from reconcile.gql_definitions.external_resources.external_resources_settings import (
@@ -16,6 +17,9 @@ from reconcile.terraform_init.integration import (
 )
 from reconcile.terraform_init.merge_request_manager import MergeRequestManager
 from reconcile.test.fixtures import Fixtures
+
+if TYPE_CHECKING:
+    from pytest_mock import MockerFixture
 
 
 @pytest.fixture

--- a/reconcile/test/terraform_init/test_terraform_init_integration.py
+++ b/reconcile/test/terraform_init/test_terraform_init_integration.py
@@ -1,15 +1,19 @@
+from __future__ import annotations
+
 import datetime
 from collections.abc import Callable
 from textwrap import dedent
+from typing import TYPE_CHECKING
 from unittest.mock import MagicMock, create_autospec
-
-from pytest_mock import MockerFixture
 
 from reconcile.gql_definitions.terraform_init.aws_accounts import AWSAccountV1
 from reconcile.terraform_init import integration
 from reconcile.terraform_init.integration import TerraformInitIntegration
 from reconcile.terraform_init.merge_request_manager import MrData
 from reconcile.utils.gql import GqlApi
+
+if TYPE_CHECKING:
+    from pytest_mock import MockerFixture
 
 
 def test_terraform_init_integration_early_exit(

--- a/reconcile/test/terraform_init/test_terraform_init_integration.py
+++ b/reconcile/test/terraform_init/test_terraform_init_integration.py
@@ -1,19 +1,21 @@
 from __future__ import annotations
 
 import datetime
-from collections.abc import Callable
 from textwrap import dedent
 from typing import TYPE_CHECKING
 from unittest.mock import MagicMock, create_autospec
 
-from reconcile.gql_definitions.terraform_init.aws_accounts import AWSAccountV1
 from reconcile.terraform_init import integration
-from reconcile.terraform_init.integration import TerraformInitIntegration
 from reconcile.terraform_init.merge_request_manager import MrData
 from reconcile.utils.gql import GqlApi
 
 if TYPE_CHECKING:
+    from collections.abc import Callable
+
     from pytest_mock import MockerFixture
+
+    from reconcile.gql_definitions.terraform_init.aws_accounts import AWSAccountV1
+    from reconcile.terraform_init.integration import TerraformInitIntegration
 
 
 def test_terraform_init_integration_early_exit(

--- a/reconcile/test/terraform_init/test_terraform_init_merge_request_manager.py
+++ b/reconcile/test/terraform_init/test_terraform_init_merge_request_manager.py
@@ -1,10 +1,12 @@
+from __future__ import annotations
+
 from collections.abc import Callable, Iterable
+from typing import TYPE_CHECKING
 from unittest.mock import ANY, MagicMock, create_autospec
 
 import pytest
 from gitlab.exceptions import GitlabGetError
 from gitlab.v4.objects import ProjectMergeRequest
-from pytest_mock import MockerFixture
 
 from reconcile.terraform_init.merge_request import LABEL, Renderer
 from reconcile.terraform_init.merge_request_manager import (
@@ -15,6 +17,9 @@ from reconcile.terraform_init.merge_request_manager import (
 from reconcile.utils.gitlab_api import GitLabApi
 from reconcile.utils.merge_request_manager.parser import Parser
 from reconcile.utils.vcs import VCS
+
+if TYPE_CHECKING:
+    from pytest_mock import MockerFixture
 
 
 def test_terrafom_init_mr(mocker: MockerFixture) -> None:

--- a/reconcile/test/terraform_init/test_terraform_init_merge_request_manager.py
+++ b/reconcile/test/terraform_init/test_terraform_init_merge_request_manager.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-from collections.abc import Callable, Iterable
 from typing import TYPE_CHECKING
 from unittest.mock import ANY, MagicMock, create_autospec
 
@@ -19,6 +18,8 @@ from reconcile.utils.merge_request_manager.parser import Parser
 from reconcile.utils.vcs import VCS
 
 if TYPE_CHECKING:
+    from collections.abc import Callable, Iterable
+
     from pytest_mock import MockerFixture
 
 

--- a/reconcile/test/terraform_vpc_resources/test_merge_request_manager.py
+++ b/reconcile/test/terraform_vpc_resources/test_merge_request_manager.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-from collections.abc import Callable, Iterable
 from typing import TYPE_CHECKING
 from unittest.mock import MagicMock, create_autospec
 
@@ -24,6 +23,8 @@ from reconcile.utils.merge_request_manager.parser import Parser
 from reconcile.utils.vcs import VCS
 
 if TYPE_CHECKING:
+    from collections.abc import Callable, Iterable
+
     from pytest_mock import MockerFixture
 
 

--- a/reconcile/test/terraform_vpc_resources/test_merge_request_manager.py
+++ b/reconcile/test/terraform_vpc_resources/test_merge_request_manager.py
@@ -1,10 +1,12 @@
+from __future__ import annotations
+
 from collections.abc import Callable, Iterable
+from typing import TYPE_CHECKING
 from unittest.mock import MagicMock, create_autospec
 
 import pytest
 from gitlab.exceptions import GitlabGetError
 from gitlab.v4.objects import ProjectMergeRequest
-from pytest_mock import MockerFixture
 
 from reconcile.terraform_vpc_resources.merge_request import (
     LABEL,
@@ -20,6 +22,9 @@ from reconcile.terraform_vpc_resources.merge_request_manager import (
 from reconcile.utils.gitlab_api import GitLabApi
 from reconcile.utils.merge_request_manager.parser import Parser
 from reconcile.utils.vcs import VCS
+
+if TYPE_CHECKING:
+    from pytest_mock import MockerFixture
 
 
 def test_vpc_request_mr_creates_file_when_action_is_create(

--- a/reconcile/test/terraform_vpc_resources/test_terraform_vpc_resources_integration.py
+++ b/reconcile/test/terraform_vpc_resources/test_terraform_vpc_resources_integration.py
@@ -1,12 +1,13 @@
+from __future__ import annotations
+
 import json
 import logging
 import random
 from collections.abc import Callable
-from typing import Any
+from typing import TYPE_CHECKING, Any
 from unittest.mock import MagicMock, call
 
 import pytest
-from pytest_mock import MockerFixture
 
 from reconcile.gql_definitions.common.app_interface_vault_settings import (
     AppInterfaceSettingsV1,
@@ -21,6 +22,9 @@ from reconcile.terraform_vpc_resources.integration import (
     TerraformVpcResourcesParams,
 )
 from reconcile.utils.secret_reader import SecretReaderBase
+
+if TYPE_CHECKING:
+    from pytest_mock import MockerFixture
 
 
 def account_dict(name: str) -> dict[str, Any]:

--- a/reconcile/test/terraform_vpc_resources/test_terraform_vpc_resources_integration.py
+++ b/reconcile/test/terraform_vpc_resources/test_terraform_vpc_resources_integration.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import json
 import logging
 import random
-from collections.abc import Callable
 from typing import TYPE_CHECKING, Any
 from unittest.mock import MagicMock, call
 
@@ -24,6 +23,8 @@ from reconcile.terraform_vpc_resources.integration import (
 from reconcile.utils.secret_reader import SecretReaderBase
 
 if TYPE_CHECKING:
+    from collections.abc import Callable
+
     from pytest_mock import MockerFixture
 
 

--- a/reconcile/test/test_acs_policies.py
+++ b/reconcile/test/test_acs_policies.py
@@ -1,9 +1,10 @@
+from __future__ import annotations
+
 import copy
-from typing import Any
+from typing import TYPE_CHECKING, Any
 from unittest.mock import Mock
 
 import pytest
-from pytest_mock import MockerFixture
 
 from reconcile.acs_policies import AcsPoliciesIntegration
 from reconcile.gql_definitions.acs.acs_policies import (
@@ -19,6 +20,9 @@ from reconcile.gql_definitions.acs.acs_policies import (
     NamespaceV1_ClusterV1,
 )
 from reconcile.utils.acs.policies import AcsPolicyApi, Policy, PolicyCondition, Scope
+
+if TYPE_CHECKING:
+    from pytest_mock import MockerFixture
 
 CLUSTER_NAME_ONE = "app-sre-stage"
 CLUSTER_ID_ONE = "5211d395-5cf7-4185-a1fb-d88f41bc7542"

--- a/reconcile/test/test_acs_rbac.py
+++ b/reconcile/test/test_acs_rbac.py
@@ -1,8 +1,10 @@
+from __future__ import annotations
+
 import copy
+from typing import TYPE_CHECKING
 from unittest.mock import Mock
 
 import pytest
-from pytest_mock import MockerFixture
 
 from reconcile.acs_rbac import (
     AcsAccessScope,
@@ -20,6 +22,9 @@ from reconcile.gql_definitions.acs.acs_rbac import (
     UserV1,
 )
 from reconcile.utils.acs import rbac
+
+if TYPE_CHECKING:
+    from pytest_mock import MockerFixture
 
 AUTH_PROVIDER_ID = "6a41743c-792b-11ee-b962-0242ac120002"
 

--- a/reconcile/test/test_aws_ami_cleanup.py
+++ b/reconcile/test/test_aws_ami_cleanup.py
@@ -46,7 +46,7 @@ def accounts() -> list[dict[str, Any]]:
 
 
 @pytest.fixture
-def ec2_client() -> Generator[EC2Client, None, None]:
+def ec2_client() -> Generator[EC2Client]:
     with mock_aws():
         yield boto3.client("ec2", region_name="us-east-1")
 

--- a/reconcile/test/test_checkpoint.py
+++ b/reconcile/test/test_checkpoint.py
@@ -7,10 +7,11 @@ import pytest
 import requests
 
 import reconcile.checkpoint as sut
-from reconcile.utils.secret_reader import SecretReaderBase
 
 if TYPE_CHECKING:
     from pytest_mock import MockerFixture
+
+    from reconcile.utils.secret_reader import SecretReaderBase
 
 
 @pytest.fixture

--- a/reconcile/test/test_checkpoint.py
+++ b/reconcile/test/test_checkpoint.py
@@ -1,12 +1,16 @@
+from __future__ import annotations
+
 from http import HTTPStatus
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import pytest
 import requests
-from pytest_mock import MockerFixture
 
 import reconcile.checkpoint as sut
 from reconcile.utils.secret_reader import SecretReaderBase
+
+if TYPE_CHECKING:
+    from pytest_mock import MockerFixture
 
 
 @pytest.fixture

--- a/reconcile/test/test_closedbox_endpoint_monitoring.py
+++ b/reconcile/test/test_closedbox_endpoint_monitoring.py
@@ -1,8 +1,9 @@
-from typing import Any
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
 from unittest.mock import ANY
 
 import pytest
-from pytest_mock import MockerFixture
 
 from reconcile.blackbox_exporter_endpoint_monitoring import (
     PROVIDER as BLACKBOX_EXPORTER_PROVIDER,
@@ -21,6 +22,9 @@ from reconcile.signalfx_endpoint_monitoring import build_probe as signalfx_probe
 from reconcile.utils.openshift_resource import ResourceInventory
 
 from .fixtures import Fixtures
+
+if TYPE_CHECKING:
+    from pytest_mock import MockerFixture
 
 fxt = Fixtures("closedbox_exporter_endpoint_monitoring")
 

--- a/reconcile/test/test_dashdotdb_dora.py
+++ b/reconcile/test/test_dashdotdb_dora.py
@@ -1,8 +1,10 @@
+from __future__ import annotations
+
 from datetime import UTC, datetime
+from typing import TYPE_CHECKING
 from unittest.mock import MagicMock
 
 import yaml
-from pytest_mock import MockerFixture
 
 from reconcile.dashdotdb_dora import (
     AppEnv,
@@ -12,6 +14,9 @@ from reconcile.dashdotdb_dora import (
     RepoChanges,
     SaasTarget,
 )
+
+if TYPE_CHECKING:
+    from pytest_mock import MockerFixture
 
 
 def test_get_repo_ref_for_sha(mocker: MockerFixture) -> None:

--- a/reconcile/test/test_database_access_manager.py
+++ b/reconcile/test/test_database_access_manager.py
@@ -1,9 +1,7 @@
 from __future__ import annotations
 
 from collections import defaultdict
-from collections.abc import Callable
 from typing import TYPE_CHECKING, Any
-from unittest.mock import MagicMock
 
 import pytest
 
@@ -32,6 +30,9 @@ from reconcile.test.fixtures import Fixtures
 from reconcile.utils.openshift_resource import OpenshiftResource
 
 if TYPE_CHECKING:
+    from collections.abc import Callable
+    from unittest.mock import MagicMock
+
     from pytest_mock import MockerFixture
 
 

--- a/reconcile/test/test_database_access_manager.py
+++ b/reconcile/test/test_database_access_manager.py
@@ -1,10 +1,11 @@
+from __future__ import annotations
+
 from collections import defaultdict
 from collections.abc import Callable
-from typing import Any
+from typing import TYPE_CHECKING, Any
 from unittest.mock import MagicMock
 
 import pytest
-from pytest_mock import MockerFixture
 
 from reconcile.database_access_manager import (
     DatabaseConnectionParameters,
@@ -29,6 +30,9 @@ from reconcile.gql_definitions.terraform_resources.database_access_manager impor
 )
 from reconcile.test.fixtures import Fixtures
 from reconcile.utils.openshift_resource import OpenshiftResource
+
+if TYPE_CHECKING:
+    from pytest_mock import MockerFixture
 
 
 @pytest.fixture

--- a/reconcile/test/test_deadmanssnitch.py
+++ b/reconcile/test/test_deadmanssnitch.py
@@ -1,7 +1,9 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
 from unittest.mock import MagicMock, create_autospec
 
 import pytest
-from pytest_mock import MockerFixture
 
 from reconcile.deadmanssnitch import (
     DeadMansSnitchIntegration,
@@ -17,6 +19,9 @@ from reconcile.utils.deadmanssnitch_api import (
     DeadMansSnitchApi,
     Snitch,
 )
+
+if TYPE_CHECKING:
+    from pytest_mock import MockerFixture
 
 
 @pytest.fixture

--- a/reconcile/test/test_gabi_authorized_users.py
+++ b/reconcile/test/test_gabi_authorized_users.py
@@ -1,11 +1,13 @@
+from __future__ import annotations
+
 from datetime import (
     UTC,
     datetime,
     timedelta,
 )
+from typing import TYPE_CHECKING
 
 import pytest
-from pytest_mock import MockerFixture
 
 import reconcile.gabi_authorized_users as gabi_u
 import reconcile.openshift_base as ob
@@ -13,6 +15,9 @@ from reconcile.test.fixtures import Fixtures
 from reconcile.utils.aggregated_list import RunnerError
 from reconcile.utils.openshift_resource import OpenshiftResource as OR
 from reconcile.utils.openshift_resource import ResourceInventory
+
+if TYPE_CHECKING:
+    from pytest_mock import MockerFixture
 
 fixture = Fixtures("gabi_authorized_users").get_anymarkup("api.yml")
 

--- a/reconcile/test/test_gcp_image_mirror.py
+++ b/reconcile/test/test_gcp_image_mirror.py
@@ -1,8 +1,10 @@
+from __future__ import annotations
+
 from collections.abc import Generator
+from typing import TYPE_CHECKING
 from unittest.mock import MagicMock, create_autospec
 
 import pytest
-from pytest_mock import MockerFixture, MockFixture
 from sretoolbox.container.skopeo import SkopeoCmdError
 
 from reconcile.gcp_image_mirror import ImageSyncItem, QuayMirror, SyncTask
@@ -20,6 +22,9 @@ from reconcile.gql_definitions.gcp.gcp_docker_repos import (
     GcpProjectV1,
 )
 from reconcile.utils.gql import GqlApi
+
+if TYPE_CHECKING:
+    from pytest_mock import MockerFixture, MockFixture
 
 TEST_PROJECT_NAME = "foo"
 AR_IMAGE_URL = f"us-docker.pkg.dev/{TEST_PROJECT_NAME}/terraform-repo-executor"
@@ -130,7 +135,7 @@ def test_process_repos_to_sync(
 @pytest.fixture()
 def gcp_mirror_instance(
     setup_mocks: None, mocker: MockerFixture
-) -> Generator[tuple[QuayMirror, MagicMock], None, None]:
+) -> Generator[tuple[QuayMirror, MagicMock]]:
     mocker.patch("reconcile.gcp_image_mirror.gql_gcp_repos")
     with QuayMirror() as qm:
         mock_skopeo: MagicMock = MagicMock()

--- a/reconcile/test/test_gcp_image_mirror.py
+++ b/reconcile/test/test_gcp_image_mirror.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-from collections.abc import Generator
 from typing import TYPE_CHECKING
 from unittest.mock import MagicMock, create_autospec
 
@@ -24,6 +23,8 @@ from reconcile.gql_definitions.gcp.gcp_docker_repos import (
 from reconcile.utils.gql import GqlApi
 
 if TYPE_CHECKING:
+    from collections.abc import Generator
+
     from pytest_mock import MockerFixture, MockFixture
 
 TEST_PROJECT_NAME = "foo"

--- a/reconcile/test/test_github_org.py
+++ b/reconcile/test/test_github_org.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-from collections.abc import Iterable, Mapping
 from typing import TYPE_CHECKING, Any
 from unittest.mock import patch
 
@@ -18,6 +17,8 @@ from reconcile.utils.aggregated_list import AggregatedList
 from .fixtures import Fixtures
 
 if TYPE_CHECKING:
+    from collections.abc import Iterable, Mapping
+
     from pytest_mock import MockerFixture
 
 fxt = Fixtures("github_org")

--- a/reconcile/test/test_github_org.py
+++ b/reconcile/test/test_github_org.py
@@ -1,10 +1,12 @@
+from __future__ import annotations
+
 from collections.abc import Iterable, Mapping
-from typing import Any
+from typing import TYPE_CHECKING, Any
 from unittest.mock import patch
 
 from github import NamedUser
+from github.Organization import Organization
 from github.Team import Team
-from pytest_mock import MockerFixture
 
 from reconcile import github_org
 from reconcile.utils import (
@@ -14,6 +16,9 @@ from reconcile.utils import (
 from reconcile.utils.aggregated_list import AggregatedList
 
 from .fixtures import Fixtures
+
+if TYPE_CHECKING:
+    from pytest_mock import MockerFixture
 
 fxt = Fixtures("github_org")
 
@@ -134,7 +139,7 @@ class TestGithubOrg:
         assert github_org.get_members(team) == ["a", "b"]
 
     def test_get_org_teams(self, mocker: MockerFixture) -> None:
-        org = mocker.create_autospec(github_org.Organization)
+        org = mocker.create_autospec(Organization)
         org.get_teams.return_value = ["teams"]
         gh = mocker.create_autospec(github_org.Github)
         gh.get_organization.return_value = org

--- a/reconcile/test/test_gitlab_housekeeping.py
+++ b/reconcile/test/test_gitlab_housekeeping.py
@@ -1,9 +1,11 @@
+from __future__ import annotations
+
 from datetime import (
     UTC,
     datetime,
     timedelta,
 )
-from typing import Any
+from typing import TYPE_CHECKING, Any
 from unittest.mock import (
     MagicMock,
     Mock,
@@ -27,7 +29,6 @@ from gitlab.v4.objects import (
     ProjectMergeRequestPipeline,
     ProjectMergeRequestResourceLabelEvent,
 )
-from pytest_mock import MockerFixture
 from UnleashClient import UnleashClient
 
 import reconcile.gitlab_housekeeping as gl_h
@@ -36,6 +37,9 @@ from reconcile.test.fixtures import Fixtures
 from reconcile.utils.gitlab_api import GitLabApi
 from reconcile.utils.secret_reader import SecretReader
 from reconcile.utils.state import State
+
+if TYPE_CHECKING:
+    from pytest_mock import MockerFixture
 
 DATE_FORMAT = "%Y-%m-%dT%H:%M:%S.%fZ"
 

--- a/reconcile/test/test_gitlab_members.py
+++ b/reconcile/test/test_gitlab_members.py
@@ -1,4 +1,6 @@
-from typing import Any
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
 from unittest.mock import create_autospec
 
 import pytest
@@ -6,7 +8,6 @@ from gitlab.v4.objects import (
     Group,
     GroupMember,
 )
-from pytest_mock import MockerFixture
 
 from reconcile import gitlab_members
 from reconcile.gitlab_members import (
@@ -27,6 +28,9 @@ from reconcile.gql_definitions.gitlab_members.permissions import (
 from reconcile.test.fixtures import Fixtures
 from reconcile.utils.gitlab_api import GitLabApi
 from reconcile.utils.pagerduty_api import PagerDutyMap
+
+if TYPE_CHECKING:
+    from pytest_mock import MockerFixture
 
 
 @pytest.fixture()

--- a/reconcile/test/test_gitlab_members.py
+++ b/reconcile/test/test_gitlab_members.py
@@ -20,17 +20,18 @@ from reconcile.gitlab_members import (
     get_permissions,
 )
 from reconcile.gql_definitions.fragments.user import User
-from reconcile.gql_definitions.fragments.vault_secret import VaultSecret
 from reconcile.gql_definitions.gitlab_members.gitlab_instances import GitlabInstanceV1
-from reconcile.gql_definitions.gitlab_members.permissions import (
-    PermissionGitlabGroupMembershipV1,
-)
 from reconcile.test.fixtures import Fixtures
 from reconcile.utils.gitlab_api import GitLabApi
 from reconcile.utils.pagerduty_api import PagerDutyMap
 
 if TYPE_CHECKING:
     from pytest_mock import MockerFixture
+
+    from reconcile.gql_definitions.fragments.vault_secret import VaultSecret
+    from reconcile.gql_definitions.gitlab_members.permissions import (
+        PermissionGitlabGroupMembershipV1,
+    )
 
 
 @pytest.fixture()

--- a/reconcile/test/test_instrumented_wrappers.py
+++ b/reconcile/test/test_instrumented_wrappers.py
@@ -1,7 +1,9 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
 from unittest.mock import create_autospec
 
 from prometheus_client import Counter
-from pytest_mock import MockerFixture
 from requests import Session
 from sretoolbox.container import (
     Image,
@@ -13,6 +15,9 @@ from reconcile.utils.instrumented_wrappers import (
     InstrumentedSession,
     InstrumentedSkopeo,
 )
+
+if TYPE_CHECKING:
+    from pytest_mock import MockerFixture
 
 
 def test_instrumented_image(mocker: MockerFixture) -> None:

--- a/reconcile/test/test_integrations_manager.py
+++ b/reconcile/test/test_integrations_manager.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import copy
 import json
 import os
@@ -5,10 +7,9 @@ from collections.abc import (
     Callable,
     Iterable,
 )
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import pytest
-from pytest_mock import MockerFixture
 
 import reconcile.integrations_manager as intop
 from reconcile.gql_definitions.common.clusters_minimal import ClusterV1
@@ -45,6 +46,9 @@ from reconcile.utils.runtime.sharding import (
     StaticShardingStrategy,
     StaticShardingV1,
 )
+
+if TYPE_CHECKING:
+    from pytest_mock import MockerFixture
 
 AWS_INTEGRATION = "aws_integration"
 OPENSHIFT_INTEGRATION = "openshift_integration"

--- a/reconcile/test/test_integrations_manager.py
+++ b/reconcile/test/test_integrations_manager.py
@@ -3,10 +3,6 @@ from __future__ import annotations
 import copy
 import json
 import os
-from collections.abc import (
-    Callable,
-    Iterable,
-)
 from typing import TYPE_CHECKING, Any
 
 import pytest
@@ -48,6 +44,11 @@ from reconcile.utils.runtime.sharding import (
 )
 
 if TYPE_CHECKING:
+    from collections.abc import (
+        Callable,
+        Iterable,
+    )
+
     from pytest_mock import MockerFixture
 
 AWS_INTEGRATION = "aws_integration"

--- a/reconcile/test/test_jenkins_api.py
+++ b/reconcile/test/test_jenkins_api.py
@@ -1,10 +1,15 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
 from unittest.mock import call, create_autospec
 
 import pytest
-from pytest_mock import MockerFixture
 from requests import Response
 
 from reconcile.utils.jenkins_api import JenkinsApi
+
+if TYPE_CHECKING:
+    from pytest_mock import MockerFixture
 
 
 @pytest.fixture

--- a/reconcile/test/test_jenkins_worker_fleets.py
+++ b/reconcile/test/test_jenkins_worker_fleets.py
@@ -1,7 +1,9 @@
+from __future__ import annotations
+
 import logging
+from typing import TYPE_CHECKING
 
 import pytest
-from pytest_mock import MockerFixture
 
 from reconcile.jenkins_worker_fleets import (
     act,
@@ -11,6 +13,9 @@ from reconcile.jenkins_worker_fleets import (
 from reconcile.test.fixtures import Fixtures
 from reconcile.utils.jenkins_api import JenkinsApi
 from reconcile.utils.terrascript_aws_client import TerrascriptClient as Terrascript
+
+if TYPE_CHECKING:
+    from pytest_mock import MockerFixture
 
 fixture = Fixtures("jenkins_worker_fleets")
 

--- a/reconcile/test/test_jira_permissions_validator.py
+++ b/reconcile/test/test_jira_permissions_validator.py
@@ -1,10 +1,11 @@
+from __future__ import annotations
+
 from collections.abc import Callable, Mapping
-from typing import Any
+from typing import TYPE_CHECKING, Any
 from unittest.mock import Mock
 
 import pytest
 from jira import JIRAError
-from pytest_mock import MockerFixture
 
 from reconcile.gql_definitions.jira_permissions_validator.jira_boards_for_permissions_validator import (
     JiraBoardV1,
@@ -24,6 +25,9 @@ from reconcile.utils.jira_client import (
     IssueType,
     JiraClient,
 )
+
+if TYPE_CHECKING:
+    from pytest_mock import MockerFixture
 
 
 @pytest.fixture

--- a/reconcile/test/test_jira_permissions_validator.py
+++ b/reconcile/test/test_jira_permissions_validator.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-from collections.abc import Callable, Mapping
 from typing import TYPE_CHECKING, Any
 from unittest.mock import Mock
 
@@ -27,6 +26,8 @@ from reconcile.utils.jira_client import (
 )
 
 if TYPE_CHECKING:
+    from collections.abc import Callable, Mapping
+
     from pytest_mock import MockerFixture
 
 

--- a/reconcile/test/test_ocm_clusters.py
+++ b/reconcile/test/test_ocm_clusters.py
@@ -1,6 +1,8 @@
+from __future__ import annotations
+
 # ruff: noqa: SIM117
 from collections.abc import Generator
-from typing import Any
+from typing import TYPE_CHECKING, Any
 from unittest.mock import (
     Mock,
     patch,
@@ -8,7 +10,6 @@ from unittest.mock import (
 
 import pytest
 from pydantic import ValidationError
-from pytest_mock import MockerFixture
 
 import reconcile.ocm_clusters as occ
 import reconcile.utils.ocm as ocmmod
@@ -41,6 +42,9 @@ from reconcile.utils.ocm.products import (
     OCMProductRosa,
 )
 from reconcile.utils.ocm_base_client import OCMBaseClient
+
+if TYPE_CHECKING:
+    from pytest_mock import MockerFixture
 
 fxt = Fixtures("clusters")
 
@@ -76,7 +80,7 @@ def ocm_rosa_cluster_post_spec() -> dict[str, Any]:
 
 
 @pytest.fixture
-def ocm_osd_cluster_spec() -> Generator[OCMSpec, None, None]:
+def ocm_osd_cluster_spec() -> Generator[OCMSpec]:
     n = OCMClusterNetwork(
         type="OpenShiftSDN",
         vpc="10.112.0.0/16",
@@ -341,7 +345,7 @@ def rosa_hosted_cp_cluster_fxt() -> dict[str, Any]:
 @pytest.fixture
 def queries_mock(
     osd_cluster_fxt: dict[str, Any],
-) -> Generator[tuple[Mock, Mock], None, None]:
+) -> Generator[tuple[Mock, Mock]]:
     with patch.object(queries, "get_app_interface_settings", autospec=True) as s:
         with patch.object(queries, "get_clusters", autospec=True) as gc:
             s.return_value = {}
@@ -352,7 +356,7 @@ def queries_mock(
 @pytest.fixture
 def ocmmap_mock(
     ocm_osd_cluster_spec: OCMSpec, ocm_mock: tuple[Mock, Mock]
-) -> Generator[tuple[Mock, Mock], None, None]:
+) -> Generator[tuple[Mock, Mock]]:
     with patch.object(OCMMap, "get", autospec=True) as get:
         with patch.object(OCMMap, "init_ocm_client_from_cluster", autospec=True):
             with patch.object(OCMMap, "cluster_specs", autospec=True) as cs:
@@ -362,7 +366,7 @@ def ocmmap_mock(
 
 
 @pytest.fixture
-def ocm_mock(mocker: MockerFixture) -> Generator[tuple[Mock, Mock], None, None]:
+def ocm_mock(mocker: MockerFixture) -> Generator[tuple[Mock, Mock]]:
     with patch.object(ocm, "init_ocm_base_client") as ioc:
         ocm_api_mock = mocker.Mock(OCMBaseClient)
         ioc.return_value = ocm_api_mock
@@ -374,27 +378,27 @@ def ocm_mock(mocker: MockerFixture) -> Generator[tuple[Mock, Mock], None, None]:
 
 
 @pytest.fixture
-def cluster_updates_mr_mock() -> Generator[Mock, None, None]:
+def cluster_updates_mr_mock() -> Generator[Mock]:
     with patch.object(mr_client_gateway, "init", autospec=True):
         with patch.object(CreateClustersUpdates, "submit", autospec=True) as ccu:
             yield ccu
 
 
 @pytest.fixture
-def get_json_mock() -> Generator[Mock, None, None]:
+def get_json_mock() -> Generator[Mock]:
     with patch.object(OCM, "_get_json", autospec=True) as get_json:
         yield get_json
 
 
 @pytest.fixture
-def osd_product() -> Generator[OCMProductOsd, None, None]:
+def osd_product() -> Generator[OCMProductOsd]:
     with patch.object(products, "get_provisioning_shard_id") as g:
         g.return_value = "provision_shard_id"
         yield OCMProductOsd()
 
 
 @pytest.fixture
-def rosa_product() -> Generator[OCMProductRosa, None, None]:
+def rosa_product() -> Generator[OCMProductRosa]:
     with patch.object(products, "get_provisioning_shard_id") as g:
         g.return_value = "provision_shard_id"
         yield OCMProductRosa(None)
@@ -415,7 +419,7 @@ def product_portfolio(
 @pytest.fixture
 def integration(
     product_portfolio: OCMProductPortfolio,
-) -> Generator[occ.OcmClusters, None, None]:
+) -> Generator[occ.OcmClusters]:
     integration = occ.OcmClusters(
         params=occ.OcmClustersParams(
             job_controller_cluster="cluster",

--- a/reconcile/test/test_ocm_clusters.py
+++ b/reconcile/test/test_ocm_clusters.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 # ruff: noqa: SIM117
-from collections.abc import Generator
 from typing import TYPE_CHECKING, Any
 from unittest.mock import (
     Mock,
@@ -44,6 +43,8 @@ from reconcile.utils.ocm.products import (
 from reconcile.utils.ocm_base_client import OCMBaseClient
 
 if TYPE_CHECKING:
+    from collections.abc import Generator
+
     from pytest_mock import MockerFixture
 
 fxt = Fixtures("clusters")

--- a/reconcile/test/test_ocm_machine_pools.py
+++ b/reconcile/test/test_ocm_machine_pools.py
@@ -1,15 +1,17 @@
+from __future__ import annotations
+
 from collections.abc import (
     Callable,
     Iterable,
     Mapping,
 )
+from typing import TYPE_CHECKING
 from unittest.mock import (
     Mock,
     create_autospec,
 )
 
 import pytest
-from pytest_mock import MockerFixture
 
 from reconcile.gql_definitions.common.clusters import (
     ClusterMachinePoolV1,
@@ -30,6 +32,9 @@ from reconcile.ocm_machine_pools import (
     run,
 )
 from reconcile.utils.ocm import OCM
+
+if TYPE_CHECKING:
+    from pytest_mock import MockerFixture
 
 
 class PoolStub(AbstractPool):

--- a/reconcile/test/test_ocm_machine_pools.py
+++ b/reconcile/test/test_ocm_machine_pools.py
@@ -1,10 +1,5 @@
 from __future__ import annotations
 
-from collections.abc import (
-    Callable,
-    Iterable,
-    Mapping,
-)
 from typing import TYPE_CHECKING
 from unittest.mock import (
     Mock,
@@ -34,6 +29,12 @@ from reconcile.ocm_machine_pools import (
 from reconcile.utils.ocm import OCM
 
 if TYPE_CHECKING:
+    from collections.abc import (
+        Callable,
+        Iterable,
+        Mapping,
+    )
+
     from pytest_mock import MockerFixture
 
 

--- a/reconcile/test/test_ocm_upgrade_scheduler_org_updater.py
+++ b/reconcile/test/test_ocm_upgrade_scheduler_org_updater.py
@@ -1,14 +1,16 @@
 from __future__ import annotations
 
 import json
-from collections.abc import Generator, Mapping
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import pytest
 
 from reconcile.ocm.types import OCMClusterNetwork, OCMSpec, OSDClusterSpec
 from reconcile.ocm_upgrade_scheduler_org_updater import render_policy
 from reconcile.utils.jinja2.utils import Jinja2TemplateError
+
+if TYPE_CHECKING:
+    from collections.abc import Generator, Mapping
 
 
 @pytest.fixture

--- a/reconcile/test/test_ocm_upgrade_scheduler_org_updater.py
+++ b/reconcile/test/test_ocm_upgrade_scheduler_org_updater.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import json
 from collections.abc import Generator, Mapping
 from typing import Any
@@ -10,7 +12,7 @@ from reconcile.utils.jinja2.utils import Jinja2TemplateError
 
 
 @pytest.fixture
-def cluster_ocm_spec() -> Generator[OCMSpec, None, None]:
+def cluster_ocm_spec() -> Generator[OCMSpec]:
     n = OCMClusterNetwork(
         vpc="10.112.0.0/16",
         service="10.120.0.0/16",

--- a/reconcile/test/test_openshift_base.py
+++ b/reconcile/test/test_openshift_base.py
@@ -1,9 +1,7 @@
 from __future__ import annotations
 
 import logging
-from collections.abc import Mapping, Sequence
 from typing import TYPE_CHECKING, Any
-from unittest.mock import MagicMock
 
 import pytest
 import yaml
@@ -22,6 +20,9 @@ from reconcile.utils import oc
 from reconcile.utils.semver_helper import make_semver
 
 if TYPE_CHECKING:
+    from collections.abc import Mapping, Sequence
+    from unittest.mock import MagicMock
+
     from pytest_mock import MockerFixture
 
 fxt = Fixtures("namespaces")

--- a/reconcile/test/test_openshift_base.py
+++ b/reconcile/test/test_openshift_base.py
@@ -1,13 +1,14 @@
+from __future__ import annotations
+
 import logging
 from collections.abc import Mapping, Sequence
-from typing import Any
+from typing import TYPE_CHECKING, Any
 from unittest.mock import MagicMock
 
 import pytest
 import yaml
 from kubernetes.dynamic import Resource
 from pydantic import BaseModel
-from pytest_mock import MockerFixture
 from qontract_utils.differ import (
     DiffPair,
     DiffResult,
@@ -19,6 +20,9 @@ import reconcile.utils.openshift_resource as resource
 from reconcile.test.fixtures import Fixtures
 from reconcile.utils import oc
 from reconcile.utils.semver_helper import make_semver
+
+if TYPE_CHECKING:
+    from pytest_mock import MockerFixture
 
 fxt = Fixtures("namespaces")
 

--- a/reconcile/test/test_openshift_cluster_bots.py
+++ b/reconcile/test/test_openshift_cluster_bots.py
@@ -1,10 +1,8 @@
 from __future__ import annotations
 
 import base64
-from collections.abc import Callable
 from subprocess import CalledProcessError
 from typing import TYPE_CHECKING, Any
-from unittest.mock import MagicMock
 from urllib.error import URLError
 
 import pytest
@@ -16,6 +14,9 @@ from reconcile.gql_definitions.openshift_cluster_bots.clusters import (
 )
 
 if TYPE_CHECKING:
+    from collections.abc import Callable
+    from unittest.mock import MagicMock
+
     from pytest_mock import MockerFixture
 
 

--- a/reconcile/test/test_openshift_cluster_bots.py
+++ b/reconcile/test/test_openshift_cluster_bots.py
@@ -1,18 +1,22 @@
+from __future__ import annotations
+
 import base64
 from collections.abc import Callable
 from subprocess import CalledProcessError
-from typing import Any
+from typing import TYPE_CHECKING, Any
 from unittest.mock import MagicMock
 from urllib.error import URLError
 
 import pytest
-from pytest_mock import MockerFixture
 
 import reconcile.openshift_cluster_bots as ocb
 from reconcile.gql_definitions.openshift_cluster_bots.clusters import (
     ClusterV1,
     VaultSecret,
 )
+
+if TYPE_CHECKING:
+    from pytest_mock import MockerFixture
 
 
 def vault_secret_dict(path: str, field: str) -> dict[str, str | None]:

--- a/reconcile/test/test_openshift_namespaces.py
+++ b/reconcile/test/test_openshift_namespaces.py
@@ -1,16 +1,21 @@
+from __future__ import annotations
+
 from collections.abc import Callable
+from typing import TYPE_CHECKING
 from unittest.mock import (
     MagicMock,
     create_autospec,
 )
 
 import pytest
-from pytest_mock import MockerFixture
 
 from reconcile import openshift_namespaces
 from reconcile.gql_definitions.common.namespaces_minimal import NamespaceV1
 from reconcile.utils.oc import OCCli
 from reconcile.utils.oc_map import OCMap
+
+if TYPE_CHECKING:
+    from pytest_mock import MockerFixture
 
 
 @pytest.fixture

--- a/reconcile/test/test_openshift_namespaces.py
+++ b/reconcile/test/test_openshift_namespaces.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-from collections.abc import Callable
 from typing import TYPE_CHECKING
 from unittest.mock import (
     MagicMock,
@@ -15,6 +14,8 @@ from reconcile.utils.oc import OCCli
 from reconcile.utils.oc_map import OCMap
 
 if TYPE_CHECKING:
+    from collections.abc import Callable
+
     from pytest_mock import MockerFixture
 
 

--- a/reconcile/test/test_openshift_resources_base.py
+++ b/reconcile/test/test_openshift_resources_base.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import copy
-from collections.abc import Mapping, Sequence
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -29,6 +28,8 @@ from reconcile.utils.openshift_resource import OpenshiftResource as OR
 from reconcile.utils.openshift_resource import ResourceInventory
 
 if TYPE_CHECKING:
+    from collections.abc import Mapping, Sequence
+
     from pytest_mock import MockerFixture
 
 fxt = Fixtures("namespaces")

--- a/reconcile/test/test_openshift_resources_base.py
+++ b/reconcile/test/test_openshift_resources_base.py
@@ -1,6 +1,9 @@
+from __future__ import annotations
+
 import copy
 from collections.abc import Mapping, Sequence
 from typing import (
+    TYPE_CHECKING,
     Any,
 )
 from unittest.mock import (
@@ -10,7 +13,6 @@ from unittest.mock import (
 
 import pytest
 from kubernetes.dynamic import Resource
-from pytest_mock import MockerFixture
 
 from reconcile import openshift_resources_base as orb
 from reconcile.openshift_base import CurrentStateSpec
@@ -25,6 +27,9 @@ from reconcile.test.fixtures import Fixtures
 from reconcile.utils import oc
 from reconcile.utils.openshift_resource import OpenshiftResource as OR
 from reconcile.utils.openshift_resource import ResourceInventory
+
+if TYPE_CHECKING:
+    from pytest_mock import MockerFixture
 
 fxt = Fixtures("namespaces")
 

--- a/reconcile/test/test_openshift_rhcs_certs.py
+++ b/reconcile/test/test_openshift_rhcs_certs.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import base64
 import time
-from collections.abc import Callable, Mapping
 from typing import TYPE_CHECKING, Any
 from unittest.mock import ANY, MagicMock, call
 
@@ -29,6 +28,8 @@ from reconcile.utils.rhcsv2_certs import (
 from reconcile.utils.vault import SecretNotFoundError
 
 if TYPE_CHECKING:
+    from collections.abc import Callable, Mapping
+
     from pytest_mock import MockerFixture
 
 

--- a/reconcile/test/test_openshift_rhcs_certs.py
+++ b/reconcile/test/test_openshift_rhcs_certs.py
@@ -1,11 +1,12 @@
+from __future__ import annotations
+
 import base64
 import time
 from collections.abc import Callable, Mapping
-from typing import Any
+from typing import TYPE_CHECKING, Any
 from unittest.mock import ANY, MagicMock, call
 
 import pytest
-from pytest_mock import MockerFixture
 
 import reconcile.openshift_rhcs_certs as rhcs_certs
 from reconcile.gql_definitions.rhcs.certs import (
@@ -26,6 +27,9 @@ from reconcile.utils.rhcsv2_certs import (
     RhcsV2CertPkcs12,
 )
 from reconcile.utils.vault import SecretNotFoundError
+
+if TYPE_CHECKING:
+    from pytest_mock import MockerFixture
 
 
 def build_vault_cert_data(

--- a/reconcile/test/test_openshift_serviceaccount_tokens.py
+++ b/reconcile/test/test_openshift_serviceaccount_tokens.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-from collections.abc import Callable, Mapping
 from typing import TYPE_CHECKING, Any
 from unittest.mock import call, create_autospec
 
@@ -23,6 +22,8 @@ from reconcile.utils.openshift_resource import ResourceInventory
 from reconcile.utils.vault import VaultClient
 
 if TYPE_CHECKING:
+    from collections.abc import Callable, Mapping
+
     from pytest_mock import MockerFixture
 
 

--- a/reconcile/test/test_openshift_serviceaccount_tokens.py
+++ b/reconcile/test/test_openshift_serviceaccount_tokens.py
@@ -1,9 +1,10 @@
+from __future__ import annotations
+
 from collections.abc import Callable, Mapping
-from typing import Any
+from typing import TYPE_CHECKING, Any
 from unittest.mock import call, create_autospec
 
 import pytest
-from pytest_mock import MockerFixture
 
 from reconcile.gql_definitions.openshift_serviceaccount_tokens.tokens import NamespaceV1
 from reconcile.openshift_serviceaccount_tokens import (
@@ -20,6 +21,9 @@ from reconcile.test.fixtures import Fixtures
 from reconcile.utils.oc import OC_Map, OCCli
 from reconcile.utils.openshift_resource import ResourceInventory
 from reconcile.utils.vault import VaultClient
+
+if TYPE_CHECKING:
+    from pytest_mock import MockerFixture
 
 
 @pytest.fixture

--- a/reconcile/test/test_openshift_upgrade_watcher.py
+++ b/reconcile/test/test_openshift_upgrade_watcher.py
@@ -1,18 +1,22 @@
+from __future__ import annotations
+
 from datetime import (
     UTC,
     datetime,
     timedelta,
 )
-from typing import Any
+from typing import TYPE_CHECKING, Any
 from unittest.mock import MagicMock
 
 import pytest
-from pytest_mock import MockerFixture
 
 from reconcile import openshift_upgrade_watcher as ouw
 from reconcile.gql_definitions.common.clusters import ClusterV1
 from reconcile.test.fixtures import Fixtures
 from reconcile.utils.models import data_default_none
+
+if TYPE_CHECKING:
+    from pytest_mock import MockerFixture
 
 fxt = Fixtures("openshift_upgrade_watcher")
 

--- a/reconcile/test/test_openshift_upgrade_watcher.py
+++ b/reconcile/test/test_openshift_upgrade_watcher.py
@@ -6,7 +6,6 @@ from datetime import (
     timedelta,
 )
 from typing import TYPE_CHECKING, Any
-from unittest.mock import MagicMock
 
 import pytest
 
@@ -16,6 +15,8 @@ from reconcile.test.fixtures import Fixtures
 from reconcile.utils.models import data_default_none
 
 if TYPE_CHECKING:
+    from unittest.mock import MagicMock
+
     from pytest_mock import MockerFixture
 
 fxt = Fixtures("openshift_upgrade_watcher")

--- a/reconcile/test/test_saasherder.py
+++ b/reconcile/test/test_saasherder.py
@@ -1,10 +1,5 @@
 from __future__ import annotations
 
-from collections.abc import (
-    Callable,
-    Iterable,
-    MutableMapping,
-)
 from datetime import UTC, datetime, timedelta
 from typing import TYPE_CHECKING, Any
 from unittest import TestCase
@@ -38,7 +33,6 @@ from reconcile.utils.jjb_client import JJB
 from reconcile.utils.openshift_resource import ResourceInventory
 from reconcile.utils.promotion_state import PromotionData
 from reconcile.utils.saasherder import SaasHerder
-from reconcile.utils.saasherder.interfaces import SaasFile as SaasFileInterface
 from reconcile.utils.saasherder.models import (
     Channel,
     Promotion,
@@ -53,7 +47,15 @@ from reconcile.utils.slo_document_manager import SLODetails
 from .fixtures import Fixtures
 
 if TYPE_CHECKING:
+    from collections.abc import (
+        Callable,
+        Iterable,
+        MutableMapping,
+    )
+
     from pydantic import BaseModel
+
+    from reconcile.utils.saasherder.interfaces import SaasFile as SaasFileInterface
 
 
 class MockJJB:

--- a/reconcile/test/test_saasherder.py
+++ b/reconcile/test/test_saasherder.py
@@ -1,10 +1,12 @@
+from __future__ import annotations
+
 from collections.abc import (
     Callable,
     Iterable,
     MutableMapping,
 )
 from datetime import UTC, datetime, timedelta
-from typing import Any
+from typing import TYPE_CHECKING, Any
 from unittest import TestCase
 from unittest.mock import (
     MagicMock,
@@ -17,7 +19,6 @@ from github import (
     Github,
     GithubException,
 )
-from pydantic import BaseModel
 
 from reconcile.gql_definitions.common.saas_files import (
     SaasResourceTemplateTargetImageV1,
@@ -50,6 +51,9 @@ from reconcile.utils.secret_reader import SecretReaderBase
 from reconcile.utils.slo_document_manager import SLODetails
 
 from .fixtures import Fixtures
+
+if TYPE_CHECKING:
+    from pydantic import BaseModel
 
 
 class MockJJB:

--- a/reconcile/test/test_secret_reader.py
+++ b/reconcile/test/test_secret_reader.py
@@ -6,7 +6,6 @@ from unittest.mock import MagicMock, create_autospec
 import pytest
 
 import reconcile.utils.secret_reader
-from reconcile.gql_definitions.fragments.vault_secret import VaultSecret
 from reconcile.utils import vault
 from reconcile.utils.secret_reader import (
     ConfigSecretReader,
@@ -18,6 +17,8 @@ from reconcile.utils.vault import VaultClient
 
 if TYPE_CHECKING:
     from pytest_mock import MockerFixture
+
+    from reconcile.gql_definitions.fragments.vault_secret import VaultSecret
 
 VAULT_READ_EXPECTED = {"key": "value"}
 VAULT_READ_ALL_EXPECTED = {"key2": "value2"}

--- a/reconcile/test/test_secret_reader.py
+++ b/reconcile/test/test_secret_reader.py
@@ -1,7 +1,9 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
 from unittest.mock import MagicMock, create_autospec
 
 import pytest
-from pytest_mock import MockerFixture
 
 import reconcile.utils.secret_reader
 from reconcile.gql_definitions.fragments.vault_secret import VaultSecret
@@ -13,6 +15,9 @@ from reconcile.utils.secret_reader import (
     VaultSecretReader,
 )
 from reconcile.utils.vault import VaultClient
+
+if TYPE_CHECKING:
+    from pytest_mock import MockerFixture
 
 VAULT_READ_EXPECTED = {"key": "value"}
 VAULT_READ_ALL_EXPECTED = {"key2": "value2"}

--- a/reconcile/test/test_slack_base.py
+++ b/reconcile/test/test_slack_base.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any
-from unittest.mock import MagicMock
 
 import pytest
 
@@ -12,6 +11,8 @@ from reconcile.slack_base import (
 from reconcile.utils.secret_reader import SecretReader
 
 if TYPE_CHECKING:
+    from unittest.mock import MagicMock
+
     from pytest_mock import MockerFixture
 
 

--- a/reconcile/test/test_slack_base.py
+++ b/reconcile/test/test_slack_base.py
@@ -1,14 +1,18 @@
-from typing import Any
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
 from unittest.mock import MagicMock
 
 import pytest
-from pytest_mock import MockerFixture
 
 from reconcile.slack_base import (
     slackapi_from_permissions,
     slackapi_from_slack_workspace,
 )
 from reconcile.utils.secret_reader import SecretReader
+
+if TYPE_CHECKING:
+    from pytest_mock import MockerFixture
 
 
 def create_api_config() -> dict[str, Any]:

--- a/reconcile/test/test_sql_query.py
+++ b/reconcile/test/test_sql_query.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-from collections.abc import Callable
 from typing import TYPE_CHECKING
 from unittest.mock import create_autospec
 
@@ -12,11 +11,14 @@ from reconcile.gql_definitions.common.smtp_client_settings import SmtpSettingsV1
 from reconcile.sql_query import split_long_query
 from reconcile.test.fixtures import Fixtures
 from reconcile.utils.oc import OCCli
-from reconcile.utils.openshift_resource import ResourceInventory
 from reconcile.utils.state import State
 
 if TYPE_CHECKING:
+    from collections.abc import Callable
+
     from pytest_mock import MockFixture
+
+    from reconcile.utils.openshift_resource import ResourceInventory
 
 
 @pytest.mark.parametrize(

--- a/reconcile/test/test_sql_query.py
+++ b/reconcile/test/test_sql_query.py
@@ -1,9 +1,11 @@
+from __future__ import annotations
+
 from collections.abc import Callable
+from typing import TYPE_CHECKING
 from unittest.mock import create_autospec
 
 import pytest
 import yaml
-from pytest_mock import MockFixture
 
 import reconcile.sql_query as intg
 from reconcile.gql_definitions.common.smtp_client_settings import SmtpSettingsV1
@@ -12,6 +14,9 @@ from reconcile.test.fixtures import Fixtures
 from reconcile.utils.oc import OCCli
 from reconcile.utils.openshift_resource import ResourceInventory
 from reconcile.utils.state import State
+
+if TYPE_CHECKING:
+    from pytest_mock import MockFixture
 
 
 @pytest.mark.parametrize(

--- a/reconcile/test/test_status_board.py
+++ b/reconcile/test/test_status_board.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-from collections.abc import Callable
 from typing import TYPE_CHECKING
 from unittest.mock import call
 
@@ -17,12 +16,15 @@ from reconcile.status_board import (
     StatusBoardExporterIntegration,
     StatusBoardHandler,
 )
-from reconcile.utils.ocm.status_board import BaseOCMSpec, ServiceMetadataSpec
 from reconcile.utils.ocm_base_client import OCMBaseClient
 from reconcile.utils.runtime.integration import PydanticRunParams
 
 if TYPE_CHECKING:
+    from collections.abc import Callable
+
     from pytest_mock import MockerFixture
+
+    from reconcile.utils.ocm.status_board import BaseOCMSpec, ServiceMetadataSpec
 
 
 class StatusBoardStub(AbstractStatusBoard):

--- a/reconcile/test/test_status_board.py
+++ b/reconcile/test/test_status_board.py
@@ -1,8 +1,10 @@
+from __future__ import annotations
+
 from collections.abc import Callable
+from typing import TYPE_CHECKING
 from unittest.mock import call
 
 import pytest
-from pytest_mock import MockerFixture
 
 from reconcile.gql_definitions.slo_documents.slo_documents import SLODocumentV1
 from reconcile.gql_definitions.status_board.status_board import StatusBoardV1
@@ -18,6 +20,9 @@ from reconcile.status_board import (
 from reconcile.utils.ocm.status_board import BaseOCMSpec, ServiceMetadataSpec
 from reconcile.utils.ocm_base_client import OCMBaseClient
 from reconcile.utils.runtime.integration import PydanticRunParams
+
+if TYPE_CHECKING:
+    from pytest_mock import MockerFixture
 
 
 class StatusBoardStub(AbstractStatusBoard):

--- a/reconcile/test/test_terraform_aws_route53.py
+++ b/reconcile/test/test_terraform_aws_route53.py
@@ -1,7 +1,13 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 import pytest
-from pytest_mock import MockerFixture
 
 import reconcile.terraform_aws_route53 as integ
+
+if TYPE_CHECKING:
+    from pytest_mock import MockerFixture
 
 
 @pytest.fixture

--- a/reconcile/test/test_terraform_resources.py
+++ b/reconcile/test/test_terraform_resources.py
@@ -1,19 +1,23 @@
+from __future__ import annotations
+
 from collections.abc import (
     Callable,
     Iterable,
     Mapping,
 )
-from typing import Any
+from typing import TYPE_CHECKING, Any
 from unittest.mock import MagicMock, create_autospec
 
 import pytest
-from pytest_mock import MockerFixture
 
 import reconcile.terraform_resources as integ
 from reconcile.gql_definitions.terraform_resources.terraform_resources_namespaces import (
     NamespaceV1,
 )
 from reconcile.utils.secret_reader import SecretReaderBase
+
+if TYPE_CHECKING:
+    from pytest_mock import MockerFixture
 
 
 def test_cannot_use_exclude_accounts_if_not_dry_run() -> None:

--- a/reconcile/test/test_terraform_resources.py
+++ b/reconcile/test/test_terraform_resources.py
@@ -1,10 +1,5 @@
 from __future__ import annotations
 
-from collections.abc import (
-    Callable,
-    Iterable,
-    Mapping,
-)
 from typing import TYPE_CHECKING, Any
 from unittest.mock import MagicMock, create_autospec
 
@@ -14,10 +9,17 @@ import reconcile.terraform_resources as integ
 from reconcile.gql_definitions.terraform_resources.terraform_resources_namespaces import (
     NamespaceV1,
 )
-from reconcile.utils.secret_reader import SecretReaderBase
 
 if TYPE_CHECKING:
+    from collections.abc import (
+        Callable,
+        Iterable,
+        Mapping,
+    )
+
     from pytest_mock import MockerFixture
+
+    from reconcile.utils.secret_reader import SecretReaderBase
 
 
 def test_cannot_use_exclude_accounts_if_not_dry_run() -> None:

--- a/reconcile/test/test_terraform_tgw_attachments.py
+++ b/reconcile/test/test_terraform_tgw_attachments.py
@@ -1,12 +1,14 @@
+from __future__ import annotations
+
 from collections.abc import (
     Callable,
     Iterable,
     Mapping,
 )
+from typing import TYPE_CHECKING
 from unittest.mock import create_autospec
 
 import pytest
-from pytest_mock import MockerFixture
 
 import reconcile.terraform_tgw_attachments as integ
 from reconcile.gql_definitions.common.app_interface_vault_settings import (
@@ -29,6 +31,9 @@ from reconcile.terraform_tgw_attachments import Accepter, DesiredStateItem, Requ
 from reconcile.utils.gql import GqlApi
 from reconcile.utils.runtime.integration import ShardedRunProposal
 from reconcile.utils.secret_reader import SecretReaderBase
+
+if TYPE_CHECKING:
+    from pytest_mock import MockerFixture
 
 QONTRACT_INTEGRATION = "terraform_tgw_attachments"
 

--- a/reconcile/test/test_terraform_tgw_attachments.py
+++ b/reconcile/test/test_terraform_tgw_attachments.py
@@ -1,10 +1,5 @@
 from __future__ import annotations
 
-from collections.abc import (
-    Callable,
-    Iterable,
-    Mapping,
-)
 from typing import TYPE_CHECKING
 from unittest.mock import create_autospec
 
@@ -33,6 +28,12 @@ from reconcile.utils.runtime.integration import ShardedRunProposal
 from reconcile.utils.secret_reader import SecretReaderBase
 
 if TYPE_CHECKING:
+    from collections.abc import (
+        Callable,
+        Iterable,
+        Mapping,
+    )
+
     from pytest_mock import MockerFixture
 
 QONTRACT_INTEGRATION = "terraform_tgw_attachments"

--- a/reconcile/test/test_terraform_users.py
+++ b/reconcile/test/test_terraform_users.py
@@ -1,8 +1,9 @@
+from __future__ import annotations
+
 from collections.abc import Callable, Iterable
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import pytest
-from pytest_mock import MockerFixture
 
 import reconcile.terraform_users as integ
 from reconcile.gql_definitions.common.pgp_reencryption_settings import (
@@ -13,6 +14,9 @@ from reconcile.terraform_users import (
     write_user_to_vault,
 )
 from reconcile.utils.gql import GqlApi
+
+if TYPE_CHECKING:
+    from pytest_mock import MockerFixture
 
 # account, console_url, user_name, encrypted_password
 FakeUser = tuple[str, str, str, str]

--- a/reconcile/test/test_terraform_users.py
+++ b/reconcile/test/test_terraform_users.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-from collections.abc import Callable, Iterable
 from typing import TYPE_CHECKING, Any
 
 import pytest
@@ -13,10 +12,13 @@ from reconcile.terraform_users import (
     send_email_invites,
     write_user_to_vault,
 )
-from reconcile.utils.gql import GqlApi
 
 if TYPE_CHECKING:
+    from collections.abc import Callable, Iterable
+
     from pytest_mock import MockerFixture
+
+    from reconcile.utils.gql import GqlApi
 
 # account, console_url, user_name, encrypted_password
 FakeUser = tuple[str, str, str, str]

--- a/reconcile/test/test_terraform_vpc_peerings.py
+++ b/reconcile/test/test_terraform_vpc_peerings.py
@@ -1,9 +1,10 @@
+from __future__ import annotations
+
 import sys
-from typing import Any, Self
+from typing import TYPE_CHECKING, Any, Self
 
 import pytest
 import testslide
-from pytest_mock import MockerFixture
 
 import reconcile.terraform_vpc_peerings as integ
 import reconcile.utils.terraform_client as terraform
@@ -15,6 +16,9 @@ from reconcile.utils import (
     aws_api,
     ocm,
 )
+
+if TYPE_CHECKING:
+    from pytest_mock import MockerFixture
 
 
 class MockOCM:

--- a/reconcile/test/test_terraform_vpc_peerings_build_desired_state.py
+++ b/reconcile/test/test_terraform_vpc_peerings_build_desired_state.py
@@ -1,8 +1,9 @@
-from typing import cast
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, cast
 
 import pytest
 import testslide
-from pytest_mock import MockerFixture
 
 import reconcile.terraform_vpc_peerings as sut
 from reconcile.test.test_terraform_vpc_peerings import (
@@ -16,6 +17,9 @@ from reconcile.utils import (
     aws_api,
     ocm,
 )
+
+if TYPE_CHECKING:
+    from pytest_mock import MockerFixture
 
 
 def test_c2c_all_clusters() -> None:

--- a/reconcile/test/test_three_way_diff_strategy.py
+++ b/reconcile/test/test_three_way_diff_strategy.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from collections.abc import Generator
 from typing import Any
 
@@ -15,7 +17,7 @@ fxt = Fixtures("openshift_resource")
 
 
 @pytest.fixture
-def deployment() -> Generator[dict[str, Any], None, None]:
+def deployment() -> Generator[dict[str, Any]]:
     yield fxt.get_anymarkup("deployment.yml")
 
 

--- a/reconcile/test/test_three_way_diff_strategy.py
+++ b/reconcile/test/test_three_way_diff_strategy.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
-from collections.abc import Generator
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import pytest
 
@@ -12,6 +11,9 @@ from reconcile.utils.three_way_diff_strategy import (
 )
 
 from .fixtures import Fixtures
+
+if TYPE_CHECKING:
+    from collections.abc import Generator
 
 fxt = Fixtures("openshift_resource")
 

--- a/reconcile/test/test_vault_replication.py
+++ b/reconcile/test/test_vault_replication.py
@@ -1,7 +1,8 @@
-from typing import Any
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
 
 import pytest
-from pytest_mock import MockerFixture
 
 import reconcile.vault_replication as integ
 from reconcile.gql_definitions.fragments.vault_secret import VaultSecret
@@ -23,6 +24,9 @@ from reconcile.utils.vault import (
     SecretNotFoundError,
     SecretVersionNotFoundError,
 )
+
+if TYPE_CHECKING:
+    from pytest_mock import MockerFixture
 
 fxt = Fixtures("vault_replication")
 

--- a/reconcile/test/test_wrong_region.py
+++ b/reconcile/test/test_wrong_region.py
@@ -1,10 +1,14 @@
-from typing import Any
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
 
 import pytest
-from pytest_mock import MockerFixture
 
 from reconcile.utils.aws_api import AWSApi
 from reconcile.utils.terrascript_aws_client import TerrascriptClient
+
+if TYPE_CHECKING:
+    from pytest_mock import MockerFixture
 
 
 @pytest.fixture

--- a/reconcile/test/unleash_feature_toggles/conftest.py
+++ b/reconcile/test/unleash_feature_toggles/conftest.py
@@ -1,9 +1,10 @@
+from __future__ import annotations
+
 from collections.abc import Callable, Mapping
-from typing import Any
+from typing import TYPE_CHECKING, Any
 from unittest.mock import MagicMock
 
 import pytest
-from pytest_mock import MockerFixture
 
 from reconcile.gql_definitions.unleash_feature_toggles.feature_toggles import (
     UnleashInstanceV1,
@@ -20,6 +21,9 @@ from reconcile.utils.unleash.server import (
     Project,
     UnleashServer,
 )
+
+if TYPE_CHECKING:
+    from pytest_mock import MockerFixture
 
 
 @pytest.fixture

--- a/reconcile/test/unleash_feature_toggles/conftest.py
+++ b/reconcile/test/unleash_feature_toggles/conftest.py
@@ -1,8 +1,6 @@
 from __future__ import annotations
 
-from collections.abc import Callable, Mapping
 from typing import TYPE_CHECKING, Any
-from unittest.mock import MagicMock
 
 import pytest
 
@@ -23,6 +21,9 @@ from reconcile.utils.unleash.server import (
 )
 
 if TYPE_CHECKING:
+    from collections.abc import Callable, Mapping
+    from unittest.mock import MagicMock
+
     from pytest_mock import MockerFixture
 
 

--- a/reconcile/test/utils/internal_groups/conftest.py
+++ b/reconcile/test/utils/internal_groups/conftest.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-from collections.abc import Callable
 from typing import TYPE_CHECKING
 
 import pytest
@@ -13,6 +12,8 @@ from reconcile.utils.internal_groups.client import (
 )
 
 if TYPE_CHECKING:
+    from collections.abc import Callable
+
     from pytest_httpserver import HTTPServer
 
 

--- a/reconcile/test/utils/internal_groups/conftest.py
+++ b/reconcile/test/utils/internal_groups/conftest.py
@@ -1,14 +1,19 @@
+from __future__ import annotations
+
 from collections.abc import Callable
+from typing import TYPE_CHECKING
 
 import pytest
 import requests
-from pytest_httpserver import HTTPServer
 
 from reconcile.test.fixtures import Fixtures
 from reconcile.utils.internal_groups.client import (
     InternalGroupsApi,
     InternalGroupsClient,
 )
+
+if TYPE_CHECKING:
+    from pytest_httpserver import HTTPServer
 
 
 @pytest.fixture

--- a/reconcile/test/utils/internal_groups/test_internal_groups_client.py
+++ b/reconcile/test/utils/internal_groups/test_internal_groups_client.py
@@ -4,7 +4,6 @@ from typing import TYPE_CHECKING
 
 import pytest
 
-from reconcile.test.fixtures import Fixtures
 from reconcile.utils.internal_groups.client import (
     InternalGroupsApi,
     InternalGroupsClient,
@@ -14,6 +13,8 @@ from reconcile.utils.internal_groups.models import Group
 
 if TYPE_CHECKING:
     from pytest_httpserver import HTTPServer
+
+    from reconcile.test.fixtures import Fixtures
 
 
 def test_internal_groups_api_create_group(

--- a/reconcile/test/utils/internal_groups/test_internal_groups_client.py
+++ b/reconcile/test/utils/internal_groups/test_internal_groups_client.py
@@ -1,5 +1,8 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 import pytest
-from pytest_httpserver import HTTPServer
 
 from reconcile.test.fixtures import Fixtures
 from reconcile.utils.internal_groups.client import (
@@ -8,6 +11,9 @@ from reconcile.utils.internal_groups.client import (
     NotFoundError,
 )
 from reconcile.utils.internal_groups.models import Group
+
+if TYPE_CHECKING:
+    from pytest_httpserver import HTTPServer
 
 
 def test_internal_groups_api_create_group(

--- a/reconcile/test/utils/jobcontroller/conftest.py
+++ b/reconcile/test/utils/jobcontroller/conftest.py
@@ -1,11 +1,15 @@
+from __future__ import annotations
+
 from collections.abc import Callable
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import pytest
-from pytest_mock import MockerFixture
 
 from reconcile.utils.jobcontroller.controller import K8sJobController
 from reconcile.utils.oc import OCCli
+
+if TYPE_CHECKING:
+    from pytest_mock import MockerFixture
 
 
 @pytest.fixture

--- a/reconcile/test/utils/membershipsources/test_app_interface_resolver.py
+++ b/reconcile/test/utils/membershipsources/test_app_interface_resolver.py
@@ -1,14 +1,10 @@
 from __future__ import annotations
 
-from collections.abc import Callable
 from typing import TYPE_CHECKING
 from unittest.mock import MagicMock
 
 import pytest
 
-from reconcile.gql_definitions.fragments.membership_source import (
-    AppInterfaceMembershipProviderSourceV1,
-)
 from reconcile.gql_definitions.membershipsources.roles import (
     BotV1,
     UserV1,
@@ -19,7 +15,13 @@ from reconcile.utils.membershipsources.app_interface_resolver import (
 )
 
 if TYPE_CHECKING:
+    from collections.abc import Callable
+
     from pytest_mock import MockerFixture
+
+    from reconcile.gql_definitions.fragments.membership_source import (
+        AppInterfaceMembershipProviderSourceV1,
+    )
 
 
 @pytest.fixture

--- a/reconcile/test/utils/membershipsources/test_app_interface_resolver.py
+++ b/reconcile/test/utils/membershipsources/test_app_interface_resolver.py
@@ -1,8 +1,10 @@
+from __future__ import annotations
+
 from collections.abc import Callable
+from typing import TYPE_CHECKING
 from unittest.mock import MagicMock
 
 import pytest
-from pytest_mock import MockerFixture
 
 from reconcile.gql_definitions.fragments.membership_source import (
     AppInterfaceMembershipProviderSourceV1,
@@ -15,6 +17,9 @@ from reconcile.utils.membershipsources import app_interface_resolver
 from reconcile.utils.membershipsources.app_interface_resolver import (
     resolve_app_interface_membership_source,
 )
+
+if TYPE_CHECKING:
+    from pytest_mock import MockerFixture
 
 
 @pytest.fixture

--- a/reconcile/test/utils/membershipsources/test_resolver.py
+++ b/reconcile/test/utils/membershipsources/test_resolver.py
@@ -1,4 +1,6 @@
-from pytest_mock import MockerFixture
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
 
 from reconcile.gql_definitions.fragments.membership_source import (
     AppInterfaceMembershipProviderSourceV1,
@@ -18,6 +20,9 @@ from reconcile.utils.membershipsources.resolver import (
     build_resolver_jobs,
     resolve_groups,
 )
+
+if TYPE_CHECKING:
+    from pytest_mock import MockerFixture
 
 
 def test_build_resolver_jobs_grouping(

--- a/reconcile/test/utils/merge_request_manager/test_merge_request_manager_.py
+++ b/reconcile/test/utils/merge_request_manager/test_merge_request_manager_.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 from typing import TYPE_CHECKING
-from unittest.mock import Mock
 
 import pytest
 from gitlab.v4.objects import ProjectMergeRequest
@@ -12,11 +11,14 @@ from reconcile.utils.gitlab_api import GitLabApi
 from reconcile.utils.merge_request_manager.merge_request_manager import (
     MergeRequestManagerBase,
 )
-from reconcile.utils.merge_request_manager.parser import Parser
 from reconcile.utils.vcs import VCS
 
 if TYPE_CHECKING:
+    from unittest.mock import Mock
+
     from pytest_mock import MockerFixture
+
+    from reconcile.utils.merge_request_manager.parser import Parser
 
 
 @pytest.fixture

--- a/reconcile/test/utils/merge_request_manager/test_merge_request_manager_.py
+++ b/reconcile/test/utils/merge_request_manager/test_merge_request_manager_.py
@@ -1,9 +1,11 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
 from unittest.mock import Mock
 
 import pytest
 from gitlab.v4.objects import ProjectMergeRequest
 from pydantic import BaseModel
-from pytest_mock import MockerFixture
 
 from reconcile.test.utils.merge_request_manager.conftest import desc_string
 from reconcile.utils.gitlab_api import GitLabApi
@@ -12,6 +14,9 @@ from reconcile.utils.merge_request_manager.merge_request_manager import (
 )
 from reconcile.utils.merge_request_manager.parser import Parser
 from reconcile.utils.vcs import VCS
+
+if TYPE_CHECKING:
+    from pytest_mock import MockerFixture
 
 
 @pytest.fixture

--- a/reconcile/test/utils/rosa/conftest.py
+++ b/reconcile/test/utils/rosa/conftest.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import tempfile
-from collections.abc import Generator
 from typing import TYPE_CHECKING
 from unittest.mock import MagicMock
 from urllib.parse import urlparse
@@ -17,6 +16,8 @@ from reconcile.utils.rosa.session import RosaSession
 from reconcile.utils.secret_reader import SecretReaderBase
 
 if TYPE_CHECKING:
+    from collections.abc import Generator
+
     from pytest_httpserver import HTTPServer
 
 

--- a/reconcile/test/utils/rosa/conftest.py
+++ b/reconcile/test/utils/rosa/conftest.py
@@ -1,10 +1,12 @@
+from __future__ import annotations
+
 import tempfile
 from collections.abc import Generator
+from typing import TYPE_CHECKING
 from unittest.mock import MagicMock
 from urllib.parse import urlparse
 
 import pytest
-from pytest_httpserver import HTTPServer
 
 from reconcile.gql_definitions.fragments.vault_secret import VaultSecret
 from reconcile.utils.jobcontroller.controller import K8sJobController
@@ -13,6 +15,9 @@ from reconcile.utils.ocm_base_client import OCMAPIClientConfiguration, OCMBaseCl
 from reconcile.utils.rosa.rosa_cli import LogHandle, RosaJob
 from reconcile.utils.rosa.session import RosaSession
 from reconcile.utils.secret_reader import SecretReaderBase
+
+if TYPE_CHECKING:
+    from pytest_httpserver import HTTPServer
 
 
 @pytest.fixture
@@ -111,7 +116,7 @@ def rosa_session(
 
 
 @pytest.fixture
-def log_file() -> Generator[str, None, None]:
+def log_file() -> Generator[str]:
     with tempfile.NamedTemporaryFile(delete=False) as f:
         f.write(b"line1\nline2\nline3\nline4\nline5\n")
         f.flush()

--- a/reconcile/test/utils/test_aws_helper.py
+++ b/reconcile/test/utils/test_aws_helper.py
@@ -1,11 +1,16 @@
+from __future__ import annotations
+
 from collections.abc import Iterable, Sequence
+from typing import TYPE_CHECKING
 
 import pytest
 from pydantic import BaseModel
-from pytest_mock import MockerFixture
 
 import reconcile.utils.aws_helper as awsh
 from reconcile.utils.secret_reader import SecretReader
+
+if TYPE_CHECKING:
+    from pytest_mock import MockerFixture
 
 
 def test_get_id_from_arn() -> None:

--- a/reconcile/test/utils/test_aws_helper.py
+++ b/reconcile/test/utils/test_aws_helper.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-from collections.abc import Iterable, Sequence
 from typing import TYPE_CHECKING
 
 import pytest
@@ -10,6 +9,8 @@ import reconcile.utils.aws_helper as awsh
 from reconcile.utils.secret_reader import SecretReader
 
 if TYPE_CHECKING:
+    from collections.abc import Iterable, Sequence
+
     from pytest_mock import MockerFixture
 
 

--- a/reconcile/test/utils/test_binary.py
+++ b/reconcile/test/utils/test_binary.py
@@ -1,11 +1,16 @@
+from __future__ import annotations
+
 import re
 from subprocess import CalledProcessError, CompletedProcess
+from typing import TYPE_CHECKING
 from unittest.mock import MagicMock, create_autospec
 
 import pytest
-from pytest_mock import MockerFixture
 
 from reconcile.utils.binary import binary, binary_version
+
+if TYPE_CHECKING:
+    from pytest_mock import MockerFixture
 
 
 def test_binary_when_exist(mocker: MockerFixture) -> None:

--- a/reconcile/test/utils/test_deadmanssnitch_api.py
+++ b/reconcile/test/utils/test_deadmanssnitch_api.py
@@ -1,10 +1,16 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 import pytest
-from pytest_httpserver import HTTPServer
 from requests.exceptions import HTTPError
 
 from reconcile.utils.deadmanssnitch_api import (
     DeadMansSnitchApi,
 )
+
+if TYPE_CHECKING:
+    from pytest_httpserver import HTTPServer
 
 TOKEN = "test_token"
 URL = "/v1/snitches"

--- a/reconcile/test/utils/test_disabled_integrations.py
+++ b/reconcile/test/utils/test_disabled_integrations.py
@@ -1,15 +1,19 @@
+from __future__ import annotations
+
 from collections.abc import Mapping
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import pytest
 from pydantic import BaseModel
-from pytest_mock import MockerFixture
 
 from reconcile.utils.disabled_integrations import (
     HasDisableIntegrations,
     disabled_integrations,
     integration_is_enabled,
 )
+
+if TYPE_CHECKING:
+    from pytest_mock import MockerFixture
 
 
 class IntMandatory(BaseModel):

--- a/reconcile/test/utils/test_disabled_integrations.py
+++ b/reconcile/test/utils/test_disabled_integrations.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-from collections.abc import Mapping
 from typing import TYPE_CHECKING, Any
 
 import pytest
@@ -13,6 +12,8 @@ from reconcile.utils.disabled_integrations import (
 )
 
 if TYPE_CHECKING:
+    from collections.abc import Mapping
+
     from pytest_mock import MockerFixture
 
 

--- a/reconcile/test/utils/test_early_exit_cache.py
+++ b/reconcile/test/utils/test_early_exit_cache.py
@@ -1,10 +1,11 @@
+from __future__ import annotations
+
 import datetime
-from typing import Any
+from typing import TYPE_CHECKING, Any
 from unittest.mock import call, create_autospec
 
 import pytest
 from deepdiff import DeepHash
-from pytest_mock import MockerFixture
 
 from reconcile.utils.early_exit_cache import (
     CacheHeadResult,
@@ -15,6 +16,9 @@ from reconcile.utils.early_exit_cache import (
     EarlyExitCache,
 )
 from reconcile.utils.state import State
+
+if TYPE_CHECKING:
+    from pytest_mock import MockerFixture
 
 INTEGRATION_NAME = "some-integration"
 INTEGRATION_VERSION = "some-integration-version"

--- a/reconcile/test/utils/test_extended_early_exit.py
+++ b/reconcile/test/utils/test_extended_early_exit.py
@@ -20,10 +20,11 @@ from reconcile.utils.extended_early_exit import (
     ExtendedEarlyExitRunnerResult,
     extended_early_exit_run,
 )
-from reconcile.utils.secret_reader import SecretReaderBase
 
 if TYPE_CHECKING:
     from pytest_mock import MockerFixture
+
+    from reconcile.utils.secret_reader import SecretReaderBase
 
 INTEGRATION = "some_integration"
 EXPECTED_INTEGRATION = "some-integration"

--- a/reconcile/test/utils/test_extended_early_exit.py
+++ b/reconcile/test/utils/test_extended_early_exit.py
@@ -1,10 +1,11 @@
+from __future__ import annotations
+
 import logging
 from logging import Logger
-from typing import Any
+from typing import TYPE_CHECKING, Any
 from unittest.mock import MagicMock, call, create_autospec
 
 import pytest
-from pytest_mock import MockerFixture
 
 from reconcile.utils.early_exit_cache import (
     CacheHeadResult,
@@ -20,6 +21,9 @@ from reconcile.utils.extended_early_exit import (
     extended_early_exit_run,
 )
 from reconcile.utils.secret_reader import SecretReaderBase
+
+if TYPE_CHECKING:
+    from pytest_mock import MockerFixture
 
 INTEGRATION = "some_integration"
 EXPECTED_INTEGRATION = "some-integration"

--- a/reconcile/test/utils/test_external_resources.py
+++ b/reconcile/test/utils/test_external_resources.py
@@ -1,10 +1,11 @@
+from __future__ import annotations
+
 import json
 from collections import Counter
 from collections.abc import Mapping
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import pytest
-from pytest_mock import MockerFixture
 
 import reconcile.utils.external_resources as uer
 from reconcile.utils.external_resource_spec import (
@@ -12,6 +13,9 @@ from reconcile.utils.external_resource_spec import (
     ExternalResourceSpecInventory,
     ExternalResourceUniqueKey,
 )
+
+if TYPE_CHECKING:
+    from pytest_mock import MockerFixture
 
 NamespaceInfo = Mapping[str, Any]
 

--- a/reconcile/test/utils/test_gitlab_api.py
+++ b/reconcile/test/utils/test_gitlab_api.py
@@ -1,8 +1,10 @@
+from __future__ import annotations
+
 import io
 import os
 import tarfile
 from collections.abc import Mapping
-from typing import Any
+from typing import TYPE_CHECKING, Any
 from unittest.mock import Mock, create_autospec
 
 import pytest
@@ -38,10 +40,12 @@ from gitlab.v4.objects import (
     ProjectMergeRequestResourceLabelEvent,
     ProjectMergeRequestResourceLabelEventManager,
 )
-from pytest_mock import MockerFixture
 from requests.exceptions import ConnectTimeout
 
 from reconcile.utils.gitlab_api import Assignment, Comment, GitLabApi
+
+if TYPE_CHECKING:
+    from pytest_mock import MockerFixture
 
 
 def test_gitlab_client_timeout(mocker: MockerFixture, patch_sleep: None) -> None:

--- a/reconcile/test/utils/test_gitlab_api.py
+++ b/reconcile/test/utils/test_gitlab_api.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import io
 import os
 import tarfile
-from collections.abc import Mapping
 from typing import TYPE_CHECKING, Any
 from unittest.mock import Mock, create_autospec
 
@@ -45,6 +44,8 @@ from requests.exceptions import ConnectTimeout
 from reconcile.utils.gitlab_api import Assignment, Comment, GitLabApi
 
 if TYPE_CHECKING:
+    from collections.abc import Mapping
+
     from pytest_mock import MockerFixture
 
 

--- a/reconcile/test/utils/test_jira_client.py
+++ b/reconcile/test/utils/test_jira_client.py
@@ -1,7 +1,12 @@
-from pytest_mock import MockerFixture
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
 
 from reconcile.gql_definitions.common.jira_settings import JiraWatcherSettingsV1
 from reconcile.utils.jira_client import JiraClient
+
+if TYPE_CHECKING:
+    from pytest_mock import MockerFixture
 
 
 def test_create_with_jira_watcher_settings(

--- a/reconcile/test/utils/test_jjb_client.py
+++ b/reconcile/test/utils/test_jjb_client.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import tempfile
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
-from unittest.mock import MagicMock
 
 import pytest
 
@@ -11,6 +10,8 @@ from reconcile.test.fixtures import Fixtures
 from reconcile.utils.jjb_client import JJB, MissingJobUrlError
 
 if TYPE_CHECKING:
+    from unittest.mock import MagicMock
+
     from pytest_mock import MockerFixture
 
 

--- a/reconcile/test/utils/test_jjb_client.py
+++ b/reconcile/test/utils/test_jjb_client.py
@@ -1,13 +1,17 @@
+from __future__ import annotations
+
 import tempfile
 from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
 from unittest.mock import MagicMock
 
 import pytest
-from pytest_mock import MockerFixture
 
 from reconcile.test.fixtures import Fixtures
 from reconcile.utils.jjb_client import JJB, MissingJobUrlError
+
+if TYPE_CHECKING:
+    from pytest_mock import MockerFixture
 
 
 @pytest.fixture

--- a/reconcile/test/utils/test_keycloak.py
+++ b/reconcile/test/utils/test_keycloak.py
@@ -1,13 +1,18 @@
+from __future__ import annotations
+
 import json
+from typing import TYPE_CHECKING
 
 import pytest
-from pytest_httpserver import HTTPServer
 
 from reconcile.utils.keycloak import (
     KeycloakAPI,
     KeycloakInstance,
     KeycloakMap,
 )
+
+if TYPE_CHECKING:
+    from pytest_httpserver import HTTPServer
 
 KEYCLOAK_DEFAULT_RESPONSE = {
     "clientId": "test-client",

--- a/reconcile/test/utils/test_ldap_client.py
+++ b/reconcile/test/utils/test_ldap_client.py
@@ -1,10 +1,14 @@
-from typing import Any
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
 
 import ldap3
 import pytest
-from pytest_mock import MockerFixture
 
 from reconcile.utils.ldap_client import LdapClient, LdapClientError
+
+if TYPE_CHECKING:
+    from pytest_mock import MockerFixture
 
 
 @pytest.fixture

--- a/reconcile/test/utils/test_lean_terraform_client.py
+++ b/reconcile/test/utils/test_lean_terraform_client.py
@@ -1,10 +1,14 @@
+from __future__ import annotations
+
 import os
 import tempfile
 from subprocess import CompletedProcess
-
-from pytest_mock import MockerFixture
+from typing import TYPE_CHECKING
 
 from reconcile.utils import lean_terraform_client
+
+if TYPE_CHECKING:
+    from pytest_mock import MockerFixture
 
 
 def test_init(mocker: MockerFixture) -> None:

--- a/reconcile/test/utils/test_oauth2_backend_application_session.py
+++ b/reconcile/test/utils/test_oauth2_backend_application_session.py
@@ -1,15 +1,19 @@
-from typing import Any
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
 from unittest.mock import call, create_autospec
 
 import pytest
 from oauthlib.oauth2 import TokenExpiredError
-from pytest_mock import MockerFixture
 from requests import Response
 from requests.adapters import HTTPAdapter
 
 from reconcile.utils.oauth2_backend_application_session import (
     OAuth2BackendApplicationSession,
 )
+
+if TYPE_CHECKING:
+    from pytest_mock import MockerFixture
 
 CLIENT_ID = "client_id"
 CLIENT_SECRET = "client_secret"

--- a/reconcile/test/utils/test_oc.py
+++ b/reconcile/test/utils/test_oc.py
@@ -1,14 +1,15 @@
+from __future__ import annotations
+
 import logging
 import os
 from subprocess import CompletedProcess
-from typing import Any, TypedDict, cast
+from typing import TYPE_CHECKING, Any, TypedDict, cast
 from unittest import TestCase
 from unittest.mock import MagicMock, patch
 
 import pytest
 from kubernetes.dynamic import Resource
 from kubernetes.dynamic.exceptions import ResourceNotFoundError
-from pytest_mock import MockerFixture
 
 import reconcile.utils.oc
 from reconcile.utils.oc import (
@@ -33,6 +34,9 @@ from reconcile.utils.secret_reader import (
     SecretNotFoundError,
     SecretReader,
 )
+
+if TYPE_CHECKING:
+    from pytest_mock import MockerFixture
 
 
 @patch.dict(os.environ, {"USE_NATIVE_CLIENT": "False"}, clear=True)

--- a/reconcile/test/utils/test_ocm.py
+++ b/reconcile/test/utils/test_ocm.py
@@ -1,10 +1,14 @@
-from typing import Any
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
 
 import pytest
-from pytest_mock import MockerFixture
 
 from reconcile.utils.ocm import OCM
 from reconcile.utils.ocm_base_client import OCMBaseClient
+
+if TYPE_CHECKING:
+    from pytest_mock import MockerFixture
 
 
 @pytest.fixture

--- a/reconcile/test/utils/test_prometheus.py
+++ b/reconcile/test/utils/test_prometheus.py
@@ -1,8 +1,10 @@
+from __future__ import annotations
+
 from collections.abc import Callable
+from typing import TYPE_CHECKING
 from urllib.parse import urlparse
 
 import pytest
-from pytest_httpserver import HTTPServer
 from requests import HTTPError
 
 from reconcile.utils.prometheus import (
@@ -11,6 +13,9 @@ from reconcile.utils.prometheus import (
     PrometheusValue,
     PrometheusVector,
 )
+
+if TYPE_CHECKING:
+    from pytest_httpserver import HTTPServer
 
 
 def test_prometheus_vector() -> None:

--- a/reconcile/test/utils/test_quay_api.py
+++ b/reconcile/test/utils/test_quay_api.py
@@ -1,13 +1,18 @@
+from __future__ import annotations
+
 import json
+from typing import TYPE_CHECKING
 
 import pytest
-from pytest_httpserver import HTTPServer
 from requests import HTTPError
 
 from reconcile.utils.quay_api import (
     QuayApi,
     QuayTeamNotFoundError,
 )
+
+if TYPE_CHECKING:
+    from pytest_httpserver import HTTPServer
 
 ORG = "some-org"
 TEAM_NAME = "some-team"

--- a/reconcile/test/utils/test_rest_api_base.py
+++ b/reconcile/test/utils/test_rest_api_base.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-from collections.abc import Generator
 from typing import TYPE_CHECKING
 
 import pytest
@@ -9,6 +8,8 @@ from requests import HTTPError
 from reconcile.utils.rest_api_base import ApiBase, BearerTokenAuth, get_next_url
 
 if TYPE_CHECKING:
+    from collections.abc import Generator
+
     from pytest_httpserver import HTTPServer
 
 

--- a/reconcile/test/utils/test_rest_api_base.py
+++ b/reconcile/test/utils/test_rest_api_base.py
@@ -1,14 +1,19 @@
+from __future__ import annotations
+
 from collections.abc import Generator
+from typing import TYPE_CHECKING
 
 import pytest
-from pytest_httpserver import HTTPServer
 from requests import HTTPError
 
 from reconcile.utils.rest_api_base import ApiBase, BearerTokenAuth, get_next_url
 
+if TYPE_CHECKING:
+    from pytest_httpserver import HTTPServer
+
 
 @pytest.fixture
-def client(httpserver: HTTPServer) -> Generator[ApiBase, None, None]:
+def client(httpserver: HTTPServer) -> Generator[ApiBase]:
     client = ApiBase(host=httpserver.url_for("/"))
     yield client
     client.cleanup()

--- a/reconcile/test/utils/test_sharding.py
+++ b/reconcile/test/utils/test_sharding.py
@@ -1,8 +1,12 @@
-import importlib
+from __future__ import annotations
 
-from pytest import MonkeyPatch
+import importlib
+from typing import TYPE_CHECKING
 
 from reconcile.utils import sharding
+
+if TYPE_CHECKING:
+    from pytest import MonkeyPatch
 
 VALUE = "saas-qontract-reconcile"
 

--- a/reconcile/test/utils/test_slack_api.py
+++ b/reconcile/test/utils/test_slack_api.py
@@ -1,6 +1,8 @@
+from __future__ import annotations
+
 from collections import namedtuple
 from collections.abc import Mapping
-from typing import Any, TypedDict
+from typing import TYPE_CHECKING, Any, TypedDict
 from unittest.mock import (
     MagicMock,
     call,
@@ -8,8 +10,6 @@ from unittest.mock import (
 )
 
 import pytest
-from pytest_httpserver import HTTPServer
-from pytest_mock import MockerFixture
 from slack_sdk import WebClient
 from slack_sdk.errors import SlackApiError
 from slack_sdk.web import SlackResponse
@@ -23,6 +23,10 @@ from reconcile.utils.slack_api import (
     SlackApiConfig,
     UserNotFoundError,
 )
+
+if TYPE_CHECKING:
+    from pytest_httpserver import HTTPServer
+    from pytest_mock import MockerFixture
 
 SlackApiMock = namedtuple("SlackApiMock", "client mock_slack_client")
 

--- a/reconcile/test/utils/test_slack_api.py
+++ b/reconcile/test/utils/test_slack_api.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 from collections import namedtuple
-from collections.abc import Mapping
 from typing import TYPE_CHECKING, Any, TypedDict
 from unittest.mock import (
     MagicMock,
@@ -25,6 +24,8 @@ from reconcile.utils.slack_api import (
 )
 
 if TYPE_CHECKING:
+    from collections.abc import Mapping
+
     from pytest_httpserver import HTTPServer
     from pytest_mock import MockerFixture
 

--- a/reconcile/test/utils/test_slo_document_manager.py
+++ b/reconcile/test/utils/test_slo_document_manager.py
@@ -1,7 +1,9 @@
+from __future__ import annotations
+
 from collections.abc import Callable
+from typing import TYPE_CHECKING
 
 import pytest
-from pytest_httpserver import HTTPServer
 from requests.exceptions import ConnectionError
 
 from reconcile.gql_definitions.fragments.saas_slo_document import (
@@ -17,6 +19,9 @@ from reconcile.gql_definitions.fragments.vault_secret import VaultSecret
 from reconcile.test.fixtures import Fixtures
 from reconcile.utils.secret_reader import SecretReaderBase
 from reconcile.utils.slo_document_manager import SLODetails, SLODocumentManager
+
+if TYPE_CHECKING:
+    from pytest_httpserver import HTTPServer
 
 
 @pytest.fixture

--- a/reconcile/test/utils/test_slo_document_manager.py
+++ b/reconcile/test/utils/test_slo_document_manager.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-from collections.abc import Callable
 from typing import TYPE_CHECKING
 
 import pytest
@@ -17,11 +16,14 @@ from reconcile.gql_definitions.fragments.saas_slo_document import (
 )
 from reconcile.gql_definitions.fragments.vault_secret import VaultSecret
 from reconcile.test.fixtures import Fixtures
-from reconcile.utils.secret_reader import SecretReaderBase
 from reconcile.utils.slo_document_manager import SLODetails, SLODocumentManager
 
 if TYPE_CHECKING:
+    from collections.abc import Callable
+
     from pytest_httpserver import HTTPServer
+
+    from reconcile.utils.secret_reader import SecretReaderBase
 
 
 @pytest.fixture

--- a/reconcile/test/utils/test_smtp_client.py
+++ b/reconcile/test/utils/test_smtp_client.py
@@ -1,10 +1,16 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 import pytest
-import smtpdfix
 
 from reconcile.utils.smtp_client import (
     SmtpClient,
     SmtpServerConnectionInfo,
 )
+
+if TYPE_CHECKING:
+    import smtpdfix
 
 
 @pytest.fixture

--- a/reconcile/test/utils/test_sqs_gateway.py
+++ b/reconcile/test/utils/test_sqs_gateway.py
@@ -1,10 +1,15 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
 from unittest.mock import create_autospec
 
 import pytest
-from pytest_mock import MockerFixture
 
 from reconcile.utils.secret_reader import SecretReader
 from reconcile.utils.sqs_gateway import SQSGateway
+
+if TYPE_CHECKING:
+    from pytest_mock import MockerFixture
 
 
 @pytest.fixture

--- a/reconcile/test/utils/test_state.py
+++ b/reconcile/test/utils/test_state.py
@@ -51,7 +51,7 @@ def accounts() -> list[dict[str, str]]:
 
 
 @pytest.fixture
-def s3_client(monkeypatch: MonkeyPatch) -> Generator[S3Client, None, None]:
+def s3_client(monkeypatch: MonkeyPatch) -> Generator[S3Client]:
     monkeypatch.setenv("AWS_ACCESS_KEY_ID", "testing")
     monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", "testing")
     monkeypatch.setenv("AWS_SECURITY_TOKEN", "testing")

--- a/reconcile/test/utils/test_terraform_client.py
+++ b/reconcile/test/utils/test_terraform_client.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import base64
 import tempfile
-from collections.abc import Callable
 from logging import DEBUG
 from operator import itemgetter
 from typing import TYPE_CHECKING, Any
@@ -24,6 +23,8 @@ from reconcile.utils.terraform_client import (
 )
 
 if TYPE_CHECKING:
+    from collections.abc import Callable
+
     from pytest_mock import MockerFixture
 
 MockAWSApi = MagicMock

--- a/reconcile/test/utils/test_terraform_client.py
+++ b/reconcile/test/utils/test_terraform_client.py
@@ -1,14 +1,15 @@
+from __future__ import annotations
+
 import base64
 import tempfile
 from collections.abc import Callable
 from logging import DEBUG
 from operator import itemgetter
-from typing import Any
+from typing import TYPE_CHECKING, Any
 from unittest.mock import MagicMock, create_autospec
 
 import pytest
 from botocore.errorfactory import ClientError
-from pytest_mock import MockerFixture
 
 from reconcile.utils.aws_api import AWSApi
 from reconcile.utils.external_resource_spec import (
@@ -21,6 +22,9 @@ from reconcile.utils.terraform_client import (
     TerraformClient,
     TerraformSpec,
 )
+
+if TYPE_CHECKING:
+    from pytest_mock import MockerFixture
 
 MockAWSApi = MagicMock
 

--- a/reconcile/test/utils/test_terraform_config_client.py
+++ b/reconcile/test/utils/test_terraform_config_client.py
@@ -1,5 +1,8 @@
+from __future__ import annotations
+
 import subprocess
 from pathlib import Path
+from typing import TYPE_CHECKING
 from unittest.mock import (
     MagicMock,
     call,
@@ -8,7 +11,6 @@ from unittest.mock import (
 )
 
 import pytest
-from pytest_mock import MockerFixture
 
 from reconcile.utils.exceptions import PrintToFileInGitRepositoryError
 from reconcile.utils.external_resource_spec import ExternalResourceSpec
@@ -18,6 +20,9 @@ from reconcile.utils.terraform.config_client import (
     TerraformConfigClient,
     TerraformConfigClientCollection,
 )
+
+if TYPE_CHECKING:
+    from pytest_mock import MockerFixture
 
 
 @pytest.fixture

--- a/reconcile/test/utils/test_terraform_config_client.py
+++ b/reconcile/test/utils/test_terraform_config_client.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import subprocess
-from pathlib import Path
 from typing import TYPE_CHECKING
 from unittest.mock import (
     MagicMock,
@@ -22,6 +21,8 @@ from reconcile.utils.terraform.config_client import (
 )
 
 if TYPE_CHECKING:
+    from pathlib import Path
+
     from pytest_mock import MockerFixture
 
 

--- a/reconcile/test/utils/test_terrascript_aws_client.py
+++ b/reconcile/test/utils/test_terrascript_aws_client.py
@@ -1,11 +1,12 @@
+from __future__ import annotations
+
 import contextlib
 import json
 from dataclasses import dataclass
-from typing import Any
+from typing import TYPE_CHECKING, Any
 from unittest.mock import MagicMock
 
 import pytest
-from pytest_mock import MockerFixture
 from terrascript.resource import (
     aws_lb,
     aws_s3_bucket,
@@ -32,6 +33,9 @@ from reconcile.utils.terrascript_aws_client import (
     TerrascriptClient,
     aws_kinesis_resource_policy,
 )
+
+if TYPE_CHECKING:
+    from pytest_mock import MockerFixture
 
 
 @pytest.fixture

--- a/reconcile/test/utils/unleash/conftest.py
+++ b/reconcile/test/utils/unleash/conftest.py
@@ -1,11 +1,16 @@
+from __future__ import annotations
+
 from collections.abc import Callable
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 import pytest
-from pytest_httpserver import HTTPServer
 
 from reconcile.test.fixtures import Fixtures
 from reconcile.utils.unleash.server import UnleashServer
+
+if TYPE_CHECKING:
+    from pytest_httpserver import HTTPServer
 
 
 @pytest.fixture

--- a/reconcile/test/utils/unleash/conftest.py
+++ b/reconcile/test/utils/unleash/conftest.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-from collections.abc import Callable
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -10,6 +9,8 @@ from reconcile.test.fixtures import Fixtures
 from reconcile.utils.unleash.server import UnleashServer
 
 if TYPE_CHECKING:
+    from collections.abc import Callable
+
     from pytest_httpserver import HTTPServer
 
 

--- a/reconcile/test/utils/unleash/test_unleash_client.py
+++ b/reconcile/test/utils/unleash/test_unleash_client.py
@@ -1,10 +1,10 @@
+from __future__ import annotations
+
 from collections.abc import Callable, Generator
-from typing import Any
+from typing import TYPE_CHECKING, Any
 from unittest.mock import ANY, MagicMock
 
 import pytest
-from pytest_httpserver import HTTPServer
-from pytest_mock import MockerFixture
 
 import reconcile.utils.unleash.client
 from reconcile.utils.unleash.client import (
@@ -15,6 +15,10 @@ from reconcile.utils.unleash.client import (
     get_feature_toggle_state,
     get_feature_variant,
 )
+
+if TYPE_CHECKING:
+    from pytest_httpserver import HTTPServer
+    from pytest_mock import MockerFixture
 
 
 @pytest.fixture(autouse=True)

--- a/reconcile/test/utils/unleash/test_unleash_client.py
+++ b/reconcile/test/utils/unleash/test_unleash_client.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-from collections.abc import Callable, Generator
 from typing import TYPE_CHECKING, Any
 from unittest.mock import ANY, MagicMock
 
@@ -17,6 +16,8 @@ from reconcile.utils.unleash.client import (
 )
 
 if TYPE_CHECKING:
+    from collections.abc import Callable, Generator
+
     from pytest_httpserver import HTTPServer
     from pytest_mock import MockerFixture
 

--- a/reconcile/utils/aggregated_list.py
+++ b/reconcile/utils/aggregated_list.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import logging
 from collections.abc import Callable, KeysView
 from typing import Any, TypedDict
@@ -43,7 +45,7 @@ class AggregatedList:
     def get_by_params_hash(self, params_hash: int) -> AggregatedItem:
         return self._dict[params_hash]
 
-    def diff(self, right_state: "AggregatedList") -> dict[str, list[AggregatedItem]]:
+    def diff(self, right_state: AggregatedList) -> dict[str, list[AggregatedItem]]:
         left_params = self.get_all_params_hash()
         right_params = right_state.get_all_params_hash()
 

--- a/reconcile/utils/cloud_resource_best_practice/aws_rds.py
+++ b/reconcile/utils/cloud_resource_best_practice/aws_rds.py
@@ -1,7 +1,10 @@
-import operator
-from typing import Any
+from __future__ import annotations
 
-from terrascript.resource import aws_db_instance
+import operator
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from terrascript.resource import aws_db_instance
 
 delete_automated_backups = "delete_automated_backups"
 skip_final_snapshot = "skip_final_snapshot"

--- a/reconcile/utils/extended_early_exit.py
+++ b/reconcile/utils/extended_early_exit.py
@@ -1,10 +1,10 @@
 from __future__ import annotations
 
 import logging
-from collections.abc import Callable, Generator, Mapping
 from contextlib import contextmanager
 from io import StringIO
 from logging import Logger
+from typing import TYPE_CHECKING
 
 from pydantic import BaseModel
 
@@ -21,7 +21,11 @@ from reconcile.utils.metrics import (
     normalize_integration_name,
     set_gauge,
 )
-from reconcile.utils.secret_reader import SecretReaderBase
+
+if TYPE_CHECKING:
+    from collections.abc import Callable, Generator, Mapping
+
+    from reconcile.utils.secret_reader import SecretReaderBase
 
 
 class ExtendedEarlyExitRunnerResult(BaseModel):

--- a/reconcile/utils/extended_early_exit.py
+++ b/reconcile/utils/extended_early_exit.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import logging
 from collections.abc import Callable, Generator, Mapping
 from contextlib import contextmanager
@@ -93,7 +95,7 @@ def _ttl_seconds(
 @contextmanager
 def log_stream_handler(
     logger: Logger,
-) -> Generator[StringIO, None, None]:
+) -> Generator[StringIO]:
     """
     Add a stream handler to the logger, and return the stream generator, automatically remove the handler when done.
 

--- a/reconcile/utils/external_resource_spec.py
+++ b/reconcile/utils/external_resource_spec.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import json
 from abc import abstractmethod
 from collections.abc import (
@@ -179,7 +181,7 @@ class ExternalResourceSpec:
     def get_secret_field(self, field: str) -> str | None:
         return self.secret.get(field)
 
-    def id_object(self) -> "ExternalResourceUniqueKey":
+    def id_object(self) -> ExternalResourceUniqueKey:
         return ExternalResourceUniqueKey.from_spec(self)
 
     def build_oc_secret(
@@ -218,7 +220,7 @@ class ExternalResourceUniqueKey:
         return f"{self.identifier}-{self.provider}"
 
     @staticmethod
-    def from_spec(spec: ExternalResourceSpec) -> "ExternalResourceUniqueKey":
+    def from_spec(spec: ExternalResourceSpec) -> ExternalResourceUniqueKey:
         return ExternalResourceUniqueKey(
             provision_provider=spec.provision_provider,
             provisioner_name=spec.provisioner_name,

--- a/reconcile/utils/github_api.py
+++ b/reconcile/utils/github_api.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import base64
 import os
 from pathlib import Path
-from types import TracebackType
 from typing import TYPE_CHECKING, Self
 from urllib.parse import urlparse
 
@@ -11,6 +10,8 @@ from github import Commit, Github, GithubException, UnknownObjectException
 from sretoolbox.utils import retry
 
 if TYPE_CHECKING:
+    from types import TracebackType
+
     from github.Repository import Repository
 
 GH_BASE_URL = os.environ.get("GITHUB_API", "https://api.github.com")

--- a/reconcile/utils/github_api.py
+++ b/reconcile/utils/github_api.py
@@ -1,13 +1,17 @@
+from __future__ import annotations
+
 import base64
 import os
 from pathlib import Path
 from types import TracebackType
-from typing import Self
+from typing import TYPE_CHECKING, Self
 from urllib.parse import urlparse
 
 from github import Commit, Github, GithubException, UnknownObjectException
-from github.Repository import Repository
 from sretoolbox.utils import retry
+
+if TYPE_CHECKING:
+    from github.Repository import Repository
 
 GH_BASE_URL = os.environ.get("GITHUB_API", "https://api.github.com")
 

--- a/reconcile/utils/gitlab_api.py
+++ b/reconcile/utils/gitlab_api.py
@@ -5,10 +5,6 @@ import logging
 import os
 import re
 import tarfile
-from collections.abc import (
-    Iterable,
-    Mapping,
-)
 from dataclasses import dataclass
 from functools import cached_property
 from operator import attrgetter
@@ -57,6 +53,11 @@ from reconcile.utils.metrics import gitlab_request
 from reconcile.utils.secret_reader import SecretReader, SecretReaderBase
 
 if TYPE_CHECKING:
+    from collections.abc import (
+        Iterable,
+        Mapping,
+    )
+
     from requests import Session
 
 # The following line will suppress

--- a/reconcile/utils/gitlab_api.py
+++ b/reconcile/utils/gitlab_api.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import io
 import logging
 import os
@@ -11,6 +13,7 @@ from dataclasses import dataclass
 from functools import cached_property
 from operator import attrgetter
 from typing import (
+    TYPE_CHECKING,
     Any,
     Self,
     cast,
@@ -47,12 +50,14 @@ from gitlab.v4.objects import (
     ProjectMergeRequestResourceLabelEvent,
     User,
 )
-from requests import Session
 from sretoolbox.utils import retry
 
 from reconcile.utils.instrumented_wrappers import InstrumentedSession
 from reconcile.utils.metrics import gitlab_request
 from reconcile.utils.secret_reader import SecretReader, SecretReaderBase
+
+if TYPE_CHECKING:
+    from requests import Session
 
 # The following line will suppress
 # `InsecureRequestWarning: Unverified HTTPS request is being made`

--- a/reconcile/utils/instrumented_wrappers.py
+++ b/reconcile/utils/instrumented_wrappers.py
@@ -1,7 +1,8 @@
-import os
-from typing import Any
+from __future__ import annotations
 
-from prometheus_client.core import Counter
+import os
+from typing import TYPE_CHECKING, Any
+
 from requests import (
     Response,
     Session,
@@ -12,6 +13,9 @@ from sretoolbox.container import (
 )
 
 from reconcile.utils import metrics
+
+if TYPE_CHECKING:
+    from prometheus_client.core import Counter
 
 # TODO: move these to a shared, constants module
 

--- a/reconcile/utils/jinja2/extensions.py
+++ b/reconcile/utils/jinja2/extensions.py
@@ -1,11 +1,16 @@
+from __future__ import annotations
+
 import base64
 import textwrap
 from collections.abc import Callable
+from typing import TYPE_CHECKING
 
 from jinja2 import nodes
 from jinja2.exceptions import TemplateRuntimeError
 from jinja2.ext import Extension
-from jinja2.parser import Parser
+
+if TYPE_CHECKING:
+    from jinja2.parser import Parser
 
 
 class B64EncodeExtension(Extension):

--- a/reconcile/utils/jinja2/extensions.py
+++ b/reconcile/utils/jinja2/extensions.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import base64
 import textwrap
-from collections.abc import Callable
 from typing import TYPE_CHECKING
 
 from jinja2 import nodes
@@ -10,6 +9,8 @@ from jinja2.exceptions import TemplateRuntimeError
 from jinja2.ext import Extension
 
 if TYPE_CHECKING:
+    from collections.abc import Callable
+
     from jinja2.parser import Parser
 
 

--- a/reconcile/utils/jobcontroller/controller.py
+++ b/reconcile/utils/jobcontroller/controller.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import logging
 import time
 from datetime import datetime
-from typing import Protocol, TextIO
+from typing import TYPE_CHECKING, Protocol, TextIO
 
 from kubernetes.client import (
     ApiClient,
@@ -21,10 +21,12 @@ from reconcile.utils.jobcontroller.models import (
     JobValidationError,
     K8sJob,
 )
-from reconcile.utils.oc import OCCli
 from reconcile.utils.oc_map import init_oc_map_from_clusters
 from reconcile.utils.openshift_resource import OpenshiftResource
-from reconcile.utils.secret_reader import SecretReaderBase
+
+if TYPE_CHECKING:
+    from reconcile.utils.oc import OCCli
+    from reconcile.utils.secret_reader import SecretReaderBase
 
 
 def build_job_controller(

--- a/reconcile/utils/jobcontroller/controller.py
+++ b/reconcile/utils/jobcontroller/controller.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import logging
 import time
 from datetime import datetime
@@ -32,7 +34,7 @@ def build_job_controller(
     namespace: str,
     secret_reader: SecretReaderBase,
     dry_run: bool,
-) -> "K8sJobController":
+) -> K8sJobController:
     """
     Builds a job controller that will act on the given cluster and namespace.
     The integration name and integration_version are used to annotate the jobs

--- a/reconcile/utils/json.py
+++ b/reconcile/utils/json.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import json
-from collections.abc import Callable
 from dataclasses import asdict, is_dataclass
 from datetime import date, datetime
 from decimal import Decimal
@@ -11,6 +10,8 @@ from typing import TYPE_CHECKING, Any, Literal
 from pydantic import BaseModel
 
 if TYPE_CHECKING:
+    from collections.abc import Callable
+
     from pydantic.main import IncEx
 
 JSON_COMPACT_SEPARATORS = (",", ":")

--- a/reconcile/utils/json.py
+++ b/reconcile/utils/json.py
@@ -1,13 +1,17 @@
+from __future__ import annotations
+
 import json
 from collections.abc import Callable
 from dataclasses import asdict, is_dataclass
 from datetime import date, datetime
 from decimal import Decimal
 from enum import Enum
-from typing import Any, Literal
+from typing import TYPE_CHECKING, Any, Literal
 
 from pydantic import BaseModel
-from pydantic.main import IncEx
+
+if TYPE_CHECKING:
+    from pydantic.main import IncEx
 
 JSON_COMPACT_SEPARATORS = (",", ":")
 

--- a/reconcile/utils/ldap_client.py
+++ b/reconcile/utils/ldap_client.py
@@ -1,8 +1,7 @@
 from __future__ import annotations
 
 from collections import defaultdict
-from collections.abc import Iterable
-from typing import Self
+from typing import TYPE_CHECKING, Self
 
 from ldap3 import (
     ALL,
@@ -10,6 +9,9 @@ from ldap3 import (
     Connection,
     Server,
 )
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
 
 
 class LdapClientError(Exception):

--- a/reconcile/utils/ldap_client.py
+++ b/reconcile/utils/ldap_client.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from collections import defaultdict
 from collections.abc import Iterable
 from typing import Self
@@ -76,7 +78,7 @@ class LdapClient:
     @classmethod
     def from_params(
         cls, server_url: str, user: str | None, password: str | None, base_dn: str
-    ) -> "LdapClient":
+    ) -> LdapClient:
         connection = Connection(
             Server(server_url, get_info=ALL),
             user,

--- a/reconcile/utils/membershipsources/app_interface_resolver.py
+++ b/reconcile/utils/membershipsources/app_interface_resolver.py
@@ -1,13 +1,10 @@
 from __future__ import annotations
 
 import base64
-from collections.abc import Generator
 from contextlib import contextmanager
+from typing import TYPE_CHECKING
 
 from reconcile import queries
-from reconcile.gql_definitions.fragments.membership_source import (
-    AppInterfaceMembershipProviderSourceV1,
-)
 from reconcile.gql_definitions.membershipsources.roles import RoleV1
 from reconcile.gql_definitions.membershipsources.roles import (
     query as mebershipsource_query,
@@ -20,6 +17,13 @@ from reconcile.utils.membershipsources.models import (
     RoleUser,
 )
 from reconcile.utils.secret_reader import SecretReader
+
+if TYPE_CHECKING:
+    from collections.abc import Generator
+
+    from reconcile.gql_definitions.fragments.membership_source import (
+        AppInterfaceMembershipProviderSourceV1,
+    )
 
 
 @contextmanager

--- a/reconcile/utils/membershipsources/app_interface_resolver.py
+++ b/reconcile/utils/membershipsources/app_interface_resolver.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import base64
 from collections.abc import Generator
 from contextlib import contextmanager
@@ -23,7 +25,7 @@ from reconcile.utils.secret_reader import SecretReader
 @contextmanager
 def gql_api_for_source(
     source: AppInterfaceMembershipProviderSourceV1,
-) -> Generator[gql.GqlApi, None, None]:
+) -> Generator[gql.GqlApi]:
     settings = queries.get_secret_reader_settings()
     secret_reader = SecretReader(settings=settings)
     username = secret_reader.read_secret(source.username)

--- a/reconcile/utils/merge_request_manager/merge_request_manager.py
+++ b/reconcile/utils/merge_request_manager/merge_request_manager.py
@@ -5,6 +5,7 @@ from abc import abstractmethod
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
+from gitlab.v4.objects import ProjectMergeRequest
 from pydantic import BaseModel
 
 from reconcile.utils.merge_request_manager.parser import (
@@ -14,8 +15,6 @@ from reconcile.utils.merge_request_manager.parser import (
 )
 
 if TYPE_CHECKING:
-    from gitlab.v4.objects import ProjectMergeRequest
-
     from reconcile.utils.vcs import VCS
 
 

--- a/reconcile/utils/merge_request_manager/merge_request_manager.py
+++ b/reconcile/utils/merge_request_manager/merge_request_manager.py
@@ -1,9 +1,10 @@
+from __future__ import annotations
+
 import logging
 from abc import abstractmethod
 from dataclasses import dataclass
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
-from gitlab.v4.objects import ProjectMergeRequest
 from pydantic import BaseModel
 
 from reconcile.utils.merge_request_manager.parser import (
@@ -12,6 +13,9 @@ from reconcile.utils.merge_request_manager.parser import (
     ParserVersionError,
 )
 from reconcile.utils.vcs import VCS
+
+if TYPE_CHECKING:
+    from gitlab.v4.objects import ProjectMergeRequest
 
 
 @dataclass

--- a/reconcile/utils/merge_request_manager/merge_request_manager.py
+++ b/reconcile/utils/merge_request_manager/merge_request_manager.py
@@ -12,10 +12,11 @@ from reconcile.utils.merge_request_manager.parser import (
     ParserError,
     ParserVersionError,
 )
-from reconcile.utils.vcs import VCS
 
 if TYPE_CHECKING:
     from gitlab.v4.objects import ProjectMergeRequest
+
+    from reconcile.utils.vcs import VCS
 
 
 @dataclass

--- a/reconcile/utils/metrics.py
+++ b/reconcile/utils/metrics.py
@@ -336,9 +336,7 @@ class MetricsContainer:
             cloned_container._counters = copy.deepcopy(self._counters)
         return cloned_container
 
-    def absorb(
-        self, other: MetricsContainer, aggregate_counters: bool = True
-    ) -> None:
+    def absorb(self, other: MetricsContainer, aggregate_counters: bool = True) -> None:
         """
         Absorbs the gauges and counter from the given container into this one.
         """

--- a/reconcile/utils/metrics.py
+++ b/reconcile/utils/metrics.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import copy
 import re
 import threading
@@ -225,11 +227,11 @@ class MetricsContainer:
         current_value = self._counters[counter.__class__].get(label_values) or 0
         self._counters[counter.__class__][label_values] = current_value + by
 
-    def _aggregate_scopes(self) -> "MetricsContainer":
+    def _aggregate_scopes(self) -> MetricsContainer:
         containers = [self] + [sub._aggregate_scopes() for sub in self._scopes.values()]
         return join_metric_containers(containers)
 
-    def collect(self) -> Generator[Metric, None, None]:
+    def collect(self) -> Generator[Metric]:
         """
         Collects all metrics from this container and all its scopes.
         """
@@ -291,7 +293,7 @@ class MetricsContainer:
             if match_labels_predicate(metric, **kwargs)
         ]
 
-    def _collect_local(self) -> Generator[Metric, None, None]:
+    def _collect_local(self) -> Generator[Metric]:
         """
         Collects only the metrics present in this container, ignoring
         any scopes.
@@ -320,7 +322,7 @@ class MetricsContainer:
             for label in raw_labels
         ]
 
-    def clone(self, keep_gauges: bool, keep_counters: bool) -> "MetricsContainer":
+    def clone(self, keep_gauges: bool, keep_counters: bool) -> MetricsContainer:
         """
         Clones this container.
         """
@@ -332,7 +334,7 @@ class MetricsContainer:
         return cloned_container
 
     def absorb(
-        self, other: "MetricsContainer", aggregate_counters: bool = True
+        self, other: MetricsContainer, aggregate_counters: bool = True
     ) -> None:
         """
         Absorbs the gauges and counter from the given container into this one.
@@ -359,8 +361,8 @@ class MetricsContainer:
 
 
 def join_metric_containers(
-    metric_containers: Iterable["MetricsContainer"], aggregate_counters: bool = True
-) -> "MetricsContainer":
+    metric_containers: Iterable[MetricsContainer], aggregate_counters: bool = True
+) -> MetricsContainer:
     """
     Join all given metric containers into a single one.
     If gauge duplicates are found, the last one wins.
@@ -462,7 +464,7 @@ class MetricCollector(Collector):
         self.metric_container = metric_container
         super().__init__()
 
-    def collect(self) -> Generator[Metric, None, None]:
+    def collect(self) -> Generator[Metric]:
         return self.metric_container.collect()
 
 

--- a/reconcile/utils/metrics.py
+++ b/reconcile/utils/metrics.py
@@ -5,14 +5,8 @@ import re
 import threading
 from abc import ABC
 from collections import defaultdict
-from collections.abc import (
-    Generator,
-    Hashable,
-    Iterable,
-    Sequence,
-)
-from types import TracebackType
 from typing import (
+    TYPE_CHECKING,
     Any,
     Self,
     TypeVar,
@@ -32,6 +26,15 @@ from prometheus_client.registry import (
     CollectorRegistry,
 )
 from pydantic import BaseModel
+
+if TYPE_CHECKING:
+    from collections.abc import (
+        Generator,
+        Hashable,
+        Iterable,
+        Sequence,
+    )
+    from types import TracebackType
 
 pushgateway_registry = CollectorRegistry()
 

--- a/reconcile/utils/oauth2_backend_application_session.py
+++ b/reconcile/utils/oauth2_backend_application_session.py
@@ -1,11 +1,15 @@
+from __future__ import annotations
+
 import threading
 from collections.abc import Mapping, MutableMapping
-from typing import Any, Self
+from typing import TYPE_CHECKING, Any, Self
 
 from oauthlib.oauth2 import BackendApplicationClient, TokenExpiredError
-from requests import Response
-from requests.adapters import BaseAdapter
 from requests_oauthlib import OAuth2Session
+
+if TYPE_CHECKING:
+    from requests import Response
+    from requests.adapters import BaseAdapter
 
 FETCH_TOKEN_HEADERS = {
     "Accept": "application/json",

--- a/reconcile/utils/oauth2_backend_application_session.py
+++ b/reconcile/utils/oauth2_backend_application_session.py
@@ -1,13 +1,14 @@
 from __future__ import annotations
 
 import threading
-from collections.abc import Mapping, MutableMapping
 from typing import TYPE_CHECKING, Any, Self
 
 from oauthlib.oauth2 import BackendApplicationClient, TokenExpiredError
 from requests_oauthlib import OAuth2Session
 
 if TYPE_CHECKING:
+    from collections.abc import Mapping, MutableMapping
+
     from requests import Response
     from requests.adapters import BaseAdapter
 

--- a/reconcile/utils/ocm/clusters.py
+++ b/reconcile/utils/ocm/clusters.py
@@ -1,11 +1,7 @@
 from __future__ import annotations
 
 from collections import defaultdict
-from collections.abc import (
-    Generator,
-    Iterable,
-)
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from reconcile.utils.ocm.base import (
     ACTIVE_SUBSCRIPTION_STATES,
@@ -29,7 +25,14 @@ from reconcile.utils.ocm.subscriptions import (
     build_subscription_filter,
     get_subscriptions,
 )
-from reconcile.utils.ocm_base_client import OCMBaseClient
+
+if TYPE_CHECKING:
+    from collections.abc import (
+        Generator,
+        Iterable,
+    )
+
+    from reconcile.utils.ocm_base_client import OCMBaseClient
 
 NODE_POOL_DESIRED_KEYS = {
     "id",

--- a/reconcile/utils/ocm/clusters.py
+++ b/reconcile/utils/ocm/clusters.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from collections import defaultdict
 from collections.abc import (
     Generator,
@@ -130,7 +132,7 @@ def discover_clusters_for_organizations(
 def get_ocm_clusters(
     ocm_api: OCMBaseClient,
     cluster_filter: Filter,
-) -> Generator[OCMCluster, None, None]:
+) -> Generator[OCMCluster]:
     for cluster_dict in ocm_api.get_paginated(
         api_path="/api/clusters_mgmt/v1/clusters",
         params={"search": cluster_filter.render(), "order": "creation_timestamp"},
@@ -149,7 +151,7 @@ def get_provision_shard_for_cluster_id(
 
 def get_service_clusters(
     ocm_api: OCMBaseClient,
-) -> Generator[FleetManagerServiceCluster, None, None]:
+) -> Generator[FleetManagerServiceCluster]:
     for cluster_dict in ocm_api.get_paginated(
         api_path="/api/osd_fleet_mgmt/v1/service_clusters",
         max_page_size=100,
@@ -164,7 +166,7 @@ def get_cluster_details_for_subscriptions(
     subscription_filter: Filter | None = None,
     cluster_filter: Filter | None = None,
     init_labels: bool = False,
-) -> Generator[ClusterDetails, None, None]:
+) -> Generator[ClusterDetails]:
     """
     Discover clusters by filtering on their subscriptions. The subscription_filter
     can be used to restrict on any subscription field. Additionally, a cluster_filter

--- a/reconcile/utils/ocm/identity_providers.py
+++ b/reconcile/utils/ocm/identity_providers.py
@@ -17,7 +17,9 @@ if TYPE_CHECKING:
 
 def get_identity_providers(
     ocm_api: OCMBaseClient, ocm_cluster: OCMCluster
-) -> Generator[OCMOIdentityProvider | OCMOIdentityProviderOidc | OCMOIdentityProviderGithub]:
+) -> Generator[
+    OCMOIdentityProvider | OCMOIdentityProviderOidc | OCMOIdentityProviderGithub
+]:
     """Get all identity providers."""
     if ocm_cluster.identity_providers.href:
         for idp_dict in ocm_api.get_paginated(

--- a/reconcile/utils/ocm/identity_providers.py
+++ b/reconcile/utils/ocm/identity_providers.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from collections.abc import Generator
 
 from reconcile.utils.ocm.base import (
@@ -11,11 +13,7 @@ from reconcile.utils.ocm_base_client import OCMBaseClient
 
 def get_identity_providers(
     ocm_api: OCMBaseClient, ocm_cluster: OCMCluster
-) -> Generator[
-    OCMOIdentityProvider | OCMOIdentityProviderOidc | OCMOIdentityProviderGithub,
-    None,
-    None,
-]:
+) -> Generator[OCMOIdentityProvider | OCMOIdentityProviderOidc | OCMOIdentityProviderGithub]:
     """Get all identity providers."""
     if ocm_cluster.identity_providers.href:
         for idp_dict in ocm_api.get_paginated(

--- a/reconcile/utils/ocm/identity_providers.py
+++ b/reconcile/utils/ocm/identity_providers.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from collections.abc import Generator
+from typing import TYPE_CHECKING
 
 from reconcile.utils.ocm.base import (
     OCMCluster,
@@ -8,7 +8,11 @@ from reconcile.utils.ocm.base import (
     OCMOIdentityProviderGithub,
     OCMOIdentityProviderOidc,
 )
-from reconcile.utils.ocm_base_client import OCMBaseClient
+
+if TYPE_CHECKING:
+    from collections.abc import Generator
+
+    from reconcile.utils.ocm_base_client import OCMBaseClient
 
 
 def get_identity_providers(

--- a/reconcile/utils/ocm/labels.py
+++ b/reconcile/utils/ocm/labels.py
@@ -123,9 +123,7 @@ def organization_label_filter() -> Filter:
     return Filter().eq("type", "Organization")
 
 
-def get_labels(
-    ocm_api: OCMBaseClient, filter: Filter
-) -> Generator[OCMLabel]:
+def get_labels(ocm_api: OCMBaseClient, filter: Filter) -> Generator[OCMLabel]:
     """
     Finds all labels that match the given filter.
     """

--- a/reconcile/utils/ocm/labels.py
+++ b/reconcile/utils/ocm/labels.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from collections import defaultdict
 from collections.abc import Generator
 from typing import Any
@@ -17,7 +19,7 @@ from reconcile.utils.ocm_base_client import OCMBaseClient
 
 def get_subscription_labels(
     ocm_api: OCMBaseClient, filter: Filter
-) -> Generator[OCMSubscriptionLabel, None, None]:
+) -> Generator[OCMSubscriptionLabel]:
     """
     Finds all subscription labels that match the given filter.
     """
@@ -100,7 +102,7 @@ def subscription_label_filter() -> Filter:
 
 def get_organization_labels(
     ocm_api: OCMBaseClient, filter: Filter
-) -> Generator[OCMOrganizationLabel, None, None]:
+) -> Generator[OCMOrganizationLabel]:
     """
     Finds all organization labels that match the given filter.
     """
@@ -120,7 +122,7 @@ def organization_label_filter() -> Filter:
 
 def get_labels(
     ocm_api: OCMBaseClient, filter: Filter
-) -> Generator[OCMLabel, None, None]:
+) -> Generator[OCMLabel]:
     """
     Finds all labels that match the given filter.
     """
@@ -147,7 +149,7 @@ def build_label_from_dict(label_dict: dict[str, Any]) -> OCMLabel:
 
 def build_container_for_prefix(
     container: LabelContainer, key_prefix: str, strip_key_prefix: bool = False
-) -> "LabelContainer":
+) -> LabelContainer:
     """
     Builds a new label container with all labels that have the given prefix.
     """

--- a/reconcile/utils/ocm/labels.py
+++ b/reconcile/utils/ocm/labels.py
@@ -1,8 +1,7 @@
 from __future__ import annotations
 
 from collections import defaultdict
-from collections.abc import Generator
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from reconcile.utils.ocm.base import (
     LabelContainer,
@@ -14,7 +13,11 @@ from reconcile.utils.ocm.base import (
     build_label_container,
 )
 from reconcile.utils.ocm.search_filters import Filter
-from reconcile.utils.ocm_base_client import OCMBaseClient
+
+if TYPE_CHECKING:
+    from collections.abc import Generator
+
+    from reconcile.utils.ocm_base_client import OCMBaseClient
 
 
 def get_subscription_labels(

--- a/reconcile/utils/ocm/manifests.py
+++ b/reconcile/utils/ocm/manifests.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from collections.abc import Generator, Mapping
 from dataclasses import dataclass
 from typing import Any
@@ -15,7 +17,7 @@ class Manifest:
 
 def get_manifests(
     ocm_client: OCMBaseClient, cluster_id: str
-) -> Generator[dict[str, Any], None, None]:
+) -> Generator[dict[str, Any]]:
     manifest = Manifest(cluster_id)
     return ocm_client.get_paginated(api_path=manifest.href)
 

--- a/reconcile/utils/ocm/manifests.py
+++ b/reconcile/utils/ocm/manifests.py
@@ -1,10 +1,12 @@
 from __future__ import annotations
 
-from collections.abc import Generator, Mapping
 from dataclasses import dataclass
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
-from reconcile.utils.ocm_base_client import OCMBaseClient
+if TYPE_CHECKING:
+    from collections.abc import Generator, Mapping
+
+    from reconcile.utils.ocm_base_client import OCMBaseClient
 
 
 @dataclass

--- a/reconcile/utils/ocm/search_filters.py
+++ b/reconcile/utils/ocm/search_filters.py
@@ -4,19 +4,22 @@ from abc import (
     ABC,
     abstractmethod,
 )
-from collections.abc import Iterable
 from dataclasses import dataclass
 from datetime import (
     datetime,
 )
 from enum import Enum
 from typing import (
+    TYPE_CHECKING,
     Any,
 )
 
 import dateparser
 
 from reconcile.utils.datetime_util import utc_now
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
 
 
 @dataclass

--- a/reconcile/utils/ocm/search_filters.py
+++ b/reconcile/utils/ocm/search_filters.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from abc import (
     ABC,
     abstractmethod,
@@ -10,7 +12,6 @@ from datetime import (
 from enum import Enum
 from typing import (
     Any,
-    Optional,
 )
 
 import dateparser
@@ -34,7 +35,7 @@ class FilterCondition:
         """
 
     @abstractmethod
-    def copy_and_merge(self, other: "FilterCondition") -> "FilterCondition":
+    def copy_and_merge(self, other: FilterCondition) -> FilterCondition:
         """
         Creates a copy of this condition and merges the other
         condition into it if possible. If merging with the other
@@ -52,7 +53,7 @@ class ListCondition(ABC, FilterCondition):
 
     values: list[Any]
 
-    def copy_and_merge(self, other: "FilterCondition") -> "FilterCondition":
+    def copy_and_merge(self, other: FilterCondition) -> FilterCondition:
         if not isinstance(other, ListCondition) or not isinstance(self, type(other)):
             raise InvalidFilterError(f"Cannot merge {self} with {other}")
         return type(self)(
@@ -105,9 +106,9 @@ class FilterObjectCondition(FilterCondition):
     AND and OR conditions within the Filter object itself.
     """
 
-    filter: "Filter"
+    filter: Filter
 
-    def copy_and_merge(self, other: "FilterCondition") -> "FilterCondition":
+    def copy_and_merge(self, other: FilterCondition) -> FilterCondition:
         raise InvalidFilterError("daterange merge not supported")
 
     def render(self) -> str:
@@ -127,7 +128,7 @@ class DateRangeCondition(FilterCondition):
     start: datetime | str | None
     end: datetime | str | None
 
-    def copy_and_merge(self, other: "FilterCondition") -> "FilterCondition":
+    def copy_and_merge(self, other: FilterCondition) -> FilterCondition:
         raise InvalidFilterError("daterange merge not supported")
 
     def render(self) -> str:
@@ -214,14 +215,14 @@ class Filter:
         """
         return next((c for c in self.conditions if c.key == key), None)
 
-    def copy(self) -> "Filter":
+    def copy(self) -> Filter:
         """
         Create an identical copy of the filter.
         """
         conditions_copy = self.conditions.copy()
         return Filter(conditions_copy, mode=self.mode)
 
-    def copy_and_override(self, condition: FilterCondition) -> "Filter":
+    def copy_and_override(self, condition: FilterCondition) -> Filter:
         """
         Creates a copy of the filter and add the condition to the copy. If the
         condition already exists, it is overridden.
@@ -232,7 +233,7 @@ class Filter:
         ]
         return copied
 
-    def add_condition(self, condition: FilterCondition) -> "Filter":
+    def add_condition(self, condition: FilterCondition) -> Filter:
         """
         Adds a condition to the filter. If the condition already exists, it is
         merged with the existing condition, if possible. If merging is not possible,
@@ -250,7 +251,7 @@ class Filter:
         merged_condition = existing_condition.copy_and_merge(condition)
         return self.copy_and_override(merged_condition)
 
-    def eq(self, key: str, value: str | None) -> "Filter":
+    def eq(self, key: str, value: str | None) -> Filter:
         """
         Copies the filter and adds a condition to the copy, that requires
         the given key to be equal to the given value. If the value is None,
@@ -260,7 +261,7 @@ class Filter:
             return self.is_in(key, [value])
         return self
 
-    def like(self, key: str, value: str | None) -> "Filter":
+    def like(self, key: str, value: str | None) -> Filter:
         """
         Copies the filter and adds a condition to the copy, that requires
         the given key to be similar to the given value based on the % wildcard.
@@ -270,7 +271,7 @@ class Filter:
             return self.add_condition(LikeCondition(key, [value]))
         return self
 
-    def is_in(self, key: str, values: Iterable[Any] | None) -> "Filter":
+    def is_in(self, key: str, values: Iterable[Any] | None) -> Filter:
         """
         Copies the filter and adds a condition to the copy, that requires
         the given key to be equal to one of the given values. If the values
@@ -282,7 +283,7 @@ class Filter:
             return self.add_condition(EqCondition(key, value_list))
         return self
 
-    def before(self, key: str, date: datetime | str | None) -> "Filter":
+    def before(self, key: str, date: datetime | str | None) -> Filter:
         """
         Copies the filter and adds a condition to the copy, that requires
         the given key to be before the given date. If the date is None,
@@ -292,7 +293,7 @@ class Filter:
             return self.add_condition(DateRangeCondition(key, None, date))
         return self
 
-    def after(self, key: str, date: datetime | str | None) -> "Filter":
+    def after(self, key: str, date: datetime | str | None) -> Filter:
         """
         Copies the filter and adds a condition to the copy, that requires
         the given key to be after the given date. If the date is None,
@@ -307,7 +308,7 @@ class Filter:
         key: str,
         start: datetime | str | None,
         end: datetime | str | None,
-    ) -> "Filter":
+    ) -> Filter:
         """
         Copies the filter and adds a condition to the copy, that requires
         the given key to be between the given dates. If the dates are None,
@@ -317,7 +318,7 @@ class Filter:
 
     def chunk_by(
         self, key: str, chunk_size: int, ignore_missing: bool = False
-    ) -> list["Filter"]:
+    ) -> list[Filter]:
         """
         Returns a list of filters, each with a subset of the values of the
         given key. Each subnet has at most chunk_size values. If the key is
@@ -365,7 +366,7 @@ class Filter:
             return " and ".join(rendered_conditions)
         raise InvalidFilterError(f"invalid filter mode: {self.mode}")
 
-    def __and__(self, other: Optional["Filter"]) -> "Filter":
+    def __and__(self, other: Filter | None) -> Filter:
         """
         Returns a new filter that is the logical AND of the current filter
         and the given filter.
@@ -388,7 +389,7 @@ class Filter:
             return and_filter
         return self
 
-    def __or__(self, other: Optional["Filter"]) -> "Filter":
+    def __or__(self, other: Filter | None) -> Filter:
         """
         Returns a new filter that is the logical OR of the current filter
         and the given filter.

--- a/reconcile/utils/ocm/service_log.py
+++ b/reconcile/utils/ocm/service_log.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from collections.abc import Generator
 from datetime import timedelta
 
@@ -15,7 +17,7 @@ CLUSTER_SERVICE_LOGS_CREATE_ENDPOINT = "/api/service_logs/v1/cluster_logs"
 
 def get_service_logs_for_cluster_uuid(
     ocm_api: OCMBaseClient, cluster_uuid: str, filter: Filter | None = None
-) -> Generator[OCMClusterServiceLog, None, None]:
+) -> Generator[OCMClusterServiceLog]:
     """
     Returns a list of service logs for a cluster, matching the optional filter.
     """

--- a/reconcile/utils/ocm/service_log.py
+++ b/reconcile/utils/ocm/service_log.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
-from collections.abc import Generator
-from datetime import timedelta
+from typing import TYPE_CHECKING
 
 from reconcile.utils.datetime_util import utc_now
 from reconcile.utils.ocm.base import (
@@ -9,7 +8,12 @@ from reconcile.utils.ocm.base import (
     OCMClusterServiceLogCreateModel,
 )
 from reconcile.utils.ocm.search_filters import Filter
-from reconcile.utils.ocm_base_client import OCMBaseClient
+
+if TYPE_CHECKING:
+    from collections.abc import Generator
+    from datetime import timedelta
+
+    from reconcile.utils.ocm_base_client import OCMBaseClient
 
 CLUSTER_SERVICE_LOGS_LIST_ENDPOINT = "/api/service_logs/v1/clusters/cluster_logs"
 CLUSTER_SERVICE_LOGS_CREATE_ENDPOINT = "/api/service_logs/v1/cluster_logs"

--- a/reconcile/utils/ocm/sre_capability_labels.py
+++ b/reconcile/utils/ocm/sre_capability_labels.py
@@ -4,14 +4,15 @@ from typing import TYPE_CHECKING, Any
 
 from pydantic import WithJsonSchema
 
-from reconcile.utils.ocm.base import (
-    LabelContainer,
-    LabelSetTypeVar,
-)
 from reconcile.utils.ocm.labels import build_container_for_prefix
 
 if TYPE_CHECKING:
     from pydantic.fields import FieldInfo
+
+    from reconcile.utils.ocm.base import (
+        LabelContainer,
+        LabelSetTypeVar,
+    )
 
 
 def sre_capability_label_key(

--- a/reconcile/utils/ocm/sre_capability_labels.py
+++ b/reconcile/utils/ocm/sre_capability_labels.py
@@ -1,13 +1,17 @@
-from typing import Any
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
 
 from pydantic import WithJsonSchema
-from pydantic.fields import FieldInfo
 
 from reconcile.utils.ocm.base import (
     LabelContainer,
     LabelSetTypeVar,
 )
 from reconcile.utils.ocm.labels import build_container_for_prefix
+
+if TYPE_CHECKING:
+    from pydantic.fields import FieldInfo
 
 
 def sre_capability_label_key(

--- a/reconcile/utils/ocm/syncsets.py
+++ b/reconcile/utils/ocm/syncsets.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from collections.abc import Generator, Mapping
 from dataclasses import dataclass
 from typing import Any
@@ -15,7 +17,7 @@ class SyncSet:
 
 def get_syncsets(
     ocm_client: OCMBaseClient, cluster_id: str
-) -> Generator[dict[str, Any], None, None]:
+) -> Generator[dict[str, Any]]:
     syncset = SyncSet(cluster_id)
     return ocm_client.get_paginated(api_path=syncset.href)
 

--- a/reconcile/utils/ocm/syncsets.py
+++ b/reconcile/utils/ocm/syncsets.py
@@ -1,10 +1,12 @@
 from __future__ import annotations
 
-from collections.abc import Generator, Mapping
 from dataclasses import dataclass
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
-from reconcile.utils.ocm_base_client import OCMBaseClient
+if TYPE_CHECKING:
+    from collections.abc import Generator, Mapping
+
+    from reconcile.utils.ocm_base_client import OCMBaseClient
 
 
 @dataclass

--- a/reconcile/utils/ocm_base_client.py
+++ b/reconcile/utils/ocm_base_client.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import logging
 from collections.abc import (
     Generator,
@@ -84,7 +86,7 @@ class OCMBaseClient:
         params: dict[str, Any] | None = None,
         max_page_size: int = 100,
         max_pages: int | None = None,
-    ) -> Generator[dict[str, Any], None, None]:
+    ) -> Generator[dict[str, Any]]:
         """
         Note, that pagination is currently broken.
         Each call will return a random order, meaning pages are not consistent.

--- a/reconcile/utils/ocm_base_client.py
+++ b/reconcile/utils/ocm_base_client.py
@@ -1,12 +1,8 @@
 from __future__ import annotations
 
 import logging
-from collections.abc import (
-    Generator,
-    Mapping,
-)
-from types import TracebackType
 from typing import (
+    TYPE_CHECKING,
     Any,
     Protocol,
     Self,
@@ -19,12 +15,20 @@ from requests import (
 )
 from sretoolbox.utils import retry
 
-from reconcile.gql_definitions.fragments.aus_organization import AUSOCMOrganization
 from reconcile.utils.metrics import ocm_request
 from reconcile.utils.secret_reader import (
     HasSecret,
     SecretReaderBase,
 )
+
+if TYPE_CHECKING:
+    from collections.abc import (
+        Generator,
+        Mapping,
+    )
+    from types import TracebackType
+
+    from reconcile.gql_definitions.fragments.aus_organization import AUSOCMOrganization
 
 REQUEST_TIMEOUT_SEC = 60
 

--- a/reconcile/utils/rest_api_base.py
+++ b/reconcile/utils/rest_api_base.py
@@ -1,13 +1,17 @@
+from __future__ import annotations
+
 import logging
-from typing import Any, Self
+from typing import TYPE_CHECKING, Any, Self
 from urllib.parse import urljoin
 
 import requests
-from urllib3 import Retry
 
 from reconcile.utils.oauth2_backend_application_session import (
     OAuth2BackendApplicationSession,
 )
+
+if TYPE_CHECKING:
+    from urllib3 import Retry
 
 
 def get_next_url(links: dict[str, dict[str, str]]) -> str | None:

--- a/reconcile/utils/rest_api_base.py
+++ b/reconcile/utils/rest_api_base.py
@@ -6,12 +6,12 @@ from urllib.parse import urljoin
 
 import requests
 
-from reconcile.utils.oauth2_backend_application_session import (
-    OAuth2BackendApplicationSession,
-)
-
 if TYPE_CHECKING:
     from urllib3 import Retry
+
+    from reconcile.utils.oauth2_backend_application_session import (
+        OAuth2BackendApplicationSession,
+    )
 
 
 def get_next_url(links: dict[str, dict[str, str]]) -> str | None:

--- a/reconcile/utils/rosa/session.py
+++ b/reconcile/utils/rosa/session.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import logging
 import tempfile
 
@@ -25,7 +27,7 @@ class RosaSessionBuilder(BaseModel, arbitrary_types_allowed=True):
 
     def build(
         self, ocm_api: OCMBaseClient, aws_account_id: str, region: str, ocm_org_id: str
-    ) -> "RosaSession":
+    ) -> RosaSession:
         return RosaSession(
             aws_account_id=aws_account_id,
             aws_region=region,

--- a/reconcile/utils/rosa/session.py
+++ b/reconcile/utils/rosa/session.py
@@ -2,21 +2,24 @@ from __future__ import annotations
 
 import logging
 import tempfile
+from typing import TYPE_CHECKING
 
 from jinja2 import Environment, FileSystemLoader
 from pydantic import BaseModel
 
-from reconcile.ocm.types import OCMSpec
 from reconcile.utils.constants import PROJ_ROOT
 from reconcile.utils.jobcontroller.controller import K8sJobController
 from reconcile.utils.jobcontroller.models import JobConcurrencyPolicy, JobStatus
-from reconcile.utils.ocm_base_client import OCMBaseClient
 from reconcile.utils.rosa.rosa_cli import (
     LogHandle,
     RosaCliError,
     RosaCliResult,
     RosaJob,
 )
+
+if TYPE_CHECKING:
+    from reconcile.ocm.types import OCMSpec
+    from reconcile.utils.ocm_base_client import OCMBaseClient
 
 
 class RosaSessionBuilder(BaseModel, arbitrary_types_allowed=True):

--- a/reconcile/utils/runtime/integration.py
+++ b/reconcile/utils/runtime/integration.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import functools
 import os
 from abc import (
@@ -9,7 +11,6 @@ from dataclasses import dataclass
 from types import ModuleType
 from typing import (
     Any,
-    Optional,
     Self,
     TypeVar,
 )
@@ -139,7 +140,7 @@ class NoParams(RunParams):
     A `RunParams` instance that does not contain any parameters.
     """
 
-    def copy_and_update(self, update: dict[str, Any]) -> "NoParams":
+    def copy_and_update(self, update: dict[str, Any]) -> NoParams:
         return NoParams()
 
     def get(self, field: str) -> None:
@@ -189,7 +190,7 @@ class QontractReconcileIntegration[RunParamsTypeVar: RunParams](ABC):
         """
         return None
 
-    def get_desired_state_shard_config(self) -> Optional["DesiredStateShardConfig"]:
+    def get_desired_state_shard_config(self) -> DesiredStateShardConfig | None:
         """
         An integration that wants to support sharded dry-runs on its desired state
         must implement this method and return a `DesiredStateShardConfig` instance.
@@ -350,7 +351,7 @@ class ModuleArgsKwargsRunParams(RunParams):
         self.args = args
         self.kwargs = kwargs
 
-    def copy_and_update(self, update: dict[str, Any]) -> "ModuleArgsKwargsRunParams":
+    def copy_and_update(self, update: dict[str, Any]) -> ModuleArgsKwargsRunParams:
         kwargs_copy = self.kwargs.copy()
         kwargs_copy.update(update)
         return ModuleArgsKwargsRunParams(self.module, *self.args, **kwargs_copy)
@@ -397,7 +398,7 @@ class ModuleBasedQontractReconcileIntegration(
             )
         return None
 
-    def get_desired_state_shard_config(self) -> Optional["DesiredStateShardConfig"]:
+    def get_desired_state_shard_config(self) -> DesiredStateShardConfig | None:
         if self._integration_supports(DESIRED_STATE_SHARD_CONFIG_FUNCTION):
             return self.params.module.desired_state_shard_config()
         return None

--- a/reconcile/utils/runtime/integration.py
+++ b/reconcile/utils/runtime/integration.py
@@ -6,6 +6,7 @@ from abc import (
     ABC,
     abstractmethod,
 )
+from collections.abc import Callable
 from dataclasses import dataclass
 from typing import (
     TYPE_CHECKING,
@@ -33,7 +34,6 @@ from reconcile.utils.secret_reader import (
 )
 
 if TYPE_CHECKING:
-    from collections.abc import Callable
     from types import ModuleType
 
 

--- a/reconcile/utils/runtime/integration.py
+++ b/reconcile/utils/runtime/integration.py
@@ -6,10 +6,9 @@ from abc import (
     ABC,
     abstractmethod,
 )
-from collections.abc import Callable
 from dataclasses import dataclass
-from types import ModuleType
 from typing import (
+    TYPE_CHECKING,
     Any,
     Self,
     TypeVar,
@@ -32,6 +31,10 @@ from reconcile.utils.secret_reader import (
     SecretReaderBase,
     create_secret_reader,
 )
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+    from types import ModuleType
 
 
 @dataclass

--- a/reconcile/utils/saasherder/models.py
+++ b/reconcile/utils/saasherder/models.py
@@ -10,10 +10,6 @@ from typing import TYPE_CHECKING, Any, NotRequired, TypedDict
 
 from pydantic import BaseModel, Field, model_validator
 
-from reconcile.gql_definitions.fragments.saas_slo_document import (
-    SLODocument,
-)
-from reconcile.utils.jenkins_api import JobBuildState
 from reconcile.utils.json import json_dumps
 from reconcile.utils.oc_connection_parameters import Cluster
 from reconcile.utils.saasherder.interfaces import (
@@ -27,10 +23,15 @@ from reconcile.utils.saasherder.interfaces import (
     SaasResourceTemplate,
     SaasResourceTemplateTarget,
 )
-from reconcile.utils.secret_reader import SecretReaderBase
 
 if TYPE_CHECKING:
     from github import Github
+
+    from reconcile.gql_definitions.fragments.saas_slo_document import (
+        SLODocument,
+    )
+    from reconcile.utils.jenkins_api import JobBuildState
+    from reconcile.utils.secret_reader import SecretReaderBase
 
 
 class Providers(Enum):

--- a/reconcile/utils/saasherder/models.py
+++ b/reconcile/utils/saasherder/models.py
@@ -1,12 +1,13 @@
+from __future__ import annotations
+
 import base64
 import json
 import logging
 from collections.abc import Iterable, Sequence
 from dataclasses import dataclass
 from enum import Enum
-from typing import Any, NotRequired, TypedDict
+from typing import TYPE_CHECKING, Any, NotRequired, TypedDict
 
-from github import Github
 from pydantic import BaseModel, Field, model_validator
 
 from reconcile.gql_definitions.fragments.saas_slo_document import (
@@ -27,6 +28,9 @@ from reconcile.utils.saasherder.interfaces import (
     SaasResourceTemplateTarget,
 )
 from reconcile.utils.secret_reader import SecretReaderBase
+
+if TYPE_CHECKING:
+    from github import Github
 
 
 class Providers(Enum):

--- a/reconcile/utils/saasherder/models.py
+++ b/reconcile/utils/saasherder/models.py
@@ -6,10 +6,15 @@ import logging
 from collections.abc import Iterable, Sequence
 from dataclasses import dataclass
 from enum import Enum
-from typing import TYPE_CHECKING, Any, NotRequired, TypedDict
+from typing import Any, NotRequired, TypedDict
 
+from github import Github
 from pydantic import BaseModel, Field, model_validator
 
+from reconcile.gql_definitions.fragments.saas_slo_document import (
+    SLODocument,
+)
+from reconcile.utils.jenkins_api import JobBuildState
 from reconcile.utils.json import json_dumps
 from reconcile.utils.oc_connection_parameters import Cluster
 from reconcile.utils.saasherder.interfaces import (
@@ -23,15 +28,7 @@ from reconcile.utils.saasherder.interfaces import (
     SaasResourceTemplate,
     SaasResourceTemplateTarget,
 )
-
-if TYPE_CHECKING:
-    from github import Github
-
-    from reconcile.gql_definitions.fragments.saas_slo_document import (
-        SLODocument,
-    )
-    from reconcile.utils.jenkins_api import JobBuildState
-    from reconcile.utils.secret_reader import SecretReaderBase
+from reconcile.utils.secret_reader import SecretReaderBase
 
 
 class Providers(Enum):

--- a/reconcile/utils/saasherder/saasherder.py
+++ b/reconcile/utils/saasherder/saasherder.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import base64
 import hashlib
 import itertools
@@ -204,11 +206,7 @@ class SaasHerder:
 
     def __iter__(
         self,
-    ) -> Generator[
-        tuple[SaasFile, SaasResourceTemplate, SaasResourceTemplateTarget],
-        None,
-        None,
-    ]:
+    ) -> Generator[tuple[SaasFile, SaasResourceTemplate, SaasResourceTemplateTarget]]:
         for saas_file in self.saas_files:
             for resource_template in saas_file.resource_templates:
                 for target in resource_template.targets:

--- a/reconcile/utils/saasherder/saasherder.py
+++ b/reconcile/utils/saasherder/saasherder.py
@@ -10,17 +10,9 @@ import re
 from collections import (
     defaultdict,
 )
-from collections.abc import (
-    Generator,
-    Iterable,
-    Mapping,
-    MutableMapping,
-    Sequence,
-)
 from contextlib import suppress
 from datetime import datetime, timedelta
-from types import TracebackType
-from typing import Any, Self
+from typing import TYPE_CHECKING, Any, Self
 
 import yaml
 from github import (
@@ -41,9 +33,6 @@ from reconcile.status import RunningState
 from reconcile.utils import helm
 from reconcile.utils.datetime_util import utc_now
 from reconcile.utils.github_api import GithubRepositoryApi
-from reconcile.utils.gitlab_api import GitLabApi
-from reconcile.utils.jenkins_api import JenkinsApi, JobBuildState
-from reconcile.utils.jjb_client import JJB
 from reconcile.utils.json import json_dumps
 from reconcile.utils.oc import (
     OCLocal,
@@ -89,10 +78,24 @@ from reconcile.utils.saasherder.models import (
     TriggerTypes,
     UpstreamJob,
 )
-from reconcile.utils.secret_reader import SecretReaderBase
 from reconcile.utils.slo_document_manager import SLODetails, SLODocumentManager
-from reconcile.utils.state import State
 from reconcile.utils.vcs import VCS
+
+if TYPE_CHECKING:
+    from collections.abc import (
+        Generator,
+        Iterable,
+        Mapping,
+        MutableMapping,
+        Sequence,
+    )
+    from types import TracebackType
+
+    from reconcile.utils.gitlab_api import GitLabApi
+    from reconcile.utils.jenkins_api import JenkinsApi, JobBuildState
+    from reconcile.utils.jjb_client import JJB
+    from reconcile.utils.secret_reader import SecretReaderBase
+    from reconcile.utils.state import State
 
 TARGET_CONFIG_HASH = "target_config_hash"
 TEMPLATE_API_VERSION = "template.openshift.io/v1"

--- a/reconcile/utils/state.py
+++ b/reconcile/utils/state.py
@@ -419,7 +419,7 @@ class State:
     @contextlib.contextmanager
     def transaction(
         self, key: str, value: Any = None
-    ) -> Generator[TransactionStateObj, None, None]:
+    ) -> Generator[TransactionStateObj]:
         """Get a context manager to set the key in the state if no exception occurs.
 
         You can set the value either via the value parameter or by setting the value attribute of the returned object.

--- a/reconcile/utils/unleash/server.py
+++ b/reconcile/utils/unleash/server.py
@@ -1,9 +1,14 @@
-from enum import StrEnum
+from __future__ import annotations
 
-import requests
+from enum import StrEnum
+from typing import TYPE_CHECKING
+
 from pydantic import BaseModel, Field
 
 from reconcile.utils.rest_api_base import ApiBase, BearerTokenAuth
+
+if TYPE_CHECKING:
+    import requests
 
 
 class FeatureToggleType(StrEnum):

--- a/tools/saas_metrics_exporter/commit_distance/channel.py
+++ b/tools/saas_metrics_exporter/commit_distance/channel.py
@@ -3,11 +3,12 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
+from reconcile.utils.secret_reader import HasSecret
+
 if TYPE_CHECKING:
     from collections.abc import Iterable
 
     from reconcile.typed_queries.saas_files import SaasFile
-    from reconcile.utils.secret_reader import HasSecret
 
 
 @dataclass


### PR DESCRIPTION
## Summary

- Moves third-party (TC002), first-party (TC001), and stdlib (TC003) imports that are used exclusively in type annotations into `if TYPE_CHECKING:` blocks across ~300 files
- Adds `from __future__ import annotations` where needed so annotations remain deferred at runtime on Python 3.12
- Fixes three importers that were accessing symbols via module re-exports that were moved to TYPE_CHECKING: `Approver` (change_owners), `ExternalResourcesSettingsV1` (external_resources), and `Organization` (github_org test)

## Test plan

- [x] `uv run ruff check --no-fix` passes with no errors
- [x] `uv run mypy` passes with no issues
- [x] `uv run pytest reconcile/test/` — 3613 passed, 104 xfailed

🤖 Generated with [Claude Code](https://claude.com/claude-code)