### PR TITLE
APPSRE-14363 chore(test): migrate testslide tests to pytest-mock

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -84,7 +84,6 @@ dev = [
     "ruff==0.15.13",
     "smtpdfix==0.5.3",
     "snakeviz==2.2.2",
-    "testslide==2.7.1",
     "types-click",
     "types-croniter",
     "types-dateparser",

--- a/reconcile/test/test_terraform_vpc_peerings.py
+++ b/reconcile/test/test_terraform_vpc_peerings.py
@@ -385,7 +385,8 @@ def test_empty_run(mocker: MockerFixture) -> None:
     integ.run(True)
 
     mocked_logging.warning.assert_called_once_with(
-        "No participating AWS accounts found, consider disabling this integration, account name: None"
+        "No participating AWS accounts found, consider disabling this integration, account name: %s",
+        None,
     )
 
 
@@ -524,6 +525,10 @@ def test_run_all_fine(run_mocks: RunMocks) -> None:
     run_mocks.terraform.apply.assert_called_once()
     run_mocks.clusters.assert_called_once()
     run_mocks.settings.assert_called_once()
+    run_mocks.terrascript.populate_vpc_peerings.assert_called_once()
+    run_mocks.terrascript.populate_configs.assert_called_once()
+    run_mocks.terrascript.dump.assert_called_once()
+    run_mocks.terrascript.terraform_configurations.assert_called_once()
 
 
 def test_run_fail_state(run_mocks: RunMocks) -> None:
@@ -569,6 +574,7 @@ def test_run_dry_run_with_failures(run_mocks: RunMocks) -> None:
         integ.run(True, print_to_file=None, enable_deletion=False)
 
     run_mocks.terraform.plan.assert_not_called()
+    run_mocks.terraform.cleanup.assert_not_called()
     run_mocks.terraform.apply.assert_not_called()
     run_mocks.exit.assert_called_once_with(1)
 
@@ -583,5 +589,6 @@ def test_run_dry_run_print_only_with_failures(run_mocks: RunMocks) -> None:
         integ.run(True, print_to_file="some/dir", enable_deletion=False)
 
     run_mocks.terraform.plan.assert_not_called()
+    run_mocks.terraform.cleanup.assert_not_called()
     run_mocks.terraform.apply.assert_not_called()
     run_mocks.exit.assert_called_once_with(0)

--- a/reconcile/test/test_terraform_vpc_peerings.py
+++ b/reconcile/test/test_terraform_vpc_peerings.py
@@ -1,10 +1,11 @@
 from __future__ import annotations
 
 import sys
+from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Self
+from unittest.mock import MagicMock
 
 import pytest
-import testslide
 
 import reconcile.terraform_vpc_peerings as integ
 import reconcile.utils.terraform_client as terraform
@@ -388,194 +389,199 @@ def test_empty_run(mocker: MockerFixture) -> None:
     )
 
 
-class TestRun(testslide.TestCase):
-    def setUp(self) -> None:
-        super().setUp()
+@dataclass
+class RunMocks:
+    awsapi: MagicMock
+    build_desired_state_vpc: MagicMock
+    build_desired_state_all_clusters: MagicMock
+    build_desired_state_vpc_mesh: MagicMock
+    terraform: MagicMock
+    terrascript: MagicMock
+    ocmmap: MagicMock
+    clusters: MagicMock
+    settings: MagicMock
+    exit: MagicMock
 
-        self.awsapi = testslide.StrictMock(aws_api.AWSApi)
-        self.mock_constructor(aws_api, "AWSApi").to_return_value(self.awsapi)
 
-        self.build_desired_state_vpc = self.mock_callable(
-            integ, "build_desired_state_vpc"
-        )
-        self.build_desired_state_all_clusters = self.mock_callable(
-            integ, "build_desired_state_all_clusters"
-        )
-        self.build_desired_state_vpc_mesh = self.mock_callable(
-            integ, "build_desired_state_vpc_mesh"
-        )
-        self.terraform = testslide.StrictMock(terraform.TerraformClient)
-        self.terrascript = testslide.StrictMock(
-            terrascript.TerrascriptClient, default_context_manager=True
-        )
-        self.mock_constructor(terraform, "TerraformClient").to_return_value(
-            self.terraform
-        )
-        self.terraform.apply_count = 1
-        self.mock_constructor(terrascript, "TerrascriptClient").to_return_value(
-            self.terrascript
-        )
-        self.ocmmap = testslide.StrictMock(ocm.OCMMap)
-        self.mock_constructor(ocm, "OCMMap").to_return_value(self.ocmmap)
-        self.mock_callable(queries, "get_aws_accounts").to_return_value([
-            {"name": "desired_account"}
-        ])
-        self.clusters = (
-            self
-            .mock_callable(queries, "get_clusters_with_peering_settings")
-            .to_return_value([
-                {"name": "aname", "ocm": "aocm", "peering": {"apeering"}}
-            ])
-            .and_assert_called_once()
-        )
-        self.settings = (
-            self
-            .mock_callable(queries, "get_secret_reader_settings")
-            .to_return_value({})
-            .and_assert_called_once()
-        )
-        self.mock_callable(external_resources, "get_settings").to_raise(
-            ValueError("No external resources settings found")
-        )
-        self.mock_callable(self.terrascript, "populate_vpc_peerings").to_return_value(
-            None
-        ).and_assert_called_once()
-        self.mock_callable(self.terrascript, "populate_configs").to_return_value(
-            None
-        ).and_assert_called_once()
-        self.mock_callable(self.terrascript, "dump").to_return_value({
-            "some_account": "/some/dir"
-        }).and_assert_called_once()
-        self.mock_callable(
-            self.terrascript, "terraform_configurations"
-        ).to_return_value({"foo": "bar"}).and_assert_called_once()
-        # Sigh...
-        self.exit = self.mock_callable(sys, "exit").to_raise(OSError("Exit called!"))
-        self.addCleanup(testslide.mock_callable.unpatch_all_callable_mocks)
+@pytest.fixture
+def run_mocks(mocker: MockerFixture) -> RunMocks:
+    awsapi = MagicMock(spec=aws_api.AWSApi)
+    mocker.patch.object(aws_api, "AWSApi", return_value=awsapi)
 
