### PR TITLE
fix httpxyz import order in qontract-cli

### DIFF
--- a/tools/qontract_cli.py
+++ b/tools/qontract_cli.py
@@ -25,6 +25,9 @@ from typing import TYPE_CHECKING, Any, cast
 import boto3
 import click
 import click.core
+
+# always import qontract_utils first to ensure httpxyz is loaded before any transitive dependency can pull in the real httpx
+import qontract_utils  # noqa: F401
 import requests
 import yaml
 from gitlab.const import PipelineStatus


### PR DESCRIPTION
tools/qontract_cli.py never imported qontract_utils before pulling in reconcile modules, so real httpx (installed transitively via lightkube) could claim sys.modules["httpx"] first and trip the ADR-020 guard. Mirrors the same fix already applied to reconcile/cli.py in ebb41542.