### PR TITLE
fix(acs-rbac): strip extra fields from AccessScope namespaces to stop reconcile loop

### DIFF
--- a/reconcile/acs_rbac.py
+++ b/reconcile/acs_rbac.py
@@ -15,7 +15,7 @@ from qontract_utils.differ import (
 from reconcile.gql_definitions.acs.acs_rbac import OidcPermissionAcsV1
 from reconcile.gql_definitions.acs.acs_rbac import query as acs_rbac_query
 from reconcile.utils import gql
-from reconcile.utils.acs.rbac import AcsRbacApi, Group, RbacResources
+from reconcile.utils.acs.rbac import AccessScopeNamespace, AcsRbacApi, Group, RbacResources
 from reconcile.utils.runtime.integration import (
     NoParams,
     QontractReconcileIntegration,
@@ -45,7 +45,7 @@ class AcsAccessScope(BaseModel):
     name: str
     description: str
     clusters: list[str]
-    namespaces: list[dict[str, str]]
+    namespaces: list[AccessScopeNamespace]
 
 
 class Permission(OidcPermissionAcsV1):
@@ -99,12 +99,8 @@ class AcsRole(BaseModel):
                 else permission.description,
                 # second arg is returned even if first arg == False
                 clusters=[cluster.name for cluster in (permission.clusters or [])],
-                # mirroring format of 'rules.includedNamespaces' in /v1/simpleaccessscopes response
                 namespaces=[
-                    {
-                        "clusterName": n.cluster.name,
-                        "namespaceName": n.name,
-                    }
+                    AccessScopeNamespace(clusterName=n.cluster.name, namespaceName=n.name)
                     for n in (permission.namespaces or [])
                 ],
             ),

--- a/reconcile/acs_rbac.py
+++ b/reconcile/acs_rbac.py
@@ -15,7 +15,12 @@ from qontract_utils.differ import (
 from reconcile.gql_definitions.acs.acs_rbac import OidcPermissionAcsV1
 from reconcile.gql_definitions.acs.acs_rbac import query as acs_rbac_query
 from reconcile.utils import gql
-from reconcile.utils.acs.rbac import AccessScopeNamespace, AcsRbacApi, Group, RbacResources
+from reconcile.utils.acs.rbac import (
+    AccessScopeNamespace,
+    AcsRbacApi,
+    Group,
+    RbacResources,
+)
 from reconcile.utils.runtime.integration import (
     NoParams,
     QontractReconcileIntegration,
@@ -100,7 +105,9 @@ class AcsRole(BaseModel):
                 # second arg is returned even if first arg == False
                 clusters=[cluster.name for cluster in (permission.clusters or [])],
                 namespaces=[
-                    AccessScopeNamespace(clusterName=n.cluster.name, namespaceName=n.name)
+                    AccessScopeNamespace(
+                        clusterName=n.cluster.name, namespaceName=n.name
+                    )
                     for n in (permission.namespaces or [])
                 ],
             ),

--- a/reconcile/test/test_acs_rbac.py
+++ b/reconcile/test/test_acs_rbac.py
@@ -192,8 +192,12 @@ def modeled_acs_roles() -> list[AcsRole]:
                 description="vuln-admin access to service namespaces in acs instance",
                 clusters=[],
                 namespaces=[
-                    AccessScopeNamespace(clusterName="stage-cluster", namespaceName="serviceA-stage"),
-                    AccessScopeNamespace(clusterName="prod-cluster", namespaceName="serviceA-prod"),
+                    AccessScopeNamespace(
+                        clusterName="stage-cluster", namespaceName="serviceA-stage"
+                    ),
+                    AccessScopeNamespace(
+                        clusterName="prod-cluster", namespaceName="serviceA-prod"
+                    ),
                 ],
             ),
             system_default=False,
@@ -386,7 +390,9 @@ def test_access_scope_strips_cluster_id_from_namespaces() -> None:
             },
         }
     )
