### PR TITLE
fix(terrascript): skip disabled ES log types instead of passing empty ARN

### DIFF
--- a/reconcile/utils/terrascript_aws_client.py
+++ b/reconcile/utils/terrascript_aws_client.py
@@ -4797,11 +4797,6 @@ class TerrascriptClient:
         for t in ElasticSearchLogGroupType:
             log_type = t.value
             if log_type not in publish_log_types:
-                publishing_options.append({
-                    "log_type": log_type,
-                    "enabled": False,
-                    "cloudwatch_log_group_arn": "",
-                })
                 continue
 
             log_type_identifier = TerrascriptClient.elasticsearch_log_group_identifier(


### PR DESCRIPTION
## Problem

When `publish_log_types` is not configured for an Elasticsearch resource,
`_get_tf_resource_elasticsearch_log_groups` generates `log_publishing_options`
entries for all three log types with `enabled=false` and
`cloudwatch_log_group_arn=""`.

The Terraform AWS provider passes these to the AWS API, which rejects the
empty ARN during new domain **creation** with:

```
ValidationException: The CloudWatch Logs ARN referring to the log group
for logging your SEARCH_SLOW_LOGS logs is invalid.
Please specify a valid ARN.
```

Existing domains are unaffected because AWS only validates the ARN strictly
on CREATE, not on UPDATE of an already-existing domain.

## History

The empty-ARN workaround was introduced in #2606 to fix a Terraform AWS
provider bug ([hashicorp/terraform-provider-aws#5752](https://github.com/hashicorp/terraform-provider-aws/issues/5752)):
removing `log_publishing_options` blocks entirely caused Terraform to show
a continuous spurious update diff on v5.x of the provider.

That provider bug was fixed in **Terraform AWS provider v6.1.0**.

## ⚠️ Prerequisite

**This PR must not be merged until the Terraform AWS provider is upgraded
to v6.1.0 or later.** On v5.x, removing the disabled entries from the
generated config will cause existing ES domains to show a continuous
spurious diff every reconcile cycle — the exact regression #2606 was
fixing.

Once the provider is on v6.1.0+, this fix is safe:
- New domain CREATE: no empty ARNs sent to AWS → passes validation
- Existing domains: one-time diff to remove disabled entries, then stable

## Fix

Skip disabled log types entirely instead of emitting entries with empty ARNs.

https://issues.redhat.com/browse/APPSRE-14663