### PR TITLE
fix(gitlab): increase default GitLabApi timeout from 30s to 120s

### DIFF
--- a/reconcile/test/utils/test_gitlab_api.py
+++ b/reconcile/test/utils/test_gitlab_api.py
@@ -123,7 +123,7 @@ def test_gitlab_api_init(
         instance["url"],
         private_token="private-token",
         ssl_verify=False,
-        timeout=30,
+        timeout=120,
         session=mocked_session.return_value,
         per_page=100,
         pagination="keyset",

--- a/reconcile/utils/gitlab_api.py
+++ b/reconcile/utils/gitlab_api.py
@@ -123,7 +123,7 @@ class GitLabApi:
         settings: Mapping | None = None,
         secret_reader: SecretReaderBase | None = None,
         project_url: str | None = None,
-        timeout: float = 30,
+        timeout: float = 120,
         session: Session | None = None,
     ):
         self.server = instance["url"]


### PR DESCRIPTION
## Summary
- Increase the default `GitLabApi` timeout from 30s to 120s to prevent `ReadTimeout` errors on large paginated API calls (e.g. listing all open MRs in `gitlab-housekeeping`)

## Alert

https://redhat-internal.slack.com/archives/CDW0S85QU/p1782900190091989

## Test plan
- [x] `reconcile/test/utils/test_gitlab_api.py` — all 36 tests pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Increased the default connection wait time for GitLab access, helping reduce timeouts and improve reliability on slower networks.
  * Updated the related test expectation to match the new behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->