### PR TITLE
feat(gitlab-projects): reconcile sharedWithGroups on GitLab projects

### DIFF
--- a/reconcile/gitlab_projects.py
+++ b/reconcile/gitlab_projects.py
@@ -91,13 +91,14 @@ def run(dry_run: bool, defer: Callable | None = None) -> None:
                 if not dry_run:
                     gl.initiate_saas_bundle_repo(project_url)
 
-        if "sharedWithGroups" in pr:
+        shared_with_groups = pr.get("sharedWithGroups")
+        if shared_with_groups is not None:
             for p in requested_projects:
                 project_url = gl.get_project_url(group, p)
                 reconcile_project_shared_groups(
                     gl=gl,
                     project_url=project_url,
-                    shared_with_groups=pr["sharedWithGroups"],
+                    shared_with_groups=shared_with_groups,
                     dry_run=dry_run,
                 )
 

--- a/reconcile/gitlab_projects.py
+++ b/reconcile/gitlab_projects.py
@@ -1,13 +1,60 @@
 import logging
 import sys
 from collections.abc import Callable
+from operator import eq
 from typing import Any
+
+from qontract_utils.differ import diff_mappings
 
 from reconcile import queries
 from reconcile.utils.defer import defer
 from reconcile.utils.gitlab_api import GitLabApi
 
 QONTRACT_INTEGRATION = "gitlab-projects"
+
+
+def reconcile_project_shared_groups(
+    gl: GitLabApi,
+    project_url: str,
+    shared_with_groups: list[dict[str, str]],
+    dry_run: bool,
+) -> None:
+    desired = {
+        sg["group"]: gl.get_access_level(sg["accessLevel"])
+        for sg in shared_with_groups
+    }
+    project = gl.get_project(project_url)
+    if project is None:
+        for group_name, access_level in desired.items():
+            logging.info([
+                "share_project_with_group",
+                project_url,
+                group_name,
+                gl.get_access_level_string(access_level),
+            ])
+        return
+
+    current = gl.get_project_shared_groups(project)
+    diff_data = diff_mappings(
+        current=current,
+        desired=desired,
+        equal=eq,
+    )
+    for group_name, access_level in diff_data.add.items():
+        access = gl.get_access_level_string(access_level)
+        logging.info(["share_project_with_group", project_url, group_name, access])
+        if not dry_run:
+            gl.share_project_with_group(project, group_name, access)
+    for group_name in diff_data.delete:
+        logging.info(["unshare_project_from_group", project_url, group_name])
+        if not dry_run:
+            gl.unshare_project_from_group(project, group_name)
+    for group_name, diff_pair in diff_data.change.items():
+        access = gl.get_access_level_string(diff_pair.desired)
+        logging.info(["change_shared_group_access", project_url, group_name, access])
+        if not dry_run:
+            gl.unshare_project_from_group(project, group_name)
+            gl.share_project_with_group(project, group_name, access)
 
 
 @defer
@@ -43,6 +90,16 @@ def run(dry_run: bool, defer: Callable | None = None) -> None:
                 logging.info(["initiate_saas_bundle_repo", group, p])
                 if not dry_run:
                     gl.initiate_saas_bundle_repo(project_url)
+
+        if "sharedWithGroups" in pr:
+            for p in requested_projects:
+                project_url = gl.get_project_url(group, p)
+                reconcile_project_shared_groups(
+                    gl=gl,
+                    project_url=project_url,
+                    shared_with_groups=pr["sharedWithGroups"],
+                    dry_run=dry_run,
+                )
 
     sys.exit(error)
 

--- a/reconcile/gitlab_projects.py
+++ b/reconcile/gitlab_projects.py
@@ -20,8 +20,7 @@ def reconcile_project_shared_groups(
     dry_run: bool,
 ) -> None:
     desired = {
-        sg["group"]: gl.get_access_level(sg["accessLevel"])
-        for sg in shared_with_groups
+        sg["group"]: gl.get_access_level(sg["accessLevel"]) for sg in shared_with_groups
     }
     project = gl.get_project(project_url)
     if project is None:

