### PR TITLE
APPSRE-14695 fix(saasherder): add target identity and per-UID soak breakdown to gate-check logs

### DIFF
--- a/reconcile/utils/saasherder/saasherder.py
+++ b/reconcile/utils/saasherder/saasherder.py
@@ -2117,8 +2117,12 @@ class SaasHerder:
         if not promotion.subscribe:
             return True
 
+        target_id = (
+            f"[saas_file={promotion.saas_file}/target_uid={promotion.saas_target_uid}]"
+        )
+
         if promotion.commit_sha in self.blocked_versions.get(promotion.url, set()):
-            logging.error(f"Commit {promotion.commit_sha} is blocked!")
+            logging.error(f"{target_id} Commit {promotion.commit_sha} is blocked!")
             return False
 
         # hotfix must run before further gates are evaluated to override them
@@ -2127,6 +2131,9 @@ class SaasHerder:
 
         now = utc_now()
         passed_soak_days = timedelta(days=0)
+        # Track (channel_name, publisher_uid, check_in, soak_contribution) for
+        # detailed logging when the soak gate fails.
+        soak_log: list[tuple[str, str, str | None, timedelta | None]] = []
 
         for channel in promotion.subscribe:
             config_hashes: set[str] = set()
@@ -2141,12 +2148,21 @@ class SaasHerder:
                     deployment and (deployment.success or deployment.has_succeeded_once)
                 ):
                     logging.error(
-                        f"Commit {promotion.commit_sha} was not "
-                        + f"published with success to channel {channel.name}"
+                        f"{target_id} Commit {promotion.commit_sha} was not "
+                        f"published with success to channel {channel.name} "
+                        f"(publisher uid: {target_uid})"
                     )
                     return False
+                contribution: timedelta | None = None
                 if check_in := deployment.check_in:
-                    passed_soak_days += now - datetime.fromisoformat(check_in)
+                    contribution = now - datetime.fromisoformat(check_in)
+                    passed_soak_days += contribution
+                soak_log.append((
+                    channel.name,
+                    target_uid,
+                    deployment.check_in,
+                    contribution,
+                ))
                 if deployment.target_config_hash:
                     config_hashes.add(deployment.target_config_hash)
 
@@ -2154,7 +2170,7 @@ class SaasHerder:
             # not have promotion_data yet
             if not config_hashes or not promotion.promotion_data:
                 logging.info(
-                    "Promotion data is missing; rely on the success state only"
+                    f"{target_id} Promotion data is missing; rely on the success state only"
                 )
                 continue
 
@@ -2174,7 +2190,7 @@ class SaasHerder:
             # is reached though.
             if not parent_saas_config:
                 logging.info(
-                    "Parent Saas config missing on target "
+                    f"{target_id} Parent Saas config missing on target; "
                     "rely on the success state only"
                 )
                 continue
@@ -2185,7 +2201,7 @@ class SaasHerder:
                 continue
 
             logging.error(
-                "Parent saas target has run with a newer "
+                f"{target_id} Parent saas target has run with a newer "
                 "configuration and the same commit (ref). "
                 "Check if other MR exists for this target, "
                 f"or update {parent_saas_config.target_config_hash} "
@@ -2194,9 +2210,14 @@ class SaasHerder:
             return False
 
         if passed_soak_days < timedelta(days=promotion.soak_days):
+            detail_lines = "\n".join(
+                f"  channel={ch} uid={uid} check_in={check_in} contribution={contribution}"
+                for ch, uid, check_in, contribution in soak_log
+            )
             logging.error(
-                f"SoakDays in publishers did not pass. So far accumulated soakDays is {passed_soak_days},"
-                f"but we have a soakDays setting of {promotion.soak_days}. We cannot proceed with this promotion."
+                f"{target_id} SoakDays gate failed for commit {promotion.commit_sha}. "
+                f"Accumulated={passed_soak_days}, required={promotion.soak_days} day(s).\n"
+                f"{detail_lines}"
             )
             return False
         return True

--- a/reconcile/utils/saasherder/saasherder.py
+++ b/reconcile/utils/saasherder/saasherder.py
@@ -2210,13 +2210,13 @@ class SaasHerder:
             return False
 
         if passed_soak_days < timedelta(days=promotion.soak_days):
-            detail_lines = "\n".join(
-                f"  channel={ch} uid={uid} check_in={check_in} contribution={contribution}"
+            detail_lines = " | ".join(
+                f"channel={ch} uid={uid} check_in={check_in} contribution={contribution}"
                 for ch, uid, check_in, contribution in soak_log
             )
             logging.error(
                 f"{target_id} SoakDays gate failed for commit {promotion.commit_sha}. "
-                f"Accumulated={passed_soak_days}, required={promotion.soak_days} day(s).\n"
+                f"Accumulated={passed_soak_days}, required={promotion.soak_days} day(s). "
                 f"{detail_lines}"
             )
             return False


### PR DESCRIPTION
## Summary

- All log messages in `_validate_promotion()` are now prefixed with `[saas_file=.../target_uid=...]` so the failing target is immediately identifiable without manual S3 cross-referencing
- The publisher UID is now included in the success-check error message
- When the soak gate fails, a per-channel per-publisher-UID breakdown is logged showing each UID's `check_in` timestamp and individual soak contribution

## Motivation

Investigated a CI failure on app-interface MR !194721 where the log only showed:

```
SoakDays in publishers did not pass. So far accumulated soakDays is 3:58:39.252499,
but we have a soakDays setting of 1. We cannot proceed with this promotion.
```

With no indication of which target or channel was failing, root-cause analysis required manual S3 inspection across 57+ publisher UIDs. The new output will look like:

```
[saas_file=rhobs-metric-collection-prod/target_uid=abc123...] SoakDays gate failed for commit f071f4b7.... Accumulated=3:58:39, required=1 day(s).
  channel=rhobs-metrics-cardinality-check-passed-prod-wave1 uid=8866fd... check_in=2026-06-29 18:37:56+00:00 contribution=3:58:38
```

Relates to APPSRE-14695.

## Test plan

- [ ] Existing saasherder unit tests pass
- [ ] Manually verify log output format in a dry-run promotion

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved promotion validation messaging to clearly reference the affected target when commits are blocked, parent configuration is missing, or newer parent configuration is detected.
  * Enhanced soak-gate failure errors to report accumulated versus required soak days, including a detailed per-check breakdown when applicable.
  * Updated publication validation to produce more complete, actionable diagnostics when publication status can’t be confirmed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->