-    def initialize_desired_states(self, error_code: bool) -> None:
-        self.build_desired_state_vpc.to_return_value((
-            [
-                {
-                    "connection_name": "desired_vpc_conn",
-                    "infra_account_name": "desired_account",
-                    "requester": {"account": {"name": "desired_account"}},
-                    "accepter": {"account": {"name": "desired_account"}},
+    build_desired_state_vpc = mocker.patch.object(integ, "build_desired_state_vpc")
+    build_desired_state_all_clusters = mocker.patch.object(
+        integ, "build_desired_state_all_clusters"
+    )
+    build_desired_state_vpc_mesh = mocker.patch.object(
+        integ, "build_desired_state_vpc_mesh"
+    )
+
+    terraform_mock = MagicMock(spec=terraform.TerraformClient)
+    terraform_mock.apply_count = 1
+    mocker.patch.object(terraform, "TerraformClient", return_value=terraform_mock)
+
+    terrascript_mock = MagicMock(spec=terrascript.TerrascriptClient)
+    terrascript_mock.__enter__ = MagicMock(return_value=terrascript_mock)
+    terrascript_mock.__exit__ = MagicMock(return_value=False)
+    mocker.patch.object(terrascript, "TerrascriptClient", return_value=terrascript_mock)
+
+    ocmmap = MagicMock(spec=ocm.OCMMap)
+    mocker.patch.object(ocm, "OCMMap", return_value=ocmmap)
+
+    mocker.patch.object(
+        queries, "get_aws_accounts", return_value=[{"name": "desired_account"}]
+    )
+    clusters = mocker.patch.object(
+        queries,
+        "get_clusters_with_peering_settings",
+        return_value=[{"name": "aname", "ocm": "aocm", "peering": {"apeering"}}],
+    )
+    settings = mocker.patch.object(
+        queries, "get_secret_reader_settings", return_value={}
+    )
+    mocker.patch.object(
+        external_resources,
+        "get_settings",
+        side_effect=ValueError("No external resources settings found"),
+    )
+
+    terrascript_mock.populate_vpc_peerings.return_value = None
+    terrascript_mock.populate_configs.return_value = None
+    terrascript_mock.dump.return_value = {"some_account": "/some/dir"}
+    terrascript_mock.terraform_configurations.return_value = {"foo": "bar"}
+
+    exit_mock = mocker.patch.object(sys, "exit", side_effect=OSError("Exit called!"))
+
+    return RunMocks(
+        awsapi=awsapi,
+        build_desired_state_vpc=build_desired_state_vpc,
+        build_desired_state_all_clusters=build_desired_state_all_clusters,
+        build_desired_state_vpc_mesh=build_desired_state_vpc_mesh,
+        terraform=terraform_mock,
+        terrascript=terrascript_mock,
+        ocmmap=ocmmap,
+        clusters=clusters,
+        settings=settings,
+        exit=exit_mock,
+    )
+
+
+def _initialize_desired_states(mocks: RunMocks, error_code: bool) -> None:
+    mocks.build_desired_state_vpc.return_value = (
+        [
+            {
+                "connection_name": "desired_vpc_conn",
+                "infra_account_name": "desired_account",
+                "requester": {"account": {"name": "desired_account"}},
+                "accepter": {"account": {"name": "desired_account"}},
+            },
+        ],
+        error_code,
+    )
+    mocks.build_desired_state_all_clusters.return_value = (
+        [
+            {
+                "connection_name": "all_clusters_vpc_conn",
+                "infra_account_name": "desired_account",
+                "requester": {"account": {"name": "all_clusters_account"}},
+                "accepter": {
+                    "account": {
+                        "name": "all_clusters_account",
+                    }
                 },
-            ],
-            error_code,
-        ))
-        self.build_desired_state_all_clusters.to_return_value((
-            [
-                {
-                    "connection_name": "all_clusters_vpc_conn",
-                    "infra_account_name": "desired_account",
-                    "requester": {"account": {"name": "all_clusters_account"}},
-                    "accepter": {
-                        "account": {
-                            "name": "all_clusters_account",
-                        }
-                    },
-                }
-            ],
-            error_code,
-        ))
-        self.build_desired_state_vpc_mesh.to_return_value((
-            [
-                {
-                    "connection_name": "mesh_vpc_conn",
-                    "infra_account_name": "desired_account",
-                    "requester": {
-                        "account": {"name": "mesh_account"},
-                    },
-                    "accepter": {
-                        "account": {"name": "mesh_account"},
-                    },
-                }
-            ],
-            error_code,
-        ))
+            }
+        ],
+        error_code,
+    )
+    mocks.build_desired_state_vpc_mesh.return_value = (
+        [
+            {
+                "connection_name": "mesh_vpc_conn",
+                "infra_account_name": "desired_account",
+                "requester": {
+                    "account": {"name": "mesh_account"},
+                },
+                "accepter": {
+                    "account": {"name": "mesh_account"},
+                },
+            }
+        ],
+        error_code,
+    )
+    mocks.terrascript.populate_additional_providers.return_value = None
 
-        self.mock_callable(self.terrascript, "populate_additional_providers").for_call(
-            "desired_account",
-            [
-                {"name": "mesh_account"},
-                {"name": "all_clusters_account"},
-                {"name": "mesh_account"},
-                {"name": "all_clusters_account"},
-            ],
-        ).to_return_value(None).and_assert_called_once()
 
-    def test_all_fine(self) -> None:
-        self.initialize_desired_states(False)
-        self.mock_callable(self.terraform, "plan").to_return_value((
-            False,
-            False,
-        )).and_assert_called_once()
-        self.mock_callable(self.terraform, "cleanup").to_return_value(
-            None
-        ).and_assert_called_once()
-        self.mock_callable(self.terraform, "apply").to_return_value(
-            False
-        ).and_assert_called_once()
-        integ.run(False, print_to_file=None, enable_deletion=False)
+def test_run_all_fine(run_mocks: RunMocks) -> None:
+    _initialize_desired_states(run_mocks, False)
+    run_mocks.terraform.plan.return_value = (False, False)
+    run_mocks.terraform.cleanup.return_value = None
+    run_mocks.terraform.apply.return_value = False
 
-    def test_fail_state(self) -> None:
-        """Ensure we don't change the world if there are failures"""
-        self.initialize_desired_states(True)
-        self.mock_callable(self.terraform, "plan").to_return_value((
-            False,
-            False,
-        )).and_assert_not_called()
-        self.mock_callable(self.terraform, "cleanup").to_return_value(
-            None
-        ).and_assert_not_called()
-        self.mock_callable(self.terraform, "apply").to_return_value(
-            None
-        ).and_assert_not_called()
-        self.exit.for_call(1).and_assert_called_once()
-        with self.assertRaises(OSError):
-            integ.run(False, print_to_file=None, enable_deletion=True)
+    integ.run(False, print_to_file=None, enable_deletion=False)
 
-    def test_dry_run(self) -> None:
-        self.initialize_desired_states(False)
+    run_mocks.terraform.plan.assert_called_once()
+    run_mocks.terraform.cleanup.assert_called_once()
+    run_mocks.terraform.apply.assert_called_once()
+    run_mocks.clusters.assert_called_once()
+    run_mocks.settings.assert_called_once()
 
-        self.mock_callable(self.terraform, "plan").to_return_value((
-            False,
-            False,
-        )).and_assert_called_once()
-        self.mock_callable(self.terraform, "cleanup").to_return_value(
-            None
-        ).and_assert_called_once()
-        self.mock_callable(self.terraform, "apply").to_return_value(
-            None
-        ).and_assert_not_called()
+
+def test_run_fail_state(run_mocks: RunMocks) -> None:
+    """Ensure we don't change the world if there are failures"""
+    _initialize_desired_states(run_mocks, True)
+    run_mocks.terraform.plan.return_value = (False, False)
+    run_mocks.terraform.cleanup.return_value = None
+    run_mocks.terraform.apply.return_value = None
+
+    with pytest.raises(OSError, match="Exit called!"):
+        integ.run(False, print_to_file=None, enable_deletion=True)
+
+    run_mocks.terraform.plan.assert_not_called()
+    run_mocks.terraform.cleanup.assert_not_called()
+    run_mocks.terraform.apply.assert_not_called()
+    run_mocks.exit.assert_called_once_with(1)
+    run_mocks.clusters.assert_called_once()
+    run_mocks.settings.assert_called_once()
+
+
+def test_run_dry_run(run_mocks: RunMocks) -> None:
+    _initialize_desired_states(run_mocks, False)
+    run_mocks.terraform.plan.return_value = (False, False)
+    run_mocks.terraform.cleanup.return_value = None
+    run_mocks.terraform.apply.return_value = None
+
+    integ.run(True, print_to_file=None, enable_deletion=False)
+
+    run_mocks.terraform.plan.assert_called_once()
+    run_mocks.terraform.cleanup.assert_called_once()
+    run_mocks.terraform.apply.assert_not_called()
+    run_mocks.clusters.assert_called_once()
+    run_mocks.settings.assert_called_once()
+
+
+def test_run_dry_run_with_failures(run_mocks: RunMocks) -> None:
+    """This is what we do during PR checks and new clusters!"""
+    _initialize_desired_states(run_mocks, True)
+    run_mocks.terraform.plan.return_value = (False, False)
+    run_mocks.terraform.apply.return_value = None
+
+    with pytest.raises(OSError, match="Exit called!"):
         integ.run(True, print_to_file=None, enable_deletion=False)
 
-    def test_dry_run_with_failures(self) -> None:
-        """This is what we do during PR checks and new clusters!"""
-        self.initialize_desired_states(True)
-        self.mock_callable(self.terraform, "plan").to_return_value((
-            False,
-            False,
-        )).and_assert_not_called()
-        self.mock_callable(self.terraform, "apply").to_return_value(
-            None
-        ).and_assert_not_called()
-        self.exit.for_call(1).and_assert_called_once()
-        with self.assertRaises(OSError):
-            integ.run(True, print_to_file=None, enable_deletion=False)
+    run_mocks.terraform.plan.assert_not_called()
+    run_mocks.terraform.apply.assert_not_called()
+    run_mocks.exit.assert_called_once_with(1)
 
-    def test_dry_run_print_only_with_failures(self) -> None:
-        """This is what we do during PR checks and new clusters!"""
-        self.initialize_desired_states(True)
-        self.mock_callable(self.terraform, "plan").to_return_value((
-            False,
-            False,
-        )).and_assert_not_called()
-        self.mock_callable(self.terraform, "apply").to_return_value(
-            None
-        ).and_assert_not_called()
-        self.exit.for_call(0).and_assert_called_once()
-        with self.assertRaises(OSError):
-            integ.run(True, print_to_file="some/dir", enable_deletion=False)
+
+def test_run_dry_run_print_only_with_failures(run_mocks: RunMocks) -> None:
+    """This is what we do during PR checks and new clusters!"""
+    _initialize_desired_states(run_mocks, True)
+    run_mocks.terraform.plan.return_value = (False, False)
+    run_mocks.terraform.apply.return_value = None
+
+    with pytest.raises(OSError, match="Exit called!"):
+        integ.run(True, print_to_file="some/dir", enable_deletion=False)
+
+    run_mocks.terraform.plan.assert_not_called()
+    run_mocks.terraform.apply.assert_not_called()
+    run_mocks.exit.assert_called_once_with(0)

--- a/reconcile/test/test_terraform_vpc_peerings.py
+++ b/reconcile/test/test_terraform_vpc_peerings.py
@@ -524,6 +524,15 @@ def test_run_all_fine(run_mocks: RunMocks) -> None:
     run_mocks.terraform.apply.assert_called_once()
     run_mocks.clusters.assert_called_once()
     run_mocks.settings.assert_called_once()
+    run_mocks.terrascript.populate_additional_providers.assert_called_once_with(
+        "desired_account",
+        [
+            {"name": "mesh_account"},
+            {"name": "all_clusters_account"},
+            {"name": "mesh_account"},
+            {"name": "all_clusters_account"},
+        ],
+    )
     run_mocks.terrascript.populate_vpc_peerings.assert_called_once()
     run_mocks.terrascript.populate_configs.assert_called_once()
     run_mocks.terrascript.dump.assert_called_once()
@@ -540,6 +549,15 @@ def test_run_fail_state(run_mocks: RunMocks) -> None:
     with pytest.raises(OSError, match="Exit called!"):
         integ.run(False, print_to_file=None, enable_deletion=True)
 
+    run_mocks.terrascript.populate_additional_providers.assert_called_once_with(
+        "desired_account",
+        [
+            {"name": "mesh_account"},
+            {"name": "all_clusters_account"},
+            {"name": "mesh_account"},
+            {"name": "all_clusters_account"},
+        ],
+    )
     run_mocks.terraform.plan.assert_not_called()
     run_mocks.terraform.cleanup.assert_not_called()
     run_mocks.terraform.apply.assert_not_called()
@@ -556,6 +574,15 @@ def test_run_dry_run(run_mocks: RunMocks) -> None:
 
     integ.run(True, print_to_file=None, enable_deletion=False)
 
+    run_mocks.terrascript.populate_additional_providers.assert_called_once_with(
+        "desired_account",
+        [
+            {"name": "mesh_account"},
+            {"name": "all_clusters_account"},
+            {"name": "mesh_account"},
+            {"name": "all_clusters_account"},
+        ],
+    )
     run_mocks.terraform.plan.assert_called_once()
     run_mocks.terraform.cleanup.assert_called_once()
     run_mocks.terraform.apply.assert_not_called()
@@ -572,6 +599,15 @@ def test_run_dry_run_with_failures(run_mocks: RunMocks) -> None:
     with pytest.raises(OSError, match="Exit called!"):
         integ.run(True, print_to_file=None, enable_deletion=False)
 
+    run_mocks.terrascript.populate_additional_providers.assert_called_once_with(
+        "desired_account",
+        [
+            {"name": "mesh_account"},
+            {"name": "all_clusters_account"},
+            {"name": "mesh_account"},
+            {"name": "all_clusters_account"},
+        ],
+    )
     run_mocks.terraform.plan.assert_not_called()
     run_mocks.terraform.cleanup.assert_not_called()
     run_mocks.terraform.apply.assert_not_called()
@@ -587,6 +623,15 @@ def test_run_dry_run_print_only_with_failures(run_mocks: RunMocks) -> None:
     with pytest.raises(OSError, match="Exit called!"):
         integ.run(True, print_to_file="some/dir", enable_deletion=False)
 
+    run_mocks.terrascript.populate_additional_providers.assert_called_once_with(
+        "desired_account",
+        [
+            {"name": "mesh_account"},
+            {"name": "all_clusters_account"},
+            {"name": "mesh_account"},
+            {"name": "all_clusters_account"},
+        ],
+    )
     run_mocks.terraform.plan.assert_not_called()
     run_mocks.terraform.cleanup.assert_not_called()
     run_mocks.terraform.apply.assert_not_called()

--- a/reconcile/test/test_terraform_vpc_peerings.py
+++ b/reconcile/test/test_terraform_vpc_peerings.py
@@ -385,8 +385,7 @@ def test_empty_run(mocker: MockerFixture) -> None:
     integ.run(True)
 
     mocked_logging.warning.assert_called_once_with(
-        "No participating AWS accounts found, consider disabling this integration, account name: %s",
-        None,
+        "No participating AWS accounts found, consider disabling this integration, account name: None"
     )
 
 

--- a/reconcile/test/test_terraform_vpc_peerings_build_desired_state.py
+++ b/reconcile/test/test_terraform_vpc_peerings_build_desired_state.py
@@ -1,9 +1,10 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, cast
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any, cast
+from unittest.mock import MagicMock
 
 import pytest
-import testslide
 
 import reconcile.terraform_vpc_peerings as sut
 from reconcile.test.test_terraform_vpc_peerings import (
@@ -553,199 +554,52 @@ def test_c2c_no_peer_account() -> None:
     assert str(ex.value).startswith("[no_account_available]")
 
 
-class TestBuildDesiredStateVpcMesh(testslide.TestCase):
-    def setUp(self) -> None:
-        super().setUp()
-        self.clusters = [
-            {
-                "name": "clustername",
-                "spec": {
-                    "region": "mars-plain-1",
-                },
-                "network": {
-                    "vpc": "172.16.0.0/12",
-                    "service": "10.0.0.0/8",
-                    "pod": "192.168.0.0/16",
-                },
-                "peering": {
-                    "connections": [
-                        {
-                            "provider": "account-vpc-mesh",
-                            "name": "peername",
-                            "vpc": {"$ref": "/aws/account/vpcs/mars-plain-1"},
-                            "manageRoutes": True,
-                            "tags": '["tag1"]',
-                        },
-                    ]
-                },
-            }
-        ]
-        self.peer = {
+@dataclass
+class VpcMeshState:
+    clusters: list[dict[str, Any]]
+    peer_account: dict[str, Any]
+    ocm_mock: MagicMock
+    ocm_map: dict[str, MagicMock]
+    awsapi: MagicMock
+    vpc_mesh_single_cluster: MagicMock
+    account_vpcs: list[dict[str, Any]]
+
+
+@pytest.fixture
+def vpc_mesh_state(mocker: MockerFixture) -> VpcMeshState:
+    peer_account: dict[str, Any] = {
+        "name": "peer_account",
+        "uid": "peeruid",
+        "terraformUsername": "peerterraformusename",
+        "automationtoken": "peeranautomationtoken",
+        "assume_role": "a:peer:role:indeed:it:is",
+        "assume_region": "mars-hellas-1",
+        "assume_cidr": "172.25.0.0/12",
+    }
+    peer_cluster: dict[str, Any] = {
+        "name": "apeerclustername",
+        "spec": {"region": "mars-olympus-2"},
+        "network": {
             "vpc": "172.17.0.0/12",
             "service": "10.1.0.0/8",
             "pod": "192.168.1.0/16",
-        }
-        self.peer_cluster = {
-            "name": "apeerclustername",
-            "spec": {
-                "region": "mars-olympus-2",
-            },
-            "network": self.peer,
-            "peering": {
-                "connections": [
-                    {
-                        "provider": "cluster-vpc-requester",
-                        "name": "peername",
-                        "vpc": {"$ref": "/aws/account/vpcs/mars-plain-1"},
-                        "manageRoutes": True,
-                        "tags": '["tag1"]',
-                    },
-                ]
-            },
-        }
-
-        self.aws_account = {
-            "name": "accountname",
-            "uid": "anuid",
-            "terraformUsername": "aterraformusename",
-            "automationtoken": "anautomationtoken",
-            "assume_role": "arole:very:useful:indeed:it:is",
-            "assume_region": "moon-tranquility-1",
-            "assume_cidr": "172.25.0.0/12",
-        }
-        self.peer_account = {
-            "name": "peer_account",
-            "uid": "peeruid",
-            "terraformUsername": "peerterraformusename",
-            "automationtoken": "peeranautomationtoken",
-            "assume_role": "a:peer:role:indeed:it:is",
-            "assume_region": "mars-hellas-1",
-            "assume_cidr": "172.25.0.0/12",
-        }
-        self.clusters[0]["peering"]["connections"][0]["cluster"] = self.peer_cluster  # type: ignore
-        self.clusters[0]["peering"]["connections"][0]["account"] = self.peer_account  # type: ignore
-        self.peer_vpc = {
-            "cidr_block": "172.30.0.0/12",
-            "vpc_id": "peervpcid",
-            "route_table_ids": ["peer_route_table_id"],
-        }
-        self.vpc_mesh_single_cluster = self.mock_callable(
-            sut, "build_desired_state_vpc_mesh_single_cluster"
-        )
-        self.maxDiff = None
-        self.ocm = testslide.StrictMock(ocm.OCM)
-        self.ocm_map = cast(
-            "ocm.OCMMap", {"clustername": self.ocm}
-        )  # the cast is to make mypy happy
-        self.ocm.get_aws_infrastructure_access_terraform_assume_role = (
-            lambda cluster, uid, tfuser: self.peer_account["assume_role"]
-        )
-        self.awsapi = cast(
-            "aws_api.AWSApi", testslide.StrictMock(aws_api.AWSApi)
-        )  # the cast is to make mypy happy
-        self.account_vpcs = [
-            {
-                "vpc_id": "vpc1",
-                "region": "moon-dark-1",
-                "cidr_block": "192.168.3.0/24",
-                "route_table_ids": ["vpc1_route_table"],
-            },
-            {
-                "vpc_id": "vpc2",
-                "region": "mars-utopia-2",
-                "cidr_block": "192.168.4.0/24",
-                "route_table_ids": ["vpc2_route_table"],
-            },
-        ]
-        self.addCleanup(testslide.mock_callable.unpatch_all_callable_mocks)
-
-    def test_all_fine(self) -> None:
-        expected = [
-            {
-                "connection_provider": "account-vpc-mesh",
-                "connection_name": "peername_peer_account-vpc1",
-                "requester": {
-                    "vpc_id": "vpc_id",
-                    "route_table_ids": ["route_table_id"],
-                    "account": self.peer_account,
-                    "region": "mars-plain-1",
-                    "cidr_block": "172.16.0.0/12",
+        },
+        "peering": {
+            "connections": [
+                {
+                    "provider": "cluster-vpc-requester",
+                    "name": "peername",
+                    "vpc": {"$ref": "/aws/account/vpcs/mars-plain-1"},
+                    "manageRoutes": True,
+                    "tags": '["tag1"]',
                 },
-                "accepter": {
-                    "vpc_id": "vpc1",
-                    "region": "moon-dark-1",
-                    "cidr_block": "192.168.3.0/24",
-                    "route_table_ids": ["vpc1_route_table"],
-                    "account": self.peer_account,
-                },
-                "deleted": False,
-            },
-            {
-                "connection_provider": "account-vpc-mesh",
-                "connection_name": "peername_peer_account-vpc2",
-                "requester": {
-                    "vpc_id": "vpc_id",
-                    "route_table_ids": ["route_table_id"],
-                    "account": self.peer_account,
-                    "region": "mars-plain-1",
-                    "cidr_block": "172.16.0.0/12",
-                },
-                "accepter": {
-                    "vpc_id": "vpc2",
-                    "region": "mars-utopia-2",
-                    "cidr_block": "192.168.4.0/24",
-                    "route_table_ids": ["vpc2_route_table"],
-                    "account": self.peer_account,
-                },
-                "deleted": False,
-            },
-        ]
-        self.vpc_mesh_single_cluster.for_call(
-            self.clusters[0],
-            self.ocm,
-            self.awsapi,
-            None,
-        ).to_return_value(expected)
-
-        rs = sut.build_desired_state_vpc_mesh(
-            self.clusters,
-            self.ocm_map,
-            self.awsapi,
-            None,
-        )
-        self.assertEqual(rs, (expected, False))
-
-    def test_cluster_raises(self) -> None:
-        self.vpc_mesh_single_cluster.to_raise(
-            sut.BadTerraformPeeringStateError("This is wrong")
-        )
-        rs = sut.build_desired_state_vpc_mesh(
-            self.clusters,
-            self.ocm_map,
-            self.awsapi,
-            None,
-        )
-        self.assertEqual(rs, ([], True))
-
-    def test_cluster_raises_unexpected(self) -> None:
-        self.vpc_mesh_single_cluster.to_raise(ValueError("Nope"))
-        with self.assertRaises(ValueError):
-            sut.build_desired_state_vpc_mesh(
-                self.clusters,
-                self.ocm_map,
-                self.awsapi,
-                None,
-            )
-
-
-class TestBuildDesiredStateVpcMeshSingleCluster(testslide.TestCase):
-    def setUp(self) -> None:
-        super().setUp()
-        self.cluster = {
+            ]
+        },
+    }
+    clusters: list[dict[str, Any]] = [
+        {
             "name": "clustername",
-            "spec": {
-                "region": "mars-plain-1",
-            },
+            "spec": {"region": "mars-plain-1"},
             "network": {
                 "vpc": "172.16.0.0/12",
                 "service": "10.0.0.0/8",
@@ -759,450 +613,444 @@ class TestBuildDesiredStateVpcMeshSingleCluster(testslide.TestCase):
                         "vpc": {"$ref": "/aws/account/vpcs/mars-plain-1"},
                         "manageRoutes": True,
                         "tags": '["tag1"]',
+                        "cluster": peer_cluster,
+                        "account": peer_account,
                     },
                 ]
             },
         }
-        self.peer = {
-            "vpc": "172.17.0.0/12",
-            "service": "10.1.0.0/8",
-            "pod": "192.168.1.0/16",
-        }
-        self.peer_cluster = {
-            "name": "apeerclustername",
-            "spec": {
-                "region": "mars-olympus-2",
+    ]
+
+    ocm_mock = MagicMock(spec=ocm.OCM)
+    ocm_mock.get_aws_infrastructure_access_terraform_assume_role.side_effect = (
+        lambda cluster, uid, tfuser: peer_account["assume_role"]
+    )
+    ocm_map = cast("ocm.OCMMap", {"clustername": ocm_mock})
+
+    awsapi = MagicMock(spec=aws_api.AWSApi)
+
+    vpc_mesh_single_cluster = mocker.patch.object(
+        sut, "build_desired_state_vpc_mesh_single_cluster"
+    )
+
+    account_vpcs: list[dict[str, Any]] = [
+        {
+            "vpc_id": "vpc1",
+            "region": "moon-dark-1",
+            "cidr_block": "192.168.3.0/24",
+            "route_table_ids": ["vpc1_route_table"],
+        },
+        {
+            "vpc_id": "vpc2",
+            "region": "mars-utopia-2",
+            "cidr_block": "192.168.4.0/24",
+            "route_table_ids": ["vpc2_route_table"],
+        },
+    ]
+
+    return VpcMeshState(
+        clusters=clusters,
+        peer_account=peer_account,
+        ocm_mock=ocm_mock,
+        ocm_map=ocm_map,
+        awsapi=awsapi,
+        vpc_mesh_single_cluster=vpc_mesh_single_cluster,
+        account_vpcs=account_vpcs,
+    )
+
+
+def test_vpc_mesh_all_fine(vpc_mesh_state: VpcMeshState) -> None:
+    expected = [
+        {
+            "connection_provider": "account-vpc-mesh",
+            "connection_name": "peername_peer_account-vpc1",
+            "requester": {
+                "vpc_id": "vpc_id",
+                "route_table_ids": ["route_table_id"],
+                "account": vpc_mesh_state.peer_account,
+                "region": "mars-plain-1",
+                "cidr_block": "172.16.0.0/12",
             },
-            "network": self.peer,
-            "peering": {
-                "connections": [
-                    {
-                        "provider": "cluster-vpc-requester",
-                        "name": "peername",
-                        "vpc": {"$ref": "/aws/account/vpcs/mars-plain-1"},
-                        "manageRoutes": True,
-                        "tags": '["tag1"]',
-                    },
-                ]
-            },
-        }
-        self.awsapi = cast(
-            "aws_api.AWSApi", testslide.StrictMock(aws_api.AWSApi)
-        )  # the cast is to make mypy happy
-        self.mock_constructor(aws_api, "AWSApi").to_return_value(self.awsapi)
-        self.find_matching_peering = self.mock_callable(sut, "find_matching_peering")
-        self.aws_account = {
-            "name": "accountname",
-            "uid": "anuid",
-            "terraformUsername": "aterraformusename",
-            "automationtoken": "anautomationtoken",
-            "assume_role": "arole:very:useful:indeed:it:is",
-            "assume_region": "moon-tranquility-1",
-            "assume_cidr": "172.25.0.0/12",
-        }
-        self.peer_account = {
-            "name": "peer_account",
-            "uid": "peeruid",
-            "terraformUsername": "peerterraformusename",
-            "automationtoken": "peeranautomationtoken",
-            "assume_role": "a:peer:role:indeed:it:is",
-            "assume_region": "mars-hellas-1",
-            "assume_cidr": "172.25.0.0/12",
-        }
-        self.cluster["peering"]["connections"][0]["cluster"] = self.peer_cluster  # type: ignore
-        self.cluster["peering"]["connections"][0]["account"] = self.peer_account  # type: ignore
-        self.peer_vpc = {
-            "cidr_block": "172.30.0.0/12",
-            "vpc_id": "peervpcid",
-            "route_table_ids": ["peer_route_table_id"],
-        }
-        self.maxDiff = None
-        self.addCleanup(testslide.mock_callable.unpatch_all_callable_mocks)
-        self.ocm = cast(
-            "ocm.OCM", testslide.StrictMock(template=ocm.OCM)
-        )  # the cast is to make mypy happy
-        self.ocm.get_aws_infrastructure_access_terraform_assume_role = (  # type: ignore
-            lambda cluster, tf_account_id, tf_user: self.peer_account["assume_role"]
-        )
-        self.account_vpcs = [
-            {
+            "accepter": {
                 "vpc_id": "vpc1",
                 "region": "moon-dark-1",
                 "cidr_block": "192.168.3.0/24",
                 "route_table_ids": ["vpc1_route_table"],
+                "account": vpc_mesh_state.peer_account,
             },
-            {
+            "deleted": False,
+        },
+        {
+            "connection_provider": "account-vpc-mesh",
+            "connection_name": "peername_peer_account-vpc2",
+            "requester": {
+                "vpc_id": "vpc_id",
+                "route_table_ids": ["route_table_id"],
+                "account": vpc_mesh_state.peer_account,
+                "region": "mars-plain-1",
+                "cidr_block": "172.16.0.0/12",
+            },
+            "accepter": {
                 "vpc_id": "vpc2",
                 "region": "mars-utopia-2",
                 "cidr_block": "192.168.4.0/24",
                 "route_table_ids": ["vpc2_route_table"],
+                "account": vpc_mesh_state.peer_account,
             },
-        ]
+            "deleted": False,
+        },
+    ]
+    vpc_mesh_state.vpc_mesh_single_cluster.return_value = expected
 
-    def test_one_cluster(self) -> None:
-        req_account = {
-            **self.peer_account,
-            "assume_region": "mars-plain-1",
-            "assume_cidr": "172.16.0.0/12",
-        }
-        self.mock_callable(self.awsapi, "get_cluster_vpc_details").for_call(
-            req_account, route_tables=True, hcp_vpc_endpoint_sg=False
-        ).to_return_value((
-            "vpc_id",
-            ["route_table_id"],
-            "subnet_id",
-            None,
-        )).and_assert_called_once()
+    rs = sut.build_desired_state_vpc_mesh(
+        vpc_mesh_state.clusters,
+        vpc_mesh_state.ocm_map,
+        vpc_mesh_state.awsapi,
+        None,
+    )
+    assert rs == (expected, False)
 
-        self.mock_callable(self.awsapi, "get_vpcs_details").for_call(
-            req_account, tags=["tag1"], route_tables=True
-        ).to_return_value(self.account_vpcs).and_assert_called_once()
 
-        expected = [
-            {
-                "connection_provider": "account-vpc-mesh",
-                "connection_name": "peername_peer_account-vpc1",
-                "infra_account_name": self.peer_account["name"],
-                "requester": {
-                    "vpc_id": "vpc_id",
-                    "route_table_ids": ["route_table_id"],
-                    "api_security_group_id": None,
-                    "account": self.peer_account,
-                    "region": "mars-plain-1",
-                    "cidr_block": "172.16.0.0/12",
-                },
-                "accepter": {
-                    "vpc_id": "vpc1",
-                    "region": "moon-dark-1",
-                    "cidr_block": "192.168.3.0/24",
-                    "route_table_ids": ["vpc1_route_table"],
-                    "account": self.peer_account,
-                },
-                "deleted": False,
-            },
-            {
-                "connection_provider": "account-vpc-mesh",
-                "connection_name": "peername_peer_account-vpc2",
-                "infra_account_name": self.peer_account["name"],
-                "requester": {
-                    "vpc_id": "vpc_id",
-                    "route_table_ids": ["route_table_id"],
-                    "api_security_group_id": None,
-                    "account": self.peer_account,
-                    "region": "mars-plain-1",
-                    "cidr_block": "172.16.0.0/12",
-                },
-                "accepter": {
-                    "vpc_id": "vpc2",
-                    "region": "mars-utopia-2",
-                    "cidr_block": "192.168.4.0/24",
-                    "route_table_ids": ["vpc2_route_table"],
-                    "account": self.peer_account,
-                },
-                "deleted": False,
-            },
-        ]
+def test_vpc_mesh_cluster_raises(vpc_mesh_state: VpcMeshState) -> None:
+    vpc_mesh_state.vpc_mesh_single_cluster.side_effect = (
+        sut.BadTerraformPeeringStateError("This is wrong")
+    )
+    rs = sut.build_desired_state_vpc_mesh(
+        vpc_mesh_state.clusters,
+        vpc_mesh_state.ocm_map,
+        vpc_mesh_state.awsapi,
+        None,
+    )
+    assert rs == ([], True)
 
-        rs = sut.build_desired_state_vpc_mesh_single_cluster(
-            self.cluster,
-            self.ocm,
-            self.awsapi,
+
+def test_vpc_mesh_cluster_raises_unexpected(vpc_mesh_state: VpcMeshState) -> None:
+    vpc_mesh_state.vpc_mesh_single_cluster.side_effect = ValueError("Nope")
+    with pytest.raises(ValueError):
+        sut.build_desired_state_vpc_mesh(
+            vpc_mesh_state.clusters,
+            vpc_mesh_state.ocm_map,
+            vpc_mesh_state.awsapi,
             None,
         )
-        self.assertEqual(rs, expected)
-
-    def test_one_cluster_private_hcp(self) -> None:
-        self.cluster["spec"] = {
-            "region": "mars-plain-1",
-            "hypershift": True,
-            "private": True,
-        }
-        req_account = {
-            **self.peer_account,
-            "assume_region": "mars-plain-1",
-            "assume_cidr": "172.16.0.0/12",
-        }
-        self.mock_callable(self.awsapi, "get_cluster_vpc_details").for_call(
-            req_account, route_tables=True, hcp_vpc_endpoint_sg=True
-        ).to_return_value((
-            "vpc_id",
-            ["route_table_id"],
-            "subnet_id",
-            "sg-vpce",
-        )).and_assert_called_once()
-
-        self.mock_callable(self.awsapi, "get_vpcs_details").for_call(
-            req_account, tags=["tag1"], route_tables=True
-        ).to_return_value(self.account_vpcs).and_assert_called_once()
-
-        expected = [
-            {
-                "connection_provider": "account-vpc-mesh",
-                "connection_name": "peername_peer_account-vpc1",
-                "infra_account_name": self.peer_account["name"],
-                "requester": {
-                    "vpc_id": "vpc_id",
-                    "route_table_ids": ["route_table_id"],
-                    "api_security_group_id": "sg-vpce",
-                    "account": self.peer_account,
-                    "region": "mars-plain-1",
-                    "cidr_block": "172.16.0.0/12",
-                },
-                "accepter": {
-                    "vpc_id": "vpc1",
-                    "region": "moon-dark-1",
-                    "cidr_block": "192.168.3.0/24",
-                    "route_table_ids": ["vpc1_route_table"],
-                    "account": self.peer_account,
-                },
-                "deleted": False,
-            },
-            {
-                "connection_provider": "account-vpc-mesh",
-                "connection_name": "peername_peer_account-vpc2",
-                "infra_account_name": self.peer_account["name"],
-                "requester": {
-                    "vpc_id": "vpc_id",
-                    "route_table_ids": ["route_table_id"],
-                    "api_security_group_id": "sg-vpce",
-                    "account": self.peer_account,
-                    "region": "mars-plain-1",
-                    "cidr_block": "172.16.0.0/12",
-                },
-                "accepter": {
-                    "vpc_id": "vpc2",
-                    "region": "mars-utopia-2",
-                    "cidr_block": "192.168.4.0/24",
-                    "route_table_ids": ["vpc2_route_table"],
-                    "account": self.peer_account,
-                },
-                "deleted": False,
-            },
-        ]
-
-        rs = sut.build_desired_state_vpc_mesh_single_cluster(
-            self.cluster, self.ocm, self.awsapi, None
-        )
-        self.assertEqual(rs, expected)
-
-    def test_no_peering_connections(self) -> None:
-        self.cluster["peering"]["connections"] = []  # type: ignore
-        rs = sut.build_desired_state_vpc_mesh_single_cluster(
-            self.cluster, self.ocm, self.awsapi, None
-        )
-        self.assertEqual(rs, [])
-
-    def test_no_peer_vpc_id(self) -> None:
-        self.mock_callable(self.awsapi, "get_cluster_vpc_details").to_return_value((
-            None,
-            [None],
-            None,
-            None,
-        )).and_assert_called_once()
-
-        desired_state = sut.build_desired_state_vpc_mesh_single_cluster(
-            self.cluster, self.ocm, self.awsapi, None
-        )
-        assert desired_state == []
 
 
-class TestBuildDesiredStateVpc(testslide.TestCase):
-    def setUp(self) -> None:
-        super().setUp()
-        self.peer = {
+@dataclass
+class VpcMeshSingleState:
+    cluster: dict[str, Any]
+    peer_account: dict[str, Any]
+    ocm_mock: MagicMock
+    awsapi: MagicMock
+    find_matching_peering: MagicMock
+    account_vpcs: list[dict[str, Any]]
+
+
+@pytest.fixture
+def vpc_mesh_single_state(mocker: MockerFixture) -> VpcMeshSingleState:
+    peer_account: dict[str, Any] = {
+        "name": "peer_account",
+        "uid": "peeruid",
+        "terraformUsername": "peerterraformusename",
+        "automationtoken": "peeranautomationtoken",
+        "assume_role": "a:peer:role:indeed:it:is",
+        "assume_region": "mars-hellas-1",
+        "assume_cidr": "172.25.0.0/12",
+    }
+    peer_cluster: dict[str, Any] = {
+        "name": "apeerclustername",
+        "spec": {"region": "mars-olympus-2"},
+        "network": {
             "vpc": "172.17.0.0/12",
             "service": "10.1.0.0/8",
             "pod": "192.168.1.0/16",
-        }
-        self.aws_account = {
-            "name": "accountname",
-            "uid": "anuid",
-            "terraformUsername": "aterraformusename",
-            "automationtoken": "anautomationtoken",
-            "assume_role": "arole:very:useful:indeed:it:is",
-            "assume_region": "moon-tranquility-1",
-            "assume_cidr": "172.25.0.0/12",
-        }
-
-        self.clusters = [
-            {
-                "name": "clustername",
-                "spec": {
-                    "region": "mars-plain-1",
+        },
+        "peering": {
+            "connections": [
+                {
+                    "provider": "cluster-vpc-requester",
+                    "name": "peername",
+                    "vpc": {"$ref": "/aws/account/vpcs/mars-plain-1"},
+                    "manageRoutes": True,
+                    "tags": '["tag1"]',
                 },
-                "network": {
-                    "vpc": "172.16.0.0/12",
-                    "service": "10.0.0.0/8",
-                    "pod": "192.168.0.0/16",
+            ]
+        },
+    }
+    cluster: dict[str, Any] = {
+        "name": "clustername",
+        "spec": {"region": "mars-plain-1"},
+        "network": {
+            "vpc": "172.16.0.0/12",
+            "service": "10.0.0.0/8",
+            "pod": "192.168.0.0/16",
+        },
+        "peering": {
+            "connections": [
+                {
+                    "provider": "account-vpc-mesh",
+                    "name": "peername",
+                    "vpc": {"$ref": "/aws/account/vpcs/mars-plain-1"},
+                    "manageRoutes": True,
+                    "tags": '["tag1"]',
+                    "cluster": peer_cluster,
+                    "account": peer_account,
                 },
-                "peering": {
-                    "connections": [
-                        {
-                            "provider": "account-vpc",
-                            "name": "peername",
-                            "vpc": {
-                                "$ref": "/aws/account/vpcs/mars-plain-1",
-                                "cidr_block": "172.30.0.0/12",
-                                "vpc_id": "avpcid",
-                                **self.peer,
-                                "region": "mars-olympus-2",
-                                "account": self.aws_account,
-                            },
-                            "manageRoutes": True,
-                        },
-                    ]
-                },
-            }
-        ]
+            ]
+        },
+    }
 
-        self.peer_cluster = {
-            "name": "apeerclustername",
-            "spec": {
-                "region": "mars-olympus-2",
-            },
-            "network": self.peer,
-            "peering": {
-                "connections": [
-                    {
-                        "provider": "account-vpc",
-                        "name": "peername",
-                        "vpc": {"$ref": "/aws/account/vpcs/mars-plain-1"},
-                        "manageRoutes": True,
-                    },
-                ]
-            },
-        }
-        self.clusters[0]["peering"]["connections"][0]["cluster"] = self.peer_cluster  # type: ignore
-        self.build_single_cluster = self.mock_callable(
-            sut, "build_desired_state_single_cluster"
-        )
-        self.ocm = testslide.StrictMock(template=ocm.OCM)
-        self.ocm_map: ocm.OCMMap = {"clustername": self.ocm}  # type: ignore
-        self.awsapi = cast(
-            "aws_api.AWSApi", testslide.StrictMock(aws_api.AWSApi)
-        )  # the cast is to make mypy happy
+    ocm_mock = MagicMock(spec=ocm.OCM)
+    ocm_mock.get_aws_infrastructure_access_terraform_assume_role.side_effect = (
+        lambda cluster_arg, tf_account_id, tf_user: peer_account["assume_role"]
+    )
 
-        self.build_single_cluster = self.mock_callable(
-            sut, "build_desired_state_vpc_single_cluster"
-        )
-        self.addCleanup(testslide.mock_callable.unpatch_all_callable_mocks)
-        self.maxDiff = None
+    awsapi = MagicMock(spec=aws_api.AWSApi)
+    find_matching_peering = mocker.patch.object(sut, "find_matching_peering")
 
-    def test_all_fine(self) -> None:
-        expected = [
-            {
-                "accepter": {
-                    "account": {
-                        "assume_cidr": "172.16.0.0/12",
-                        "assume_region": "mars-plain-1",
-                        "assume_role": "this:wonderful:role:hell:yeah",
-                        "automationtoken": "anautomationtoken",
-                        "name": "accountname",
-                        "terraformUsername": "aterraformusename",
-                        "uid": "anuid",
-                    },
-                    "cidr_block": "172.30.0.0/12",
-                    "region": "mars-olympus-2",
-                    "vpc_id": "avpcid",
-                },
-                "connection_name": "peername",
-                "connection_provider": "account-vpc",
-                "deleted": False,
-                "requester": {
-                    "account": {
-                        "assume_cidr": "172.16.0.0/12",
-                        "assume_region": "mars-plain-1",
-                        "assume_role": "this:wonderful:role:hell:yeah",
-                        "automationtoken": "anautomationtoken",
-                        "name": "accountname",
-                        "terraformUsername": "aterraformusename",
-                        "uid": "anuid",
-                    },
-                    "cidr_block": "172.16.0.0/12",
-                    "region": "mars-plain-1",
-                    "route_table_ids": ["routetableid"],
-                    "vpc_id": "vpcid",
-                },
-            }
-        ]
-        self.build_single_cluster.for_call(
-            self.clusters[0], self.ocm, self.awsapi, None
-        ).to_return_value(expected).and_assert_called_once()
+    account_vpcs: list[dict[str, Any]] = [
+        {
+            "vpc_id": "vpc1",
+            "region": "moon-dark-1",
+            "cidr_block": "192.168.3.0/24",
+            "route_table_ids": ["vpc1_route_table"],
+        },
+        {
+            "vpc_id": "vpc2",
+            "region": "mars-utopia-2",
+            "cidr_block": "192.168.4.0/24",
+            "route_table_ids": ["vpc2_route_table"],
+        },
+    ]
 
-        rs = sut.build_desired_state_vpc(
-            self.clusters, self.ocm_map, self.awsapi, account_filter=None
-        )
-        self.assertEqual(rs, (expected, False))
-
-    def test_cluster_fails(self) -> None:
-        self.build_single_cluster.to_raise(
-            sut.BadTerraformPeeringStateError("I have failed")
-        )
-
-        self.assertEqual(
-            sut.build_desired_state_vpc(
-                self.clusters, self.ocm_map, self.awsapi, account_filter=None
-            ),
-            ([], True),
-        )
-
-    def test_error_persists(self) -> None:
-        self.clusters.append(self.clusters[0].copy())
-        self.clusters[1]["name"] = "afailingcluster"
-        self.ocm_map["afailingcluster"] = self.ocm  # type: ignore
-        self.build_single_cluster.for_call(
-            self.clusters[0], self.ocm, self.awsapi, None
-        ).to_return_value([{"a dict": "a value"}]).and_assert_called_once()
-        self.mock_callable(sut, "build_desired_state_vpc_single_cluster").for_call(
-            self.clusters[1],
-            self.ocm,
-            self.awsapi,
-            None,
-        ).to_raise(sut.BadTerraformPeeringStateError("Fail!")).and_assert_called_once()
-
-        self.assertEqual(
-            sut.build_desired_state_vpc(
-                self.clusters, self.ocm_map, self.awsapi, account_filter=None
-            ),
-            ([{"a dict": "a value"}], True),
-        )
-
-    def test_other_exceptions_raise(self) -> None:
-        self.clusters.append(self.clusters[0].copy())
-        self.clusters[1]["name"] = "afailingcluster"
-        self.ocm_map["afailingcluster"] = self.ocm  # type: ignore
-        self.build_single_cluster.for_call(
-            self.clusters[0], self.ocm, self.awsapi, None
-        ).to_raise(ValueError("I am not planned!")).and_assert_called_once()
-        with self.assertRaises(ValueError):
-            sut.build_desired_state_vpc(
-                self.clusters, self.ocm_map, self.awsapi, account_filter=None
-            )
+    return VpcMeshSingleState(
+        cluster=cluster,
+        peer_account=peer_account,
+        ocm_mock=ocm_mock,
+        awsapi=awsapi,
+        find_matching_peering=find_matching_peering,
+        account_vpcs=account_vpcs,
+    )
 
 
-class TestBuildDesiredStateVpcSingleCluster(testslide.TestCase):
-    def setUp(self) -> None:
-        super().setUp()
-        self.peer = {
-            "vpc": "172.17.0.0/12",
-            "service": "10.1.0.0/8",
-            "pod": "192.168.1.0/16",
-        }
-        self.aws_account = {
-            "name": "accountname",
-            "uid": "anuid",
-            "terraformUsername": "aterraformusename",
-            "automationtoken": "anautomationtoken",
-            "assume_role": "arole:very:useful:indeed:it:is",
-            "assume_region": "moon-tranquility-1",
-            "assume_cidr": "172.25.0.0/12",
-        }
+def test_vpc_mesh_single_one_cluster(vpc_mesh_single_state: VpcMeshSingleState) -> None:
+    vpc_mesh_single_state.awsapi.get_cluster_vpc_details.return_value = (
+        "vpc_id",
+        ["route_table_id"],
+        "subnet_id",
+        None,
+    )
+    vpc_mesh_single_state.awsapi.get_vpcs_details.return_value = (
+        vpc_mesh_single_state.account_vpcs
+    )
 
-        self.cluster = {
-            "name": "clustername",
-            "spec": {
+    expected = [
+        {
+            "connection_provider": "account-vpc-mesh",
+            "connection_name": "peername_peer_account-vpc1",
+            "infra_account_name": vpc_mesh_single_state.peer_account["name"],
+            "requester": {
+                "vpc_id": "vpc_id",
+                "route_table_ids": ["route_table_id"],
+                "api_security_group_id": None,
+                "account": vpc_mesh_single_state.peer_account,
                 "region": "mars-plain-1",
+                "cidr_block": "172.16.0.0/12",
             },
+            "accepter": {
+                "vpc_id": "vpc1",
+                "region": "moon-dark-1",
+                "cidr_block": "192.168.3.0/24",
+                "route_table_ids": ["vpc1_route_table"],
+                "account": vpc_mesh_single_state.peer_account,
+            },
+            "deleted": False,
+        },
+        {
+            "connection_provider": "account-vpc-mesh",
+            "connection_name": "peername_peer_account-vpc2",
+            "infra_account_name": vpc_mesh_single_state.peer_account["name"],
+            "requester": {
+                "vpc_id": "vpc_id",
+                "route_table_ids": ["route_table_id"],
+                "api_security_group_id": None,
+                "account": vpc_mesh_single_state.peer_account,
+                "region": "mars-plain-1",
+                "cidr_block": "172.16.0.0/12",
+            },
+            "accepter": {
+                "vpc_id": "vpc2",
+                "region": "mars-utopia-2",
+                "cidr_block": "192.168.4.0/24",
+                "route_table_ids": ["vpc2_route_table"],
+                "account": vpc_mesh_single_state.peer_account,
+            },
+            "deleted": False,
+        },
+    ]
+
+    rs = sut.build_desired_state_vpc_mesh_single_cluster(
+        vpc_mesh_single_state.cluster,
+        vpc_mesh_single_state.ocm_mock,
+        vpc_mesh_single_state.awsapi,
+        None,
+    )
+    assert rs == expected
+    vpc_mesh_single_state.awsapi.get_cluster_vpc_details.assert_called_once()
+    vpc_mesh_single_state.awsapi.get_vpcs_details.assert_called_once()
+
+
+def test_vpc_mesh_single_one_cluster_private_hcp(
+    vpc_mesh_single_state: VpcMeshSingleState,
+) -> None:
+    vpc_mesh_single_state.cluster["spec"] = {
+        "region": "mars-plain-1",
+        "hypershift": True,
+        "private": True,
+    }
+    vpc_mesh_single_state.awsapi.get_cluster_vpc_details.return_value = (
+        "vpc_id",
+        ["route_table_id"],
+        "subnet_id",
+        "sg-vpce",
+    )
+    vpc_mesh_single_state.awsapi.get_vpcs_details.return_value = (
+        vpc_mesh_single_state.account_vpcs
+    )
+
+    expected = [
+        {
+            "connection_provider": "account-vpc-mesh",
+            "connection_name": "peername_peer_account-vpc1",
+            "infra_account_name": vpc_mesh_single_state.peer_account["name"],
+            "requester": {
+                "vpc_id": "vpc_id",
+                "route_table_ids": ["route_table_id"],
+                "api_security_group_id": "sg-vpce",
+                "account": vpc_mesh_single_state.peer_account,
+                "region": "mars-plain-1",
+                "cidr_block": "172.16.0.0/12",
+            },
+            "accepter": {
+                "vpc_id": "vpc1",
+                "region": "moon-dark-1",
+                "cidr_block": "192.168.3.0/24",
+                "route_table_ids": ["vpc1_route_table"],
+                "account": vpc_mesh_single_state.peer_account,
+            },
+            "deleted": False,
+        },
+        {
+            "connection_provider": "account-vpc-mesh",
+            "connection_name": "peername_peer_account-vpc2",
+            "infra_account_name": vpc_mesh_single_state.peer_account["name"],
+            "requester": {
+                "vpc_id": "vpc_id",
+                "route_table_ids": ["route_table_id"],
+                "api_security_group_id": "sg-vpce",
+                "account": vpc_mesh_single_state.peer_account,
+                "region": "mars-plain-1",
+                "cidr_block": "172.16.0.0/12",
+            },
+            "accepter": {
+                "vpc_id": "vpc2",
+                "region": "mars-utopia-2",
+                "cidr_block": "192.168.4.0/24",
+                "route_table_ids": ["vpc2_route_table"],
+                "account": vpc_mesh_single_state.peer_account,
+            },
+            "deleted": False,
+        },
+    ]
+
+    rs = sut.build_desired_state_vpc_mesh_single_cluster(
+        vpc_mesh_single_state.cluster,
+        vpc_mesh_single_state.ocm_mock,
+        vpc_mesh_single_state.awsapi,
+        None,
+    )
+    assert rs == expected
+    vpc_mesh_single_state.awsapi.get_cluster_vpc_details.assert_called_once()
+    vpc_mesh_single_state.awsapi.get_vpcs_details.assert_called_once()
+
+
+def test_vpc_mesh_single_no_peering_connections(
+    vpc_mesh_single_state: VpcMeshSingleState,
+) -> None:
+    vpc_mesh_single_state.cluster["peering"]["connections"] = []  # type: ignore
+    rs = sut.build_desired_state_vpc_mesh_single_cluster(
+        vpc_mesh_single_state.cluster,
+        vpc_mesh_single_state.ocm_mock,
+        vpc_mesh_single_state.awsapi,
+        None,
+    )
+    assert rs == []
+
+
+def test_vpc_mesh_single_no_peer_vpc_id(
+    vpc_mesh_single_state: VpcMeshSingleState,
+) -> None:
+    vpc_mesh_single_state.awsapi.get_cluster_vpc_details.return_value = (
+        None,
+        [None],
+        None,
+        None,
+    )
+
+    desired_state = sut.build_desired_state_vpc_mesh_single_cluster(
+        vpc_mesh_single_state.cluster,
+        vpc_mesh_single_state.ocm_mock,
+        vpc_mesh_single_state.awsapi,
+        None,
+    )
+    assert desired_state == []
+    vpc_mesh_single_state.awsapi.get_cluster_vpc_details.assert_called_once()
+
+
+@dataclass
+class VpcState:
+    clusters: list[dict[str, Any]]
+    aws_account: dict[str, Any]
+    ocm_mock: MagicMock
+    ocm_map: dict[str, MagicMock]
+    awsapi: MagicMock
+    build_single_cluster: MagicMock
+
+
+@pytest.fixture
+def vpc_state(mocker: MockerFixture) -> VpcState:
+    aws_account: dict[str, Any] = {
+        "name": "accountname",
+        "uid": "anuid",
+        "terraformUsername": "aterraformusename",
+        "automationtoken": "anautomationtoken",
+        "assume_role": "arole:very:useful:indeed:it:is",
+        "assume_region": "moon-tranquility-1",
+        "assume_cidr": "172.25.0.0/12",
+    }
+    peer: dict[str, Any] = {
+        "vpc": "172.17.0.0/12",
+        "service": "10.1.0.0/8",
+        "pod": "192.168.1.0/16",
+    }
+    peer_cluster: dict[str, Any] = {
+        "name": "apeerclustername",
+        "spec": {"region": "mars-olympus-2"},
+        "network": peer,
+        "peering": {
+            "connections": [
+                {
+                    "provider": "account-vpc",
+                    "name": "peername",
+                    "vpc": {"$ref": "/aws/account/vpcs/mars-plain-1"},
+                    "manageRoutes": True,
+                },
+            ]
+        },
+    }
+    clusters: list[dict[str, Any]] = [
+        {
+            "name": "clustername",
+            "spec": {"region": "mars-plain-1"},
             "network": {
                 "vpc": "172.16.0.0/12",
                 "service": "10.0.0.0/8",
@@ -1217,222 +1065,379 @@ class TestBuildDesiredStateVpcSingleCluster(testslide.TestCase):
                             "$ref": "/aws/account/vpcs/mars-plain-1",
                             "cidr_block": "172.30.0.0/12",
                             "vpc_id": "avpcid",
-                            **self.peer,
+                            **peer,
                             "region": "mars-olympus-2",
-                            "account": self.aws_account,
+                            "account": aws_account,
                         },
                         "manageRoutes": True,
+                        "cluster": peer_cluster,
                     },
                 ]
             },
         }
+    ]
 
-        self.peer_cluster = {
-            "name": "apeerclustername",
-            "spec": {
+    ocm_mock = MagicMock(spec=ocm.OCM)
+    ocm_map = cast("ocm.OCMMap", {"clustername": ocm_mock})
+    awsapi = MagicMock(spec=aws_api.AWSApi)
+    build_single_cluster = mocker.patch.object(
+        sut, "build_desired_state_vpc_single_cluster"
+    )
+
+    return VpcState(
+        clusters=clusters,
+        aws_account=aws_account,
+        ocm_mock=ocm_mock,
+        ocm_map=ocm_map,
+        awsapi=awsapi,
+        build_single_cluster=build_single_cluster,
+    )
+
+
+def test_vpc_all_fine(vpc_state: VpcState) -> None:
+    expected = [
+        {
+            "accepter": {
+                "account": {
+                    "assume_cidr": "172.16.0.0/12",
+                    "assume_region": "mars-plain-1",
+                    "assume_role": "this:wonderful:role:hell:yeah",
+                    "automationtoken": "anautomationtoken",
+                    "name": "accountname",
+                    "terraformUsername": "aterraformusename",
+                    "uid": "anuid",
+                },
+                "cidr_block": "172.30.0.0/12",
                 "region": "mars-olympus-2",
+                "vpc_id": "avpcid",
             },
-            "network": self.peer,
-            "peering": {
-                "connections": [
-                    {
-                        "provider": "account-vpc",
-                        "name": "peername",
-                        "vpc": {"$ref": "/aws/account/vpcs/mars-plain-1"},
-                        "manageRoutes": True,
-                    },
-                ]
+            "connection_name": "peername",
+            "connection_provider": "account-vpc",
+            "deleted": False,
+            "requester": {
+                "account": {
+                    "assume_cidr": "172.16.0.0/12",
+                    "assume_region": "mars-plain-1",
+                    "assume_role": "this:wonderful:role:hell:yeah",
+                    "automationtoken": "anautomationtoken",
+                    "name": "accountname",
+                    "terraformUsername": "aterraformusename",
+                    "uid": "anuid",
+                },
+                "cidr_block": "172.16.0.0/12",
+                "region": "mars-plain-1",
+                "route_table_ids": ["routetableid"],
+                "vpc_id": "vpcid",
             },
         }
-        self.cluster["peering"]["connections"][0]["cluster"] = self.peer_cluster  # type: ignore
-        self.build_single_cluster = self.mock_callable(
-            sut, "build_desired_state_single_cluster"
-        )
-        self.ocm = cast(
-            "ocm.OCM", testslide.StrictMock(template=ocm.OCM)
-        )  # the cast is to make mypy happy
-        self.awsapi = cast(
-            "aws_api.AWSApi", testslide.StrictMock(aws_api.AWSApi)
-        )  # the cast is to make mypy happy
-        self.mock_constructor(aws_api, "AWSApi").to_return_value(self.awsapi)
-        self.ocm.get_aws_infrastructure_access_terraform_assume_role = (  # type: ignore
-            lambda cluster, tf_account_id, tf_user: self.aws_account["assume_role"]
-        )
-        self.addCleanup(testslide.mock_callable.unpatch_all_callable_mocks)
-        self.maxDiff = None
+    ]
+    vpc_state.build_single_cluster.return_value = expected
 
-    def test_all_fine(self) -> None:
-        expected = [
-            {
-                "accepter": {
-                    "account": {
-                        "assume_cidr": "172.16.0.0/12",
-                        "assume_region": "mars-plain-1",
-                        "assume_role": "this:wonderful:role:hell:yeah",
-                        "automationtoken": "anautomationtoken",
-                        "name": "accountname",
-                        "terraformUsername": "aterraformusename",
-                        "uid": "anuid",
-                    },
-                    "cidr_block": "172.30.0.0/12",
-                    "region": "mars-olympus-2",
-                    "vpc_id": "avpcid",
-                },
-                "connection_name": "peername",
-                "connection_provider": "account-vpc",
-                "infra_account_name": "accountname",
-                "deleted": False,
-                "requester": {
-                    "account": {
-                        "assume_cidr": "172.16.0.0/12",
-                        "assume_region": "mars-plain-1",
-                        "assume_role": "this:wonderful:role:hell:yeah",
-                        "automationtoken": "anautomationtoken",
-                        "name": "accountname",
-                        "terraformUsername": "aterraformusename",
-                        "uid": "anuid",
-                    },
-                    "cidr_block": "172.16.0.0/12",
-                    "region": "mars-plain-1",
-                    "route_table_ids": ["routetableid"],
-                    "api_security_group_id": None,
-                    "vpc_id": "vpcid",
-                },
-            }
-        ]
-        self.mock_callable(
-            self.awsapi,
-            "get_cluster_vpc_details",
-        ).for_call(
-            self.aws_account, route_tables=True, hcp_vpc_endpoint_sg=False
-        ).to_return_value((
-            "vpcid",
-            ["routetableid"],
-            {},
-            None,
-        )).and_assert_called_once()
-        self.mock_callable(
-            self.ocm, "get_aws_infrastructure_access_terraform_assume_role"
-        ).for_call(
-            self.cluster["name"],
-            self.aws_account["uid"],
-            self.aws_account["terraformUsername"],
-        ).to_return_value("this:wonderful:role:hell:yeah").and_assert_called_once()
-        rs = sut.build_desired_state_vpc_single_cluster(
-            self.cluster, self.ocm, self.awsapi, None
-        )
-        self.assertEqual(rs, expected)
+    rs = sut.build_desired_state_vpc(
+        vpc_state.clusters, vpc_state.ocm_map, vpc_state.awsapi, account_filter=None
+    )
+    assert rs == (expected, False)
+    vpc_state.build_single_cluster.assert_called_once()
 
-    def test_private_hcp(self) -> None:
-        self.cluster["spec"] = {
-            "region": "mars-plain-1",
-            "hypershift": True,
-            "private": True,
+
+def test_vpc_cluster_fails(vpc_state: VpcState) -> None:
+    vpc_state.build_single_cluster.side_effect = sut.BadTerraformPeeringStateError(
+        "I have failed"
+    )
+
+    assert sut.build_desired_state_vpc(
+        vpc_state.clusters, vpc_state.ocm_map, vpc_state.awsapi, account_filter=None
+    ) == ([], True)
+
+
+def test_vpc_error_persists(vpc_state: VpcState) -> None:
+    vpc_state.clusters.append(vpc_state.clusters[0].copy())
+    vpc_state.clusters[1]["name"] = "afailingcluster"
+    vpc_state.ocm_map["afailingcluster"] = vpc_state.ocm_mock  # type: ignore
+    vpc_state.build_single_cluster.side_effect = [
+        [{"a dict": "a value"}],
+        sut.BadTerraformPeeringStateError("Fail!"),
+    ]
+
+    assert sut.build_desired_state_vpc(
+        vpc_state.clusters, vpc_state.ocm_map, vpc_state.awsapi, account_filter=None
+    ) == ([{"a dict": "a value"}], True)
+    assert vpc_state.build_single_cluster.call_count == 2
+
+
+def test_vpc_other_exceptions_raise(vpc_state: VpcState) -> None:
+    vpc_state.clusters.append(vpc_state.clusters[0].copy())
+    vpc_state.clusters[1]["name"] = "afailingcluster"
+    vpc_state.ocm_map["afailingcluster"] = vpc_state.ocm_mock  # type: ignore
+    vpc_state.build_single_cluster.side_effect = ValueError("I am not planned!")
+    with pytest.raises(ValueError):
+        sut.build_desired_state_vpc(
+            vpc_state.clusters, vpc_state.ocm_map, vpc_state.awsapi, account_filter=None
+        )
+
+
+@dataclass
+class VpcSingleState:
+    cluster: dict[str, Any]
+    aws_account: dict[str, Any]
+    ocm_mock: MagicMock
+    awsapi: MagicMock
+
+
+@pytest.fixture
+def vpc_single_state() -> VpcSingleState:
+    aws_account: dict[str, Any] = {
+        "name": "accountname",
+        "uid": "anuid",
+        "terraformUsername": "aterraformusename",
+        "automationtoken": "anautomationtoken",
+        "assume_role": "arole:very:useful:indeed:it:is",
+        "assume_region": "moon-tranquility-1",
+        "assume_cidr": "172.25.0.0/12",
+    }
+    peer: dict[str, Any] = {
+        "vpc": "172.17.0.0/12",
+        "service": "10.1.0.0/8",
+        "pod": "192.168.1.0/16",
+    }
+    peer_cluster: dict[str, Any] = {
+        "name": "apeerclustername",
+        "spec": {"region": "mars-olympus-2"},
+        "network": peer,
+        "peering": {
+            "connections": [
+                {
+                    "provider": "account-vpc",
+                    "name": "peername",
+                    "vpc": {"$ref": "/aws/account/vpcs/mars-plain-1"},
+                    "manageRoutes": True,
+                },
+            ]
+        },
+    }
+    cluster: dict[str, Any] = {
+        "name": "clustername",
+        "spec": {"region": "mars-plain-1"},
+        "network": {
+            "vpc": "172.16.0.0/12",
+            "service": "10.0.0.0/8",
+            "pod": "192.168.0.0/16",
+        },
+        "peering": {
+            "connections": [
+                {
+                    "provider": "account-vpc",
+                    "name": "peername",
+                    "vpc": {
+                        "$ref": "/aws/account/vpcs/mars-plain-1",
+                        "cidr_block": "172.30.0.0/12",
+                        "vpc_id": "avpcid",
+                        **peer,
+                        "region": "mars-olympus-2",
+                        "account": aws_account,
+                    },
+                    "manageRoutes": True,
+                    "cluster": peer_cluster,
+                },
+            ]
+        },
+    }
+
+    ocm_mock = MagicMock(spec=ocm.OCM)
+    ocm_mock.get_aws_infrastructure_access_terraform_assume_role.side_effect = (
+        lambda cluster_arg, tf_account_id, tf_user: aws_account["assume_role"]
+    )
+
+    awsapi = MagicMock(spec=aws_api.AWSApi)
+
+    return VpcSingleState(
+        cluster=cluster,
+        aws_account=aws_account,
+        ocm_mock=ocm_mock,
+        awsapi=awsapi,
+    )
+
+
+def test_vpc_single_all_fine(vpc_single_state: VpcSingleState) -> None:
+    expected = [
+        {
+            "accepter": {
+                "account": {
+                    "assume_cidr": "172.16.0.0/12",
+                    "assume_region": "mars-plain-1",
+                    "assume_role": "this:wonderful:role:hell:yeah",
+                    "automationtoken": "anautomationtoken",
+                    "name": "accountname",
+                    "terraformUsername": "aterraformusename",
+                    "uid": "anuid",
+                },
+                "cidr_block": "172.30.0.0/12",
+                "region": "mars-olympus-2",
+                "vpc_id": "avpcid",
+            },
+            "connection_name": "peername",
+            "connection_provider": "account-vpc",
+            "infra_account_name": "accountname",
+            "deleted": False,
+            "requester": {
+                "account": {
+                    "assume_cidr": "172.16.0.0/12",
+                    "assume_region": "mars-plain-1",
+                    "assume_role": "this:wonderful:role:hell:yeah",
+                    "automationtoken": "anautomationtoken",
+                    "name": "accountname",
+                    "terraformUsername": "aterraformusename",
+                    "uid": "anuid",
+                },
+                "cidr_block": "172.16.0.0/12",
+                "region": "mars-plain-1",
+                "route_table_ids": ["routetableid"],
+                "api_security_group_id": None,
+                "vpc_id": "vpcid",
+            },
         }
-        expected = [
-            {
-                "accepter": {
-                    "account": {
-                        "assume_cidr": "172.16.0.0/12",
-                        "assume_region": "mars-plain-1",
-                        "assume_role": "this:wonderful:role:hell:yeah",
-                        "automationtoken": "anautomationtoken",
-                        "name": "accountname",
-                        "terraformUsername": "aterraformusename",
-                        "uid": "anuid",
-                    },
-                    "cidr_block": "172.30.0.0/12",
-                    "region": "mars-olympus-2",
-                    "vpc_id": "avpcid",
+    ]
+    vpc_single_state.awsapi.get_cluster_vpc_details.return_value = (
+        "vpcid",
+        ["routetableid"],
+        {},
+        None,
+    )
+    vpc_single_state.ocm_mock.get_aws_infrastructure_access_terraform_assume_role = (
+        MagicMock(return_value="this:wonderful:role:hell:yeah")
+    )
+
+    rs = sut.build_desired_state_vpc_single_cluster(
+        vpc_single_state.cluster,
+        vpc_single_state.ocm_mock,
+        vpc_single_state.awsapi,
+        None,
+    )
+    assert rs == expected
+    vpc_single_state.awsapi.get_cluster_vpc_details.assert_called_once()
+    vpc_single_state.ocm_mock.get_aws_infrastructure_access_terraform_assume_role.assert_called_once_with(
+        vpc_single_state.cluster["name"],
+        vpc_single_state.aws_account["uid"],
+        vpc_single_state.aws_account["terraformUsername"],
+    )
+
+
+def test_vpc_single_private_hcp(vpc_single_state: VpcSingleState) -> None:
+    vpc_single_state.cluster["spec"] = {
+        "region": "mars-plain-1",
+        "hypershift": True,
+        "private": True,
+    }
+    expected = [
+        {
+            "accepter": {
+                "account": {
+                    "assume_cidr": "172.16.0.0/12",
+                    "assume_region": "mars-plain-1",
+                    "assume_role": "this:wonderful:role:hell:yeah",
+                    "automationtoken": "anautomationtoken",
+                    "name": "accountname",
+                    "terraformUsername": "aterraformusename",
+                    "uid": "anuid",
                 },
-                "connection_name": "peername",
-                "connection_provider": "account-vpc",
-                "infra_account_name": "accountname",
-                "deleted": False,
-                "requester": {
-                    "account": {
-                        "assume_cidr": "172.16.0.0/12",
-                        "assume_region": "mars-plain-1",
-                        "assume_role": "this:wonderful:role:hell:yeah",
-                        "automationtoken": "anautomationtoken",
-                        "name": "accountname",
-                        "terraformUsername": "aterraformusename",
-                        "uid": "anuid",
-                    },
-                    "cidr_block": "172.16.0.0/12",
-                    "region": "mars-plain-1",
-                    "route_table_ids": ["routetableid"],
-                    "api_security_group_id": "sg-vpce",
-                    "vpc_id": "vpcid",
+                "cidr_block": "172.30.0.0/12",
+                "region": "mars-olympus-2",
+                "vpc_id": "avpcid",
+            },
+            "connection_name": "peername",
+            "connection_provider": "account-vpc",
+            "infra_account_name": "accountname",
+            "deleted": False,
+            "requester": {
+                "account": {
+                    "assume_cidr": "172.16.0.0/12",
+                    "assume_region": "mars-plain-1",
+                    "assume_role": "this:wonderful:role:hell:yeah",
+                    "automationtoken": "anautomationtoken",
+                    "name": "accountname",
+                    "terraformUsername": "aterraformusename",
+                    "uid": "anuid",
                 },
-            }
-        ]
-        self.mock_callable(
-            self.awsapi,
-            "get_cluster_vpc_details",
-        ).for_call(
-            self.aws_account, route_tables=True, hcp_vpc_endpoint_sg=True
-        ).to_return_value((
-            "vpcid",
-            ["routetableid"],
-            {},
-            "sg-vpce",
-        )).and_assert_called_once()
-        self.mock_callable(
-            self.ocm, "get_aws_infrastructure_access_terraform_assume_role"
-        ).for_call(
-            self.cluster["name"],
-            self.aws_account["uid"],
-            self.aws_account["terraformUsername"],
-        ).to_return_value("this:wonderful:role:hell:yeah").and_assert_called_once()
-        rs = sut.build_desired_state_vpc_single_cluster(
-            self.cluster, self.ocm, self.awsapi, None
-        )
-        self.assertEqual(rs, expected)
+                "cidr_block": "172.16.0.0/12",
+                "region": "mars-plain-1",
+                "route_table_ids": ["routetableid"],
+                "api_security_group_id": "sg-vpce",
+                "vpc_id": "vpcid",
+            },
+        }
+    ]
+    vpc_single_state.awsapi.get_cluster_vpc_details.return_value = (
+        "vpcid",
+        ["routetableid"],
+        {},
+        "sg-vpce",
+    )
+    vpc_single_state.ocm_mock.get_aws_infrastructure_access_terraform_assume_role = (
+        MagicMock(return_value="this:wonderful:role:hell:yeah")
+    )
 
-    def test_different_provider(self) -> None:
-        self.cluster["peering"]["connections"][0]["provider"] = "something-else"  # type: ignore
-        self.assertEqual(
-            sut.build_desired_state_vpc_single_cluster(
-                self.cluster,
-                self.ocm,
-                self.awsapi,
-                None,
-            ),
-            [],
-        )
+    rs = sut.build_desired_state_vpc_single_cluster(
+        vpc_single_state.cluster,
+        vpc_single_state.ocm_mock,
+        vpc_single_state.awsapi,
+        None,
+    )
+    assert rs == expected
+    vpc_single_state.awsapi.get_cluster_vpc_details.assert_called_once()
+    vpc_single_state.ocm_mock.get_aws_infrastructure_access_terraform_assume_role.assert_called_once_with(
+        vpc_single_state.cluster["name"],
+        vpc_single_state.aws_account["uid"],
+        vpc_single_state.aws_account["terraformUsername"],
+    )
 
-    def test_no_vpc_id(self) -> None:
-        self.mock_callable(self.awsapi, "get_cluster_vpc_details").to_return_value((
+
+def test_vpc_single_different_provider(vpc_single_state: VpcSingleState) -> None:
+    vpc_single_state.cluster["peering"]["connections"][0]["provider"] = "something-else"  # type: ignore
+    assert (
+        sut.build_desired_state_vpc_single_cluster(
+            vpc_single_state.cluster,
+            vpc_single_state.ocm_mock,
+            vpc_single_state.awsapi,
             None,
-            None,
-            None,
-            None,
-        )).and_assert_called_once()
-
-        self.mock_callable(
-            self.ocm, "get_aws_infrastructure_access_terraform_assume_role"
-        ).to_return_value("a:role:that:you:will:like").and_assert_called_once()
-
-        desired_state = sut.build_desired_state_vpc_single_cluster(
-            self.cluster, self.ocm, self.awsapi, None
         )
-        assert desired_state == []
+        == []
+    )
 
-    def test_aws_exception(self) -> None:
-        exc_txt = "AWS Problem!"
-        self.mock_callable(self.awsapi, "get_cluster_vpc_details").to_raise(
-            Exception(exc_txt)
+
+def test_vpc_single_no_vpc_id(vpc_single_state: VpcSingleState) -> None:
+    vpc_single_state.awsapi.get_cluster_vpc_details.return_value = (
+        None,
+        None,
+        None,
+        None,
+    )
+    vpc_single_state.ocm_mock.get_aws_infrastructure_access_terraform_assume_role.return_value = (
+        "a:role:that:you:will:like"
+    )
+
+    desired_state = sut.build_desired_state_vpc_single_cluster(
+        vpc_single_state.cluster,
+        vpc_single_state.ocm_mock,
+        vpc_single_state.awsapi,
+        None,
+    )
+    assert desired_state == []
+    vpc_single_state.awsapi.get_cluster_vpc_details.assert_called_once()
+    vpc_single_state.ocm_mock.get_aws_infrastructure_access_terraform_assume_role.assert_called_once()
+
+
+def test_vpc_single_aws_exception(vpc_single_state: VpcSingleState) -> None:
+    exc_txt = "AWS Problem!"
+    vpc_single_state.awsapi.get_cluster_vpc_details.side_effect = Exception(exc_txt)
+    vpc_single_state.ocm_mock.get_aws_infrastructure_access_terraform_assume_role.return_value = (
+        "a:role:that:you:will:like"
+    )
+
+    with pytest.raises(Exception, match=exc_txt):
+        sut.build_desired_state_vpc_single_cluster(
+            vpc_single_state.cluster,
+            vpc_single_state.ocm_mock,
+            vpc_single_state.awsapi,
+            None,
         )
-
-        self.mock_callable(
-            self.ocm, "get_aws_infrastructure_access_terraform_assume_role"
-        ).to_return_value("a:role:that:you:will:like").and_assert_called_once()
-
-        with pytest.raises(Exception, match=exc_txt):
-            sut.build_desired_state_vpc_single_cluster(
-                self.cluster,
-                self.ocm,
-                self.awsapi,
-                None,
-            )
+    vpc_single_state.ocm_mock.get_aws_infrastructure_access_terraform_assume_role.assert_called_once()

--- a/reconcile/test/test_terraform_vpc_peerings_build_desired_state.py
+++ b/reconcile/test/test_terraform_vpc_peerings_build_desired_state.py
@@ -559,7 +559,7 @@ class VpcMeshState:
     clusters: list[dict[str, Any]]
     peer_account: dict[str, Any]
     ocm_mock: MagicMock
-    ocm_map: dict[str, MagicMock]
+    ocm_map: Any
     awsapi: MagicMock
     vpc_mesh_single_cluster: MagicMock
     account_vpcs: list[dict[str, Any]]
@@ -999,7 +999,7 @@ def test_vpc_mesh_single_one_cluster_private_hcp(
 def test_vpc_mesh_single_no_peering_connections(
     vpc_mesh_single_state: VpcMeshSingleState,
 ) -> None:
-    vpc_mesh_single_state.cluster["peering"]["connections"] = []  # type: ignore
+    vpc_mesh_single_state.cluster["peering"]["connections"] = []
     rs = sut.build_desired_state_vpc_mesh_single_cluster(
         vpc_mesh_single_state.cluster,
         vpc_mesh_single_state.ocm_mock,
@@ -1034,7 +1034,7 @@ class VpcState:
     clusters: list[dict[str, Any]]
     aws_account: dict[str, Any]
     ocm_mock: MagicMock
-    ocm_map: dict[str, MagicMock]
+    ocm_map: Any
     awsapi: MagicMock
     build_single_cluster: MagicMock
 
@@ -1181,7 +1181,7 @@ def test_vpc_cluster_fails(vpc_state: VpcState) -> None:
 def test_vpc_error_persists(vpc_state: VpcState) -> None:
     vpc_state.clusters.append(vpc_state.clusters[0].copy())
     vpc_state.clusters[1]["name"] = "afailingcluster"
-    vpc_state.ocm_map["afailingcluster"] = vpc_state.ocm_mock  # type: ignore
+    vpc_state.ocm_map["afailingcluster"] = vpc_state.ocm_mock
     vpc_state.build_single_cluster.side_effect = [
         [{"a dict": "a value"}],
         sut.BadTerraformPeeringStateError("Fail!"),
@@ -1196,7 +1196,7 @@ def test_vpc_error_persists(vpc_state: VpcState) -> None:
 def test_vpc_other_exceptions_raise(vpc_state: VpcState) -> None:
     vpc_state.clusters.append(vpc_state.clusters[0].copy())
     vpc_state.clusters[1]["name"] = "afailingcluster"
-    vpc_state.ocm_map["afailingcluster"] = vpc_state.ocm_mock  # type: ignore
+    vpc_state.ocm_map["afailingcluster"] = vpc_state.ocm_mock
     vpc_state.build_single_cluster.side_effect = ValueError("I am not planned!")
     with pytest.raises(ValueError):
         sut.build_desired_state_vpc(
@@ -1420,7 +1420,7 @@ def test_vpc_single_private_hcp(vpc_single_state: VpcSingleState) -> None:
 
 
 def test_vpc_single_different_provider(vpc_single_state: VpcSingleState) -> None:
-    vpc_single_state.cluster["peering"]["connections"][0]["provider"] = "something-else"  # type: ignore
+    vpc_single_state.cluster["peering"]["connections"][0]["provider"] = "something-else"
     assert (
         sut.build_desired_state_vpc_single_cluster(
             vpc_single_state.cluster,

--- a/reconcile/test/test_terraform_vpc_peerings_build_desired_state.py
+++ b/reconcile/test/test_terraform_vpc_peerings_build_desired_state.py
@@ -709,6 +709,12 @@ def test_vpc_mesh_all_fine(vpc_mesh_state: VpcMeshState) -> None:
         None,
     )
     assert rs == (expected, False)
+    vpc_mesh_state.vpc_mesh_single_cluster.assert_called_once_with(
+        vpc_mesh_state.clusters[0],
+        vpc_mesh_state.ocm_mock,
+        vpc_mesh_state.awsapi,
+        None,
+    )
 
 
 def test_vpc_mesh_cluster_raises(vpc_mesh_state: VpcMeshState) -> None:
@@ -741,7 +747,6 @@ class VpcMeshSingleState:
     peer_account: dict[str, Any]
     ocm_mock: MagicMock
     awsapi: MagicMock
-    find_matching_peering: MagicMock
     account_vpcs: list[dict[str, Any]]
 
 
@@ -805,7 +810,6 @@ def vpc_mesh_single_state(mocker: MockerFixture) -> VpcMeshSingleState:
     )
 
     awsapi = MagicMock(spec=aws_api.AWSApi)
-    find_matching_peering = mocker.patch.object(sut, "find_matching_peering")
 
     account_vpcs: list[dict[str, Any]] = [
         {
@@ -827,7 +831,6 @@ def vpc_mesh_single_state(mocker: MockerFixture) -> VpcMeshSingleState:
         peer_account=peer_account,
         ocm_mock=ocm_mock,
         awsapi=awsapi,
-        find_matching_peering=find_matching_peering,
         account_vpcs=account_vpcs,
     )
 
@@ -895,8 +898,18 @@ def test_vpc_mesh_single_one_cluster(vpc_mesh_single_state: VpcMeshSingleState) 
         None,
     )
     assert rs == expected
-    vpc_mesh_single_state.awsapi.get_cluster_vpc_details.assert_called_once()
-    vpc_mesh_single_state.awsapi.get_vpcs_details.assert_called_once()
+    assert vpc_mesh_single_state.peer_account["assume_region"] == "mars-plain-1"
+    assert vpc_mesh_single_state.peer_account["assume_cidr"] == "172.16.0.0/12"
+    vpc_mesh_single_state.awsapi.get_cluster_vpc_details.assert_called_once_with(
+        vpc_mesh_single_state.peer_account,
+        route_tables=True,
+        hcp_vpc_endpoint_sg=False,
+    )
+    vpc_mesh_single_state.awsapi.get_vpcs_details.assert_called_once_with(
+        vpc_mesh_single_state.peer_account,
+        tags=["tag1"],
+        route_tables=True,
+    )
 
 
 def test_vpc_mesh_single_one_cluster_private_hcp(
@@ -969,8 +982,18 @@ def test_vpc_mesh_single_one_cluster_private_hcp(
         None,
     )
     assert rs == expected
-    vpc_mesh_single_state.awsapi.get_cluster_vpc_details.assert_called_once()
-    vpc_mesh_single_state.awsapi.get_vpcs_details.assert_called_once()
+    assert vpc_mesh_single_state.peer_account["assume_region"] == "mars-plain-1"
+    assert vpc_mesh_single_state.peer_account["assume_cidr"] == "172.16.0.0/12"
+    vpc_mesh_single_state.awsapi.get_cluster_vpc_details.assert_called_once_with(
+        vpc_mesh_single_state.peer_account,
+        route_tables=True,
+        hcp_vpc_endpoint_sg=True,
+    )
+    vpc_mesh_single_state.awsapi.get_vpcs_details.assert_called_once_with(
+        vpc_mesh_single_state.peer_account,
+        tags=["tag1"],
+        route_tables=True,
+    )
 
 
 def test_vpc_mesh_single_no_peering_connections(
@@ -1137,7 +1160,12 @@ def test_vpc_all_fine(vpc_state: VpcState) -> None:
         vpc_state.clusters, vpc_state.ocm_map, vpc_state.awsapi, account_filter=None
     )
     assert rs == (expected, False)
-    vpc_state.build_single_cluster.assert_called_once()
+    vpc_state.build_single_cluster.assert_called_once_with(
+        vpc_state.clusters[0],
+        vpc_state.ocm_mock,
+        vpc_state.awsapi,
+        None,
+    )
 
 
 def test_vpc_cluster_fails(vpc_state: VpcState) -> None:
@@ -1411,8 +1439,8 @@ def test_vpc_single_no_vpc_id(vpc_single_state: VpcSingleState) -> None:
         None,
         None,
     )
-    vpc_single_state.ocm_mock.get_aws_infrastructure_access_terraform_assume_role.return_value = (
-        "a:role:that:you:will:like"
+    vpc_single_state.ocm_mock.get_aws_infrastructure_access_terraform_assume_role = (
+        MagicMock(return_value="a:role:that:you:will:like")
     )
 
     desired_state = sut.build_desired_state_vpc_single_cluster(
@@ -1429,8 +1457,8 @@ def test_vpc_single_no_vpc_id(vpc_single_state: VpcSingleState) -> None:
 def test_vpc_single_aws_exception(vpc_single_state: VpcSingleState) -> None:
     exc_txt = "AWS Problem!"
     vpc_single_state.awsapi.get_cluster_vpc_details.side_effect = Exception(exc_txt)
-    vpc_single_state.ocm_mock.get_aws_infrastructure_access_terraform_assume_role.return_value = (
-        "a:role:that:you:will:like"
+    vpc_single_state.ocm_mock.get_aws_infrastructure_access_terraform_assume_role = (
+        MagicMock(return_value="a:role:that:you:will:like")
     )
 
     with pytest.raises(Exception, match=exc_txt):

--- a/uv.lock
+++ b/uv.lock
@@ -2219,7 +2219,6 @@ dev = [
     { name = "ruff" },
     { name = "smtpdfix" },
     { name = "snakeviz" },
-    { name = "testslide" },
     { name = "types-click" },
     { name = "types-croniter" },
     { name = "types-dateparser" },
@@ -2305,7 +2304,6 @@ dev = [
     { name = "ruff", specifier = "==0.15.13" },
     { name = "smtpdfix", specifier = "==0.5.3" },
     { name = "snakeviz", specifier = "==2.2.2" },
-    { name = "testslide", specifier = "==2.7.1" },
     { name = "types-click" },
     { name = "types-croniter" },
     { name = "types-dateparser" },
@@ -2751,17 +2749,6 @@ wheels = [
 ]
 
 [[package]]
-name = "testslide"
-version = "2.7.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "psutil" },
-    { name = "pygments" },
-    { name = "typeguard" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/ee/6f/c8d6d60a597c693559dab3b3362bd01e2212530e9a163eb0164af81e1ec1/TestSlide-2.7.1.tar.gz", hash = "sha256:d25890d5c383f673fac44a5f9e2561b7118d04f29f2c2b3d4f549e6db94cb34d", size = 50255, upload-time = "2023-03-16T14:09:41.204Z" }
-
-[[package]]
 name = "toml"
 version = "0.10.2"
 source = { registry = "https://pypi.org/simple" }
@@ -2794,15 +2781,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/53/a3/1585216310e344e8102c22482f6060c7a6ea0322b63e026372e6dcefcfd6/truststore-0.10.4.tar.gz", hash = "sha256:9d91bd436463ad5e4ee4aba766628dd6cd7010cf3e2461756b3303710eebc301", size = 26169, upload-time = "2025-08-12T18:49:02.73Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/19/97/56608b2249fe206a67cd573bc93cd9896e1efb9e98bce9c163bcdc704b88/truststore-0.10.4-py3-none-any.whl", hash = "sha256:adaeaecf1cbb5f4de3b1959b42d41f6fab57b2b1666adb59e89cb0b53361d981", size = 18660, upload-time = "2025-08-12T18:49:01.46Z" },
-]
-
-[[package]]
-name = "typeguard"
-version = "2.13.3"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/3a/38/c61bfcf62a7b572b5e9363a802ff92559cb427ee963048e1442e3aef7490/typeguard-2.13.3.tar.gz", hash = "sha256:00edaa8da3a133674796cf5ea87d9f4b4c367d77476e185e80251cc13dfbb8c4", size = 40604, upload-time = "2021-12-10T21:09:39.158Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/9a/bb/d43e5c75054e53efce310e79d63df0ac3f25e34c926be5dffb7d283fb2a8/typeguard-2.13.3-py3-none-any.whl", hash = "sha256:5e3e3be01e887e7eafae5af63d1f36c849aaa94e3a0112097312aabfa16284f1", size = 17605, upload-time = "2021-12-10T21:09:37.844Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- Rewrites `test_terraform_vpc_peerings.py` (the `TestRun` class) and `test_terraform_vpc_peerings_build_desired_state.py` (4 testslide test classes) to use pytest-mock and `MagicMock` instead of testslide
- Removes `testslide==2.7.1` from the dev dependency group and updates `uv.lock`

## Why

testslide is incompatible with Python 3.14 (PEP 649 deferred annotation evaluation causes `RuntimeError: dictionary changed size during iteration` in `testslide/strict_mock.py:416` when iterating `__annotations__`). The library is effectively unmaintained (Red Hat Bugzilla #2343971). This is a prerequisite for the Python 3.14 upgrade (APPSRE-14363).

## Changes

- `testslide.TestCase` subclasses → standalone pytest functions with `@pytest.fixture` for shared setup
- `testslide.StrictMock(X)` → `MagicMock(spec=X)`
- `self.mock_constructor(module, "Class").to_return_value(mock)` → `mocker.patch.object(module, "Class", return_value=mock)`
- `self.mock_callable(obj, "method").to_return_value(val).and_assert_called_once()` → set `return_value`, then `assert_called_once()` after the call
- `.to_raise(exc)` → `.side_effect = exc`

## Test plan

- [ ] All 42 tests in the two files pass with Python 3.12 (`uv run pytest reconcile/test/test_terraform_vpc_peerings.py reconcile/test/test_terraform_vpc_peerings_build_desired_state.py`)
- [ ] `ruff check` passes on both files

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Removed an unused development dependency from the project setup.
* **Tests**
  * Refactored Terraform VPC peering integration tests from class-based patterns to pytest module-level tests.
  * Refactored Terraform VPC peering desired-state tests to use pytest fixtures and dataclass-based shared mock state.
  * Strengthened assertions across success, dry-run, and failure paths, including recoverable vs unexpected error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->