### PR TITLE
fix: fail in case tekton timoeut invalid

### DIFF
--- a/reconcile/openshift_saas_deploy.py
+++ b/reconcile/openshift_saas_deploy.py
@@ -284,14 +284,10 @@ def run(
         sys.exit(ExitCodes.SUCCESS)
 
     # check enable_init_projects flag status
-    # enable_init_projects = get_feature_toggle_state(
-    #     "enable_init_projects",
-    #     default=False,
-    # )
-    enable_init_projects = False
-    print("*******enable_init_projects*****")
-    print(enable_init_projects)
-    print("*******enable_init_projects*****")
+    enable_init_projects = get_feature_toggle_state(
+        "enable_init_projects",
+        default=False,
+    )
     ri, oc_map = ob.fetch_current_state(
         namespaces=[ns.model_dump(by_alias=True) for ns in saasherder.namespaces],
         thread_pool_size=thread_pool_size,

--- a/reconcile/openshift_saas_deploy.py
+++ b/reconcile/openshift_saas_deploy.py
@@ -284,10 +284,14 @@ def run(
         sys.exit(ExitCodes.SUCCESS)
 
     # check enable_init_projects flag status
-    enable_init_projects = get_feature_toggle_state(
-        "enable_init_projects",
-        default=False,
-    )
+    # enable_init_projects = get_feature_toggle_state(
+    #     "enable_init_projects",
+    #     default=False,
+    # )
+    enable_init_projects = False
+    print("*******enable_init_projects*****")
+    print(enable_init_projects)
+    print("*******enable_init_projects*****")
     ri, oc_map = ob.fetch_current_state(
         namespaces=[ns.model_dump(by_alias=True) for ns in saasherder.namespaces],
         thread_pool_size=thread_pool_size,

--- a/reconcile/openshift_saas_deploy_trigger_base.py
+++ b/reconcile/openshift_saas_deploy_trigger_base.py
@@ -50,6 +50,18 @@ class TektonTimeoutBadValueError(Exception):
     pass
 
 
+def _validate_tekton_timeout(
+    saas_file_name: str, env_name: str, timeout: str | None
+) -> None:
+    if not timeout:
+        return
+    seconds = dhms_to_seconds(timeout)
+    if seconds < 3600:  # 1 hour
+        raise TektonTimeoutBadValueError(
+            f"[{saas_file_name}/{env_name}] timeout {timeout} is smaller than 60 minutes"
+        )
+
+
 @defer
 def run(
     dry_run: bool,
@@ -267,19 +279,23 @@ def _trigger_tekton(
         )
         return False
 
-    tkn_trigger_resource, tkn_name = _construct_tekton_trigger_resource(
-        spec.saas_file_name,
-        spec.env_name,
-        tkn_pipeline_name,
-        spec.timeout,
-        tkn_cluster_console_url,
-        tkn_namespace_name,
-        integration,
-        integration_version,
-        saasherder.include_trigger_trace,
-        spec.reason,
-        spec.target_ref,
-    )
+    try:
+        tkn_trigger_resource, tkn_name = _construct_tekton_trigger_resource(
+            spec.saas_file_name,
+            spec.env_name,
+            tkn_pipeline_name,
+            spec.timeout,
+            tkn_cluster_console_url,
+            tkn_namespace_name,
+            integration,
+            integration_version,
+            saasherder.include_trigger_trace,
+            spec.reason,
+            spec.target_ref,
+        )
+    except TektonTimeoutBadValueError as e:
+        logging.error(str(e))
+        return True
 
     error = False
     to_trigger = _register_trigger(tkn_name, already_triggered)
@@ -397,13 +413,8 @@ def _construct_tekton_trigger_resource(
         },
     }
 
+    _validate_tekton_timeout(saas_file_name, env_name, timeout)
     if timeout:
-        seconds = dhms_to_seconds(timeout)
-        if seconds < 3600:  # 1 hour
-            raise TektonTimeoutBadValueError(
-                f"timeout {timeout} is smaller than 60 minutes"
-            )
-
         body["spec"]["timeouts"] = {
             "pipeline": "0",
             "tasks": timeout,


### PR DESCRIPTION
When a saas file has timeout set below 60 minutes (e.g. 30m0s), trigger-configs previously raised TektonTimeoutBadValueError as an uncaught exception inside threaded.run, producing a noisy traceback and making it hard to see which saas file/env failed.

This change catches that error in _trigger_tekton, logs a clear message including saas_file_name and env_name, and returns error=True so the integration exits with a non-zero status through the normal failure path.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened Tekton pipeline timeout validation with stricter minimum duration requirements.
  * Improved error handling and logging for timeout configuration issues.

* **Refactor**
  * Optimized timeout validation logic for better maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->