### PR TITLE
fix(ldap_api): scope get_users to active users container

### DIFF
--- a/qontract_utils/qontract_utils/ldap_api/api.py
+++ b/qontract_utils/qontract_utils/ldap_api/api.py
@@ -207,6 +207,10 @@ class LdapApi:
     def get_users(self, usernames: Iterable[str]) -> list[LdapUser]:
         """Check which usernames exist in LDAP.
 
+        Locked/preserved accounts are treated as not existing: FreeIPA doesn't
+        hard-delete deprovisioned users, it moves them under a preserved
+        container and sets nsAccountLock, while still keeping objectclass=person.
+
         Args:
             usernames: Usernames to check
 
@@ -219,8 +223,12 @@ class LdapApi:
         if not usernames:
             return []
         user_filter = "".join(f"(uid={escape_filter_chars(u)})" for u in usernames)
+        # Exclude locked/preserved (deprovisioned) IPA accounts: they keep
+        # objectclass=person and would otherwise still match this filter.
         _, status, results, _ = self._connection.search(
-            self.base_dn, f"(&(objectclass=person)(|{user_filter}))", attributes=["uid"]
+            self.base_dn,
+            f"(&(objectclass=person)(!(nsAccountLock=TRUE))(|{user_filter}))",
+            attributes=["uid"],
         )
         self._check_ldap_response(status)
 

--- a/qontract_utils/qontract_utils/ldap_api/api.py
+++ b/qontract_utils/qontract_utils/ldap_api/api.py
@@ -207,9 +207,12 @@ class LdapApi:
     def get_users(self, usernames: Iterable[str]) -> list[LdapUser]:
         """Check which usernames exist in LDAP.
 
-        Locked/preserved accounts are treated as not existing: FreeIPA doesn't
-        hard-delete deprovisioned users, it moves them under a preserved
-        container and sets nsAccountLock, while still keeping objectclass=person.
+        Only searches the active users container (cn=users,cn=accounts under
+        base_dn): FreeIPA doesn't hard-delete deprovisioned users, it moves
+        them out of this container into a separate preserved-users container.
+        Accounts merely disabled via `ipa user-disable` (nsAccountLock=TRUE)
+        stay active and remain in this container, so they are still correctly
+        reported as existing.
 
         Args:
             usernames: Usernames to check
@@ -223,11 +226,9 @@ class LdapApi:
         if not usernames:
             return []
         user_filter = "".join(f"(uid={escape_filter_chars(u)})" for u in usernames)
-        # Exclude locked/preserved (deprovisioned) IPA accounts: they keep
-        # objectclass=person and would otherwise still match this filter.
         _, status, results, _ = self._connection.search(
-            self.base_dn,
-            f"(&(objectclass=person)(!(nsAccountLock=TRUE))(|{user_filter}))",
+            f"cn=users,cn=accounts,{self.base_dn}",
+            f"(&(objectclass=person)(|{user_filter}))",
             attributes=["uid"],
         )
         self._check_ldap_response(status)

