### PR TITLE
feat(signalfx_endpoint_monitoring): emit COO Probe alongside legacy Probe

### DIFF
--- a/reconcile/signalfx_endpoint_monitoring.py
+++ b/reconcile/signalfx_endpoint_monitoring.py
@@ -17,6 +17,8 @@ QONTRACT_INTEGRATION_VERSION = make_semver(0, 1, 0)
 LOG = logging.getLogger(__name__)
 
 PROVIDER = "signalfx"
+COO_NAMESPACE_NAME = "app-sre-observability-per-cluster"
+MANAGED_TYPES = ["Probe.monitoring.coreos.com", "Probe.monitoring.rhobs"]
 
 
 def run(dry_run: bool, thread_pool_size: int, internal: bool) -> None:
@@ -29,6 +31,7 @@ def run(dry_run: bool, thread_pool_size: int, internal: bool) -> None:
             dry_run=dry_run,
             thread_pool_size=thread_pool_size,
             internal=internal,
+            managed_types=MANAGED_TYPES,
         )
     except Exception as e:
         LOG.error(e)
@@ -61,32 +64,55 @@ def build_probe(
     ]
     relabeling.append({"action": "labeldrop", "regex": "namespace"})
 
-    body: dict[str, Any] = {
+    spec: dict[str, Any] = {
+        "jobName": provider.name,
+        "interval": provider.checkInterval or "10s",
+        "prober": prober_url,
+        "targets": {
+            "staticConfig": {
+                "relabelingConfigs": relabeling,
+                "labels": provider.metric_labels,
+                "static": [ep.name for ep in endpoints],
+            }
+        },
+    }
+    if provider.timeout:
+        spec["scrapeTimeout"] = provider.timeout
+
+    namespace = signalfx.namespace
+
+    coreos_body: dict[str, Any] = {
         "apiVersion": "monitoring.coreos.com/v1",
         "kind": "Probe",
         "metadata": {
             "name": provider.name,
-            "namespace": signalfx.namespace.get("name"),
+            "namespace": namespace.get("name"),
             "labels": {"prometheus": "app-sre"},
         },
-        "spec": {
-            "jobName": provider.name,
-            "interval": provider.checkInterval or "10s",
-            "prober": prober_url,
-            "targets": {
-                "staticConfig": {
-                    "relabelingConfigs": relabeling,
-                    "labels": provider.metric_labels,
-                    "static": [ep.name for ep in endpoints],
-                }
-            },
-        },
+        "spec": spec,
     }
-    if provider.timeout:
-        body["spec"]["scrapeTimeout"] = provider.timeout
+    coo_namespace: dict[str, Any] = {**namespace, "name": COO_NAMESPACE_NAME}
+    rhobs_body: dict[str, Any] = {
+        "apiVersion": "monitoring.rhobs/v1",
+        "kind": "Probe",
+        "metadata": {
+            "name": provider.name,
+            "namespace": COO_NAMESPACE_NAME,
+            "labels": {"prometheus": "app-sre"},
+        },
+        "spec": spec,
+    }
     return [
         (
-            OpenshiftResource(body, QONTRACT_INTEGRATION, QONTRACT_INTEGRATION_VERSION),
-            signalfx.namespace,
-        )
+            OpenshiftResource(
+                coreos_body, QONTRACT_INTEGRATION, QONTRACT_INTEGRATION_VERSION
+            ),
+            namespace,
+        ),
+        (
+            OpenshiftResource(
+                rhobs_body, QONTRACT_INTEGRATION, QONTRACT_INTEGRATION_VERSION
+            ),
+            coo_namespace,
+        ),
     ]

--- a/reconcile/test/test_closedbox_endpoint_monitoring.py
+++ b/reconcile/test/test_closedbox_endpoint_monitoring.py
@@ -129,9 +129,10 @@ def test_signalfx_probe_building(mocker: MockerFixture) -> None:
     provider_endpoints = endpoints.get(provider)
     assert provider_endpoints is not None
     probes = signalfx_probe_builder(provider, provider_endpoints)
-    assert len(probes) == 1
+    assert len(probes) == 2
 
-    probe_resource, _ = probes[0]
+    probe_resource, namespace = probes[0]
+    assert probe_resource.body["apiVersion"] == "monitoring.coreos.com/v1"
 
     # verify prober url decomposition
     spec = probe_resource.body.get("spec", {})
@@ -169,6 +170,13 @@ def test_signalfx_probe_building(mocker: MockerFixture) -> None:
         "targetLabel": "instance",
     } in spec["targets"]["staticConfig"]["relabelingConfigs"]
 
