### PR TITLE
fix httpxyz

### DIFF
--- a/reconcile/cli.py
+++ b/reconcile/cli.py
@@ -11,6 +11,9 @@ from signal import SIGUSR1
 from typing import TYPE_CHECKING, Any
 
 import click
+
+# always import qontract_utils first to ensure httpxyz is loaded before any transitive dependency can pull in the real httpx
+import qontract_utils  # noqa: F401
 import sentry_sdk
 from sentry_sdk.integrations.logging import LoggingIntegration
 


### PR DESCRIPTION
fixes 

```
11:03:03 INTEGRATION gitlab-fork-compliance
11:03:05 Traceback (most recent call last):
11:03:05   File "/opt/app-root/bin/qontract-reconcile", line 10, in <module>
11:03:05     sys.exit(integration())
11:03:05              ~~~~~~~~~~~^^
11:03:05   File "/opt/app-root/lib64/python3.14/site-packages/click/core.py", line 1569, in __call__
11:03:05     return self.main(*args, **kwargs)
11:03:05            ~~~~~~~~~^^^^^^^^^^^^^^^^^
11:03:05   File "/opt/app-root/lib64/python3.14/site-packages/click/core.py", line 1490, in main
11:03:05     rv = self.invoke(ctx)
11:03:05   File "/opt/app-root/lib64/python3.14/site-packages/click/core.py", line 1970, in invoke
11:03:05     return _process_result(sub_ctx.command.invoke(sub_ctx))
11:03:05                            ~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^
11:03:05   File "/opt/app-root/lib64/python3.14/site-packages/click/core.py", line 1353, in invoke
11:03:05     return ctx.invoke(self.callback, **ctx.params)
11:03:05            ~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
11:03:05   File "/opt/app-root/lib64/python3.14/site-packages/click/core.py", line 907, in invoke
11:03:05     return callback(*args, **kwargs)
11:03:05   File "/opt/app-root/lib64/python3.14/site-packages/click/decorators.py", line 34, in new_func
11:03:05     return f(get_current_context(), *args, **kwargs)
11:03:05   File "/work/reconcile/cli.py", line 3191, in gitlab_fork_compliance
11:03:05     import reconcile.gitlab_fork_compliance
11:03:05   File "/work/reconcile/gitlab_fork_compliance.py", line 13, in <module>
11:03:05     from reconcile.utils.mr.labels import BLOCKED_BOT_ACCESS
11:03:05   File "/work/reconcile/utils/mr/__init__.py", line 3, in <module>
11:03:05     from reconcile.utils.mr.app_interface_reporter import CreateAppInterfaceReporter
11:03:05   File "/work/reconcile/utils/mr/app_interface_reporter.py", line 6, in <module>
11:03:05     from qontract_utils.ruamel import PreservedScalarString
11:03:05   File "/work/qontract_utils/qontract_utils/__init__.py", line 3, in <module>
11:03:05     from qontract_utils import _httpxyz_compat as _httpxyz_compat
11:03:05   File "/work/qontract_utils/qontract_utils/_httpxyz_compat.py", line 20, in <module>
11:03:05     raise RuntimeError(msg)
11:03:05 RuntimeError: httpxyz must be imported before any library that uses httpx. sys.modules['httpx'] is <module 'httpx' from '/opt/app-root/lib64/python3.14/site-packages/httpx/__init__.py'>, expected httpxyz. See ADR-020.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated command-line startup imports to ensure consistent HTTP behavior.
  * No user-facing functionality or CLI behavior changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->