### PR TITLE
fix(glhk): remove unreliable detailed_merge_status gate from rebase-error detection

### DIFF
--- a/reconcile/gitlab_housekeeping.py
+++ b/reconcile/gitlab_housekeeping.py
@@ -1438,7 +1438,7 @@ def run_error_healthcheck(
     consecutive_failure_limit: int = 3,
 ) -> None:
     """Check error labels for queue-eligible MRs. Apply/remove
-    rebase-error based on merge_error field and detailed_merge_status,
+    rebase-error based on merge_error field from .get(),
     pipeline-error based on consecutive failure count, and remove
     merge-error if any new notes have been posted since the label was applied."""
     for mr in project_merge_requests:

--- a/reconcile/gitlab_housekeeping.py
+++ b/reconcile/gitlab_housekeeping.py
@@ -1457,26 +1457,22 @@ def run_error_healthcheck(
         labels = set(mr.labels)
 
         has_rebase_error = REBASE_ERROR in labels
-        mr_detailed = getattr(mr, "detailed_merge_status", None)
-        if mr_detailed == "need_rebase":
-            try:
-                fresh = gl.get_merge_request(mr.iid)
-            except gitlab.exceptions.GitlabGetError as e:
-                logging.warning([
-                    "error-healthcheck",
-                    "rebase-status-refresh-failed",
-                    gl.project.name,
-                    mr.iid,
-                    str(e),
-                ])
-                rebase_failed = has_rebase_error
-            else:
-                fresh_merge_error = getattr(fresh, "merge_error", None)
-                rebase_failed = bool(
-                    fresh_merge_error and "Rebase failed" in fresh_merge_error
-                )
+        try:
+            fresh = gl.get_merge_request(mr.iid)
+        except gitlab.exceptions.GitlabGetError as e:
+            logging.warning([
+                "error-healthcheck",
+                "rebase-status-refresh-failed",
+                gl.project.name,
+                mr.iid,
+                str(e),
+            ])
+            rebase_failed = has_rebase_error
         else:
-            rebase_failed = False
+            fresh_merge_error = getattr(fresh, "merge_error", None)
+            rebase_failed = bool(
+                fresh_merge_error and "Rebase failed" in fresh_merge_error
+            )
 
         if rebase_failed and not has_rebase_error:
             logging.warning([

--- a/reconcile/test/test_gitlab_housekeeping.py
+++ b/reconcile/test/test_gitlab_housekeeping.py
@@ -1505,13 +1505,18 @@ def test_healthcheck_ignores_non_rebase_merge_error(
     mocked_gl.add_label_to_merge_request.assert_not_called()
 
 
+@pytest.mark.parametrize(
+    "list_status",
+    ["unchecked", "need_rebase"],
+)
 def test_healthcheck_preserves_rebase_error_on_api_failure(
     project: Project,
+    list_status: str,
 ) -> None:
     """rebase-error label is preserved when fresh .get() raises GitlabGetError."""
     mr = _make_healthcheck_mr(
         labels=["lgtm", "rebase-error"],
-        detailed_merge_status="need_rebase",
+        detailed_merge_status=list_status,
     )
     mocked_gl = create_autospec(GitLabApi)
     mocked_gl.project = project

--- a/reconcile/test/test_gitlab_housekeeping.py
+++ b/reconcile/test/test_gitlab_housekeeping.py
@@ -1343,13 +1343,18 @@ def test_healthcheck_skips_non_queue_eligible_mrs(project: Project) -> None:
     mocked_gl.remove_label.assert_not_called()
 
 
+@pytest.mark.parametrize(
+    "list_status",
+    ["need_rebase", "ci_must_pass", "unchecked"],
+)
 def test_healthcheck_applies_rebase_error_on_merge_error_field(
     project: Project,
+    list_status: str,
 ) -> None:
-    """detailed_merge_status='need_rebase' in .list() triggers .get() which confirms merge_error."""
+    """.get() confirms merge_error regardless of detailed_merge_status from .list()."""
     mr = _make_healthcheck_mr(
         labels=["lgtm"],
-        detailed_merge_status="need_rebase",
+        detailed_merge_status=list_status,
     )
     fresh_mr = create_autospec(ProjectMergeRequest)
     fresh_mr.merge_error = (
@@ -1375,17 +1380,21 @@ def test_healthcheck_applies_rebase_error_on_merge_error_field(
     "resolved_status",
     ["mergeable", "ci_must_pass"],
 )
-def test_healthcheck_removes_rebase_error_when_detailed_status_cleared(
+def test_healthcheck_removes_rebase_error_when_merge_error_cleared(
     project: Project,
     resolved_status: str,
 ) -> None:
-    """rebase-error is removed when detailed_merge_status is no longer need_rebase."""
+    """rebase-error is removed when .get() confirms merge_error is cleared."""
     mr = _make_healthcheck_mr(
         labels=["lgtm", "rebase-error"],
         detailed_merge_status=resolved_status,
     )
+    fresh_mr = create_autospec(ProjectMergeRequest)
+    fresh_mr.merge_error = None
+
     mocked_gl = create_autospec(GitLabApi)
     mocked_gl.project = project
+    mocked_gl.get_merge_request.return_value = fresh_mr
     mocked_gl.get_merge_request_pipelines.return_value = _make_pipelines(["success"])
 
     gl_h.run_error_healthcheck(
@@ -1394,7 +1403,7 @@ def test_healthcheck_removes_rebase_error_when_detailed_status_cleared(
         project_merge_requests=[mr],
     )
 
-    mocked_gl.get_merge_request.assert_not_called()
+    mocked_gl.get_merge_request.assert_called_once_with(mr.iid)
     mocked_gl.remove_label.assert_called_once_with(mr, "rebase-error")
     mocked_gl.add_label_to_merge_request.assert_not_called()
 


### PR DESCRIPTION
## Summary

Fix rebase-error detection in `run_error_healthcheck` by removing the unreliable `detailed_merge_status` gate and calling `.get()` unconditionally.

PR #5668 (merged July 14) gated the `.get()` call on `detailed_merge_status == "need_rebase"` from the `.list()` endpoint. This gate is dead code — GitLab's `.list()` does not proactively update merge status ([docs](https://docs.gitlab.com/api/merge_requests/#merge-requests-list-response-notes)), and `merge_error` is not in the `.list()` response schema at all.

## Root cause

From the [GitLab Merge requests API docs](https://docs.gitlab.com/api/merge_requests/):

> Listing merge requests **might not proactively update `merge_status`**, as this can be an expensive operation.

> `merge_error` | string | If set, the error message shown when a merge fails.

`merge_error` only appears in the single MR (`.get()`) response. The `.list()` endpoint does not include it.

## Evidence

**Instrumented dry-run via `qd`** (July 15, 2026): ran the real `gitlab-housekeeping` integration locally with probe logging on `.list()` vs `.get()` fields.

- `.list()` returned `detailed_merge_status=unchecked` for **100% of app-interface MRs** (sample: 128 MRs). The gate `== "need_rebase"` never fires.
- `merge_error` was `ABSENT` from `.list()` for every MR — even test MR 197061 which had `merge_error='Rebase failed: ...'` on `.get()`.

**Test MR 197061** (draft, deliberate conflict): triggered `POST /rebase` → rebase failed → compared both endpoints on the same MR:

| Endpoint | `merge_error` | `detailed_merge_status` |
|----------|---------------|------------------------|
| `.get()` | `"Rebase failed: Rebase locally, resolve all conflicts, then push the branch."` | `draft_status` |
| `.list()` | **ABSENT** | `need_rebase` |

**End-to-end verification**: ran the fix with gates loosened in dry-run. The fix detected **two real production MRs** (195819, 196043) with undetected rebase failures that the deployed code was missing. Both have `has_conflicts=False` — the exact class of failure reported on MR 196827.

**MR 196827** (Wang Di's report): label event history confirms `rebase-error` was never applied despite the MR being approved and in the queue for 6+ hours with the PR #5668 fix deployed.

## Changes

1. **Healthcheck fix**: remove the `detailed_merge_status == "need_rebase"` gate. Call `.get()` unconditionally for every queue-eligible MR and check `merge_error` directly.
2. **Tests**: parametrize the detection test to cover `need_rebase`, `ci_must_pass`, and `unchecked` — proving detection works regardless of what `.list()` returns. Update removal test to mock `.get()` since it's now always called.

## API cost

One `.get()` per approved, non-draft MR per healthcheck cycle. Typically 2-4 MRs pass all gates (confirmed from probe: 128 total, 2 checked). Negligible.

Written by Claude

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved rebase-failure detection in merge-request health checks by using the refreshed merge error details.
  * Updated behavior so the `REBASE_ERROR` label is added or removed based on the current rebase failure state from the latest merge error.
  * If refreshed merge-request details can’t be retrieved, the existing `REBASE_ERROR` label state is preserved.
* **Tests**
  * Updated and expanded healthcheck test coverage to match the new rebase-error handling behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->