### PR TITLE
Fix S3 gateway VPC endpoint route table association for cluster VPCs

### DIFF
--- a/reconcile/test/utils/test_terrascript_aws_client.py
+++ b/reconcile/test/utils/test_terrascript_aws_client.py
@@ -13,6 +13,7 @@ from terrascript.resource import (
     aws_s3_bucket_policy,
 )
 
+from reconcile.gql_definitions.fragments.aws_vpc_request import VPCRequest
 from reconcile.terraform_tgw_attachments import (
     Accepter,
     ClusterAccountProviderInfo,
@@ -2044,3 +2045,67 @@ def test_populate_tgw_attachments_unique_sg_rule_ids_per_cluster(
     assert len(set(sg_rule_ids)) == len(sg_rule_ids), (
         "Security group rule IDs must be unique"
     )
+
+
+def test_populate_vpc_requests_s3_gateway_endpoint_route_tables(
+    mocker: MockerFixture,
+    ts: TerrascriptClient,
+    gql_class_factory: Any,
+) -> None:
+    """S3 gateway endpoints must associate private route tables, not tag them."""
+    mocked_add_resource = mocker.patch.object(ts, "add_resource")
+    vpc_request = gql_class_factory(
+        VPCRequest,
+        {
+            "identifier": "cluster-vpc",
+            "delete": False,
+            "account": {
+                "name": "cluster-account",
+                "uid": "123456789012",
+                "terraformUsername": None,
+                "automationToken": {
+                    "path": "path",
+                    "field": "field",
+                    "version": None,
+                    "format": None,
+                },
+                "disable": None,
+                "supportedDeploymentRegions": ["us-east-1"],
+                "resourcesDefaultRegion": "us-east-1",
+                "providerVersion": "5.7.1",
+                "terraformState": None,
+                "enableDeletion": None,
+                "deletionApprovals": None,
+                "organization": None,
+            },
+            "region": "us-east-1",
+            "cidr_block": {"networkAddress": "10.0.0.0/16"},
+            "vpc_tags": None,
+            "subnets": {
+                "private": ["10.0.1.0/24", "10.0.2.0/24"],
+                "public": ["10.0.101.0/24", "10.0.102.0/24"],
+                "availability_zones": ["us-east-1a", "us-east-1b"],
+                "private_subnet_tags": None,
+                "public_subnet_tags": None,
+            },
+        },
+    )
+
+    ts.populate_vpc_requests([vpc_request], "5.7.1")
+
+    endpoint_modules = [
+        call.args[1]
+        for call in mocked_add_resource.call_args_list
+        if call.args[1]._name == "cluster-vpc-endpoint"
+    ]
+    assert len(endpoint_modules) == 1
+    endpoint_module = endpoint_modules[0]
+    s3_endpoint = endpoint_module["endpoints"]["s3"]
+
+    assert s3_endpoint["service_type"] == "Gateway"
+    assert (
+        s3_endpoint["route_table_ids"]
+        == "${module.cluster-vpc.private_route_table_ids}"
+    )
+    assert "route_table_ids" not in s3_endpoint["tags"]
+    assert s3_endpoint["tags"]["Name"] == "cluster-vpc--vpce-s3"

--- a/reconcile/utils/terrascript_aws_client.py
+++ b/reconcile/utils/terrascript_aws_client.py
@@ -1371,11 +1371,11 @@ class TerrascriptClient:
                 "endpoints": {
                     "s3": {
                         "service": "s3",
-                        "serivce_type": "Gateway",
+                        "service_type": "Gateway",
+                        "route_table_ids": f"${{{vpc_module.private_route_table_ids}}}",
                         "tags": {
                             "managed_by_integration": self.integration,
                             "Name": f"{request.identifier}--vpce-s3",
-                            "route_table_ids": vpc_module.vpc.private_route_table_ids,
                         },
                     }
                 },


### PR DESCRIPTION
## Summary
- Fix `service_type` typo so S3 endpoints are created as Gateway endpoints instead of defaulting to Interface.
- Move `route_table_ids` out of `tags` and reference `module.<vpc>.private_route_table_ids` so private route tables get S3 prefix-list routes.
- Wrap `route_table_ids` in `${...}` interpolation so Terrascript emits a Terraform list expression instead of a plain string (fixes plan error: "set of string required").

## Test plan
- [x] `uv run pytest reconcile/test/utils/test_terrascript_aws_client.py::test_populate_vpc_requests_s3_gateway_endpoint_route_tables -xvs`
- [x] Manual `terraform init` + `terraform plan` for `appsres11ue1` shows 3 private route tables associated with the S3 gateway endpoint
- [ ] Apply in prod and confirm S3 prefix-list routes appear in private route tables


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected S3 VPC endpoint configuration to properly place route table IDs outside of tags, ensuring they reference the VPC module's private route table outputs correctly.

* **Tests**
  * Added test coverage for S3 Gateway endpoint configuration with private route tables.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->