### PR TITLE
filter SKIPPED pipelines to prevent deadlock after skip-ci rebases

### DIFF
--- a/reconcile/gitlab_housekeeping.py
+++ b/reconcile/gitlab_housekeeping.py
@@ -840,6 +840,7 @@ def _form_omm_group(
         if has_overlapping_labels(mr_labels, group_labels):
             continue
         pipelines = gl.get_merge_request_pipelines(mr)
+        pipelines = [p for p in pipelines if p.status != PipelineStatus.SKIPPED]
         if not pipelines:
             continue
         if pipelines[0].status not in {
@@ -951,6 +952,7 @@ def _rebase_merge_requests_active_cap(
     needs_rebase: list[ProjectMergeRequest] = []
     for mr in merge_requests:
         pipelines = gl.get_merge_request_pipelines(mr)
+        pipelines = [p for p in pipelines if p.status != PipelineStatus.SKIPPED]
         if is_rebased(mr, gl):
             if pipelines and pipelines[0].status in {
                 PipelineStatus.RUNNING,
@@ -1354,6 +1356,10 @@ def merge_merge_requests(
                     fork_project_id=mr.source_project_id,
                     pipelines=timed_out_pipelines,
                 )
+
+        pipelines = [p for p in pipelines if p.status != PipelineStatus.SKIPPED]
+        if not pipelines:
+            continue
 
         if wait_for_pipeline:
             running_pipelines = [

--- a/reconcile/test/test_gitlab_housekeeping.py
+++ b/reconcile/test/test_gitlab_housekeeping.py
@@ -2710,3 +2710,67 @@ def test_omm_group_unhandled_status_rebased_stays_active(
     assert merges == 0
     mr.merge.assert_not_called()
     clear_mock.assert_not_called()
+
+
+# --- Skipped pipeline filtering in serial merge and _form_omm_group ---
+
+
+def test_serial_merge_skipped_pipeline_filtered_merges_on_success(
+    mocker: MockerFixture,
+) -> None:
+    """After an OMM skip-ci rebase, the SKIPPED pipeline lands at pipelines[0].
+    The serial merge path should filter it out and merge on the SUCCESS pipeline."""
+    mr = _make_merge_mr(10, ["approved", "tenant-foo"])
+    items = [_make_merge_item(mr)]
+
+    _call_merge(
+        mocker,
+        items,
+        rebase=True,
+        rebased_iids={10},
+        pipelines_by_iid={
+            10: [_skipped_pipeline(), _success_pipeline()],
+        },
+    )
+
+    mr.merge.assert_called_once()
+
+
+def test_serial_merge_all_skipped_pipelines_skips_mr(
+    mocker: MockerFixture,
+) -> None:
+    """When all pipelines are SKIPPED, the serial merge path should skip the MR
+    (no merge, no crash) rather than blocking on the SKIPPED status."""
+    mr = _make_merge_mr(10, ["approved", "tenant-foo"])
+    items = [_make_merge_item(mr)]
+
+    _call_merge(
+        mocker,
+        items,
+        rebase=True,
+        rebased_iids={10},
+        pipelines_by_iid={
+            10: [_skipped_pipeline(), _skipped_pipeline()],
+        },
+    )
+
+    mr.merge.assert_not_called()
+
+
+def test_form_omm_group_skipped_pipeline_filtered_includes_candidate(
+    mocker: MockerFixture,
+) -> None:
+    """_form_omm_group should filter SKIPPED pipelines and include an MR
+    whose underlying pipeline is SUCCESS."""
+    mr = _make_merge_mr(10, ["approved", "tenant-foo"])
+    items = [_make_merge_item(mr)]
+
+    mocked_gl = create_autospec(GitLabApi)
+    mocked_gl.get_merge_request_pipelines.return_value = [
+        _skipped_pipeline(),
+        _success_pipeline(),
+    ]
+
+    candidates = gl_h._form_omm_group(mocked_gl, items, set())
+
+    assert candidates == [mr]


### PR DESCRIPTION
## Problem

When OMM rebases an MR with `skip_ci=True`, GitLab creates a SKIPPED `merge_request_event` pipeline. `get_merge_request_pipelines` sorts by `created_at` descending, so this SKIPPED pipeline lands at `pipelines[0]` (it's the most recent action on the MR).

Slack Thread: https://redhat-internal.slack.com/archives/CCRND57FW/p1781546583668859

If the OMM window expires and the system falls back to serial merging:

1. The MR is still rebased (the skip-ci rebase brought it up to date)
2. The rebase loop sees `is_rebased = True` → skips it (no new CI pipeline created)
3. Serial merge checks `pipelines[0].status` → SKIPPED ≠ SUCCESS → `continue`
4. **Deadlock**: the MR is rebased but can't merge, and nothing triggers a new pipeline

The MR stays stuck until an external event (another merge, manual push) moves the target branch and forces a re-rebase with CI. Prerequisites confirmed on MR 192584, where a user identified SKIPPED pipelines at the top of the pipeline list and force-merged to unblock.

## Fix

Filter SKIPPED pipelines in three code paths that access `pipelines[0]` without accounting for skip-ci rebases:

1. **Serial merge path** (primary fix): filter after pipeline timeout handling, before `wait_for_pipeline` and the `pipelines[0].status == SUCCESS` check. If all pipelines are SKIPPED, the MR is skipped gracefully.

2. **Rebase eligibility** (`_rebase_merge_requests_active_cap`): filter before checking if a rebased MR counts as `already_active`. Without this, a SKIPPED pipeline at `pipelines[0]` would make the MR not count as active, consuming an extra rebase slot.

3. **`_form_omm_group` candidate selection**: filter before checking `pipelines[0].status`. Without this, an MR with a SKIPPED pipeline at position 0 would be excluded from future OMM groups even though it has a valid pipeline behind it.

All three use the same one-liner already established in `_process_omm_group` (line 1135):

```python
pipelines = [p for p in pipelines if p.status != PipelineStatus.SKIPPED]
```

## Note on scope

The filter removes all SKIPPED pipelines regardless of source, consistent with the existing filter in `_process_omm_group` (line 1135).

## Tests

- `test_serial_merge_skipped_pipeline_filtered_merges_on_success`: `[SKIPPED, SUCCESS]` → merges
- `test_serial_merge_all_skipped_pipelines_skips_mr`: `[SKIPPED, SKIPPED]` → skipped gracefully
- `test_form_omm_group_skipped_pipeline_filtered_includes_candidate`: `[SKIPPED, SUCCESS]` → included as candidate

Generated By Claude