### PR TITLE
fix: filter post-rebase fork pipelines in OMM group to avoid CI wait

### DIFF
--- a/reconcile/gitlab_housekeeping.py
+++ b/reconcile/gitlab_housekeeping.py
@@ -1099,18 +1099,23 @@ def _process_omm_group(
 
         # skip_ci=True rebase causes GitLab to create a "skipped" pipeline;
         # filter these out so the real (pre-rebase) pipeline drives decisions.
-        # Also filter post-rebase fork pipelines: a skip-ci rebase pushes a
-        # new commit to the fork, which can trigger CI there.  We keep fork
-        # pipelines for the *old* SHA (pre-rebase CI results) but discard
-        # those matching the current MR HEAD (post-rebase noise).
-        pipelines = [
-            p for p in pipelines
-            if p.status != PipelineStatus.SKIPPED
-            and not (p.project_id != gl.project.id and p.sha == mr.sha)
-        ]
+        pipelines = [p for p in pipelines if p.status != PipelineStatus.SKIPPED]
+
+        mr_is_rebased = is_rebased(mr, gl)
+
+        # After a skip-ci rebase the fork may start its own CI for the new
+        # commit.  Filter those post-rebase fork pipelines only when the MR
+        # is already rebased — for non-rebased MRs the current-HEAD fork
+        # pipeline is the real CI result we need.
+        if mr_is_rebased:
+            pipelines = [
+                p
+                for p in pipelines
+                if not (p.project_id != gl.project.id and p.sha == mr.sha)
+            ]
 
         if not pipelines:
-            if is_rebased(mr, gl):
+            if mr_is_rebased:
                 logging.info([
                     "omm-group",
                     "no-pipelines-rebased",
@@ -1135,7 +1140,7 @@ def _process_omm_group(
             ).inc()
             continue
 
-        if is_rebased(mr, gl):
+        if mr_is_rebased:
             if latest_status != PipelineStatus.SUCCESS:
                 if latest_status not in {
                     PipelineStatus.RUNNING,

--- a/reconcile/gitlab_housekeeping.py
+++ b/reconcile/gitlab_housekeeping.py
@@ -1099,7 +1099,15 @@ def _process_omm_group(
 
         # skip_ci=True rebase causes GitLab to create a "skipped" pipeline;
         # filter these out so the real (pre-rebase) pipeline drives decisions.
-        pipelines = [p for p in pipelines if p.status != PipelineStatus.SKIPPED]
+        # Also filter post-rebase fork pipelines: a skip-ci rebase pushes a
+        # new commit to the fork, which can trigger CI there.  We keep fork
+        # pipelines for the *old* SHA (pre-rebase CI results) but discard
+        # those matching the current MR HEAD (post-rebase noise).
+        pipelines = [
+            p for p in pipelines
+            if p.status != PipelineStatus.SKIPPED
+            and not (p.project_id != gl.project.id and p.sha == mr.sha)
+        ]
 
         if not pipelines:
             if is_rebased(mr, gl):
@@ -1136,6 +1144,14 @@ def _process_omm_group(
                     logging.info([
                         "omm-group",
                         "unhandled-status-rebased",
+                        gl.project.name,
+                        mr.iid,
+                        latest_status,
+                    ])
+                else:
+                    logging.info([
+                        "omm-group",
+                        "waiting-pipeline-rebased",
                         gl.project.name,
                         mr.iid,
                         latest_status,
@@ -1215,6 +1231,13 @@ def _process_omm_group(
             continue
 
         if latest_status in {PipelineStatus.RUNNING, PipelineStatus.PENDING}:
+            logging.info([
+                "omm-group",
+                "waiting-pipeline-not-rebased",
+                gl.project.name,
+                mr.iid,
+                latest_status,
+            ])
             any_active = True
             continue
 

--- a/reconcile/test/test_gitlab_housekeeping.py
+++ b/reconcile/test/test_gitlab_housekeeping.py
@@ -1727,6 +1727,7 @@ def _make_merge_mr(
     source_project_id: int = 3,
     squash: bool = False,
     author: str = "user",
+    sha: str | None = None,
 ) -> Mock:
     mr = create_autospec(ProjectMergeRequest)
     mr.iid = iid
@@ -1738,7 +1739,7 @@ def _make_merge_mr(
     mr.merge_status = "can_be_merged"
     mr.draft = False
     mr.commits.return_value = [create_autospec(ProjectCommit)]
-    mr.sha = f"sha-{iid}"
+    mr.sha = sha if sha is not None else f"sha-{iid}"
     mr.target_branch = "master"
     return mr
 
@@ -1824,12 +1825,22 @@ def _call_merge(
     return mocked_gl
 
 
-def _success_pipeline() -> Mock:
-    return create_autospec(ProjectMergeRequestPipeline, status="success")
+def _success_pipeline(
+    project_id: int = 1, sha: str = "pipeline-sha"
+) -> Mock:
+    p = create_autospec(ProjectMergeRequestPipeline, status="success")
+    p.project_id = project_id
+    p.sha = sha
+    return p
 
 
-def _running_pipeline() -> Mock:
-    return create_autospec(ProjectMergeRequestPipeline, status="running")
+def _running_pipeline(
+    project_id: int = 1, sha: str = "pipeline-sha"
+) -> Mock:
+    p = create_autospec(ProjectMergeRequestPipeline, status="running")
+    p.project_id = project_id
+    p.sha = sha
+    return p
 
 
 def test_multi_merge_two_non_overlapping_tenants(
@@ -2038,7 +2049,7 @@ def _make_omm_gl(*, head_sha: str = "abc123") -> Mock:
     """
     mocked_gl = create_autospec(GitLabApi)
     project = Mock()
-    project.id = "proj-1"
+    project.id = 1
     project.name = "test-project"
     project.squash_option = "never"
     branch_mock = Mock()
@@ -2567,8 +2578,13 @@ def test_multi_merge_disabled_single_merge_on_rebase(
 # --- OMM skipped pipeline handling tests ---
 
 
-def _skipped_pipeline() -> Mock:
-    return create_autospec(ProjectMergeRequestPipeline, status="skipped")
+def _skipped_pipeline(
+    project_id: int = 1, sha: str = "pipeline-sha"
+) -> Mock:
+    p = create_autospec(ProjectMergeRequestPipeline, status="skipped")
+    p.project_id = project_id
+    p.sha = sha
+    return p
 
 
 @pytest.mark.parametrize(
@@ -2669,8 +2685,13 @@ def test_omm_group_all_skipped_pipelines_rebased_stays_active(
     clear_mock.assert_not_called()
 
 
-def _canceled_pipeline() -> Mock:
-    return create_autospec(ProjectMergeRequestPipeline, status="canceled")
+def _canceled_pipeline(
+    project_id: int = 1, sha: str = "pipeline-sha"
+) -> Mock:
+    p = create_autospec(ProjectMergeRequestPipeline, status="canceled")
+    p.project_id = project_id
+    p.sha = sha
+    return p
 
 
 @pytest.mark.parametrize(
@@ -2718,6 +2739,130 @@ def test_omm_group_unhandled_status_rebased_stays_active(
 
     assert merges == 0
     mr.merge.assert_not_called()
+    clear_mock.assert_not_called()
+
+
+# --- Fork pipeline SHA filtering in OMM group ---
+
+
+@pytest.mark.parametrize(
+    "merge_sha, squash_sha",
+    [("abc123", None), (None, "abc123")],
+    ids=["merge-commit", "squash-commit"],
+)
+def test_omm_group_fork_pipeline_post_rebase_filtered_merges(
+    mocker: MockerFixture,
+    merge_sha: str | None,
+    squash_sha: str | None,
+) -> None:
+    """After skip-ci rebase, fork pipelines matching the new MR SHA are
+    filtered out.  The pre-rebase fork SUCCESS pipeline (old SHA) should
+    drive the merge decision."""
+    _setup_omm_group_mocks(mocker)
+    mocker.patch(
+        "reconcile.gitlab_housekeeping.is_rebased",
+        return_value=True,
+    )
+    mocker.patch(
+        "reconcile.gitlab_housekeeping.clear_omm_group",
+    )
+
+    lead = create_autospec(ProjectMergeRequest)
+    lead.merge_commit_sha = merge_sha
+    lead.squash_commit_sha = squash_sha
+    lead.target_branch = "master"
+
+    fork_id = 99
+    new_sha = "rebased-sha"
+    old_sha = "pre-rebase-sha"
+
+    mr = _make_merge_mr(
+        11,
+        ["approved", "tenant-bar", "omm-pending"],
+        source_project_id=fork_id,
+        sha=new_sha,
+    )
+
+    mocker.patch(
+        "reconcile.gitlab_housekeeping.get_omm_pending_mrs",
+        return_value=[mr],
+    )
+
+    mocked_gl = _make_omm_gl(head_sha="abc123")
+    mocked_gl.get_merge_request_pipelines.return_value = [
+        _running_pipeline(project_id=fork_id, sha=new_sha),
+        _success_pipeline(project_id=fork_id, sha=old_sha),
+    ]
+
+    merges = gl_h._process_omm_group(
+        dry_run=False,
+        gl=mocked_gl,
+        lead=lead,
+        app_sre_usernames=set(),
+    )
+
+    assert merges == 1
+    mr.merge.assert_called_once()
+
+
+@pytest.mark.parametrize(
+    "merge_sha, squash_sha",
+    [("abc123", None), (None, "abc123")],
+    ids=["merge-commit", "squash-commit"],
+)
+def test_omm_group_fork_pipeline_running_old_sha_waits(
+    mocker: MockerFixture,
+    merge_sha: str | None,
+    squash_sha: str | None,
+) -> None:
+    """A rebased fork MR whose real CI (old SHA) is still RUNNING should
+    wait.  The running fork pipeline is kept because its SHA differs from
+    mr.sha."""
+    _setup_omm_group_mocks(mocker)
+    mocker.patch(
+        "reconcile.gitlab_housekeeping.is_rebased",
+        return_value=True,
+    )
+    clear_mock = mocker.patch(
+        "reconcile.gitlab_housekeeping.clear_omm_group",
+    )
+
+    lead = create_autospec(ProjectMergeRequest)
+    lead.merge_commit_sha = merge_sha
+    lead.squash_commit_sha = squash_sha
+    lead.target_branch = "master"
+
+    fork_id = 99
+    new_sha = "rebased-sha"
+    old_sha = "pre-rebase-sha"
+
+    mr = _make_merge_mr(
+        11,
+        ["approved", "tenant-bar", "omm-pending"],
+        source_project_id=fork_id,
+        sha=new_sha,
+    )
+
+    mocker.patch(
+        "reconcile.gitlab_housekeeping.get_omm_pending_mrs",
+        return_value=[mr],
+    )
+
+    mocked_gl = _make_omm_gl(head_sha="abc123")
+    mocked_gl.get_merge_request_pipelines.return_value = [
+        _running_pipeline(project_id=fork_id, sha=old_sha),
+    ]
+
+    merges = gl_h._process_omm_group(
+        dry_run=False,
+        gl=mocked_gl,
+        lead=lead,
+        app_sre_usernames=set(),
+    )
+
+    assert merges == 0
+    mr.merge.assert_not_called()
+    mr.rebase.assert_not_called()
     clear_mock.assert_not_called()
 
 

--- a/reconcile/test/test_gitlab_housekeeping.py
+++ b/reconcile/test/test_gitlab_housekeeping.py
@@ -1825,18 +1825,14 @@ def _call_merge(
     return mocked_gl
 
 
-def _success_pipeline(
-    project_id: int = 1, sha: str = "pipeline-sha"
-) -> Mock:
+def _success_pipeline(project_id: int = 1, sha: str = "pipeline-sha") -> Mock:
     p = create_autospec(ProjectMergeRequestPipeline, status="success")
     p.project_id = project_id
     p.sha = sha
     return p
 
 
-def _running_pipeline(
-    project_id: int = 1, sha: str = "pipeline-sha"
-) -> Mock:
+def _running_pipeline(project_id: int = 1, sha: str = "pipeline-sha") -> Mock:
     p = create_autospec(ProjectMergeRequestPipeline, status="running")
     p.project_id = project_id
     p.sha = sha
@@ -2578,9 +2574,7 @@ def test_multi_merge_disabled_single_merge_on_rebase(
 # --- OMM skipped pipeline handling tests ---
 
 
-def _skipped_pipeline(
-    project_id: int = 1, sha: str = "pipeline-sha"
-) -> Mock:
+def _skipped_pipeline(project_id: int = 1, sha: str = "pipeline-sha") -> Mock:
     p = create_autospec(ProjectMergeRequestPipeline, status="skipped")
     p.project_id = project_id
     p.sha = sha
@@ -2685,9 +2679,7 @@ def test_omm_group_all_skipped_pipelines_rebased_stays_active(
     clear_mock.assert_not_called()
 
 
-def _canceled_pipeline(
-    project_id: int = 1, sha: str = "pipeline-sha"
-) -> Mock:
+def _canceled_pipeline(project_id: int = 1, sha: str = "pipeline-sha") -> Mock:
     p = create_autospec(ProjectMergeRequestPipeline, status="canceled")
     p.project_id = project_id
     p.sha = sha

--- a/reconcile/test/test_gitlab_housekeeping.py
+++ b/reconcile/test/test_gitlab_housekeeping.py
@@ -2802,6 +2802,65 @@ def test_omm_group_fork_pipeline_post_rebase_filtered_merges(
     [("abc123", None), (None, "abc123")],
     ids=["merge-commit", "squash-commit"],
 )
+def test_omm_group_fork_pipeline_not_rebased_triggers_skip_ci(
+    mocker: MockerFixture,
+    merge_sha: str | None,
+    squash_sha: str | None,
+) -> None:
+    """A non-rebased fork MR whose current-HEAD fork pipeline is SUCCESS
+    should trigger a skip-ci rebase.  The fork SHA filter must NOT discard
+    the pipeline when the MR is not yet rebased."""
+    _setup_omm_group_mocks(mocker)
+    mocker.patch(
+        "reconcile.gitlab_housekeeping.is_rebased",
+        return_value=False,
+    )
+    mocker.patch(
+        "reconcile.gitlab_housekeeping.clear_omm_group",
+    )
+
+    lead = create_autospec(ProjectMergeRequest)
+    lead.merge_commit_sha = merge_sha
+    lead.squash_commit_sha = squash_sha
+    lead.target_branch = "master"
+
+    fork_id = 99
+    current_sha = "current-head-sha"
+
+    mr = _make_merge_mr(
+        11,
+        ["approved", "tenant-bar", "omm-pending"],
+        source_project_id=fork_id,
+        sha=current_sha,
+    )
+
+    mocker.patch(
+        "reconcile.gitlab_housekeeping.get_omm_pending_mrs",
+        return_value=[mr],
+    )
+
+    mocked_gl = _make_omm_gl(head_sha="abc123")
+    mocked_gl.get_merge_request_pipelines.return_value = [
+        _success_pipeline(project_id=fork_id, sha=current_sha),
+    ]
+
+    merges = gl_h._process_omm_group(
+        dry_run=False,
+        gl=mocked_gl,
+        lead=lead,
+        app_sre_usernames=set(),
+    )
+
+    assert merges == 0
+    mr.merge.assert_not_called()
+    mr.rebase.assert_called_once_with(skip_ci=True)
+
+
+@pytest.mark.parametrize(
+    "merge_sha, squash_sha",
+    [("abc123", None), (None, "abc123")],
+    ids=["merge-commit", "squash-commit"],
+)
 def test_omm_group_fork_pipeline_running_old_sha_waits(
     mocker: MockerFixture,
     merge_sha: str | None,


### PR DESCRIPTION
### Problem

When `_process_omm_group` performs a `skip_ci=True` rebase on a fork-based MR, GitLab suppresses the MR-event pipeline on the target project but the fork repo's own CI fires a `push`-source pipeline on the new commit. Since `get_merge_request_pipelines` returns all pipelines (including fork ones), the code sees the fork's running pipeline and waits for it to complete (~8+ minutes per rebase), defeating the purpose of `skip_ci=True`.

Observed in production with MR 193109 (`jharting/app-interface` → `service/app-interface`): the skip-ci rebase at 14:15:42 triggered fork pipeline 16120963, causing the OMM group to wait for it instead of merging immediately on the pre-rebase SUCCESS result.

### Fix

Filter out fork pipelines whose SHA matches `mr.sha` (the current MR HEAD after rebase), **gated on the rebased state**. The filter only activates when `is_rebased` is True, so non-rebased MRs retain their current-HEAD fork pipeline for correct CI decisions.

```python
mr_is_rebased = is_rebased(mr, gl)

if mr_is_rebased:
    pipelines = [
        p for p in pipelines
        if not (p.project_id != gl.project.id and p.sha == mr.sha)
    ]
```

Without the gate, the filter would unconditionally remove the fork's current-SHA pipeline on the first OMM visit (before any rebase). This could permanently stall single-pipeline fork MRs (empty list, silent `continue`) or cause decisions to be driven by stale older pipelines instead of the current CI result.

The `is_rebased` result is computed once and reused in the later branching logic, replacing the two separate `is_rebased(mr, gl)` calls.

Non-fork MRs are completely unaffected since all their pipelines have `project_id == gl.project.id`.

### Testing

- `test_omm_group_fork_pipeline_post_rebase_filtered_merges` -- post-rebase fork pipeline is ignored, MR merges on pre-rebase SUCCESS
- `test_omm_group_fork_pipeline_running_old_sha_waits` -- fork pipeline with old SHA still running is kept, code correctly waits
- `test_omm_group_fork_pipeline_not_rebased_triggers_skip_ci` -- non-rebased fork MR's current-SHA pipeline is preserved and triggers skip-ci rebase