### PR TITLE
feat(qontract-api): split celery queues and autoscale worker via KEDA

### DIFF
--- a/openshift/qontract-api.yaml
+++ b/openshift/qontract-api.yaml
@@ -787,6 +787,8 @@ parameters:
     required: true
 
   ## Prod worker (qontract-api-prod queue) Pod limits
+  # The -Q queue name must match QUEUE_PROD in
+  # qontract_api/qontract_api/tasks/__init__.py.
   - name: QAPI_WORKER_PROD_CELERY_OPTS
     description: Celery options for the prod worker (binds it to the prod queue)
     value: "--pool solo -Q qontract-api-prod"
@@ -808,6 +810,8 @@ parameters:
     required: true
 
   ## MR-check worker (qontract-api-mr-check queue) Pod limits
+  # The -Q queue name must match QUEUE_MR_CHECK in
+  # qontract_api/qontract_api/tasks/__init__.py.
   - name: QAPI_WORKER_MR_CHECK_CELERY_OPTS
     description: Celery options for the mr-check worker (binds it to the mr-check queue)
     value: "--pool solo -Q qontract-api-mr-check"

--- a/openshift/qontract-api.yaml
+++ b/openshift/qontract-api.yaml
@@ -21,7 +21,6 @@ objects:
       QAPI_DEBUG: "${QAPI_DEBUG}"
       QAPI_ROOT_PATH: "${QAPI_ROOT_PATH}"
       QAPI_LOG_LEVEL: "${QAPI_LOG_LEVEL}"
-      QAPI_CELERY_OPTS: "${QAPI_CELERY_OPTS}"
       QAPI_UVICORN_OPTS: "${QAPI_UVICORN_OPTS}"
 
 
@@ -349,7 +348,9 @@ objects:
         app.kubernetes.io/component: subscriber
         app.kubernetes.io/name: qontract-api
 
-  # --------- WORKER DEPLOYMENT --------------
+  # --------- PROD WORKER DEPLOYMENT --------------
+  # Consumes the qontract-api-prod Celery queue (dry_run=False, real writes).
+  # Replica count is managed by the qontract-api-worker ScaledObject (KEDA) below.
   - apiVersion: policy/v1
     kind: PodDisruptionBudget
     metadata:
@@ -379,7 +380,6 @@ objects:
         app.kubernetes.io/name: qontract-api
       name: qontract-api-worker
     spec:
-      replicas: ${{QAPI_WORKER_REPLICAS}}
       selector:
         matchLabels:
           app.kubernetes.io/component: worker
@@ -417,6 +417,8 @@ objects:
             - env:
                 - name: QAPI_START_MODE
                   value: worker
+                - name: QAPI_CELERY_OPTS
+                  value: "${QAPI_WORKER_PROD_CELERY_OPTS}"
                 - name: QAPI_WORKER_METRICS_PORT
                   value: "${QAPI_WORKER_METRICS_PORT}"
                 - name: QAPI_WORKER_TEMP_DIR
@@ -468,7 +470,7 @@ objects:
               emptyDir:
                 sizeLimit: 50Mi
 
-  # ---------- WORKER SERVICE (PROMETHEUS) -----------
+  # ---------- PROD WORKER SERVICE (PROMETHEUS) -----------
   - apiVersion: v1
     kind: Service
     metadata:
@@ -484,6 +486,206 @@ objects:
       selector:
         app.kubernetes.io/component: worker
         app.kubernetes.io/name: qontract-api
