### PR TITLE
fix: suppress SyntaxWarning from sshtunnel on Python 3.14

### DIFF
--- a/reconcile/utils/jump_host.py
+++ b/reconcile/utils/jump_host.py
@@ -3,9 +3,12 @@ import random
 import shutil
 import tempfile
 import threading
+import warnings
 from dataclasses import dataclass
 
-from sshtunnel import SSHTunnelForwarder
+with warnings.catch_warnings():
+    warnings.filterwarnings("ignore", category=SyntaxWarning)
+    from sshtunnel import SSHTunnelForwarder
 
 from reconcile.utils import gql
 from reconcile.utils.exceptions import FetchResourceError


### PR DESCRIPTION
sshtunnel uses `return` in a `finally` block which triggers a SyntaxWarning on Python 3.14. Suppress it at import time using catch_warnings() since we cannot update the dependency.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Reduced noisy warnings that could appear when the app loads certain connection-related components.
  * Improved startup behavior by making a dependency load more quietly and safely.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->