+    # verify COO rhobs probe
+    coo_probe, coo_namespace = probes[1]
+    assert coo_probe.body["apiVersion"] == "monitoring.rhobs/v1"
+    assert coo_namespace["name"] == "app-sre-observability-per-cluster"
+    assert coo_namespace["cluster"] == namespace["cluster"]
+    assert coo_probe.body["spec"] == spec
+
 
 @pytest.mark.parametrize(
     "probe_idx,expected_namespace,expected_resource_type",
@@ -203,7 +211,19 @@ def test_blackbox_exporter_filling_desired_state(
     )
 
 
-def test_signalfx_filling_desired_state(mocker: MockerFixture) -> None:
+@pytest.mark.parametrize(
+    "probe_idx,expected_namespace,expected_resource_type",
+    [
+        (0, "openshift-customer-monitoring", "Probe.monitoring.coreos.com"),
+        (1, "app-sre-observability-per-cluster", "Probe.monitoring.rhobs"),
+    ],
+)
+def test_signalfx_filling_desired_state(
+    mocker: MockerFixture,
+    probe_idx: int,
+    expected_namespace: str,
+    expected_resource_type: str,
+) -> None:
     ep_query = mocker.patch.object(queries, "get_service_monitoring_endpoints")
     ep_query.return_value = get_endpoint_fixtures("test_endpoint.yaml")
     add_desired_mock = mocker.patch.object(ResourceInventory, "add_desired")
@@ -211,15 +231,15 @@ def test_signalfx_filling_desired_state(mocker: MockerFixture) -> None:
     endpoints = get_endpoints(SIGNALFX_PROVIDER)
     provider = next(iter(endpoints.keys()))
     probes = signalfx_probe_builder(provider, endpoints[provider])
-    assert len(probes) > 0
-    probe, ns = probes[0]
+    assert len(probes) == 2
+    probe, ns = probes[probe_idx]
     fill_desired_state(ns, probe, ResourceInventory())
 
     assert add_desired_mock.call_count == 1
     add_desired_mock.assert_called_with(
         cluster="app-sre-stage-01",
-        namespace="openshift-customer-monitoring",
-        resource_type="Probe.monitoring.coreos.com",
+        namespace=expected_namespace,
+        resource_type=expected_resource_type,
         name="signalfx-exporter-http-2xx",
         value=ANY,
     )


### PR DESCRIPTION
## What

`signalfx_endpoint_monitoring` only ever built a single `Probe` body with `apiVersion: monitoring.coreos.com/v1`, unlike `blackbox_exporter_endpoint_monitoring`, which was already extended to also emit `monitoring.rhobs/v1` into `app-sre-observability-per-cluster` as part of the COO migration.

This meant `signalfx`-provider probes (e.g. `catchpoint-result-importer`) could never get a COO counterpart no matter what changed in app-interface, since there was no code path that creates one — confirmed via `coo-parity-check` (a new CronJob comparing scrape/rule parity between the legacy and COO Prometheus stacks, APPSRE-14333) reporting `catchpoint-result-importer` as permanently missing in COO on `appsrep11ue1`.

## How

Mirrors `blackbox_exporter_endpoint_monitoring`'s dual-emission pattern exactly:
- Build both the legacy `coreos_body` and a new `rhobs_body` targeting `app-sre-observability-per-cluster`
- Add `Probe.monitoring.rhobs` to `managed_types`
- Return both resources from `build_probe`

## Test plan

- [x] Updated `test_signalfx_probe_building` to assert 2 probes are built, with a new assertion block verifying the COO `rhobs` probe's `apiVersion`, target namespace, and that its `spec` matches the legacy probe's `spec`
- [x] Updated `test_signalfx_filling_desired_state` to parametrize over both probes (mirroring `test_blackbox_exporter_filling_desired_state`), verifying both the legacy and COO resource get added to the desired state with the correct namespace/resource_type
- [x] `uv run pytest reconcile/test/test_closedbox_endpoint_monitoring.py -v` — 11 passed
- [x] `uv run ruff check` / `uv run ruff format --check` — clean
- [x] `uv run mypy reconcile/signalfx_endpoint_monitoring.py` — no issues

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Endpoint monitoring now provisions probes for both the existing SignalFx monitoring setup and the consolidated OpenShift observability system.
  * Probes are created in their appropriate namespaces while keeping existing scraping intervals and timeout behavior consistent.

* **Bug Fixes**
  * Improved reconciliation so all supported probe destinations are correctly tracked and managed during updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->