+
+  # --------- MR-CHECK WORKER DEPLOYMENT --------------
+  # Consumes the qontract-api-mr-check Celery queue (dry_run=True, read-only
+  # validation runs). Kept as a separate Deployment + queue so a stuck/blocked
+  # prod reconciliation can't starve MR-check validation capacity, or vice versa.
+  # Replica count is managed by the qontract-api-worker-mr-check ScaledObject
+  # (KEDA) below.
+  - apiVersion: policy/v1
+    kind: PodDisruptionBudget
+    metadata:
+      name: qontract-api-worker-mr-check
+    spec:
+      minAvailable: 1
+      selector:
+        matchLabels:
+          app.kubernetes.io/component: worker-mr-check
+
+  - apiVersion: v1
+    kind: ServiceAccount
+    imagePullSecrets: "${{IMAGE_PULL_SECRETS}}"
+    metadata:
+      name: qontract-api-worker-mr-check
+      labels:
+        app.kubernetes.io/component: worker-mr-check
+        app.kubernetes.io/name: qontract-api
+
+  - apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      annotations:
+        ignore-check.kube-linter.io/unset-cpu-requirements: "no cpu limits"
+      labels:
+        app.kubernetes.io/component: worker-mr-check
+        app.kubernetes.io/name: qontract-api
+      name: qontract-api-worker-mr-check
+    spec:
+      selector:
+        matchLabels:
+          app.kubernetes.io/component: worker-mr-check
+          app.kubernetes.io/name: qontract-api
+      template:
+        metadata:
+          labels:
+            app.kubernetes.io/component: worker-mr-check
+            app.kubernetes.io/name: qontract-api
+        spec:
+          restartPolicy: Always
+          serviceAccountName: qontract-api-worker-mr-check
+          affinity:
+            podAntiAffinity:
+              preferredDuringSchedulingIgnoredDuringExecution:
+                - podAffinityTerm:
+                    labelSelector:
+                      matchExpressions:
+                        - key: app.kubernetes.io/component
+                          operator: In
+                          values:
+                            - worker-mr-check
+                    topologyKey: topology.kubernetes.io/zone
+                  weight: 100
+                - podAffinityTerm:
+                    labelSelector:
+                      matchExpressions:
+                        - key: app.kubernetes.io/component
+                          operator: In
+                          values:
+                            - worker-mr-check
+                    topologyKey: kubernetes.io/hostname
+                  weight: 1
+          containers:
+            - env:
+                - name: QAPI_START_MODE
+                  value: worker
+                - name: QAPI_CELERY_OPTS
+                  value: "${QAPI_WORKER_MR_CHECK_CELERY_OPTS}"
+                - name: QAPI_WORKER_METRICS_PORT
+                  value: "${QAPI_WORKER_METRICS_PORT}"
+                - name: QAPI_WORKER_TEMP_DIR
+                  value: /worker-temp-dir
+                - name: QAPI_SENTRY_DSN
+                  valueFrom:
+                    secretKeyRef:
+                      name: ${QAPI_SENTRY_SECRET_NAME}
+                      key: dsn
+              envFrom:
+                - secretRef:
+                    name: qontract-api-secret
+                    optional: true
+                - configMapRef:
+                    name: qontract-api-config
+                    optional: true
+              image: "${IMAGE}:${IMAGE_TAG}"
+              name: worker-mr-check
+              ports:
+                - containerPort: ${{QAPI_WORKER_METRICS_PORT}}
+              readinessProbe:
+                httpGet:
+                  path: /metrics
+                  port: ${{QAPI_WORKER_METRICS_PORT}}
+                periodSeconds: 15
+                timeoutSeconds: 5
+              startupProbe:
+                tcpSocket:
+                  port: ${{QAPI_WORKER_METRICS_PORT}}
+                initialDelaySeconds: 5
+                periodSeconds: 5
+                timeoutSeconds: 5
+              livenessProbe:
+                tcpSocket:
+                  port: ${{QAPI_WORKER_METRICS_PORT}}
+                periodSeconds: 30
+                timeoutSeconds: 5
+              resources:
+                requests:
+                  cpu: ${{QAPI_WORKER_MR_CHECK_CPU_REQUESTS}}
+                  memory: ${{QAPI_WORKER_MR_CHECK_MEMORY_REQUESTS}}
+                limits:
+                  memory: ${{QAPI_WORKER_MR_CHECK_MEMORY_LIMITS}}
+              volumeMounts:
+                - mountPath: /worker-temp-dir
+                  name: worker-temp-dir
+          volumes:
+            - name: worker-temp-dir
+              emptyDir:
+                sizeLimit: 50Mi
+
+  # ---------- MR-CHECK WORKER SERVICE (PROMETHEUS) -----------
+  - apiVersion: v1
+    kind: Service
+    metadata:
+      labels:
+        app.kubernetes.io/component: worker-mr-check
+        app.kubernetes.io/name: qontract-api
+      name: qontract-api-worker-mr-check
+    spec:
+      ports:
+        - name: "http"
+          port: ${{QAPI_WORKER_METRICS_PORT}}
+          targetPort: ${{QAPI_WORKER_METRICS_PORT}}
+      selector:
+        app.kubernetes.io/component: worker-mr-check
+        app.kubernetes.io/name: qontract-api
+
+  # ---------- KEDA AUTOSCALING (APPSRE-14860) -----------
+  # Scales each worker Deployment on the backlog (list length) of its Celery
+  # queue in the Redis/Valkey broker, instead of a fixed replica count. This
+  # ensures a stuck task (e.g. an unreachable OpenShift cluster) doesn't just
+  # serialize behind a fixed pod count - extra pods spin up to drain the
+  # backlog. Queue names below must match QUEUE_PROD/QUEUE_MR_CHECK in
+  # qontract_api/qontract_api/tasks/__init__.py.
+  - apiVersion: keda.sh/v1alpha1
+    kind: TriggerAuthentication
+    metadata:
+      name: qontract-api-worker-redis-auth
+    spec:
+      secretTargetRef:
+        - parameter: address
+          name: qontract-api-secret
+          key: KEDA_REDIS_ADDRESS
+        - parameter: password
+          name: qontract-api-secret
+          key: KEDA_REDIS_PASSWORD
+
+  - apiVersion: keda.sh/v1alpha1
+    kind: ScaledObject
+    metadata:
+      name: qontract-api-worker
+    spec:
+      scaleTargetRef:
+        name: qontract-api-worker
+      minReplicaCount: ${{QAPI_WORKER_PROD_MIN_REPLICAS}}
+      maxReplicaCount: ${{QAPI_WORKER_PROD_MAX_REPLICAS}}
+      triggers:
+        - type: redis
+          metadata:
+            listName: qontract-api-prod
+            listLength: "${QAPI_WORKER_PROD_QUEUE_TARGET_LENGTH}"
+            databaseIndex: "0"
+            enableTLS: "true"
+          authenticationRef:
+            name: qontract-api-worker-redis-auth
+
+  - apiVersion: keda.sh/v1alpha1
+    kind: ScaledObject
+    metadata:
+      name: qontract-api-worker-mr-check
+    spec:
+      scaleTargetRef:
+        name: qontract-api-worker-mr-check
+      minReplicaCount: ${{QAPI_WORKER_MR_CHECK_MIN_REPLICAS}}
+      maxReplicaCount: ${{QAPI_WORKER_MR_CHECK_MAX_REPLICAS}}
+      triggers:
+        - type: redis
+          metadata:
+            listName: qontract-api-mr-check
+            listLength: "${QAPI_WORKER_MR_CHECK_QUEUE_TARGET_LENGTH}"
+            databaseIndex: "0"
+            enableTLS: "true"
+          authenticationRef:
+            name: qontract-api-worker-redis-auth
 
 parameters:
   # Global config
@@ -508,9 +710,6 @@ parameters:
     description: Port to expose the API app on
     value: "8080"
     required: true
-
-  - name: QAPI_CELERY_OPTS
-    description: Celery options
 
   - name: QAPI_UVICORN_OPTS
     description: Uvicorn options
@@ -581,31 +780,83 @@ parameters:
     value: "100m"
     required: true
 
-  # Worker config
+  # Worker config (shared by both prod and mr-check worker deployments)
   - name: QAPI_WORKER_METRICS_PORT
     description: Port to expose the web app on
     value: "8000"
     required: true
 