--- a/reconcile/queries.py
+++ b/reconcile/queries.py
@@ -367,6 +367,10 @@ GITLAB_INSTANCES_QUERY = """
     projectRequests {
       group
       projects
+      sharedWithGroups {
+        group
+        accessLevel
+      }
     }
     sslVerify
   }

--- a/reconcile/test/test_gitlab_projects.py
+++ b/reconcile/test/test_gitlab_projects.py
@@ -56,6 +56,31 @@ def test_reconcile_project_shared_groups_dry_run_missing_project(
     assert "share_project_with_group" in caplog.text
 
 
+def test_run_skips_null_shared_with_groups(mocker: MockerFixture) -> None:
+    gl = create_autospec(GitLabApi)
+    gl.get_group_id_and_projects.return_value = ("1", {"existing-project"})
+    mocker.patch("reconcile.gitlab_projects.queries.get_gitlab_instance", return_value={
+        "projectRequests": [
+            {
+                "group": "service",
+                "projects": ["existing-project"],
+                "sharedWithGroups": None,
+            },
+        ],
+    })
+    mocker.patch("reconcile.gitlab_projects.queries.get_app_interface_settings", return_value={})
+    mocker.patch("reconcile.gitlab_projects.queries.get_code_components", return_value=[])
+    mocker.patch("reconcile.gitlab_projects.GitLabApi", return_value=gl)
+    reconcile_mock = mocker.patch(
+        "reconcile.gitlab_projects.reconcile_project_shared_groups"
+    )
+    mocker.patch("reconcile.gitlab_projects.sys.exit")
+
+    gitlab_projects.run(dry_run=True)
+
+    reconcile_mock.assert_not_called()
+
+
 def test_reconcile_project_shared_groups_unshare(mocker: MockerFixture) -> None:
     gl = create_autospec(GitLabApi)
     project = create_autospec(Project)

--- a/reconcile/test/test_gitlab_projects.py
+++ b/reconcile/test/test_gitlab_projects.py
@@ -1,0 +1,83 @@
+import logging
+from unittest.mock import create_autospec
+
+import pytest
+from gitlab.const import DEVELOPER_ACCESS
+from gitlab.v4.objects import Project
+from pytest_mock import MockerFixture
+
+from reconcile import gitlab_projects
+from reconcile.utils.gitlab_api import GitLabApi
+
+
+def test_reconcile_project_shared_groups_add(mocker: MockerFixture) -> None:
+    gl = create_autospec(GitLabApi)
+    project = create_autospec(Project)
+    project.shared_with_groups = []
+    gl.get_project.return_value = project
+    gl.get_access_level.return_value = DEVELOPER_ACCESS
+    gl.get_access_level_string.return_value = "developer"
+
+    gitlab_projects.reconcile_project_shared_groups(
+        gl=gl,
+        project_url="http://gitlab.example.com/service/my-project",
+        shared_with_groups=[
+            {"group": "argo-platform-admin", "accessLevel": "developer"},
+        ],
+        dry_run=False,
+    )
+
+    gl.get_access_level.assert_called_once_with("developer")
+    gl.share_project_with_group.assert_called_once_with(
+        project, "argo-platform-admin", "developer"
+    )
+
+
+def test_reconcile_project_shared_groups_dry_run_missing_project(
+    mocker: MockerFixture,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    gl = create_autospec(GitLabApi)
+    gl.get_project.return_value = None
+    gl.get_access_level.return_value = DEVELOPER_ACCESS
+    gl.get_access_level_string.return_value = "developer"
+
+    with caplog.at_level(logging.INFO):
+        gitlab_projects.reconcile_project_shared_groups(
+            gl=gl,
+            project_url="http://gitlab.example.com/service/my-project",
+            shared_with_groups=[
+                {"group": "argo-platform-admin", "accessLevel": "developer"},
+            ],
+            dry_run=True,
+        )
+
+    gl.share_project_with_group.assert_not_called()
+    assert "share_project_with_group" in caplog.text
+
+
+def test_reconcile_project_shared_groups_unshare(mocker: MockerFixture) -> None:
+    gl = create_autospec(GitLabApi)
+    project = create_autospec(Project)
+    project.shared_with_groups = [
+        {
+            "group_name": "argo-platform-admin",
+            "group_full_path": "argo-platform-admin",
+            "group_access_level": DEVELOPER_ACCESS,
+        },
+    ]
+    gl.get_project.return_value = project
+    gl.get_project_shared_groups.return_value = {
+        "argo-platform-admin": DEVELOPER_ACCESS,
+    }
+
+    gitlab_projects.reconcile_project_shared_groups(
+        gl=gl,
+        project_url="http://gitlab.example.com/service/my-project",
+        shared_with_groups=[],
+        dry_run=False,
+    )
+
+    gl.unshare_project_from_group.assert_called_once_with(
+        project, "argo-platform-admin"
+    )

--- a/reconcile/test/test_gitlab_projects.py
+++ b/reconcile/test/test_gitlab_projects.py
@@ -9,50 +9,88 @@ from pytest_mock import MockerFixture
 from reconcile import gitlab_projects
 from reconcile.utils.gitlab_api import GitLabApi
 
+PROJECT_URL = "http://gitlab.example.com/service/my-project"
+ARGO_PLATFORM_ADMIN_SHARE = [
+    {"group": "argo-platform-admin", "accessLevel": "developer"},
+]
 
-def test_reconcile_project_shared_groups_add(mocker: MockerFixture) -> None:
+
+@pytest.fixture
+def project_url() -> str:
+    return PROJECT_URL
+
+
+@pytest.fixture
+def argo_platform_admin_share() -> list[dict[str, str]]:
+    return list(ARGO_PLATFORM_ADMIN_SHARE)
+
+
+@pytest.fixture
+def mocked_gitlab_api() -> GitLabApi:
     gl = create_autospec(GitLabApi)
-    project = create_autospec(Project)
-    project.shared_with_groups = []
-    gl.get_project.return_value = project
     gl.get_access_level.return_value = DEVELOPER_ACCESS
     gl.get_access_level_string.return_value = "developer"
+    return gl
+
+
+@pytest.fixture
+def mocked_project() -> Project:
+    project = create_autospec(Project)
+    project.shared_with_groups = []
+    return project
+
+
+@pytest.fixture
+def mocked_project_with_argo_share() -> Project:
+    project = create_autospec(Project)
+    project.shared_with_groups = [
+        {
+            "group_name": "argo-platform-admin",
+            "group_full_path": "argo-platform-admin",
+            "group_access_level": DEVELOPER_ACCESS,
+        },
+    ]
+    return project
+
+
+def test_reconcile_project_shared_groups_add(
+    mocked_gitlab_api: GitLabApi,
+    mocked_project: Project,
+    project_url: str,
+    argo_platform_admin_share: list[dict[str, str]],
+) -> None:
+    mocked_gitlab_api.get_project.return_value = mocked_project
 
     gitlab_projects.reconcile_project_shared_groups(
-        gl=gl,
-        project_url="http://gitlab.example.com/service/my-project",
-        shared_with_groups=[
-            {"group": "argo-platform-admin", "accessLevel": "developer"},
-        ],
+        gl=mocked_gitlab_api,
+        project_url=project_url,
+        shared_with_groups=argo_platform_admin_share,
         dry_run=False,
     )
 
-    gl.get_access_level.assert_called_once_with("developer")
-    gl.share_project_with_group.assert_called_once_with(
-        project, "argo-platform-admin", "developer"
+    mocked_gitlab_api.get_access_level.assert_called_once_with("developer")
+    mocked_gitlab_api.share_project_with_group.assert_called_once_with(
+        mocked_project, "argo-platform-admin", "developer"
     )
 
 
 def test_reconcile_project_shared_groups_dry_run_missing_project(
-    mocker: MockerFixture,
+    mocked_gitlab_api: GitLabApi,
+    project_url: str,
+    argo_platform_admin_share: list[dict[str, str]],
     caplog: pytest.LogCaptureFixture,
 ) -> None:
-    gl = create_autospec(GitLabApi)
-    gl.get_project.return_value = None
-    gl.get_access_level.return_value = DEVELOPER_ACCESS
-    gl.get_access_level_string.return_value = "developer"
+    mocked_gitlab_api.get_project.return_value = None
 
     with caplog.at_level(logging.INFO):
         gitlab_projects.reconcile_project_shared_groups(
-            gl=gl,
-            project_url="http://gitlab.example.com/service/my-project",
-            shared_with_groups=[
-                {"group": "argo-platform-admin", "accessLevel": "developer"},
-            ],
+            gl=mocked_gitlab_api,
+            project_url=project_url,
+            shared_with_groups=argo_platform_admin_share,
             dry_run=True,
         )
 
-    gl.share_project_with_group.assert_not_called()
+    mocked_gitlab_api.share_project_with_group.assert_not_called()
     assert "share_project_with_group" in caplog.text
 
 
@@ -88,28 +126,23 @@ def test_run_skips_null_shared_with_groups(mocker: MockerFixture) -> None:
     reconcile_mock.assert_not_called()
 
 
-def test_reconcile_project_shared_groups_unshare(mocker: MockerFixture) -> None:
-    gl = create_autospec(GitLabApi)
-    project = create_autospec(Project)
-    project.shared_with_groups = [
-        {
-            "group_name": "argo-platform-admin",
-            "group_full_path": "argo-platform-admin",
-            "group_access_level": DEVELOPER_ACCESS,
-        },
-    ]
-    gl.get_project.return_value = project
-    gl.get_project_shared_groups.return_value = {
+def test_reconcile_project_shared_groups_unshare(
+    mocked_gitlab_api: GitLabApi,
+    mocked_project_with_argo_share: Project,
+    project_url: str,
+) -> None:
+    mocked_gitlab_api.get_project.return_value = mocked_project_with_argo_share
+    mocked_gitlab_api.get_project_shared_groups.return_value = {
         "argo-platform-admin": DEVELOPER_ACCESS,
     }
 
     gitlab_projects.reconcile_project_shared_groups(
-        gl=gl,
-        project_url="http://gitlab.example.com/service/my-project",
+        gl=mocked_gitlab_api,
+        project_url=project_url,
         shared_with_groups=[],
         dry_run=False,
     )
 
-    gl.unshare_project_from_group.assert_called_once_with(
-        project, "argo-platform-admin"
+    mocked_gitlab_api.unshare_project_from_group.assert_called_once_with(
+        mocked_project_with_argo_share, "argo-platform-admin"
     )

--- a/reconcile/test/test_gitlab_projects.py
+++ b/reconcile/test/test_gitlab_projects.py
@@ -59,17 +59,24 @@ def test_reconcile_project_shared_groups_dry_run_missing_project(
 def test_run_skips_null_shared_with_groups(mocker: MockerFixture) -> None:
     gl = create_autospec(GitLabApi)
     gl.get_group_id_and_projects.return_value = ("1", {"existing-project"})
-    mocker.patch("reconcile.gitlab_projects.queries.get_gitlab_instance", return_value={
-        "projectRequests": [
-            {
-                "group": "service",
-                "projects": ["existing-project"],
-                "sharedWithGroups": None,
-            },
-        ],
-    })
-    mocker.patch("reconcile.gitlab_projects.queries.get_app_interface_settings", return_value={})
-    mocker.patch("reconcile.gitlab_projects.queries.get_code_components", return_value=[])
+    mocker.patch(
+        "reconcile.gitlab_projects.queries.get_gitlab_instance",
+        return_value={
+            "projectRequests": [
+                {
+                    "group": "service",
+                    "projects": ["existing-project"],
+                    "sharedWithGroups": None,
+                },
+            ],
+        },
+    )
+    mocker.patch(
+        "reconcile.gitlab_projects.queries.get_app_interface_settings", return_value={}
+    )
+    mocker.patch(
+        "reconcile.gitlab_projects.queries.get_code_components", return_value=[]
+    )
     mocker.patch("reconcile.gitlab_projects.GitLabApi", return_value=gl)
     reconcile_mock = mocker.patch(
         "reconcile.gitlab_projects.reconcile_project_shared_groups"

--- a/reconcile/test/test_gitlab_projects.py
+++ b/reconcile/test/test_gitlab_projects.py
@@ -1,5 +1,5 @@
 import logging
-from unittest.mock import create_autospec
+from unittest.mock import Mock, create_autospec
 
 import pytest
 from gitlab.const import DEVELOPER_ACCESS
@@ -26,7 +26,7 @@ def argo_platform_admin_share() -> list[dict[str, str]]:
 
 
 @pytest.fixture
-def mocked_gitlab_api() -> GitLabApi:
+def mocked_gitlab_api() -> Mock:
     gl = create_autospec(GitLabApi)
     gl.get_access_level.return_value = DEVELOPER_ACCESS
     gl.get_access_level_string.return_value = "developer"
@@ -34,14 +34,14 @@ def mocked_gitlab_api() -> GitLabApi:
 
 
 @pytest.fixture
-def mocked_project() -> Project:
+def mocked_project() -> Mock:
     project = create_autospec(Project)
     project.shared_with_groups = []
     return project
 
 
 @pytest.fixture
-def mocked_project_with_argo_share() -> Project:
+def mocked_project_with_argo_share() -> Mock:
     project = create_autospec(Project)
     project.shared_with_groups = [
         {
@@ -54,8 +54,8 @@ def mocked_project_with_argo_share() -> Project:
 
 
 def test_reconcile_project_shared_groups_add(
-    mocked_gitlab_api: GitLabApi,
-    mocked_project: Project,
+    mocked_gitlab_api: Mock,
+    mocked_project: Mock,
     project_url: str,
     argo_platform_admin_share: list[dict[str, str]],
 ) -> None:
@@ -75,7 +75,7 @@ def test_reconcile_project_shared_groups_add(
 
 
 def test_reconcile_project_shared_groups_dry_run_missing_project(
-    mocked_gitlab_api: GitLabApi,
+    mocked_gitlab_api: Mock,
     project_url: str,
     argo_platform_admin_share: list[dict[str, str]],
     caplog: pytest.LogCaptureFixture,
@@ -127,8 +127,8 @@ def test_run_skips_null_shared_with_groups(mocker: MockerFixture) -> None:
 
 
 def test_reconcile_project_shared_groups_unshare(
-    mocked_gitlab_api: GitLabApi,
-    mocked_project_with_argo_share: Project,
+    mocked_gitlab_api: Mock,
+    mocked_project_with_argo_share: Mock,
     project_url: str,
 ) -> None:
     mocked_gitlab_api.get_project.return_value = mocked_project_with_argo_share

--- a/reconcile/test/utils/test_gitlab_api.py
+++ b/reconcile/test/utils/test_gitlab_api.py
@@ -7,6 +7,7 @@ from typing import TYPE_CHECKING, Any
 from unittest.mock import Mock, create_autospec
 
 import pytest
+from gitlab.const import DEVELOPER_ACCESS, MAINTAINER_ACCESS
 from gitlab.exceptions import GitlabGetError
 from gitlab.v4.objects import (
     CurrentUser,
@@ -542,6 +543,61 @@ def test_get_app_sre_group_users(
     assert members == expected_members
     mocked_gl.groups.get.assert_called_once_with("app-sre")
     mocked_group.members.list.assert_called_once_with(get_all=True)
+
+
+def test_get_project_shared_groups() -> None:
+    project = create_autospec(Project)
+    project.shared_with_groups = [
+        {
+            "group_id": 1,
+            "group_name": "argo-platform-admin",
+            "group_full_path": "argo-platform-admin",
+            "group_access_level": DEVELOPER_ACCESS,
+        },
+        {
+            "group_id": 2,
+            "group_name": "other-group",
+            "group_full_path": "parent/other-group",
+            "group_access_level": MAINTAINER_ACCESS,
+        },
+    ]
+
+    shared_groups = GitLabApi.get_project_shared_groups(project)
+
+    assert shared_groups == {
+        "argo-platform-admin": DEVELOPER_ACCESS,
+        "parent/other-group": MAINTAINER_ACCESS,
+    }
+
+
+def test_share_project_with_group(
+    mocked_gitlab_api: GitLabApi,
+    mocked_gl: Mock,
+) -> None:
+    project = create_autospec(Project)
+    group = create_autospec(Group, id="42")
+    mocked_gl.groups.get.return_value = group
+
+    mocked_gitlab_api.share_project_with_group(
+        project, "argo-platform-admin", "developer"
+    )
+
+    mocked_gl.groups.get.assert_called_once_with("argo-platform-admin")
+    project.share.assert_called_once_with("42", DEVELOPER_ACCESS)
+
+
+def test_unshare_project_from_group(
+    mocked_gitlab_api: GitLabApi,
+    mocked_gl: Mock,
+) -> None:
+    project = create_autospec(Project)
+    group = create_autospec(Group, id="42")
+    mocked_gl.groups.get.return_value = group
+
+    mocked_gitlab_api.unshare_project_from_group(project, "argo-platform-admin")
+
+    mocked_gl.groups.get.assert_called_once_with("argo-platform-admin")
+    project.unshare.assert_called_once_with("42")
 
 
 def test_get_group_id_and_projects(

--- a/reconcile/utils/gitlab_api.py
+++ b/reconcile/utils/gitlab_api.py
@@ -344,6 +344,24 @@ class GitLabApi:
     def get_project_url(self, group: str, project: str) -> str:
         return f"{self.server}/{group}/{project}"
 
+    @staticmethod
+    def get_project_shared_groups(project: Project) -> dict[str, int]:
+        result: dict[str, int] = {}
+        for shared in project.shared_with_groups or []:
+            group_path = shared.get("group_full_path") or shared["group_name"]
+            result[group_path] = shared["group_access_level"]
+        return result
+
+    def share_project_with_group(
+        self, project: Project, group_name: str, access: str
+    ) -> None:
+        group = self.get_group(group_name)
+        project.share(group.id, self.get_access_level(access))
+
+    def unshare_project_from_group(self, project: Project, group_name: str) -> None:
+        group = self.get_group(group_name)
+        project.unshare(group.id)
+
     @retry()
     def get_project(self, repo_url: str) -> Project | None:
         repo = repo_url.removeprefix(self.server).strip("/")


### PR DESCRIPTION
## Summary

- Extend `gitlab-projects` integration to reconcile `sharedWithGroups` from `projectRequests`
- Add `GitLabApi` methods for listing, sharing, and unsharing project groups
- Use `diff_mappings` for add/delete/access-level-change reconciliation
- Dry-run supported (logs actions without API mutations)
- Unit tests for API wrappers and reconcile logic

## Motivation

Implements the reconciler side of APPSRE-14651 so declared shared group assignments are applied via GitLab API (`project.share` / `project.unshare`).

## Dependencies

- **Requires** qontract-schemas PR adding `sharedWithGroups` to `gitlab-instance-1.yml` (merge first)

## Related

- Jira: APPSRE-14651

## Test plan

- [x] `uv run pytest reconcile/test/test_gitlab_projects.py reconcile/test/utils/test_gitlab_api.py::test_get_project_shared_groups reconcile/test/utils/test_gitlab_api.py::test_share_project_with_group reconcile/test/utils/test_gitlab_api.py::test_unshare_project_from_group`
- [x] `uv run ruff check reconcile/gitlab_projects.py`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced GitLab project reconciliation to sync shared-with groups, including access level updates.
  * Project requests can now specify shared group details, which are applied during reconciliation.
* **Bug Fixes**
  * Access level changes are implemented by unsharing and re-sharing with the desired access.
  * Dry-run mode now logs the intended group sharing/unsharing actions when a project can’t be fetched.
* **Tests**
  * Added unit tests and API tests covering adding shares, unsharing, dry-run behavior, and skipping reconciliation when shared-group data is null.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->