### PR TITLE
chore(ocm): remove dead code from reconcile/utils/ocm/

### DIFF
--- a/reconcile/test/ocm/test_utils_ocm_clusters.py
+++ b/reconcile/test/ocm/test_utils_ocm_clusters.py
@@ -18,10 +18,7 @@ from reconcile.utils.ocm import (
 from reconcile.utils.ocm.base import (
     ACTIVE_SUBSCRIPTION_STATES,
     ClusterDetails,
-    ClusterManagementReference,
-    FleetManagerServiceCluster,
     OCMCluster,
-    OCMModelLink,
     OCMOrganizationLabel,
     OCMSubscriptionLabel,
     build_label_container,
@@ -29,10 +26,8 @@ from reconcile.utils.ocm.base import (
 from reconcile.utils.ocm.clusters import (
     discover_clusters_by_labels,
     discover_clusters_for_organizations,
-    discover_clusters_for_subscriptions,
     get_cluster_details_for_subscriptions,
     get_node_pools,
-    get_service_clusters,
 )
 from reconcile.utils.ocm.labels import label_filter
 from reconcile.utils.ocm.search_filters import Filter
@@ -69,38 +64,6 @@ def build_cluster_details(
         ),
         capabilities={},
     )
-
-
-def test_utils_ocm_discover_clusters_for_subscriptions(
-    ocm_api: OCMBaseClient, mocker: MockerFixture
-) -> None:
-    get_clusters_for_subscriptions_mock = mocker.patch.object(
-        clusters, "get_cluster_details_for_subscriptions"
-    )
-    discover_clusters_for_subscriptions(
-        ocm_api,
-        ["sub1", "sub2"],
-    )
-
-    get_clusters_for_subscriptions_mock.assert_called_once_with(
-        ocm_api=ocm_api,
-        subscription_filter=Filter().is_in("id", ["sub1", "sub2"]),
-        cluster_filter=None,
-    )
-
-
-def test_utils_ocm_discover_clusters_for_empty_subscriptions_id_list(
-    ocm_api: OCMBaseClient, mocker: MockerFixture
-) -> None:
-    get_clusters_for_subscriptions_mock = mocker.patch.object(
-        clusters, "get_cluster_details_for_subscriptions"
-    )
-    assert not discover_clusters_for_subscriptions(
-        ocm_api,
-        [],
-    )
-
-    get_clusters_for_subscriptions_mock.assert_not_called()
 
 
 def test_utils_ocm_discover_clusters_for_organizations(
@@ -327,43 +290,3 @@ def test_get_node_pools(mocker: MockFixture) -> None:
     assert node_pools[0]["instance_type"] == node_pool["instance_type"]
     assert node_pools[0]["replicas"] == node_pool["replicas"]
     assert "foo" not in node_pools[0]
-
-
-def test_get_service_clusters_empty(mocker: MockFixture) -> None:
-    ocm = mocker.patch("reconcile.utils.ocm_base_client.OCMBaseClient", autospec=True)
-    ocm.get_paginated.return_value = []
-
-    service_clusters = list(get_service_clusters(ocm_api=ocm))
-
-    assert service_clusters == []
-
-
-def test_get_service_clusters_no_provision_shard(mocker: MockFixture) -> None:
-    ocm = mocker.patch("reconcile.utils.ocm_base_client.OCMBaseClient", autospec=True)
-    cluster_a = FleetManagerServiceCluster(
-        cluster_management_reference=ClusterManagementReference(
-            cluster_id="test1",
-            href="href1",
-        ),
-        provision_shard_reference=OCMModelLink(
-            id="shard1",
-        ),
-    )
-    data_a = cluster_a.model_dump(by_alias=True)
-    cluster_b = FleetManagerServiceCluster(
-        cluster_management_reference=ClusterManagementReference(
-            cluster_id="test2",
-            href="href2",
-        ),
-        provision_shard_reference=OCMModelLink(
-            id="shard2",
-        ),
-    )
-    data_b = cluster_b.model_dump(by_alias=True)
-    data_b["provision_shard_reference"] = {}
-
-    ocm.get_paginated.return_value = [data_a, data_b]
-
-    service_clusters = list(get_service_clusters(ocm_api=ocm))
-
-    assert service_clusters == [cluster_a]

--- a/reconcile/test/ocm/test_utils_ocm_labels.py
+++ b/reconcile/test/ocm/test_utils_ocm_labels.py
@@ -21,11 +21,8 @@ from reconcile.utils.ocm.labels import (
     add_subscription_label,
     build_container_for_prefix,
     build_label_from_dict,
-    delete_ocm_label,
     get_cluster_labels_for_cluster_id,
     get_organization_labels,
-    get_subscription_labels,
-    update_ocm_label,
 )
 from reconcile.utils.ocm.search_filters import Filter
 
@@ -173,41 +170,6 @@ def test_utils_get_organization_labels(
     )
 
 
-def test_utils_get_subscription_labels(
-    ocm_api: OCMBaseClient,
-    mocker: MockerFixture,
-    register_ocm_url_responses: Callable[[list[OcmUrl]], int],
-) -> None:
-    get_labels_call_recorder = mocker.patch.object(
-        labels, "get_labels", wraps=labels.get_labels
-    )
-    register_ocm_url_responses([
-        OcmUrl(method="GET", uri="/api/accounts_mgmt/v1/labels").add_list_response([
-            build_subscription_label("label", "value", "sub_id").model_dump(
-                by_alias=True
-            )
-        ])
-    ])
-
-    filter = Filter().eq("additional", "filter")
-    org_labels = list(
-        get_subscription_labels(
-            ocm_api=ocm_api,
-            filter=filter,
-        )
-    )
-
-    # make sure we got the label we expected
-    assert len(org_labels) == 1
-    assert isinstance(org_labels[0], OCMSubscriptionLabel)
-    assert org_labels[0].key == "label"
-
-    # make sure the filter was applied correctly
-    get_labels_call_recorder.assert_called_once_with(
-        ocm_api=ocm_api, filter=filter.eq("type", "Subscription")
-    )
-
-
 def test_build_label_filter_for_key() -> None:
     filter = labels.label_filter("foo")
     assert filter == Filter().eq("key", "foo")
@@ -347,40 +309,6 @@ def test_add_subscription_labels(
     add_subscription_label(ocm_api, cluster.ocm_cluster, "label", "value")
 
     ocm_calls = find_all_ocm_http_requests("POST")
-    assert len(ocm_calls) == 1
-
-
-def test_update_ocm_labels(
-    ocm_api: OCMBaseClient,
-    register_ocm_url_responses: Callable[[list[OcmUrl]], int],
-    find_all_ocm_http_requests: Callable[[str], list[Request]],
-) -> None:
-    cluster = build_cluster_details(subs_labels=[("label", "value")])
-
-    register_ocm_url_responses([
-        OcmUrl(method="PATCH", uri="/label/label_id"),
-    ])
-
-    update_ocm_label(ocm_api, cluster.labels["label"], "value2")
-
-    ocm_calls = find_all_ocm_http_requests("PATCH")
-    assert len(ocm_calls) == 1
-
-
-def test_delete_ocm_labels(
-    ocm_api: OCMBaseClient,
-    register_ocm_url_responses: Callable[[list[OcmUrl]], int],
-    find_all_ocm_http_requests: Callable[[str], list[Request]],
-) -> None:
-    cluster = build_cluster_details(subs_labels=[("label", "value")])
-
-    register_ocm_url_responses([
-        OcmUrl(method="DELETE", uri="/label/label_id"),
-    ])
-
-    delete_ocm_label(ocm_api, cluster.labels["label"])
-
-    ocm_calls = find_all_ocm_http_requests("DELETE")
     assert len(ocm_calls) == 1
 
 

--- a/reconcile/test/ocm/test_utils_ocm_manifest.py
+++ b/reconcile/test/ocm/test_utils_ocm_manifest.py
@@ -27,49 +27,6 @@ def build_manifest(cluster_id: str, manifest_id: str) -> dict[str, Any]:
     }
 
 
-def test_utils_get_manifests(
-    ocm_api: OCMBaseClient,
-    mocker: MockerFixture,
-    register_ocm_url_responses: Callable[[list[OcmUrl]], int],
-) -> None:
-    get_manifests_call = mocker.patch.object(
-        manifests, "get_manifests", wraps=manifests.get_manifests
-    )
-    cluster_id = "123abc"
-    manifest_list_kind_value = "ManifestList"
-    manifest_a = {
-        "kind": "Manifest",
-        "id": "manifest1",
-    }
-    manifest_b = {
-        "kind": "Manifest",
-        "id": "manifest2",
-    }
-    register_ocm_url_responses([
-        OcmUrl(
-            method="GET",
-            uri=f"/api/clusters_mgmt/v1/clusters/{cluster_id}/external_configuration/manifests",
-        ).add_paginated_get_response(
-            page=1,
-            size=2,
-            total=2,
-            kind=manifest_list_kind_value,
-            items=[
-                manifest_a,
-                manifest_b,
-            ],
-        )
-    ])
-
-    response = manifests.get_manifests(ocm_client=ocm_api, cluster_id=cluster_id)
-
-    assert list(response) == [manifest_a, manifest_b]
-
-    get_manifests_call.assert_called_once_with(
-        ocm_client=ocm_api, cluster_id=cluster_id
-    )
-
-
 def test_utils_get_manifest(
     ocm_api: OCMBaseClient,
     mocker: MockerFixture,

--- a/reconcile/test/ocm/test_utils_ocm_syncset.py
+++ b/reconcile/test/ocm/test_utils_ocm_syncset.py
@@ -27,47 +27,6 @@ def build_syncset(cluster_id: str, syncset_id: str) -> dict[str, Any]:
     }
 
 
-def test_utils_get_syncsets(
-    ocm_api: OCMBaseClient,
-    mocker: MockerFixture,
-    register_ocm_url_responses: Callable[[list[OcmUrl]], int],
-) -> None:
-    get_syncsets_call = mocker.patch.object(
-        syncsets, "get_syncsets", wraps=syncsets.get_syncsets
-    )
-    cluster_id = "123abc"
-    syncset_list_kind_value = "SyncsetList"
-    syncet_a = {
-        "kind": "Syncset",
-        "id": "syncset1",
-    }
-    syncset_b = {
-        "kind": "Syncset",
-        "id": "syncset2",
-    }
-    register_ocm_url_responses([
-        OcmUrl(
-            method="GET",
-            uri=f"/api/clusters_mgmt/v1/clusters/{cluster_id}/external_configuration/syncsets",
-        ).add_paginated_get_response(
-            page=1,
-            size=2,
-            total=2,
-            kind=syncset_list_kind_value,
-            items=[
-                syncet_a,
-                syncset_b,
-            ],
-        )
-    ])
-
-    response = syncsets.get_syncsets(ocm_client=ocm_api, cluster_id=cluster_id)
-
-    assert list(response) == [syncet_a, syncset_b]
-
-    get_syncsets_call.assert_called_once_with(ocm_client=ocm_api, cluster_id=cluster_id)
-
-
 def test_utils_get_syncset(
     ocm_api: OCMBaseClient,
     mocker: MockerFixture,

--- a/reconcile/utils/ocm/clusters.py
+++ b/reconcile/utils/ocm/clusters.py
@@ -8,12 +8,10 @@ from reconcile.utils.ocm.base import (
     PRODUCT_ID_OSD,
     PRODUCT_ID_ROSA,
     ClusterDetails,
-    FleetManagerServiceCluster,
     OCMCluster,
     OCMClusterState,
     OCMOrganizationLabel,
     OCMSubscriptionLabel,
-    ProvisionShard,
     build_label_container,
 )
 from reconcile.utils.ocm.labels import (
@@ -88,28 +86,6 @@ def discover_clusters_by_labels(
     return clusters
 
 
-def discover_clusters_for_subscriptions(
-    ocm_api: OCMBaseClient,
-    subscription_ids: list[str],
-    cluster_filter: Filter | None = None,
-) -> list[ClusterDetails]:
-    """
-    Discover clusters by filtering on their subscription IDs.
-    Additionally, a cluster_filter can be applied to narrow the
-    discovered clusters.
-    """
-    if not subscription_ids:
-        return []
-
-    return list(
-        get_cluster_details_for_subscriptions(
-            ocm_api=ocm_api,
-            subscription_filter=Filter().is_in("id", subscription_ids),
-            cluster_filter=cluster_filter,
-        )
-    )
-
-
 def discover_clusters_for_organizations(
     ocm_api: OCMBaseClient,
     organization_ids: Iterable[str],
@@ -142,26 +118,6 @@ def get_ocm_clusters(
         max_page_size=100,
     ):
         yield OCMCluster(**cluster_dict)
-
-
-def get_provision_shard_for_cluster_id(
-    ocm_api: OCMBaseClient,
-    id: str,
-) -> ProvisionShard:
-    data = ocm_api.get(api_path=f"/api/clusters_mgmt/v1/clusters/{id}/provision_shard")
-    return ProvisionShard(**data)
-
-
-def get_service_clusters(
-    ocm_api: OCMBaseClient,
-) -> Generator[FleetManagerServiceCluster]:
-    for cluster_dict in ocm_api.get_paginated(
-        api_path="/api/osd_fleet_mgmt/v1/service_clusters",
-        max_page_size=100,
-    ):
-        if not cluster_dict.get("provision_shard_reference"):
-            continue
-        yield FleetManagerServiceCluster(**cluster_dict)
 
 
 def get_cluster_details_for_subscriptions(

--- a/reconcile/utils/ocm/labels.py
+++ b/reconcile/utils/ocm/labels.py
@@ -20,19 +20,6 @@ if TYPE_CHECKING:
     from reconcile.utils.ocm_base_client import OCMBaseClient
 
 
-def get_subscription_labels(
-    ocm_api: OCMBaseClient, filter: Filter
-) -> Generator[OCMSubscriptionLabel]:
-    """
-    Finds all subscription labels that match the given filter.
-    """
-    for subscription_label in get_labels(
-        ocm_api=ocm_api, filter=filter & subscription_label_filter()
-    ):
-        if isinstance(subscription_label, OCMSubscriptionLabel):
-            yield subscription_label
-
-
 def add_subscription_label(
     ocm_api: OCMBaseClient,
     ocm_cluster: OCMCluster,
@@ -61,18 +48,6 @@ def add_label(
     )
 
 
-def update_ocm_label(
-    ocm_api: OCMBaseClient,
-    ocm_label: OCMLabel,
-    value: str,
-) -> None:
-    """Update the label value in the given OCM label."""
-    ocm_api.patch(
-        api_path=ocm_label.href,
-        data={"kind": "Label", "key": ocm_label.key, "value": value},
-    )
-
-
 def update_label(
     ocm_api: OCMBaseClient,
     label_container_href: str,
@@ -84,11 +59,6 @@ def update_label(
         api_path=f"{label_container_href}/{label}",
         data={"kind": "Label", "key": label, "value": value},
     )
-
-
-def delete_ocm_label(ocm_api: OCMBaseClient, ocm_label: OCMLabel) -> None:
-    """Delete the given OCM label."""
-    ocm_api.delete(api_path=ocm_label.href)
 
 
 def delete_label(ocm_api: OCMBaseClient, label_container_href: str, label: str) -> None:

--- a/reconcile/utils/ocm/manifests.py
+++ b/reconcile/utils/ocm/manifests.py
@@ -4,7 +4,7 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
-    from collections.abc import Generator, Mapping
+    from collections.abc import Mapping
 
     from reconcile.utils.ocm_base_client import OCMBaseClient
 
@@ -15,13 +15,6 @@ class Manifest:
         self.href = f"/api/clusters_mgmt/v1/clusters/{cluster_id}/external_configuration/manifests"
 
     href: str
-
-
-def get_manifests(
-    ocm_client: OCMBaseClient, cluster_id: str
-) -> Generator[dict[str, Any]]:
-    manifest = Manifest(cluster_id)
-    return ocm_client.get_paginated(api_path=manifest.href)
 
 
 def get_manifest(ocm_client: OCMBaseClient, cluster_id: str, manifest_id: str) -> Any:

--- a/reconcile/utils/ocm/ocm.py
+++ b/reconcile/utils/ocm/ocm.py
@@ -29,7 +29,6 @@ STATUS_READY = "ready"
 STATUS_FAILED = "failed"
 STATUS_DELETING = "deleting"
 
-AMS_API_BASE = "/api/accounts_mgmt"
 CS_API_BASE = "/api/clusters_mgmt"
 
 MACHINE_POOL_DESIRED_KEYS = {
@@ -40,28 +39,9 @@ MACHINE_POOL_DESIRED_KEYS = {
     "labels",
     "taints",
 }
-UPGRADE_CHANNELS = {"stable", "fast", "candidate"}
-UPGRADE_POLICY_DESIRED_KEYS = {
-    "id",
-    "schedule_type",
-    "schedule",
-    "next_run",
-    "version",
-    "state",
-}
-ADDON_UPGRADE_POLICY_DESIRED_KEYS = {
-    "id",
-    "addon_id",
-    "schedule_type",
-    "schedule",
-    "next_run",
-    "version",
-}
 ROUTER_DESIRED_KEYS = {"id", "listening", "dns_name", "route_selectors"}
 CLUSTER_ADDON_DESIRED_KEYS = {"id", "parameters"}
 
-DISABLE_UWM_ATTR = "disable_user_workload_monitoring"
-CLUSTER_ADMIN_LABEL_KEY = "capability.cluster.manage_cluster_admin"
 REQUEST_TIMEOUT_SEC = 60
 
 

--- a/reconcile/utils/ocm/products.py
+++ b/reconcile/utils/ocm/products.py
@@ -47,7 +47,6 @@ SPEC_ATTR_MULTI_AZ = "multi_az"
 SPEC_ATTR_HYPERSHIFT = "hypershift"
 SPEC_ATTR_SUBNET_IDS = "subnet_ids"
 SPEC_ATTR_AVAILABILITY_ZONES = "availability_zones"
-SPEC_ATTR_FIPS = "fips"
 
 SPEC_ATTR_NETWORK = "network"
 IGNORE_NETWORK_TYPE_ATTR = "type"

--- a/reconcile/utils/ocm/syncsets.py
+++ b/reconcile/utils/ocm/syncsets.py
@@ -4,7 +4,7 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
-    from collections.abc import Generator, Mapping
+    from collections.abc import Mapping
 
     from reconcile.utils.ocm_base_client import OCMBaseClient
 
@@ -15,13 +15,6 @@ class SyncSet:
         self.href = f"/api/clusters_mgmt/v1/clusters/{cluster_id}/external_configuration/syncsets"
 
     href: str
-
-
-def get_syncsets(
-    ocm_client: OCMBaseClient, cluster_id: str
-) -> Generator[dict[str, Any]]:
-    syncset = SyncSet(cluster_id)
-    return ocm_client.get_paginated(api_path=syncset.href)
 
 
 def get_syncset(ocm_client: OCMBaseClient, cluster_id: str, syncset_id: str) -> Any:


### PR DESCRIPTION
## Summary
- Remove 15 unused symbols from `reconcile/utils/ocm/` with zero production callers
- Unused constants in `ocm.py`: `AMS_API_BASE`, `UPGRADE_CHANNELS`, `UPGRADE_POLICY_DESIRED_KEYS`, `ADDON_UPGRADE_POLICY_DESIRED_KEYS`, `DISABLE_UWM_ATTR`, `CLUSTER_ADMIN_LABEL_KEY`, and `SPEC_ATTR_FIPS` in `products.py`
- Functions only exercised by their own unit test: `get_provision_shard_for_cluster_id`, `discover_clusters_for_subscriptions`, `get_service_clusters` (`clusters.py`); `get_subscription_labels`, `update_ocm_label`, `delete_ocm_label` (`labels.py`); the list-all `get_manifests`/`get_syncsets` variants (their singular counterparts remain in use by `dynatrace_token_provider`)
- Drops now-unused imports and the corresponding dedicated tests

## Test plan
- [x] `uv run ruff check` / `uv run ruff format --check` on changed files — clean
- [x] `uv run mypy reconcile/utils/ocm/ reconcile/test/ocm/` — no issues
- [x] `uv run pytest reconcile/test/ocm/` — 364 passed
- [x] `uv run pytest reconcile/` — 3626 passed (31 pre-existing failures unrelated to this change, due to missing `skopeo`/`sloth` binaries in the local environment)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Streamlined OCM utility surface by removing retired bulk/indirect operations (subscription-ID cluster discovery, subscription label get/update/delete, manifest listing, and sync set listing).
  - Continued supporting single-resource retrieval and direct label key/container operations.
  - Removed obsolete upgrade/policy-related constants and other unused definitions.

- **Tests**
  - Updated the test suite to align with the streamlined OCM utilities.
  - Dropped assertions tied to previously rejected node-pool fields to reflect the current returned payload shape.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->