-  ## Worker Pod limits
-  - name: QAPI_WORKER_REPLICAS
-    description: Worker replicas
-    value: "3"
+  ## Prod worker (qontract-api-prod queue) Pod limits
+  - name: QAPI_WORKER_PROD_CELERY_OPTS
+    description: Celery options for the prod worker (binds it to the prod queue)
+    value: "--pool solo -Q qontract-api-prod"
     required: true
 
   - name: QAPI_WORKER_MEMORY_REQUESTS
-    description: Worker memory requests
+    description: Prod worker memory requests
     value: "200Mi"
     required: true
 
   - name: QAPI_WORKER_MEMORY_LIMITS
-    description: Worker memory limits
+    description: Prod worker memory limits
     value: "200Mi"
     required: true
 
   - name: QAPI_WORKER_CPU_REQUESTS
-    description: Worker cpu requests
+    description: Prod worker cpu requests
     value: "100m"
+    required: true
+
+  ## MR-check worker (qontract-api-mr-check queue) Pod limits
+  - name: QAPI_WORKER_MR_CHECK_CELERY_OPTS
+    description: Celery options for the mr-check worker (binds it to the mr-check queue)
+    value: "--pool solo -Q qontract-api-mr-check"
+    required: true
+
+  - name: QAPI_WORKER_MR_CHECK_MEMORY_REQUESTS
+    description: MR-check worker memory requests
+    value: "200Mi"
+    required: true
+
+  - name: QAPI_WORKER_MR_CHECK_MEMORY_LIMITS
+    description: MR-check worker memory limits
+    value: "200Mi"
+    required: true
+
+  - name: QAPI_WORKER_MR_CHECK_CPU_REQUESTS
+    description: MR-check worker cpu requests
+    value: "100m"
+    required: true
+
+  ## KEDA autoscaling (APPSRE-14860)
+  - name: QAPI_WORKER_PROD_MIN_REPLICAS
+    description: Minimum prod worker replicas
+    value: "3"
+    required: true
+
+  - name: QAPI_WORKER_PROD_MAX_REPLICAS
+    description: Maximum prod worker replicas
+    value: "15"
+    required: true
+
+  - name: QAPI_WORKER_PROD_QUEUE_TARGET_LENGTH
+    description: Target qontract-api-prod queue length per prod worker replica
+    value: "5"
+    required: true
+
+  - name: QAPI_WORKER_MR_CHECK_MIN_REPLICAS
+    description: Minimum mr-check worker replicas
+    value: "3"
+    required: true
+
+  - name: QAPI_WORKER_MR_CHECK_MAX_REPLICAS
+    description: Maximum mr-check worker replicas
+    value: "15"
+    required: true
+
+  - name: QAPI_WORKER_MR_CHECK_QUEUE_TARGET_LENGTH
+    description: Target qontract-api-mr-check queue length per mr-check worker replica
+    value: "5"
     required: true
 
   # OPA sidecar

--- a/qontract_api/pyproject.toml
+++ b/qontract_api/pyproject.toml
@@ -163,7 +163,7 @@ disallow_incomplete_defs = true
 [[tool.mypy.overrides]]
 # Below are all of the packages that don't implement stub packages. Mypy will throw an error if we don't ignore the
 # missing imports. See: https://mypy.readthedocs.io/en/stable/running_mypy.html#missing-imports
-module = ["celery.*", "jose", "billiard.einfo.*"]
+module = ["celery.*", "jose", "billiard.einfo.*", "kombu.*"]
 ignore_missing_imports = true
 
 # [tool.coverage.report]

--- a/qontract_api/qontract_api/integrations/github_owners/router.py
+++ b/qontract_api/qontract_api/integrations/github_owners/router.py
@@ -21,7 +21,11 @@ from qontract_api.integrations.github_owners.tasks import (
 )
 from qontract_api.logger import get_logger
 from qontract_api.models import TaskStatus
-from qontract_api.tasks import get_celery_task_result, wait_for_task_completion
+from qontract_api.tasks import (
+    get_celery_task_result,
+    queue_for,
+    wait_for_task_completion,
+)
 
 logger = get_logger(__name__)
 