-    assert scope.namespaces == [rbac.AccessScopeNamespace(clusterName="prod-cluster", namespaceName="my-ns")]
+    assert scope.namespaces == [
+        rbac.AccessScopeNamespace(clusterName="prod-cluster", namespaceName="my-ns")
+    ]
 
 
 def test_get_desired_state(

--- a/reconcile/test/test_acs_rbac.py
+++ b/reconcile/test/test_acs_rbac.py
@@ -22,6 +22,7 @@ from reconcile.gql_definitions.acs.acs_rbac import (
     UserV1,
 )
 from reconcile.utils.acs import rbac
+from reconcile.utils.acs.rbac import AccessScopeNamespace
 
 if TYPE_CHECKING:
     from pytest_mock import MockerFixture
@@ -191,8 +192,8 @@ def modeled_acs_roles() -> list[AcsRole]:
                 description="vuln-admin access to service namespaces in acs instance",
                 clusters=[],
                 namespaces=[
-                    {"clusterName": "stage-cluster", "namespaceName": "serviceA-stage"},
-                    {"clusterName": "prod-cluster", "namespaceName": "serviceA-prod"},
+                    AccessScopeNamespace(clusterName="stage-cluster", namespaceName="serviceA-stage"),
+                    AccessScopeNamespace(clusterName="prod-cluster", namespaceName="serviceA-prod"),
                 ],
             ),
             system_default=False,
@@ -327,10 +328,12 @@ def api_response_access_scopes() -> list[rbac.AccessScope]:
                         {
                             "clusterName": "stage-cluster",
                             "namespaceName": "serviceA-stage",
+                            "clusterId": "cluster-uuid-1",
                         },
                         {
                             "clusterName": "prod-cluster",
                             "namespaceName": "serviceA-prod",
+                            "clusterId": "cluster-uuid-2",
                         },
                     ],
                 },
@@ -361,6 +364,29 @@ def api_response_permission_sets() -> list[rbac.PermissionSet]:
             }
         ),
     ]
+
+
+def test_access_scope_strips_cluster_id_from_namespaces() -> None:
+    # ACS API started returning a 'clusterId' field in namespace items; it must
+    # be stripped so the desired-vs-current comparison stays idempotent.
+    scope = rbac.AccessScope(
+        api_data={
+            "id": "42",
+            "name": "my-scope",
+            "description": "desc",
+            "rules": {
+                "includedClusters": [],
+                "includedNamespaces": [
+                    {
+                        "clusterName": "prod-cluster",
+                        "namespaceName": "my-ns",
+                        "clusterId": "some-uuid",
+                    }
+                ],
+            },
+        }
+    )
+    assert scope.namespaces == [rbac.AccessScopeNamespace(clusterName="prod-cluster", namespaceName="my-ns")]
 
 
 def test_get_desired_state(

--- a/reconcile/utils/acs/rbac.py
+++ b/reconcile/utils/acs/rbac.py
@@ -1,6 +1,6 @@
 from typing import Any
 
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 from reconcile.utils.acs.base import AcsBaseApi
 
@@ -60,16 +60,20 @@ class Group(BaseModel):
         )
 
 
+class AccessScopeNamespace(BaseModel):
+    cluster_name: str = Field(alias="clusterName")
+    namespace_name: str = Field(alias="namespaceName")
+
+
 class AccessScope(BaseModel):
     id: str
     name: str
     description: str
     clusters: list[str]
-    namespaces: list[dict[str, str]]
+    namespaces: list[AccessScopeNamespace]
 
     def __init__(self, api_data: Any) -> None:
         # attributes defined within stackrox(ACS) API for GET /v1/simpleaccessscopes/{id}
-        unrestricted = False
         AcsBaseApi.check_len_attributes(["id", "name"], api_data)
 
         # it is valid for the default Unrestricted access scope to have null 'rules'
@@ -85,7 +89,10 @@ class AccessScope(BaseModel):
             else api_data["rules"].get("includedClusters", []),
             namespaces=[]
             if unrestricted
