### PR TITLE
Enforce minimum OMM group size of 3

### DIFF
--- a/reconcile/gitlab_housekeeping.py
+++ b/reconcile/gitlab_housekeeping.py
@@ -82,6 +82,7 @@ HOLD_LABELS = [
 ERROR_LABELS = [MERGE_ERROR, PIPELINE_ERROR]
 
 TENANT_LABEL_PREFIX = "tenant-"
+MIN_OMM_GROUP_SIZE = 3  # 1 lead + 2 pending MRs
 
 QONTRACT_INTEGRATION = "gitlab-housekeeping"
 EXPIRATION_DATE_FORMAT = "%Y-%m-%d"
@@ -1405,7 +1406,7 @@ def merge_merge_requests(
                     merge_requests=merge_requests,
                     merged_labels=merged_labels,
                 )
-                if candidates:
+                if len(candidates) >= MIN_OMM_GROUP_SIZE - 1:  # -1 for the lead
                     apply_omm_group_lead(dry_run, gl, mr)
                     apply_omm_pending(dry_run, gl, candidates)
             break

--- a/reconcile/test/test_gitlab_housekeeping.py
+++ b/reconcile/test/test_gitlab_housekeeping.py
@@ -1861,7 +1861,8 @@ def test_multi_merge_two_non_overlapping_tenants(
 ) -> None:
     mr1 = _make_merge_mr(10, ["approved", "tenant-foo"])
     mr2 = _make_merge_mr(11, ["approved", "tenant-bar"])
-    items = [_make_merge_item(mr1), _make_merge_item(mr2)]
+    mr3 = _make_merge_mr(12, ["approved", "tenant-baz"])
+    items = [_make_merge_item(mr1), _make_merge_item(mr2), _make_merge_item(mr3)]
 
     _call_merge(
         mocker,
@@ -1871,12 +1872,15 @@ def test_multi_merge_two_non_overlapping_tenants(
         pipelines_by_iid={
             10: [_success_pipeline()],
             11: [_success_pipeline()],
+            12: [_success_pipeline()],
         },
     )
 
     mr1.merge.assert_called_once()
     mr2.merge.assert_not_called()
     mr2.rebase.assert_called_once_with(skip_ci=True)
+    mr3.merge.assert_not_called()
+    mr3.rebase.assert_called_once_with(skip_ci=True)
 
 
 def test_multi_merge_overlapping_tenants_serialized(
@@ -1899,6 +1903,33 @@ def test_multi_merge_overlapping_tenants_serialized(
 
     mr1.merge.assert_called_once()
     mr2.merge.assert_not_called()
+
+
+def test_multi_merge_below_min_group_size_no_omm(
+    mocker: MockerFixture,
+) -> None:
+    """With only 1 non-overlapping candidate, group size < MIN_OMM_GROUP_SIZE
+    so no OMM group should form."""
+    mr1 = _make_merge_mr(10, ["approved", "tenant-foo"])
+    mr2 = _make_merge_mr(11, ["approved", "tenant-bar"])
+    items = [_make_merge_item(mr1), _make_merge_item(mr2)]
+
+    mocked_gl = _call_merge(
+        mocker,
+        items,
+        rebase=True,
+        rebased_iids={10},
+        pipelines_by_iid={
+            10: [_success_pipeline()],
+            11: [_success_pipeline()],
+        },
+    )
+
+    mr1.merge.assert_called_once()
+    mr2.merge.assert_not_called()
+    mr2.rebase.assert_not_called()
+    for call in mocked_gl.add_label_to_merge_request.call_args_list:
+        assert call.args[1] not in {"omm-group-lead", "omm-pending"}
 
 
 def test_multi_merge_no_tenant_labels_falls_back_serial(
@@ -1979,8 +2010,9 @@ def test_multi_merge_skip_ci_rebase_failure_handled(
 ) -> None:
     mr1 = _make_merge_mr(10, ["approved", "tenant-foo"])
     mr2 = _make_merge_mr(11, ["approved", "tenant-bar"])
+    mr3 = _make_merge_mr(12, ["approved", "tenant-baz"])
     mr2.rebase.side_effect = GitlabMRRebaseError("rebase conflict")
-    items = [_make_merge_item(mr1), _make_merge_item(mr2)]
+    items = [_make_merge_item(mr1), _make_merge_item(mr2), _make_merge_item(mr3)]
 
     mocked_gl = _call_merge(
         mocker,
@@ -1990,6 +2022,7 @@ def test_multi_merge_skip_ci_rebase_failure_handled(
         pipelines_by_iid={
             10: [_success_pipeline()],
             11: [_success_pipeline()],
+            12: [_success_pipeline()],
         },
     )
 


### PR DESCRIPTION
## Summary
Enforce minimum OMM group size of 3
Adds a minimum group size requirement for optimistic multi-merge (OMM) groups. A group is now only formed when there are at least 2 pending candidates in addition to the lead MR (total size >= 3).

This avoids creating an OMM group for a single pending MR where the overhead of group management (labeling, window tracking, CI checks) isn't justified over regular serial merging.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enforced minimum group size requirement for merge request coordination workflows. The setup process now requires a lead plus at least two additional participants with pending merge requests before the workflow can begin.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->