@@ -55,6 +59,7 @@ def github_owners(
     """
     reconcile_github_owners_task.apply_async(
         task_id=request.state.request_id,
+        queue=queue_for(dry_run=reconcile_request.dry_run),
         kwargs={
             "organizations": reconcile_request.organizations,
             "dry_run": reconcile_request.dry_run,

--- a/qontract_api/qontract_api/integrations/glitchtip/router.py
+++ b/qontract_api/qontract_api/integrations/glitchtip/router.py
@@ -19,7 +19,11 @@ from qontract_api.integrations.glitchtip.schemas import (
 from qontract_api.integrations.glitchtip.tasks import reconcile_glitchtip_task
 from qontract_api.logger import get_logger
 from qontract_api.models import TaskStatus
-from qontract_api.tasks import get_celery_task_result, wait_for_task_completion
+from qontract_api.tasks import (
+    get_celery_task_result,
+    queue_for,
+    wait_for_task_completion,
+)
 
 logger = get_logger(__name__)
 
@@ -53,6 +57,7 @@ def glitchtip_reconcile(
     """
     reconcile_glitchtip_task.apply_async(
         task_id=request.state.request_id,
+        queue=queue_for(dry_run=reconcile_request.dry_run),
         kwargs={
             "instances": reconcile_request.instances,
             "dry_run": reconcile_request.dry_run,

--- a/qontract_api/qontract_api/integrations/glitchtip_project_alerts/router.py
+++ b/qontract_api/qontract_api/integrations/glitchtip_project_alerts/router.py
@@ -21,7 +21,11 @@ from qontract_api.integrations.glitchtip_project_alerts.tasks import (
 )
 from qontract_api.logger import get_logger
 from qontract_api.models import TaskStatus
-from qontract_api.tasks import get_celery_task_result, wait_for_task_completion
+from qontract_api.tasks import (
+    get_celery_task_result,
+    queue_for,
+    wait_for_task_completion,
+)
 
 logger = get_logger(__name__)
 
@@ -55,6 +59,7 @@ def glitchtip_project_alerts(
     """
     reconcile_glitchtip_project_alerts_task.apply_async(
         task_id=request.state.request_id,
+        queue=queue_for(dry_run=reconcile_request.dry_run),
         kwargs={
             "instances": reconcile_request.instances,
             "dry_run": reconcile_request.dry_run,

--- a/qontract_api/qontract_api/integrations/openshift_namespaces/router.py
+++ b/qontract_api/qontract_api/integrations/openshift_namespaces/router.py
@@ -20,7 +20,11 @@ from qontract_api.integrations.openshift_namespaces.tasks import (
     reconcile_openshift_namespaces_task,
 )
 from qontract_api.models import TaskStatus
-from qontract_api.tasks import get_celery_task_result, wait_for_task_completion
+from qontract_api.tasks import (
+    get_celery_task_result,
+    queue_for,
+    wait_for_task_completion,
+)
 
 router = APIRouter(prefix="/openshift-namespaces")
 
@@ -38,6 +42,7 @@ def openshift_namespaces_reconcile(
     """Queue openshift-namespaces reconciliation task."""
     reconcile_openshift_namespaces_task.apply_async(
         task_id=request.state.request_id,
+        queue=queue_for(dry_run=reconcile_request.dry_run),
         kwargs={
             "clusters": reconcile_request.clusters,
             "dry_run": reconcile_request.dry_run,

--- a/qontract_api/qontract_api/integrations/slack_usergroups/router.py
+++ b/qontract_api/qontract_api/integrations/slack_usergroups/router.py
@@ -21,7 +21,11 @@ from qontract_api.integrations.slack_usergroups.tasks import (
 )
 from qontract_api.logger import get_logger
 from qontract_api.models import TaskStatus
-from qontract_api.tasks import get_celery_task_result, wait_for_task_completion
+from qontract_api.tasks import (
+    get_celery_task_result,
+    queue_for,
+    wait_for_task_completion,
+)
 
 logger = get_logger(__name__)
 
@@ -56,6 +60,7 @@ def slack_usergroups(
     # Queue Celery task (async execution in background worker)
     reconcile_slack_usergroups_task.apply_async(
         task_id=request.state.request_id,
+        queue=queue_for(dry_run=reconcile_request.dry_run),
         kwargs={
             "workspaces": reconcile_request.workspaces,
             "dry_run": reconcile_request.dry_run,

--- a/qontract_api/qontract_api/tasks/__init__.py
+++ b/qontract_api/qontract_api/tasks/__init__.py
@@ -6,6 +6,7 @@ from typing import Any
 import celery
 import structlog
 from celery import Celery
+from kombu import Queue
 from prometheus_client import Counter, Histogram
 
 from qontract_api.config import settings
@@ -19,6 +20,20 @@ from qontract_api.tasks._utils import (
 )
 
 logger = structlog.getLogger(__name__)
+
+QUEUE_PROD = "qontract-api-prod"
+QUEUE_MR_CHECK = "qontract-api-mr-check"
+
+
+def queue_for(*, dry_run: bool) -> str:
+    """Return the Celery queue name for a reconciliation task.
+
+    Dry-run (MR check) and production tasks run on separate queues so that
+    one class of work can't block the other, and so each can be
+    autoscaled independently.
+    """
+    return QUEUE_MR_CHECK if dry_run else QUEUE_PROD
+
 
 task_elapsed_time = Histogram(
     name="qontract_reconcile_worker_task_elapsed_seconds",
@@ -130,6 +145,8 @@ celery_app = Celery(
     event_serializer="json",
     accept_content=["application/json", "application/x-python-serialize"],
     result_accept_content=["application/json", "application/x-python-serialize"],
+    task_default_queue=QUEUE_PROD,
+    task_queues=(Queue(QUEUE_PROD), Queue(QUEUE_MR_CHECK)),
     include=[
         "qontract_api.tasks.health",
         "qontract_api.integrations.slack_usergroups.tasks",
@@ -141,11 +158,14 @@ celery_app = Celery(
 )
 
 __all__ = [
+    "QUEUE_MR_CHECK",
+    "QUEUE_PROD",
     "BackgroundTask",
     "celery_app",
     "deduplicated_task",
     "get_celery_task_result",
     "get_logger",
+    "queue_for",
     "setup_logger",
     "wait_for_task_completion",
 ]

--- a/qontract_api/qontract_api/tasks/_deduplication.py
+++ b/qontract_api/qontract_api/tasks/_deduplication.py
@@ -81,8 +81,14 @@ def deduplicated_task(
             if kwargs.get("dry_run", True):
                 return func(*args, **kwargs)
 
+            # Keep the pre-existing key format (with the now-constant
+            # dry_run=false segment) so that during a rolling deploy, old
+            # and new worker pods compute the identical lock key for the
+            # same production task - a differing format would let an old
+            # and a new pod both believe they hold the lock for the same
+            # resource.
             lock_key_suffix = lock_key_fn(*args, **kwargs)
-            lock_key = f"task_lock:{func.__name__}:{lock_key_suffix}"
+            lock_key = f"task_lock:{func.__name__}:dry_run=false:{lock_key_suffix}"
 
             logger.debug(
                 f"Attempting to acquire lock for task {func.__name__}",

--- a/qontract_api/qontract_api/tasks/_deduplication.py
+++ b/qontract_api/qontract_api/tasks/_deduplication.py
@@ -31,6 +31,11 @@ def deduplicated_task(
     - Redis/Valkey: Native lock with Lua scripts + watch-dog
     - Other backends: Backend-specific distributed locking
 
+    Dry-run tasks (kwarg `dry_run=True`) are read-only and never write
+    anything, so they bypass locking entirely and always execute. Locking
+    only applies to production (`dry_run=False`) runs, where concurrent
+    writes to the same resource must be prevented.
+
     Args:
         lock_key_fn: Function to generate lock key from task arguments.
                     Example: `lambda workspace, **kw: workspace`
@@ -70,12 +75,14 @@ def deduplicated_task(
 
         @wraps(func)
         def wrapper(*args: P.args, **kwargs: P.kwargs) -> R:
-            # Generate lock key from task arguments.
-            # Always include dry_run in the key so that dry-run and production
-            # tasks for the same resources do not block each other.
+            # Dry-run tasks never write anything, so there is no correctness
+            # reason to serialize them - skip locking entirely so MR-check
+            # traffic isn't throttled by unrelated in-flight dry runs.
+            if kwargs.get("dry_run", True):
+                return func(*args, **kwargs)
+
             lock_key_suffix = lock_key_fn(*args, **kwargs)
-            dry_run = str(kwargs.get("dry_run", True)).lower()
-            lock_key = f"task_lock:{func.__name__}:dry_run={dry_run}:{lock_key_suffix}"
+            lock_key = f"task_lock:{func.__name__}:{lock_key_suffix}"
 
             logger.debug(
                 f"Attempting to acquire lock for task {func.__name__}",

--- a/qontract_api/tests/integrations/glitchtip/test_router.py
+++ b/qontract_api/tests/integrations/glitchtip/test_router.py
@@ -14,6 +14,7 @@ from qontract_api.integrations.glitchtip.schemas import (
     GlitchtipTaskResult,
 )
 from qontract_api.models import Secret, TaskStatus, TokenData
+from qontract_api.tasks import QUEUE_MR_CHECK, QUEUE_PROD
 
 
 @pytest.fixture
@@ -73,6 +74,7 @@ def test_post_reconcile_queues_task(
     call_kwargs = mock_task.apply_async.call_args.kwargs["kwargs"]
     assert call_kwargs["dry_run"] is True
     assert len(call_kwargs["instances"]) == 1
+    assert mock_task.apply_async.call_args.kwargs["queue"] == QUEUE_MR_CHECK
 
 
 @patch("qontract_api.integrations.glitchtip.router.reconcile_glitchtip_task")
@@ -110,6 +112,7 @@ def test_post_reconcile_dry_run_false(
     assert response.status_code == HTTPStatus.ACCEPTED
     call_kwargs = mock_task.apply_async.call_args.kwargs["kwargs"]
     assert call_kwargs["dry_run"] is False
+    assert mock_task.apply_async.call_args.kwargs["queue"] == QUEUE_PROD
 
 
 def test_post_reconcile_requires_auth(

--- a/qontract_api/tests/integrations/openshift_namespaces/test_router.py
+++ b/qontract_api/tests/integrations/openshift_namespaces/test_router.py
@@ -7,6 +7,7 @@ from fastapi.testclient import TestClient
 
 from qontract_api.auth import create_access_token
 from qontract_api.models import TokenData
+from qontract_api.tasks import QUEUE_MR_CHECK, QUEUE_PROD
 
 
 @pytest.fixture
@@ -17,7 +18,7 @@ def auth_headers() -> dict[str, str]:
     return {"Authorization": f"Bearer {test_token}"}
 
 
-def _request_body() -> dict:
+def _request_body(*, dry_run: bool = True) -> dict:
     return {
         "clusters": [
             {
@@ -31,7 +32,7 @@ def _request_body() -> dict:
                 "namespaces": [{"name": "app-a"}],
             }
         ],
-        "dry_run": True,
+        "dry_run": dry_run,
     }
 
 
@@ -55,6 +56,26 @@ def test_post_reconcile_returns_202(
     assert data["status"] == "pending"
     assert "status_url" in data
     mock_task.apply_async.assert_called_once()
+    assert mock_task.apply_async.call_args.kwargs["queue"] == QUEUE_MR_CHECK
+
+
+@patch(
+    "qontract_api.integrations.openshift_namespaces.router.reconcile_openshift_namespaces_task"
+)
+def test_post_reconcile_dry_run_false_uses_prod_queue(
+    mock_task: MagicMock,
+    client_with_cache: TestClient,
+    auth_headers: dict[str, str],
+) -> None:
+    """POST /reconcile with dry_run=False routes to the prod queue."""
+    response = client_with_cache.post(
+        "/api/v1/integrations/openshift-namespaces/reconcile",
+        json=_request_body(dry_run=False),
+        headers=auth_headers,
+    )
+    assert response.status_code == 202
+    mock_task.apply_async.assert_called_once()
+    assert mock_task.apply_async.call_args.kwargs["queue"] == QUEUE_PROD
 
 
 @patch(

--- a/qontract_api/tests/integrations/slack_usergroups/test_slack_usergroups_router.py
+++ b/qontract_api/tests/integrations/slack_usergroups/test_slack_usergroups_router.py
@@ -19,6 +19,7 @@ from qontract_api.slack.domain import (
     SlackUsergroupConfig,
     SlackWorkspace,
 )
+from qontract_api.tasks import QUEUE_MR_CHECK, QUEUE_PROD
 
 
 @pytest.fixture
@@ -85,6 +86,7 @@ def test_post_reconcile_queues_task(
     call_kwargs = mock_task.apply_async.call_args.kwargs["kwargs"]
     assert call_kwargs["dry_run"] is True
     assert len(call_kwargs["workspaces"]) == 1
+    assert mock_task.apply_async.call_args.kwargs["queue"] == QUEUE_MR_CHECK
 
 
 @patch(
@@ -120,6 +122,7 @@ def test_post_reconcile_dry_run_false(
     assert response.status_code == HTTPStatus.ACCEPTED
     call_kwargs = mock_task.apply_async.call_args.kwargs["kwargs"]
     assert call_kwargs["dry_run"] is False
+    assert mock_task.apply_async.call_args.kwargs["queue"] == QUEUE_PROD
 
 
 def test_post_reconcile_requires_auth(

--- a/qontract_api/tests/integrations/test_github_owners_router.py
+++ b/qontract_api/tests/integrations/test_github_owners_router.py
@@ -14,6 +14,7 @@ from qontract_api.integrations.github_owners.schemas import (
     GithubOwnersTaskResult,
 )
 from qontract_api.models import Secret, TaskStatus, TokenData
+from qontract_api.tasks import QUEUE_MR_CHECK, QUEUE_PROD
 
 
 @pytest.fixture
@@ -70,6 +71,7 @@ def test_post_reconcile_queues_task(
     call_kwargs = mock_task.apply_async.call_args.kwargs["kwargs"]
     assert call_kwargs["dry_run"] is True
     assert len(call_kwargs["organizations"]) == 1
+    assert mock_task.apply_async.call_args.kwargs["queue"] == QUEUE_MR_CHECK
 
 
 @patch("qontract_api.integrations.github_owners.router.reconcile_github_owners_task")
@@ -94,6 +96,7 @@ def test_post_reconcile_dry_run_false(
     assert response.status_code == HTTPStatus.ACCEPTED
     call_kwargs = mock_task.apply_async.call_args.kwargs["kwargs"]
     assert call_kwargs["dry_run"] is False
+    assert mock_task.apply_async.call_args.kwargs["queue"] == QUEUE_PROD
 
 
 def test_post_reconcile_requires_auth(

--- a/qontract_api/tests/integrations/test_glitchtip_project_alerts_router.py
+++ b/qontract_api/tests/integrations/test_glitchtip_project_alerts_router.py
@@ -17,6 +17,7 @@ from qontract_api.integrations.glitchtip_project_alerts.schemas import (
     GlitchtipProjectAlertsTaskResult,
 )
 from qontract_api.models import Secret, TaskStatus, TokenData
+from qontract_api.tasks import QUEUE_MR_CHECK, QUEUE_PROD
 
 
 @pytest.fixture
@@ -74,6 +75,7 @@ def test_post_reconcile_queues_task(
     call_kwargs = mock_task.apply_async.call_args.kwargs["kwargs"]
     assert call_kwargs["dry_run"] is True
     assert len(call_kwargs["instances"]) == 1
+    assert mock_task.apply_async.call_args.kwargs["queue"] == QUEUE_MR_CHECK
 
 
 @patch(
@@ -109,6 +111,7 @@ def test_post_reconcile_dry_run_false(
     assert response.status_code == HTTPStatus.ACCEPTED
     call_kwargs = mock_task.apply_async.call_args.kwargs["kwargs"]
     assert call_kwargs["dry_run"] is False
+    assert mock_task.apply_async.call_args.kwargs["queue"] == QUEUE_PROD
 
 
 def test_post_reconcile_requires_auth(

--- a/qontract_api/tests/tasks/test_deduplication.py
+++ b/qontract_api/tests/tasks/test_deduplication.py
@@ -31,7 +31,7 @@ def test_deduplicated_task_success(mock_cache: MagicMock) -> None:
     assert result == "processed-workspace-1"
     # Verify lock was attempted with correct key
     mock_cache.lock.assert_called_once_with(
-        "task_lock:test_task:workspace-1", timeout=60
+        "task_lock:test_task:dry_run=false:workspace-1", timeout=60
     )
 
 
@@ -95,7 +95,9 @@ def test_deduplicated_task_with_multiple_args(mock_cache: MagicMock) -> None:
 
     assert result == "result-a-b-10"
     # Verify lock key includes both x and y
-    mock_cache.lock.assert_called_once_with("task_lock:test_task:a-b", timeout=120)
+    mock_cache.lock.assert_called_once_with(
+        "task_lock:test_task:dry_run=false:a-b", timeout=120
+    )
 
 
 def test_deduplicated_task_lock_timeout(mock_cache: MagicMock) -> None:
@@ -110,7 +112,7 @@ def test_deduplicated_task_lock_timeout(mock_cache: MagicMock) -> None:
 
     # Verify custom timeout was used
     mock_cache.lock.assert_called_once_with(
-        "task_lock:test_task:workspace-1", timeout=300
+        "task_lock:test_task:dry_run=false:workspace-1", timeout=300
     )
 
 
@@ -148,7 +150,9 @@ def test_deduplicated_task_with_kwargs(mock_cache: MagicMock) -> None:
         result = test_task(workspace="test-ws", dry_run=False)
 
     assert result == {"workspace": "test-ws", "dry_run": False}
-    mock_cache.lock.assert_called_once_with("task_lock:test_task:test-ws", timeout=60)
+    mock_cache.lock.assert_called_once_with(
+        "task_lock:test_task:dry_run=false:test-ws", timeout=60
+    )
 
 
 def test_deduplicated_task_dry_run_never_locks(mock_cache: MagicMock) -> None:
@@ -207,7 +211,9 @@ def test_deduplicated_task_production_still_dedupes_concurrent_same_resource(
 
     assert isinstance(result, TaskResult)
     assert result.status == TaskStatus.SKIPPED
-    mock_cache.lock.assert_called_once_with("task_lock:test_task:ws-1", timeout=60)
+    mock_cache.lock.assert_called_once_with(
+        "task_lock:test_task:dry_run=false:ws-1", timeout=60
+    )
 
 
 def test_deduplicated_task_preserves_function_name() -> None:
@@ -243,5 +249,5 @@ def test_deduplicated_task_with_complex_lock_key(mock_cache: MagicMock) -> None:
     assert result == 2
     # Lock key should be sorted workspace names
     mock_cache.lock.assert_called_once_with(
-        "task_lock:test_task:ws-a,ws-b", timeout=600
+        "task_lock:test_task:dry_run=false:ws-a,ws-b", timeout=600
     )

--- a/qontract_api/tests/tasks/test_deduplication.py
+++ b/qontract_api/tests/tasks/test_deduplication.py
@@ -19,27 +19,27 @@ def mock_cache() -> MagicMock:
 
 
 def test_deduplicated_task_success(mock_cache: MagicMock) -> None:
-    """Test task executes when lock is acquired."""
+    """Test production task executes when lock is acquired."""
 
-    @deduplicated_task(lock_key_fn=lambda x: x, timeout=60)
-    def test_task(x: str) -> str:
+    @deduplicated_task(lock_key_fn=lambda x, **_: x, timeout=60)
+    def test_task(x: str, *, dry_run: bool = False) -> str:
         return f"processed-{x}"
 
     with patch("qontract_api.tasks._deduplication.get_cache", return_value=mock_cache):
-        result = test_task("workspace-1")
+        result = test_task("workspace-1", dry_run=False)
 
     assert result == "processed-workspace-1"
     # Verify lock was attempted with correct key
     mock_cache.lock.assert_called_once_with(
-        "task_lock:test_task:dry_run=true:workspace-1", timeout=60
+        "task_lock:test_task:workspace-1", timeout=60
     )
 
 
 def test_deduplicated_task_skips_duplicate(mock_cache: MagicMock) -> None:
-    """Test task skips execution when lock cannot be acquired (duplicate)."""
+    """Test production task skips execution when lock cannot be acquired (duplicate)."""
 
-    @deduplicated_task(lock_key_fn=lambda x: x, timeout=60)
-    def test_task(x: str) -> str:
+    @deduplicated_task(lock_key_fn=lambda x, **_: x, timeout=60)
+    def test_task(x: str, *, dry_run: bool = False) -> str:
         return f"processed-{x}"
 
     # Mock: lock acquisition fails (RuntimeError)
@@ -48,7 +48,7 @@ def test_deduplicated_task_skips_duplicate(mock_cache: MagicMock) -> None:
     )
 
     with patch("qontract_api.tasks._deduplication.get_cache", return_value=mock_cache):
-        result = test_task("workspace-1")
+        result = test_task("workspace-1", dry_run=False)
 
     # Should return TaskResult with SKIPPED status, not a raw dict
     assert isinstance(result, TaskResult)
@@ -64,8 +64,8 @@ def test_deduplicated_task_preserves_concrete_subclass_on_skip(
     class CustomTaskResult(TaskResult):
         pass
 
-    @deduplicated_task(lock_key_fn=lambda x: x, timeout=60)
-    def test_task(x: str) -> CustomTaskResult:
+    @deduplicated_task(lock_key_fn=lambda x, **_: x, timeout=60)
+    def test_task(x: str, *, dry_run: bool = False) -> CustomTaskResult:
         return CustomTaskResult(status=TaskStatus.SUCCESS)
 
     mock_cache.lock.return_value.__enter__.side_effect = RuntimeError(
@@ -73,7 +73,7 @@ def test_deduplicated_task_preserves_concrete_subclass_on_skip(
     )
 
     with patch("qontract_api.tasks._deduplication.get_cache", return_value=mock_cache):
-        result = test_task("workspace-1")
+        result = test_task("workspace-1", dry_run=False)
 
     assert isinstance(result, CustomTaskResult)
     assert result.status == TaskStatus.SKIPPED
@@ -87,32 +87,30 @@ def test_deduplicated_task_with_multiple_args(mock_cache: MagicMock) -> None:
         lock_key_fn=lambda x, y, **_: f"{x}-{y}",
         timeout=120,
     )
-    def test_task(x: str, y: str, z: int = 0) -> str:
+    def test_task(x: str, y: str, z: int = 0, *, dry_run: bool = False) -> str:
         return f"result-{x}-{y}-{z}"
 
     with patch("qontract_api.tasks._deduplication.get_cache", return_value=mock_cache):
-        result = test_task("a", "b", z=10)
+        result = test_task("a", "b", z=10, dry_run=False)
 
     assert result == "result-a-b-10"
     # Verify lock key includes both x and y
-    mock_cache.lock.assert_called_once_with(
-        "task_lock:test_task:dry_run=true:a-b", timeout=120
-    )
+    mock_cache.lock.assert_called_once_with("task_lock:test_task:a-b", timeout=120)
 
 
 def test_deduplicated_task_lock_timeout(mock_cache: MagicMock) -> None:
     """Test task uses custom timeout for lock."""
 
-    @deduplicated_task(lock_key_fn=lambda x: x, timeout=300)
-    def test_task(x: str) -> str:
+    @deduplicated_task(lock_key_fn=lambda x, **_: x, timeout=300)
+    def test_task(x: str, *, dry_run: bool = False) -> str:
         return f"result-{x}"
 
     with patch("qontract_api.tasks._deduplication.get_cache", return_value=mock_cache):
-        test_task("workspace-1")
+        test_task("workspace-1", dry_run=False)
 
     # Verify custom timeout was used
     mock_cache.lock.assert_called_once_with(
-        "task_lock:test_task:dry_run=true:workspace-1", timeout=300
+        "task_lock:test_task:workspace-1", timeout=300
     )
 
 
@@ -121,15 +119,15 @@ def test_deduplicated_task_releases_lock_on_exception(
 ) -> None:
     """Test lock is released even when task raises exception."""
 
-    @deduplicated_task(lock_key_fn=lambda x: x, timeout=60)
-    def test_task(x: str) -> str:
+    @deduplicated_task(lock_key_fn=lambda x, **_: x, timeout=60)
+    def test_task(x: str, *, dry_run: bool = False) -> str:
         raise ValueError("Task failed")
 
     with (
         patch("qontract_api.tasks._deduplication.get_cache", return_value=mock_cache),
         pytest.raises(ValueError, match="Task failed"),
     ):
-        test_task("workspace-1")
+        test_task("workspace-1", dry_run=False)
 
     # Lock context manager should still be entered and exited
     mock_cache.lock.return_value.__enter__.assert_called_once()
@@ -150,28 +148,66 @@ def test_deduplicated_task_with_kwargs(mock_cache: MagicMock) -> None:
         result = test_task(workspace="test-ws", dry_run=False)
 
     assert result == {"workspace": "test-ws", "dry_run": False}
-    mock_cache.lock.assert_called_once_with(
-        "task_lock:test_task:dry_run=false:test-ws", timeout=60
-    )
+    mock_cache.lock.assert_called_once_with("task_lock:test_task:test-ws", timeout=60)
 
 
-def test_deduplicated_task_dry_run_and_production_use_separate_keys(
-    mock_cache: MagicMock,
-) -> None:
-    """dry_run=true and dry_run=false tasks must not share a lock key."""
+def test_deduplicated_task_dry_run_never_locks(mock_cache: MagicMock) -> None:
+    """Dry-run tasks must bypass locking entirely - they never write anything."""
 
     @deduplicated_task(lock_key_fn=lambda workspace, **_: workspace, timeout=60)
     def test_task(workspace: str, *, dry_run: bool = True) -> str:
         return workspace
 
     with patch("qontract_api.tasks._deduplication.get_cache", return_value=mock_cache):
-        test_task(workspace="ws-1", dry_run=True)
-        test_task(workspace="ws-1", dry_run=False)
+        first = test_task(workspace="ws-1", dry_run=True)
+        second = test_task(workspace="ws-1", dry_run=True)
 
-    calls = [call.args[0] for call in mock_cache.lock.call_args_list]
-    assert calls[0] == "task_lock:test_task:dry_run=true:ws-1"
-    assert calls[1] == "task_lock:test_task:dry_run=false:ws-1"
-    assert calls[0] != calls[1]
+    # Both calls executed - no serialization for read-only dry runs.
+    assert first == "ws-1"
+    assert second == "ws-1"
+    mock_cache.lock.assert_not_called()
+
+
+def test_deduplicated_task_dry_run_bypasses_lock_even_when_contended(
+    mock_cache: MagicMock,
+) -> None:
+    """A held production lock must not block a concurrent dry-run for the same resource."""
+
+    @deduplicated_task(lock_key_fn=lambda workspace, **_: workspace, timeout=60)
+    def test_task(workspace: str, *, dry_run: bool = True) -> str:
+        return workspace
+
+    # Even if the cache would refuse a lock, dry-run must never ask for one.
+    mock_cache.lock.return_value.__enter__.side_effect = RuntimeError(
+        "Lock not acquired"
+    )
+
+    with patch("qontract_api.tasks._deduplication.get_cache", return_value=mock_cache):
+        result = test_task(workspace="ws-1", dry_run=True)
+
+    assert result == "ws-1"
+    mock_cache.lock.assert_not_called()
+
+
+def test_deduplicated_task_production_still_dedupes_concurrent_same_resource(
+    mock_cache: MagicMock,
+) -> None:
+    """Concurrent dry_run=False calls for the same resource must still dedupe."""
+
+    @deduplicated_task(lock_key_fn=lambda workspace, **_: workspace, timeout=60)
+    def test_task(workspace: str, *, dry_run: bool = True) -> str:
+        return workspace
+
+    mock_cache.lock.return_value.__enter__.side_effect = RuntimeError(
+        "Lock not acquired"
+    )
+
+    with patch("qontract_api.tasks._deduplication.get_cache", return_value=mock_cache):
+        result = test_task(workspace="ws-1", dry_run=False)
+
+    assert isinstance(result, TaskResult)
+    assert result.status == TaskStatus.SKIPPED
+    mock_cache.lock.assert_called_once_with("task_lock:test_task:ws-1", timeout=60)
 
 
 def test_deduplicated_task_preserves_function_name() -> None:
@@ -193,7 +229,7 @@ def test_deduplicated_task_with_complex_lock_key(mock_cache: MagicMock) -> None:
         ),
         timeout=600,
     )
-    def test_task(workspaces: list[dict[str, str]]) -> int:
+    def test_task(workspaces: list[dict[str, str]], *, dry_run: bool = False) -> int:
         return len(workspaces)
 
     workspaces = [
@@ -202,10 +238,10 @@ def test_deduplicated_task_with_complex_lock_key(mock_cache: MagicMock) -> None:
     ]
 
     with patch("qontract_api.tasks._deduplication.get_cache", return_value=mock_cache):
-        result = test_task(workspaces)
+        result = test_task(workspaces, dry_run=False)
 
     assert result == 2
     # Lock key should be sorted workspace names
     mock_cache.lock.assert_called_once_with(
-        "task_lock:test_task:dry_run=true:ws-a,ws-b", timeout=600
+        "task_lock:test_task:ws-a,ws-b", timeout=600
     )


### PR DESCRIPTION
## Summary
- Split the `qontract-api-worker` Celery queue into `qontract-api-prod` (dry_run=False) and `qontract-api-mr-check` (dry_run=True), each with its own worker Deployment, so a stuck task on one can't block the other (this is what happened during the openshift-namespaces-api prod rollout when an OpenShift cluster was unreachable).
- Added a KEDA `ScaledObject` + `TriggerAuthentication` per worker Deployment, scaling on Redis queue backlog (`listLength`) instead of a fixed replica count (min 3, max 15).
- Dry-run tasks now skip the distributed lock entirely in `_deduplication.py` - they never write anything, so there's no correctness reason to serialize them, and locking them would have defeated the point of autoscaling the mr-check pool.
- Kept the production lock key format stable (`task_lock:{name}:dry_run=false:{suffix}`) so old and new worker pods compute the identical key for the same resource during a rolling deploy.
- Companion app-interface MR wires up the SaaS file, secret template, and Prometheus alerts.

## Test plan
- [x] `uv run pytest` in `qontract_api/` - 505 passed
- [x] `uv run ruff check` / `ruff format --check` - clean
- [x] `uv run mypy` - clean
- [x] Verified queue name constants (`qontract_api/tasks/__init__.py`) match the `listName` values in `openshift/qontract-api.yaml`'s ScaledObjects

Jira: APPSRE-14860

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Reconciliation tasks are now routed to dedicated production or merge-request-check queues based on the request’s `dry_run` flag.
  * Split worker processing into separate deployments with dedicated KEDA autoscaling for production vs merge-request checks.
* **Bug Fixes**
  * Dry-run executions now bypass distributed locking (and associated deduplication behavior), preventing interference with production runs.
* **Tests**
  * Expanded integration and unit tests to verify queue routing and dry-run deduplication/locking behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->