### PR TITLE
Add thanos-querier URL column to qontract-cli get clusters

### DIFF
--- a/tools/qontract_cli.py
+++ b/tools/qontract_cli.py
@@ -304,8 +304,13 @@ def clusters(ctx: click.Context, name: str) -> None:
         jh = c.get("jumpHost")
         if jh:
             c["sshuttle"] = f"sshuttle -r {jh['hostname']} {c['network']['vpc']}"
+        prometheus_url = c.get("prometheusUrl")
+        if prometheus_url:
+            c["thanosQuerierUrl"] = prometheus_url.replace(
+                "prometheus", "thanos-querier", 1
+            )
 
-    columns = ["name", "consoleUrl", "prometheusUrl", "sshuttle"]
+    columns = ["name", "consoleUrl", "prometheusUrl", "thanosQuerierUrl", "sshuttle"]
     print_output(ctx.obj["options"], clusters, columns)
 
 


### PR DESCRIPTION
## Summary
- `qontract-cli get clusters` (used to generate clusters.md in app-interface-output) now includes a `thanosQuerierUrl` column alongside `prometheusUrl`.
- The URL is derived from the existing `prometheusUrl` by swapping the `prometheus` subdomain for `thanos-querier`, so no schema or data changes are required.

## Test plan
- [x] Verified the derivation logic manually (`prometheus.<cluster>.devshift.net` -> `thanos-querier.<cluster>.devshift.net`)
- [ ] Run `qontract-cli get clusters --output md` against a real bundle to confirm the new column renders correctly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The cluster listing output now includes a new `thanosQuerierUrl` column for each cluster.
  * This value is automatically derived from the cluster’s Prometheus URL, making the related endpoint easier to find alongside existing cluster details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->