### PR TITLE
fix(alert-report): use re.search to handle cluster-prefixed alert titles

### DIFF
--- a/tools/alert_report.py
+++ b/tools/alert_report.py
@@ -68,7 +68,7 @@ def group_alerts(messages: list[dict]) -> dict[str, list[Alert]]:
             if "title" not in at:
                 continue
 
-            mg = re.match(r"Alert: (.*) \[(FIRING:\d+|RESOLVED)\] *(.*)$", at["title"])
+            mg = re.search(r"Alert: (.*) \[(FIRING:\d+|RESOLVED)\] *(.*)$", at["title"])
             if not mg:
                 continue
 

--- a/tools/test/test_alert_report.py
+++ b/tools/test/test_alert_report.py
@@ -13,22 +13,22 @@ CLUSTER_PREFIXED_MESSAGES = [
     {
         "subtype": "bot_message",
         "bot_id": "BFYPB540Z",
-        "ts": "1750000100.000000",
+        "ts": "1750000200.000000",
         "username": "app-sre-alerts (appsrep11ue1)",
         "attachments": [
             {
-                "title": "[appsrep11ue1]Alert: ClusterPrefixedAlert [FIRING:1]  some alert message"
+                "title": "[appsrep11ue1]Alert: ClusterPrefixedAlert [RESOLVED]  some alert message"
             }
         ],
     },
     {
         "subtype": "bot_message",
         "bot_id": "BFYPB540Z",
-        "ts": "1750000200.000000",
+        "ts": "1750000100.000000",
         "username": "app-sre-alerts (appsrep11ue1)",
         "attachments": [
             {
-                "title": "[appsrep11ue1]Alert: ClusterPrefixedAlert [RESOLVED]  some alert message"
+                "title": "[appsrep11ue1]Alert: ClusterPrefixedAlert [FIRING:1]  some alert message"
             }
         ],
     },

--- a/tools/test/test_alert_report.py
+++ b/tools/test/test_alert_report.py
@@ -16,7 +16,9 @@ CLUSTER_PREFIXED_MESSAGES = [
         "ts": "1750000100.000000",
         "username": "app-sre-alerts (appsrep11ue1)",
         "attachments": [
-            {"title": "[appsrep11ue1]Alert: ClusterPrefixedAlert [FIRING:1]  some alert message"}
+            {
+                "title": "[appsrep11ue1]Alert: ClusterPrefixedAlert [FIRING:1]  some alert message"
+            }
         ],
     },
     {
@@ -25,7 +27,9 @@ CLUSTER_PREFIXED_MESSAGES = [
         "ts": "1750000200.000000",
         "username": "app-sre-alerts (appsrep11ue1)",
         "attachments": [
-            {"title": "[appsrep11ue1]Alert: ClusterPrefixedAlert [RESOLVED]  some alert message"}
+            {
+                "title": "[appsrep11ue1]Alert: ClusterPrefixedAlert [RESOLVED]  some alert message"
+            }
         ],
     },
 ]

--- a/tools/test/test_alert_report.py
+++ b/tools/test/test_alert_report.py
@@ -6,6 +6,30 @@ from tools.alert_report import (
     group_alerts,
 )
 
+# Messages with cluster-name prefix in the attachment title, e.g.
+# "[appsrep11ue1]Alert: AlertName [FIRING:1]  message"
+# introduced when the Alertmanager Slack template was updated to include the cluster.
+CLUSTER_PREFIXED_MESSAGES = [
+    {
+        "subtype": "bot_message",
+        "bot_id": "BFYPB540Z",
+        "ts": "1750000100.000000",
+        "username": "app-sre-alerts (appsrep11ue1)",
+        "attachments": [
+            {"title": "[appsrep11ue1]Alert: ClusterPrefixedAlert [FIRING:1]  some alert message"}
+        ],
+    },
+    {
+        "subtype": "bot_message",
+        "bot_id": "BFYPB540Z",
+        "ts": "1750000200.000000",
+        "username": "app-sre-alerts (appsrep11ue1)",
+        "attachments": [
+            {"title": "[appsrep11ue1]Alert: ClusterPrefixedAlert [RESOLVED]  some alert message"}
+        ],
+    },
+]
+
 messages = Fixtures("slack_api").get_anymarkup("conversations_history_messages.yaml")
 
 
@@ -72,3 +96,18 @@ def test_alert_stats() -> None:
     assert art.triggered_alerts == 1
     assert art.resolved_alerts == 1
     assert median(art.elapsed_times) == 300
+
+
+def test_group_alerts_cluster_prefixed_title() -> None:
+    """Attachment titles with a [cluster] prefix are parsed correctly."""
+    alerts = group_alerts(CLUSTER_PREFIXED_MESSAGES)
+    assert "ClusterPrefixedAlert" in alerts
+    assert len(alerts["ClusterPrefixedAlert"]) == 2
+
+
+def test_alert_stats_cluster_prefixed_title() -> None:
+    alert_stats = gen_alert_stats(group_alerts(CLUSTER_PREFIXED_MESSAGES))
+    stat = alert_stats["ClusterPrefixedAlert"]
+    assert stat.triggered_alerts == 1
+    assert stat.resolved_alerts == 1
+    assert len(stat.elapsed_times) == 1


### PR DESCRIPTION
## Summary

- The Alertmanager Slack template was updated on 2026-05-18 (app-interface !188169) to prepend the cluster name to alert attachment titles: `[cluster]Alert: AlertName [FIRING:1] message`
- `group_alerts()` used `re.match()` which anchors to the start of the string, so the pattern never matched and every message was silently skipped
- All four 30-day alert reports (`sd-app-sre`, `team-uhc` alert/info/warning) have been empty since the July 1 monthly run

## Fix

Switch from `re.match()` to `re.search()` in `tools/alert_report.py` — finds the pattern anywhere in the string, compatible with both the old and new title formats.

Two new tests added covering the cluster-prefixed title format.

## Test plan

- [ ] `make unittest` passes
- [ ] `test_group_alerts_cluster_prefixed_title` and `test_alert_stats_cluster_prefixed_title` pass
- [ ] Manually trigger the alert report job to verify populated output

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved alert title handling so alerts with prefixes in the title are now recognized and grouped correctly.
  * Alert summaries and status counts are now more accurate for these prefixed alert messages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->