-            else api_data["rules"].get("includedNamespaces", []),
+            else [
+                AccessScopeNamespace(clusterName=ns["clusterName"], namespaceName=ns["namespaceName"])
+                for ns in api_data["rules"].get("includedNamespaces", [])
+            ],
             description=api_data.get("description", ""),
         )
 
@@ -226,7 +233,7 @@ class AcsRbacApi(AcsBaseApi):
         name: str,
         desc: str,
         clusters: list[str],
-        namespaces: list[dict[str, str]],
+        namespaces: list[AccessScopeNamespace],
     ) -> str:
         # response is the created access_scope id
         json = {
@@ -234,7 +241,7 @@ class AcsRbacApi(AcsBaseApi):
             "description": desc,
             "rules": {
                 "includedClusters": clusters,
-                "includedNamespaces": namespaces,
+                "includedNamespaces": [ns.model_dump(by_alias=True) for ns in namespaces],
             },
         }
 
@@ -251,14 +258,14 @@ class AcsRbacApi(AcsBaseApi):
         name: str,
         desc: str,
         clusters: list[str],
-        namespaces: list[dict[str, str]],
+        namespaces: list[AccessScopeNamespace],
     ) -> None:
         json = {
             "name": name,
             "description": desc,
             "rules": {
                 "includedClusters": clusters,
-                "includedNamespaces": namespaces,
+                "includedNamespaces": [ns.model_dump(by_alias=True) for ns in namespaces],
             },
         }
 

--- a/reconcile/utils/acs/rbac.py
+++ b/reconcile/utils/acs/rbac.py
@@ -90,7 +90,9 @@ class AccessScope(BaseModel):
             namespaces=[]
             if unrestricted
             else [
-                AccessScopeNamespace(clusterName=ns["clusterName"], namespaceName=ns["namespaceName"])
+                AccessScopeNamespace(
+                    clusterName=ns["clusterName"], namespaceName=ns["namespaceName"]
+                )
                 for ns in api_data["rules"].get("includedNamespaces", [])
             ],
             description=api_data.get("description", ""),
@@ -241,7 +243,9 @@ class AcsRbacApi(AcsBaseApi):
             "description": desc,
             "rules": {
                 "includedClusters": clusters,
-                "includedNamespaces": [ns.model_dump(by_alias=True) for ns in namespaces],
+                "includedNamespaces": [
+                    ns.model_dump(by_alias=True) for ns in namespaces
+                ],
             },
         }
 
@@ -265,7 +269,9 @@ class AcsRbacApi(AcsBaseApi):
             "description": desc,
             "rules": {
                 "includedClusters": clusters,
-                "includedNamespaces": [ns.model_dump(by_alias=True) for ns in namespaces],
+                "includedNamespaces": [
+                    ns.model_dump(by_alias=True) for ns in namespaces
+                ],
             },
         }
 


### PR DESCRIPTION
## Summary

- ACS API started returning a `clusterId` field in `includedNamespaces` items; the reconciler built desired state without it, so current vs desired always differed → perpetual update loop in `appsrep09ue1`
- Replace `list[dict[str, str]]` with a typed `AccessScopeNamespace` Pydantic model using `Field(alias=...)` for `clusterName`/`namespaceName` — the parser only captures known fields and silently drops any extras the API adds
- `model_dump(by_alias=True)` handles serialization back to camelCase for the ACS API payload

## Test plan

- [ ] `uv run pytest reconcile/test/test_acs_rbac.py -x -q` — all 10 pass
- [ ] `test_access_scope_strips_cluster_id_from_namespaces` regression test covers the exact scenario: API response with `clusterId` field is parsed without it
- [ ] `api_response_access_scopes` fixture now includes `clusterId` in namespace items to exercise stripping through the full current-state path

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of access-scope namespaces so namespace entries are stored and sent in the expected format.
  * Cluster identifiers are now removed from namespace entries when displaying or processing them, reducing inconsistent data.
  * Access-scope updates and creation now preserve namespace details more reliably.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->