### PR TITLE
APPSRE-14722 fix(openshift-rhcs-certs): trigger regeneration on certificate_format change

### DIFF
--- a/reconcile/openshift_rhcs_certs.py
+++ b/reconcile/openshift_rhcs_certs.py
@@ -156,6 +156,25 @@ def cert_expires_within_threshold(
     return False
 
 
+def cert_format_mismatch(
+    ns: NamespaceV1,
+    cert_resource: OpenshiftResourceRhcsCert,
+    vault_cert_secret: Mapping[str, Any],
+) -> bool:
+    """Check if the Vault secret's keys don't match the desired certificate_format."""
+    desired_format = get_certificate_format(cert_resource)
+    match desired_format:
+        case CertificateFormat.PEM:
+            is_mismatch = "tls.crt" not in vault_cert_secret
+        case CertificateFormat.PKCS12:
+            is_mismatch = "keystore.pkcs12.b64" not in vault_cert_secret
+    if is_mismatch:
+        logging.info(
+            f"Certificate format mismatch: cluster='{ns.cluster.name}', namespace='{ns.name}', secret='{cert_resource.secret_name}', desired_format='{desired_format}'"
+        )
+    return is_mismatch
+
+
 def get_vault_cert_secret(
     ns: NamespaceV1,
     cert_resource: OpenshiftResourceRhcsCert,
@@ -226,8 +245,10 @@ def fetch_openshift_resource_for_cert_resource(
 ) -> OR:
     vault_base_path = f"{rhcs_settings.vault_base_path}/{QONTRACT_INTEGRATION}"
     vault_cert_secret = get_vault_cert_secret(ns, cert_resource, vault, vault_base_path)
-    if vault_cert_secret is None or cert_expires_within_threshold(
-        ns, cert_resource, vault_cert_secret
+    if (
+        vault_cert_secret is None
+        or cert_expires_within_threshold(ns, cert_resource, vault_cert_secret)
+        or cert_format_mismatch(ns, cert_resource, vault_cert_secret)
     ):
         vault_cert_secret = generate_vault_cert_secret(
             dry_run,

--- a/reconcile/test/test_openshift_rhcs_certs.py
+++ b/reconcile/test/test_openshift_rhcs_certs.py
@@ -13,6 +13,7 @@ from reconcile.gql_definitions.rhcs.certs import (
 )
 from reconcile.openshift_rhcs_certs import (
     QONTRACT_INTEGRATION,
+    cert_format_mismatch,
     construct_rhcs_cert_oc_secret,
     fetch_desired_state,
     get_namespaces_with_rhcs_certs,
@@ -439,6 +440,75 @@ def test_openshift_rhcs_certs__get_namespaces_with_shared_resources(
     assert any(r for r in shared_ns.openshift_resources), (
         "RHCS-cert not propagated from sharedResources"
     )
+
+
+@pytest.mark.parametrize(
+    ("desired_format", "vault_data_format", "expected"),
+    [
+        ("PEM", "PEM", False),
+        ("PKCS12", "PKCS12", False),
+        ("PKCS12", "PEM", True),
+        ("PEM", "PKCS12", True),
+    ],
+)
+def test_cert_format_mismatch(
+    namespaces: list[NamespaceV1],
+    desired_format: str,
+    vault_data_format: str,
+    expected: bool,
+) -> None:
+    """Test format mismatch detection between desired config and Vault secret keys."""
+    ns = namespaces[0]
+    cert_resource = ns.openshift_resources[0]
+    cert_resource.certificate_format = desired_format
+    vault_secret = build_vault_cert_data(vault_data_format)
+
+    assert cert_format_mismatch(ns, cert_resource, vault_secret) is expected
+
+
+def test_openshift_rhcs_certs__fetch_desired_state_format_mismatch(
+    mocker: MockerFixture,
+    mock_rhcs_cert_provider: MagicMock,
+    namespaces: list[NamespaceV1],
+    ri: ResourceInventory,
+    query_func: Callable,
+) -> None:
+    """Test that a certificate_format mismatch triggers regeneration."""
+    mock_vault = mocker.patch("reconcile.openshift_rhcs_certs.VaultClient.get_instance")
+    vault_instance = mock_vault.return_value
+    vault_instance.read.return_value = "FAKE_SA_PASSWORD"
+    vault_instance.write.return_value = None
+    mocker.patch("reconcile.openshift_rhcs_certs.metrics.set_gauge")
+
+    # Vault has PEM data for test-cert-pkcs12 (format mismatch!)
+    cert_secrets_by_name = {
+        "test-cert-1": build_vault_cert_data("PEM", expiring=False),
+        "test-cert-2": build_vault_cert_data("PEM", expiring=False),
+        "test-cert-shared": build_vault_cert_data("PEM", expiring=False),
+        "test-cert-pkcs12": build_vault_cert_data("PEM", expiring=False),  # mismatch!
+        "test-cert-shared-pkcs12": build_vault_cert_data("PKCS12", expiring=False),
+    }
+    vault_instance.read_all.side_effect = create_vault_read_all_side_effect(
+        cert_secrets_by_name
+    )
+
+    new_cert = RhcsV2CertPkcs12(
+        pkcs12_keystore="NEW_KEYSTORE",
+        pkcs12_truststore="NEW_TRUSTSTORE",
+        expiration_timestamp=int(time.time()) + 86400 * 90,
+    )
+    mock_cert_generator = mocker.patch(
+        "reconcile.openshift_rhcs_certs.generate_cert", return_value=new_cert
+    )
+
+    fetch_desired_state(False, namespaces, ri, query_func)
+
+    # Only the format-mismatched cert should be regenerated
+    assert mock_cert_generator.call_count == 1
+    assert vault_instance.write.call_count == 1
+    secret_data = vault_instance.write.call_args[1]["secret"]["data"]
+    assert "keystore.pkcs12.b64" in secret_data
+    assert "truststore.pkcs12.b64" in secret_data
 
 
 def test_openshift_rhcs_certs__early_exit_desired_state(

--- a/reconcile/test/test_openshift_rhcs_certs.py
+++ b/reconcile/test/test_openshift_rhcs_certs.py
@@ -459,6 +459,7 @@ def test_cert_format_mismatch(
 ) -> None:
     """Test format mismatch detection between desired config and Vault secret keys."""
     ns = namespaces[0]
+    assert ns.openshift_resources
     cert_resource = ns.openshift_resources[0]
     cert_resource.certificate_format = desired_format
     vault_secret = build_vault_cert_data(vault_data_format)


### PR DESCRIPTION
## Summary

The `openshift-rhcs-certs` integration did not trigger certificate regeneration when
`certificate_format` changed (e.g. from PEM to PKCS12). It only regenerated when the
cert was missing in Vault or approaching the `auto_renew_threshold_days` expiry threshold.

This meant that changing `certificate_format: PKCS12` in a namespace config had no effect
until the next renewal cycle — which could be months away. The K8s Secret would be created
with the correct `type: Opaque` for PKCS12, but populated with old PEM data keys (`tls.crt`,
`tls.key`, `ca.crt`) instead of the expected PKCS12 keys (`keystore.pkcs12.b64`,
`truststore.pkcs12.b64`).

**Workaround before this fix:** manually deleting the Vault secret to force regeneration.

### Changes

- Added `cert_format_mismatch()` that detects when the Vault secret's keys don't match the
  desired `certificate_format` (PEM expects `tls.crt`, PKCS12 expects `keystore.pkcs12.b64`)
- Added the mismatch check to the regeneration condition in
  `fetch_openshift_resource_for_cert_resource()`

### Context

Discovered during IC shift on 2026-07-02 while investigating a tenant request in
[#sd-app-sre](https://redhat-internal.slack.com/archives/CCRND57FW/p1782988263405989).

JIRA: [APPSRE-14722](https://redhat.atlassian.net/browse/APPSRE-14722)

## Test plan

- [x] Parametrized unit test for `cert_format_mismatch()` covering all 4 format combinations
- [x] Integration test verifying only the format-mismatched cert triggers regeneration
- [x] All 13 existing + new tests pass
- [x] ruff lint clean
- [x] mypy strict clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved certificate reconciliation so it now detects when stored certificate data doesn’t match the expected format and regenerates it automatically.
  * Reduced cases where certificates could remain in the wrong key format, helping keep managed secrets consistent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->