--- a/qontract_utils/tests/ldap_api/test_ldap_api.py
+++ b/qontract_utils/tests/ldap_api/test_ldap_api.py
@@ -176,6 +176,7 @@ def test_get_users_builds_correct_filter(
     assert call_args[0][0] == "dc=example,dc=com"
     filter_str = call_args[0][1]
     assert "(objectclass=person)" in filter_str
+    assert "(!(nsAccountLock=TRUE))" in filter_str
     assert "(uid=alice)" in filter_str
     assert "(uid=bob)" in filter_str
 

--- a/qontract_utils/tests/ldap_api/test_ldap_api.py
+++ b/qontract_utils/tests/ldap_api/test_ldap_api.py
@@ -173,12 +173,38 @@ def test_get_users_builds_correct_filter(
         ldap_api.get_users(["alice", "bob"])
 
     call_args = mock_ldap3.connection.search.call_args
-    assert call_args[0][0] == "dc=example,dc=com"
+    assert call_args[0][0] == "cn=users,cn=accounts,dc=example,dc=com"
     filter_str = call_args[0][1]
     assert "(objectclass=person)" in filter_str
-    assert "(!(nsAccountLock=TRUE))" in filter_str
     assert "(uid=alice)" in filter_str
     assert "(uid=bob)" in filter_str
+
+
+def test_get_users_scopes_search_to_active_users_container(
+    mock_ldap3: MagicMock, ldap_api: LdapApi
+) -> None:
+    """Test get_users only searches the active users container.
+
+    FreeIPA moves deprovisioned accounts out of cn=users,cn=accounts into a
+    separate preserved-users container, but accounts merely disabled via
+    `ipa user-disable` (nsAccountLock=TRUE) stay active and remain in this
+    container. Scoping the search here -- rather than filtering on
+    nsAccountLock -- avoids treating a disabled-but-still-employed user as
+    deprovisioned.
+    """
+    mock_ldap3.connection.search.return_value = (
+        True,
+        {"result": 0, "description": "success"},
+        [{"attributes": {"uid": ["alice"]}}],
+        None,
+    )
+
+    with ldap_api:
+        result = ldap_api.get_users(["alice"])
+
+    call_args = mock_ldap3.connection.search.call_args
+    assert call_args[0][0] == "cn=users,cn=accounts,dc=example,dc=com"
+    assert {u.username for u in result} == {"alice"}
 
 
 def test_get_users_escapes_special_characters(


### PR DESCRIPTION
## Summary
- `ldap-users-api` stopped detecting deprovisioned users to delete after RedHat migrated its directory backend from LDAP (`ldap.corp.redhat.com`) to FreeIPA (`s1.idm-001.prod.iad2.dc.redhat.com`).
- Root cause: FreeIPA doesn't hard-delete deprovisioned accounts like the legacy LDAP server did. It locks them (`nsAccountLock: TRUE`) and moves them into a preserved container (`cn=deleted users,cn=accounts,cn=provisioning,...`), but the entry still has `objectclass=person`. `LdapApi.get_users()` only filtered on `objectclass=person`, so these preserved/locked accounts were reported as `exists=True`, and the integration never proposed deleting them.
- Fix: scope the LDAP search in `get_users()` to the active users container (`cn=users,cn=accounts,<base_dn>`) instead of filtering on `nsAccountLock`. `nsAccountLock=TRUE` is also set by `ipa user-disable` on accounts that stay fully active (not moved to the preserved container) — filtering on it alone would have misclassified those still-employed disabled users as deprovisioned and queued their access for deletion. Scoping to the active users container correctly distinguishes deprovisioned accounts (moved out) from merely-disabled ones (stay in).

Confirmed against production IPA that all 21 known-stale usernames sit under the preserved container, and confirmed a local dry-run of `ldap-users-api` now correctly flags all 21 for deletion.

## Test plan
- [x] Added `test_get_users_scopes_search_to_active_users_container` and updated `test_get_users_builds_correct_filter` to assert the search is scoped to `cn=users,cn=accounts,<base_dn>`; confirmed both failed against the unscoped search, then passed after the fix
- [x] Full `qontract_utils/tests/ldap_api/test_ldap_api.py` suite passes (33 passed)
- [x] `ruff check`, `ruff format --check`, `mypy` clean for the changed files
- [x] Local dry-run of `ldap-users-api` integration now correctly logs `delete_user` for all 21 known-stale usernames

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved LDAP user lookups by limiting searches to the active users container, avoiding matches outside the current users scope.
  * Updated FreeIPA-related handling so locked/deprovisioned users are excluded from results, while accounts disabled with `nsAccountLock=TRUE` are handled as intended (still treated as existing per behavior).
  * Added/strengthened automated coverage to ensure the correct search scope and filters are used.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->