### PR TITLE
chore(qontract-utils): add from __future__ import annotations to vcs …

### DIFF
--- a/qontract_utils/qontract_utils/vcs/owners_parser.py
+++ b/qontract_utils/qontract_utils/vcs/owners_parser.py
@@ -6,12 +6,17 @@ Ported from reconcile/utils/repo_owners.py but modernized to ADR standards.
 Following ADR-012: Fully Typed Pydantic Models Over Nested Dicts
 """
 
+from __future__ import annotations
+
 import logging
 from collections.abc import Callable
+from typing import TYPE_CHECKING
 
 from qontract_utils.ruamel import create_ruamel_instance, yaml
 from qontract_utils.vcs.models import OwnersFileData, RepoOwners
-from qontract_utils.vcs.provider_protocol import VCSApiProtocol
+
+if TYPE_CHECKING:
+    from qontract_utils.vcs.provider_protocol import VCSApiProtocol
 
 logger = logging.getLogger(__name__)
 

--- a/qontract_utils/qontract_utils/vcs/provider_protocol.py
+++ b/qontract_utils/qontract_utils/vcs/provider_protocol.py
@@ -4,12 +4,15 @@ Defines interfaces for VCS API clients and providers to enable
 extensible provider registry pattern.
 """
 
+from __future__ import annotations
+
 from dataclasses import dataclass, field
 from enum import StrEnum
-from typing import Any, Protocol
+from typing import TYPE_CHECKING, Any, Protocol
 
-from qontract_utils.hooks import Hooks
-from qontract_utils.vcs.models import Provider
+if TYPE_CHECKING:
+    from qontract_utils.hooks import Hooks
+    from qontract_utils.vcs.models import Provider
 
 AUTO_MERGE_LABEL = "bot/automerge"
 """Label used to trigger automatic merging of merge requests."""

--- a/qontract_utils/qontract_utils/vcs/provider_registry.py
+++ b/qontract_utils/qontract_utils/vcs/provider_registry.py
@@ -3,9 +3,15 @@
 Implements registry pattern for extensible VCS provider support.
 """
 
-from qontract_utils.vcs.models import Provider
-from qontract_utils.vcs.provider_protocol import VCSProviderProtocol
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 from qontract_utils.vcs.providers import GitHubProvider, GitLabProvider
+
+if TYPE_CHECKING:
+    from qontract_utils.vcs.models import Provider
+    from qontract_utils.vcs.provider_protocol import VCSProviderProtocol
 
 
 class VCSProviderRegistry:

--- a/qontract_utils/qontract_utils/vcs/providers/github_client.py
+++ b/qontract_utils/qontract_utils/vcs/providers/github_client.py
@@ -1,5 +1,7 @@
 """GitHub Repository API client with hook system for metrics and rate limiting."""
 
+from __future__ import annotations
+
 import contextvars
 import time
 from dataclasses import dataclass
@@ -11,10 +13,11 @@ from prometheus_client import Counter, Histogram
 
 from qontract_utils.hooks import Hooks, invoke_with_hooks, with_hooks
 from qontract_utils.metrics import DEFAULT_BUCKETS_EXTERNAL_API
-from qontract_utils.vcs.provider_protocol import CreateMergeRequestInput
 
 if TYPE_CHECKING:
     from github.Repository import Repository
+
+    from qontract_utils.vcs.provider_protocol import CreateMergeRequestInput
 
 logger = structlog.get_logger(__name__)
 

--- a/qontract_utils/qontract_utils/vcs/providers/github_provider.py
+++ b/qontract_utils/qontract_utils/vcs/providers/github_provider.py
@@ -1,13 +1,18 @@
 """GitHub provider implementation for VCS provider registry."""
 
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
 from urllib.parse import urlparse
 
 from pydantic import BaseModel
 
-from qontract_utils.hooks import Hooks
 from qontract_utils.vcs.models import Provider
-from qontract_utils.vcs.provider_protocol import VCSApiProtocol
 from qontract_utils.vcs.providers.github_client import GitHubRepoApi
+
+if TYPE_CHECKING:
+    from qontract_utils.hooks import Hooks
+    from qontract_utils.vcs.provider_protocol import VCSApiProtocol
 
 
 class Repo(BaseModel):

--- a/qontract_utils/qontract_utils/vcs/providers/gitlab_provider.py
+++ b/qontract_utils/qontract_utils/vcs/providers/gitlab_provider.py
@@ -4,14 +4,19 @@ Following ADR-011: Dependency Injection Pattern
 Following ADR-017: VCS Provider Registry Pattern
 """
 
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
 from urllib.parse import urlparse
 
 from pydantic import BaseModel
 
-from qontract_utils.pagerduty_api.client import Hooks
 from qontract_utils.vcs.models import Provider
-from qontract_utils.vcs.provider_protocol import VCSApiProtocol
 from qontract_utils.vcs.providers.gitlab_client import GitLabRepoApi
+
+if TYPE_CHECKING:
+    from qontract_utils.pagerduty_api.client import Hooks
+    from qontract_utils.vcs.provider_protocol import VCSApiProtocol
 
 
 class Repo(BaseModel):

--- a/qontract_utils/qontract_utils/vcs/vcs_client.py
+++ b/qontract_utils/qontract_utils/vcs/vcs_client.py
@@ -3,9 +3,15 @@
 Provides unified interface for working with Git repositories across platforms.
 """
 
-from qontract_utils.vcs.models import RepoOwners
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 from qontract_utils.vcs.owners_parser import OwnersParser
-from qontract_utils.vcs.provider_protocol import VCSApiProtocol
+
+if TYPE_CHECKING:
+    from qontract_utils.vcs.models import RepoOwners
+    from qontract_utils.vcs.provider_protocol import VCSApiProtocol
 
 
 class VCSClient:


### PR DESCRIPTION
…modules

Add `from __future__ import annotations` and move type-only imports to TYPE_CHECKING blocks in qontract_utils/vcs files, preparing for py314 where lazy annotation evaluation is the default.

Refs: APPSRE-14363

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated internal handling of type annotations across VCS-related components.
  * Reduced unnecessary imports at runtime while keeping existing behavior unchanged.
  * Improved code maintainability and compatibility with static type checking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->