### PR TITLE
qontract-utils k8s: no retry

### DIFF
--- a/qontract_api/qontract_api/kubernetes/cluster_client_map.py
+++ b/qontract_api/qontract_api/kubernetes/cluster_client_map.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Self
 
 from pydantic import BaseModel
-from qontract_utils.hooks import DEFAULT_RETRY_CONFIG, Hooks
+from qontract_utils.hooks import NO_RETRY_CONFIG, Hooks
 from qontract_utils.kubernetes import KubernetesApi
 
 from qontract_api.kubernetes.workspace_client import KubernetesWorkspaceClient
@@ -56,7 +56,7 @@ class ClusterClientMap:
                     params.server,
                     params.token,
                     insecure_skip_tls_verify=params.insecure_skip_tls_verify,
-                    hooks=Hooks(retry_config=DEFAULT_RETRY_CONFIG),
+                    hooks=Hooks(retry_config=NO_RETRY_CONFIG),
                 )
                 self._api_clients.append(api)
                 self._clients[params.cluster_name] = KubernetesWorkspaceClient(


### PR DESCRIPTION
Don't retry to reach clusters.
If a cluster isn't reachable, it blocks a worker for more than 5 minutes. After a few `/reconcile` loops, all workers will be blocked.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated Kubernetes API interactions to avoid automatic retries in multi-cluster client operations, providing more predictable request behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->