### PR TITLE
fix(glhk): gate OMM group formation on lead tenant-label eligibility

### DIFF
--- a/reconcile/gitlab_housekeeping.py
+++ b/reconcile/gitlab_housekeeping.py
@@ -1417,7 +1417,7 @@ def merge_merge_requests(
         merges += 1
 
         if rebase and merges == 1:
-            if multi_merge:
+            if multi_merge and is_eligible_for_optimistic_merge(mr):
                 candidates = _form_omm_group(
                     gl=gl,
                     merge_requests=merge_requests,

--- a/reconcile/gitlab_housekeeping.py
+++ b/reconcile/gitlab_housekeeping.py
@@ -1426,6 +1426,9 @@ def merge_merge_requests(
                 if candidates:
                     apply_omm_group_lead(dry_run, gl, mr)
                     apply_omm_pending(dry_run, gl, candidates)
+            elif multi_merge:
+                # lead has no tenant labels — fall back to serial merge
+                logging.info(["omm-group", "lead-ineligible", gl.project.name, mr.iid])
             break
 
     merge_batch_size_histogram.labels(project_id=gl.project.id).observe(merges)

--- a/reconcile/test/test_gitlab_housekeeping.py
+++ b/reconcile/test/test_gitlab_housekeeping.py
@@ -2096,6 +2096,8 @@ def test_multi_merge_overlapping_tenants_serialized(
 def test_multi_merge_no_tenant_labels_falls_back_serial(
     mocker: MockerFixture,
 ) -> None:
+    # Lead has no tenant labels → ineligible for OMM, falls back to serial merge.
+    # Candidate has a tenant label but must not be rebased or merged.
     mr1 = _make_merge_mr(10, ["approved"])
     mr2 = _make_merge_mr(11, ["approved", "tenant-bar"])
     items = [_make_merge_item(mr1), _make_merge_item(mr2)]
@@ -2114,6 +2116,36 @@ def test_multi_merge_no_tenant_labels_falls_back_serial(
     mr1.merge.assert_called_once()
     mr2.merge.assert_not_called()
     mr2.rebase.assert_not_called()
+
+
+def test_multi_merge_candidate_no_tenant_labels_excluded(
+    mocker: MockerFixture,
+) -> None:
+    """Candidate without tenant labels is skipped by _form_omm_group's eligibility filter."""
+    mr1 = _make_merge_mr(10, ["approved", "tenant-foo"])
+    mr2 = _make_merge_mr(11, ["approved"])
+    mr3 = _make_merge_mr(12, ["approved", "tenant-bar"])
+    items = [_make_merge_item(mr1), _make_merge_item(mr2), _make_merge_item(mr3)]
+
+    _call_merge(
+        mocker,
+        items,
+        rebase=True,
+        rebased_iids={10},
+        pipelines_by_iid={
+            10: [_success_pipeline()],
+            11: [_success_pipeline()],
+            12: [_success_pipeline()],
+        },
+    )
+
+    mr1.merge.assert_called_once()
+    # mr2 has no tenant labels — excluded from OMM group, not rebased
+    mr2.merge.assert_not_called()
+    mr2.rebase.assert_not_called()
+    # mr3 is eligible and non-overlapping — included in OMM group
+    mr3.merge.assert_not_called()
+    mr3.rebase.assert_called_once_with(skip_ci=True)
 
 
 def test_multi_merge_three_mrs_partial_overlap(

--- a/reconcile/test/test_gitlab_housekeeping.py
+++ b/reconcile/test/test_gitlab_housekeeping.py
@@ -2096,8 +2096,8 @@ def test_multi_merge_overlapping_tenants_serialized(
 def test_multi_merge_no_tenant_labels_falls_back_serial(
     mocker: MockerFixture,
 ) -> None:
-    mr1 = _make_merge_mr(10, ["approved", "tenant-foo"])
-    mr2 = _make_merge_mr(11, ["approved"])
+    mr1 = _make_merge_mr(10, ["approved"])
+    mr2 = _make_merge_mr(11, ["approved", "tenant-bar"])
     items = [_make_merge_item(mr1), _make_merge_item(mr2)]
 
     _call_merge(
@@ -2113,6 +2113,7 @@ def test_multi_merge_no_tenant_labels_falls_back_serial(
 
     mr1.merge.assert_called_once()
     mr2.merge.assert_not_called()
+    mr2.rebase.assert_not_called()
 
 
 def test_multi_merge_three_mrs_partial_overlap(


### PR DESCRIPTION
## Problem

When the first serially-merged MR (the OMM group lead) has no tenant labels, `merged_labels` is empty and `_form_omm_group` cannot detect overlap between the lead and candidates. Candidates get skip-ci rebased and merged without CI validating against the lead's changes, breaking the non-overlap safety guarantee.

## Why this matters

The skip-ci rebase at group formation means candidates' pipelines run against pre-lead code. When the pipeline succeeds and the candidate is rebased, `_process_omm_member` merges it — but no CI ever validated the candidate against the lead's changes. The tenant-label overlap check is the only mechanism compensating for the skipped CI, and it's ineffective when the lead contributes nothing to `merged_labels`.

## Fix

Gate OMM group formation on `is_eligible_for_optimistic_merge(mr)` so that a lead without tenant labels falls back to serial merge instead of forming a group with an empty overlap set. This is consistent with how candidates are already handled — `is_eligible_for_optimistic_merge` in `_form_omm_group` already excludes candidates without tenant labels with the rationale "conservatively serialised."

## Testing

The existing `test_multi_merge_no_tenant_labels_falls_back_serial` test was rewritten to cover the lead case (lead without labels, candidate with labels) instead of the candidate case, which is already covered by the overlap and partial-overlap tests exercising `_form_omm_group`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Optimistic multi-merge grouping is now applied only to merge requests that meet optimistic-merge eligibility, avoiding attempts on ineligible merges.
  * Improved fallback behavior when tenant labels are missing, preventing unnecessary rebase actions and ensuring proper candidate filtering.
* **Tests**
  * Updated and added coverage to confirm ineligible merge requests are excluded from optimistic multi-merge candidate handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->