### PR TITLE
feat(qontract-api): pin deployment images by tag and digest

### DIFF
--- a/openshift/qontract-api.yaml
+++ b/openshift/qontract-api.yaml
@@ -110,7 +110,7 @@ objects:
                 - configMapRef:
                     name: qontract-api-config
                     optional: true
-              image: "${IMAGE}:${IMAGE_TAG}"
+              image: "${IMAGE}:${IMAGE_TAG}@${IMAGE_DIGEST}"
               name: api
               ports:
                 - containerPort: ${{QAPI_APP_PORT}}
@@ -147,7 +147,7 @@ objects:
                   memory: ${{QAPI_API_MEMORY_LIMITS}}
             # OPA sidecar for parameter-level authorization
             - name: opa
-              image: "${OPA_IMAGE}:${OPA_IMAGE_TAG}"
+              image: "${OPA_IMAGE}:${OPA_IMAGE_TAG}@${OPA_IMAGE_DIGEST}"
               args:
                 - run
                 - --ignore=.*
@@ -302,7 +302,7 @@ objects:
                 - configMapRef:
                     name: qontract-api-config
                     optional: true
-              image: "${IMAGE}:${IMAGE_TAG}"
+              image: "${IMAGE}:${IMAGE_TAG}@${IMAGE_DIGEST}"
               name: subscriber
               ports:
                 - containerPort: ${{QAPI_SUBSCRIBER_METRICS_PORT}}
@@ -435,7 +435,7 @@ objects:
                 - configMapRef:
                     name: qontract-api-config
                     optional: true
-              image: "${IMAGE}:${IMAGE_TAG}"
+              image: "${IMAGE}:${IMAGE_TAG}@${IMAGE_DIGEST}"
               name: worker
               ports:
                 - containerPort: ${{QAPI_WORKER_METRICS_PORT}}
@@ -577,7 +577,7 @@ objects:
                 - configMapRef:
                     name: qontract-api-config
                     optional: true
-              image: "${IMAGE}:${IMAGE_TAG}"
+              image: "${IMAGE}:${IMAGE_TAG}@${IMAGE_DIGEST}"
               name: worker-mr-check
               ports:
                 - containerPort: ${{QAPI_WORKER_METRICS_PORT}}
@@ -704,6 +704,11 @@ parameters:
     description: qontract-api version
     value: "latest"
     required: true
+
+  - name: IMAGE_DIGEST
+    description: qontract-api image digest
+    value: ''
+    required: false
 
   # Api config
   - name: QAPI_APP_PORT
@@ -879,6 +884,11 @@ parameters:
     description: OPA sidecar image tag
     value: "latest"
     required: true
+
+  - name: OPA_IMAGE_DIGEST
+    description: OPA sidecar image digest
+    value: ''
+    required: false
 
   - name: QAPI_OPA_CPU_REQUESTS
     description: OPA sidecar cpu requests

--- a/openshift/qontract-api.yaml
+++ b/openshift/qontract-api.yaml
@@ -708,7 +708,7 @@ parameters:
   - name: IMAGE_DIGEST
     description: qontract-api image digest
     value: ''
-    required: false
+    required: true
 
   # Api config
   - name: QAPI_APP_PORT
@@ -888,7 +888,7 @@ parameters:
   - name: OPA_IMAGE_DIGEST
     description: OPA sidecar image digest
     value: ''
-    required: false
+    required: true
 
   - name: QAPI_OPA_CPU_REQUESTS
     description: OPA sidecar cpu requests

--- a/reconcile/test/utils/test_mr.py
+++ b/reconcile/test/utils/test_mr.py
@@ -287,6 +287,73 @@ resourceTemplates:
     assert expected == result
 
 
+SAAS_QONTRACT_API_CONTENT = """---
+resourceTemplates:
+- name: qontract-api
+  url: https://github.com/app-sre/qontract-reconcile
+  path: /openshift/qontract-api.yaml
+  parameters:
+    REGISTRY_IMG: quay.io/redhat-services-prod/app-sre-tenant/qontract-reconcile-master/qontract-api-master
+    OPA_IMAGE_TAG: bef841a
+    OPA_IMAGE_DIGEST: sha256:be4eacddfd280a3b27a3cfc5da2877dbbdfb906d4abbb131dda97ffbdf0ee5e3
+  targets:
+  - name: qontract-api-production
+    ref: bce6d549314824beab7809cb8c0ae4127bbedaa3
+"""
+
+
+def build_saas_qontract_api_gitlab_cli_mock() -> MagicMock:
+    cli = MagicMock(spec=GitLabApi)
+    cli.project = MagicMock()
+    cli.get_raw_file.return_value = bytes(SAAS_QONTRACT_API_CONTENT, "utf-8")
+    return cli
+
+
+@patch("reconcile.utils.mr.promote_qontract.Image")
+def test_update_opa_image_pin_success(image_mock: MagicMock) -> None:
+    commit_sha = "1q2w3e4r5t6y7u8i9o0p1q2w3e4r5t6y7u8i9o0p"
+    image_mock.return_value.digest = "sha256:newdigest"
+    mr = PromoteQontractReconcileCommercial("1q2w3e4", commit_sha)
+    gitlab_cli = build_saas_qontract_api_gitlab_cli_mock()
+
+    mr._update_opa_image_pin(gitlab_cli)
+
+    image_mock.assert_called_once_with(
+        f"quay.io/redhat-services-prod/app-sre-tenant/qontract-reconcile-master/opa-master:{commit_sha}",
+        timeout=60,
+    )
+    gitlab_cli.update_file.assert_called_once()
+    new_content = gitlab_cli.update_file.call_args.kwargs["content"]
+    assert f"OPA_IMAGE_TAG: {commit_sha}" in new_content
+    assert "OPA_IMAGE_DIGEST: sha256:newdigest" in new_content
+
+
+@patch("reconcile.utils.mr.promote_qontract.Image")
+def test_update_opa_image_pin_skips_on_exception(image_mock: MagicMock) -> None:
+    image_mock.side_effect = Exception("boom")
+    mr = PromoteQontractReconcileCommercial(
+        "1q2w3e4", "1q2w3e4r5t6y7u8i9o0p1q2w3e4r5t6y7u8i9o0p"
+    )
+    gitlab_cli = build_saas_qontract_api_gitlab_cli_mock()
+
+    mr._update_opa_image_pin(gitlab_cli)
+
+    gitlab_cli.update_file.assert_not_called()
+
+
+@patch("reconcile.utils.mr.promote_qontract.Image")
+def test_update_opa_image_pin_skips_on_falsy_image(image_mock: MagicMock) -> None:
+    image_mock.return_value = None
+    mr = PromoteQontractReconcileCommercial(
+        "1q2w3e4", "1q2w3e4r5t6y7u8i9o0p1q2w3e4r5t6y7u8i9o0p"
+    )
+    gitlab_cli = build_saas_qontract_api_gitlab_cli_mock()
+
+    mr._update_opa_image_pin(gitlab_cli)
+
+    gitlab_cli.update_file.assert_not_called()
+
+
 @pytest.fixture
 def users() -> list[User]:
     return [

--- a/reconcile/test/utils/test_mr.py
+++ b/reconcile/test/utils/test_mr.py
@@ -350,7 +350,9 @@ def test_update_opa_image_pin_skips_on_exception(
 def test_update_opa_image_pin_skips_on_falsy_image(
     image_mock: MagicMock, saas_qontract_api_gitlab_cli_mock: MagicMock
 ) -> None:
-    image_mock.return_value = None
+    # Image() always returns an Image instance, never None - the realistic
+    # falsy case is Image.__bool__ returning False (manifest not found).
+    image_mock.return_value.__bool__.return_value = False
     mr = PromoteQontractReconcileCommercial(
         "1q2w3e4", "1q2w3e4r5t6y7u8i9o0p1q2w3e4r5t6y7u8i9o0p"
     )

--- a/reconcile/test/utils/test_mr.py
+++ b/reconcile/test/utils/test_mr.py
@@ -302,7 +302,8 @@ resourceTemplates:
 """
 
 
-def build_saas_qontract_api_gitlab_cli_mock() -> MagicMock:
+@pytest.fixture
+def saas_qontract_api_gitlab_cli_mock() -> MagicMock:
     cli = MagicMock(spec=GitLabApi)
     cli.project = MagicMock()
     cli.get_raw_file.return_value = bytes(SAAS_QONTRACT_API_CONTENT, "utf-8")
@@ -310,11 +311,13 @@ def build_saas_qontract_api_gitlab_cli_mock() -> MagicMock:
 
 
 @patch("reconcile.utils.mr.promote_qontract.Image")
-def test_update_opa_image_pin_success(image_mock: MagicMock) -> None:
+def test_update_opa_image_pin_success(
+    image_mock: MagicMock, saas_qontract_api_gitlab_cli_mock: MagicMock
+) -> None:
     commit_sha = "1q2w3e4r5t6y7u8i9o0p1q2w3e4r5t6y7u8i9o0p"
     image_mock.return_value.digest = "sha256:newdigest"
     mr = PromoteQontractReconcileCommercial("1q2w3e4", commit_sha)
-    gitlab_cli = build_saas_qontract_api_gitlab_cli_mock()
+    gitlab_cli = saas_qontract_api_gitlab_cli_mock
 
     mr._update_opa_image_pin(gitlab_cli)
 
@@ -329,12 +332,14 @@ def test_update_opa_image_pin_success(image_mock: MagicMock) -> None:
 
 
 @patch("reconcile.utils.mr.promote_qontract.Image")
-def test_update_opa_image_pin_skips_on_exception(image_mock: MagicMock) -> None:
+def test_update_opa_image_pin_skips_on_exception(
+    image_mock: MagicMock, saas_qontract_api_gitlab_cli_mock: MagicMock
+) -> None:
     image_mock.side_effect = Exception("boom")
     mr = PromoteQontractReconcileCommercial(
         "1q2w3e4", "1q2w3e4r5t6y7u8i9o0p1q2w3e4r5t6y7u8i9o0p"
     )
-    gitlab_cli = build_saas_qontract_api_gitlab_cli_mock()
+    gitlab_cli = saas_qontract_api_gitlab_cli_mock
 
     mr._update_opa_image_pin(gitlab_cli)
 
@@ -342,12 +347,14 @@ def test_update_opa_image_pin_skips_on_exception(image_mock: MagicMock) -> None:
 
 
 @patch("reconcile.utils.mr.promote_qontract.Image")
-def test_update_opa_image_pin_skips_on_falsy_image(image_mock: MagicMock) -> None:
+def test_update_opa_image_pin_skips_on_falsy_image(
+    image_mock: MagicMock, saas_qontract_api_gitlab_cli_mock: MagicMock
+) -> None:
     image_mock.return_value = None
     mr = PromoteQontractReconcileCommercial(
         "1q2w3e4", "1q2w3e4r5t6y7u8i9o0p1q2w3e4r5t6y7u8i9o0p"
     )
-    gitlab_cli = build_saas_qontract_api_gitlab_cli_mock()
+    gitlab_cli = saas_qontract_api_gitlab_cli_mock
 
     mr._update_opa_image_pin(gitlab_cli)
 

--- a/reconcile/test/utils/test_mr.py
+++ b/reconcile/test/utils/test_mr.py
@@ -311,44 +311,42 @@ def saas_qontract_api_gitlab_cli_mock() -> MagicMock:
 
 
 @patch("reconcile.utils.mr.promote_qontract.Image")
-def test_update_opa_image_pin_success(
-    image_mock: MagicMock, saas_qontract_api_gitlab_cli_mock: MagicMock
-) -> None:
+def test_resolve_opa_image_pin_replacements_success(image_mock: MagicMock) -> None:
     commit_sha = "1q2w3e4r5t6y7u8i9o0p1q2w3e4r5t6y7u8i9o0p"
     image_mock.return_value.digest = "sha256:newdigest"
     mr = PromoteQontractReconcileCommercial("1q2w3e4", commit_sha)
-    gitlab_cli = saas_qontract_api_gitlab_cli_mock
 
-    mr._update_opa_image_pin(gitlab_cli)
+    replacements = mr._resolve_opa_image_pin_replacements()
 
     image_mock.assert_called_once_with(
         f"quay.io/redhat-services-prod/app-sre-tenant/qontract-reconcile-master/opa-master:{commit_sha}",
         timeout=60,
     )
-    gitlab_cli.update_file.assert_called_once()
-    new_content = gitlab_cli.update_file.call_args.kwargs["content"]
-    assert f"OPA_IMAGE_TAG: {commit_sha}" in new_content
-    assert "OPA_IMAGE_DIGEST: sha256:newdigest" in new_content
+    assert (
+        "$.resourceTemplates[?(@.name == 'qontract-api')].parameters.OPA_IMAGE_TAG",
+        commit_sha,
+    ) in replacements
+    assert (
+        "$.resourceTemplates[?(@.name == 'qontract-api')].parameters.OPA_IMAGE_DIGEST",
+        "sha256:newdigest",
+    ) in replacements
 
 
 @patch("reconcile.utils.mr.promote_qontract.Image")
-def test_update_opa_image_pin_skips_on_exception(
-    image_mock: MagicMock, saas_qontract_api_gitlab_cli_mock: MagicMock
+def test_resolve_opa_image_pin_replacements_skips_on_exception(
+    image_mock: MagicMock,
 ) -> None:
     image_mock.side_effect = Exception("boom")
     mr = PromoteQontractReconcileCommercial(
         "1q2w3e4", "1q2w3e4r5t6y7u8i9o0p1q2w3e4r5t6y7u8i9o0p"
     )
-    gitlab_cli = saas_qontract_api_gitlab_cli_mock
 
-    mr._update_opa_image_pin(gitlab_cli)
-
-    gitlab_cli.update_file.assert_not_called()
+    assert mr._resolve_opa_image_pin_replacements() == []
 
 
 @patch("reconcile.utils.mr.promote_qontract.Image")
-def test_update_opa_image_pin_skips_on_falsy_image(
-    image_mock: MagicMock, saas_qontract_api_gitlab_cli_mock: MagicMock
+def test_resolve_opa_image_pin_replacements_skips_on_falsy_image(
+    image_mock: MagicMock,
 ) -> None:
     # Image() always returns an Image instance, never None - the realistic
     # falsy case is Image.__bool__ returning False (manifest not found).
@@ -356,11 +354,44 @@ def test_update_opa_image_pin_skips_on_falsy_image(
     mr = PromoteQontractReconcileCommercial(
         "1q2w3e4", "1q2w3e4r5t6y7u8i9o0p1q2w3e4r5t6y7u8i9o0p"
     )
+
+    assert mr._resolve_opa_image_pin_replacements() == []
+
+
+@patch("reconcile.utils.mr.promote_qontract.Image")
+def test_saas_qontract_api_ref_and_opa_pin_share_one_write(
+    image_mock: MagicMock, saas_qontract_api_gitlab_cli_mock: MagicMock
+) -> None:
+    """
+    Regression test: the qontract-api-production ref bump and the OPA pin
+    both target saas-qontract-api.yaml. _process_by/_process_file_with_json_paths
+    always read from main_branch, so writing them separately would have the
+    second write clobber the first (it never sees the first commit already
+    made to self.branch). They must be applied via a single read-modify-write.
+    """
+    commit_sha = "1q2w3e4r5t6y7u8i9o0p1q2w3e4r5t6y7u8i9o0p"
+    image_mock.return_value.digest = "sha256:newdigest"
+    mr = PromoteQontractReconcileCommercial("1q2w3e4", commit_sha)
     gitlab_cli = saas_qontract_api_gitlab_cli_mock
 
-    mr._update_opa_image_pin(gitlab_cli)
+    mr._process_file_with_json_paths(
+        gitlab_cli=gitlab_cli,
+        path="data/services/app-interface/cicd/ci-int/saas-qontract-api.yaml",
+        replacements=[
+            (
+                "$.resourceTemplates[?(@.url == 'https://github.com/app-sre/qontract-reconcile')].targets[?(@.name == 'qontract-api-production')].ref",
+                commit_sha,
+            ),
+            *mr._resolve_opa_image_pin_replacements(),
+        ],
+    )
 
-    gitlab_cli.update_file.assert_not_called()
+    gitlab_cli.get_raw_file.assert_called_once()
+    gitlab_cli.update_file.assert_called_once()
+    new_content = gitlab_cli.update_file.call_args.kwargs["content"]
+    assert f"ref: {commit_sha}" in new_content
+    assert f"OPA_IMAGE_TAG: {commit_sha}" in new_content
+    assert "OPA_IMAGE_DIGEST: sha256:newdigest" in new_content
 
 
 @pytest.fixture

--- a/reconcile/utils/mr/promote_qontract.py
+++ b/reconcile/utils/mr/promote_qontract.py
@@ -236,15 +236,20 @@ Please use `/retest` once the RPA finished (that should be the case after ~5min 
         image_uri = f"{OPA_MASTER_IMAGE}:{self.commit_sha}"
         try:
             img = Image(image_uri, timeout=IMAGE_REQUEST_TIMEOUT)
-            digest = img.digest if img else None
         except Exception as e:
-            digest = None
             logging.warning(
                 f"could not resolve OPA image digest for {image_uri}, "
                 f"skipping OPA_IMAGE_TAG/OPA_IMAGE_DIGEST bump this cycle: {e}"
             )
-        if not digest:
             return
+
+        if not img:
+            logging.info(
+                f"no digest resolved for OPA image {image_uri}, skipping pin update"
+            )
+            return
+
+        digest = img.digest
 
         self._process_file_with_json_paths(
             gitlab_cli=gitlab_cli,

--- a/reconcile/utils/mr/promote_qontract.py
+++ b/reconcile/utils/mr/promote_qontract.py
@@ -1,16 +1,25 @@
 from __future__ import annotations
 
+import logging
 from io import StringIO
 from typing import TYPE_CHECKING
 
 from jsonpath_ng.ext import parser
 from qontract_utils.ruamel import create_ruamel_instance
+from sretoolbox.container import Image
 
 from reconcile.typed_queries.users import get_users
 from reconcile.utils.mr.base import MergeRequestBase
 
 if TYPE_CHECKING:
     from reconcile.utils.gitlab_api import GitLabApi
+
+# matches reconcile/utils/saasherder/saasherder.py REQUEST_TIMEOUT
+IMAGE_REQUEST_TIMEOUT = 60
+
+OPA_MASTER_IMAGE = (
+    "quay.io/redhat-services-prod/app-sre-tenant/qontract-reconcile-master/opa-master"
+)
 
 
 class PromoteQontractSchemas(MergeRequestBase):
@@ -206,6 +215,52 @@ Please use `/retest` once the RPA finished (that should be the case after ~5min 
             content=new_content,
         )
 
+    def _update_opa_image_pin(self, gitlab_cli: GitLabApi) -> None:
+        """
+        Best-effort refresh of the OPA sidecar's digest pin in
+        saas-qontract-api.yaml.
+
+        The OPA image is rebuilt from this repo on every push (same commit
+        as the main image), but saasherder only auto-resolves parameters
+        literally named IMAGE_DIGEST/REPO_DIGEST via REGISTRY_IMG - it has
+        no generic mechanism for a second per-commit image. So we resolve
+        and pin it here instead.
+
+        This must not raise: unlike the other process() steps, it depends
+        on the OPA image already being mirrored to quay.io, which can lag
+        behind this MR by a few minutes. Any failure here would otherwise
+        abort the whole MR (see MergeRequestBase.submit_to_gitlab) and
+        block the unrelated bumps below. On failure we just skip - the
+        existing pin stays in place and we retry on the next promotion.
+        """
+        image_uri = f"{OPA_MASTER_IMAGE}:{self.commit_sha}"
+        try:
+            img = Image(image_uri, timeout=IMAGE_REQUEST_TIMEOUT)
+            digest = img.digest if img else None
+        except Exception as e:
+            digest = None
+            logging.warning(
+                f"could not resolve OPA image digest for {image_uri}, "
+                f"skipping OPA_IMAGE_TAG/OPA_IMAGE_DIGEST bump this cycle: {e}"
+            )
+        if not digest:
+            return
+
+        self._process_file_with_json_paths(
+            gitlab_cli=gitlab_cli,
+            path="data/services/app-interface/cicd/ci-int/saas-qontract-api.yaml",
+            replacements=[
+                (
+                    "$.resourceTemplates[?(@.name == 'qontract-api')].parameters.OPA_IMAGE_TAG",
+                    self.commit_sha,
+                ),
+                (
+                    "$.resourceTemplates[?(@.name == 'qontract-api')].parameters.OPA_IMAGE_DIGEST",
+                    digest,
+                ),
+            ],
+        )
+
     def process(self, gitlab_cli: GitLabApi) -> None:
         # .env
         self._process_by(
@@ -251,6 +306,9 @@ Please use `/retest` once the RPA finished (that should be the case after ~5min 
             search_text="$.resourceTemplates[?(@.url == 'https://github.com/app-sre/qontract-reconcile')].targets[?(@.name == 'qontract-api-production')].ref",
             replace_text=self.commit_sha,
         )
+
+        # data/services/app-interface/cicd/ci-int/saas-qontract-api.yaml (OPA sidecar digest pin)
+        self._update_opa_image_pin(gitlab_cli)
 
         # data/services/app-interface/terraform-repo/cicd/ci-int/saas-terraform-repo.yaml
         self._process_by(

--- a/reconcile/utils/mr/promote_qontract.py
+++ b/reconcile/utils/mr/promote_qontract.py
@@ -215,23 +215,24 @@ Please use `/retest` once the RPA finished (that should be the case after ~5min 
             content=new_content,
         )
 
-    def _update_opa_image_pin(self, gitlab_cli: GitLabApi) -> None:
+    def _resolve_opa_image_pin_replacements(self) -> list[tuple[str, str]]:
         """
-        Best-effort refresh of the OPA sidecar's digest pin in
+        Best-effort resolution of the OPA sidecar's tag/digest pin for
         saas-qontract-api.yaml.
 
         The OPA image is rebuilt from this repo on every push (same commit
         as the main image), but saasherder only auto-resolves parameters
         literally named IMAGE_DIGEST/REPO_DIGEST via REGISTRY_IMG - it has
         no generic mechanism for a second per-commit image. So we resolve
-        and pin it here instead.
+        it here instead.
 
         This must not raise: unlike the other process() steps, it depends
         on the OPA image already being mirrored to quay.io, which can lag
         behind this MR by a few minutes. Any failure here would otherwise
         abort the whole MR (see MergeRequestBase.submit_to_gitlab) and
-        block the unrelated bumps below. On failure we just skip - the
-        existing pin stays in place and we retry on the next promotion.
+        block the unrelated bumps below. On failure we return no
+        replacements - the existing pin stays in place in the caller's
+        write and we retry on the next promotion.
         """
         image_uri = f"{OPA_MASTER_IMAGE}:{self.commit_sha}"
         try:
@@ -241,30 +242,24 @@ Please use `/retest` once the RPA finished (that should be the case after ~5min 
                 f"could not resolve OPA image digest for {image_uri}, "
                 f"skipping OPA_IMAGE_TAG/OPA_IMAGE_DIGEST bump this cycle: {e}"
             )
-            return
+            return []
 
         if not img:
             logging.info(
                 f"no digest resolved for OPA image {image_uri}, skipping pin update"
             )
-            return
+            return []
 
-        digest = img.digest
-
-        self._process_file_with_json_paths(
-            gitlab_cli=gitlab_cli,
-            path="data/services/app-interface/cicd/ci-int/saas-qontract-api.yaml",
-            replacements=[
-                (
-                    "$.resourceTemplates[?(@.name == 'qontract-api')].parameters.OPA_IMAGE_TAG",
-                    self.commit_sha,
-                ),
-                (
-                    "$.resourceTemplates[?(@.name == 'qontract-api')].parameters.OPA_IMAGE_DIGEST",
-                    digest,
-                ),
-            ],
-        )
+        return [
+            (
+                "$.resourceTemplates[?(@.name == 'qontract-api')].parameters.OPA_IMAGE_TAG",
+                self.commit_sha,
+            ),
+            (
+                "$.resourceTemplates[?(@.name == 'qontract-api')].parameters.OPA_IMAGE_DIGEST",
+                img.digest,
+            ),
+        ]
 
     def process(self, gitlab_cli: GitLabApi) -> None:
         # .env
@@ -304,16 +299,21 @@ Please use `/retest` once the RPA finished (that should be the case after ~5min 
         )
 
         # data/services/app-interface/cicd/ci-int/saas-qontract-api.yaml
-        self._process_by(
-            "json_path",
+        # (qontract-api-production ref bump + OPA sidecar digest pin, in one
+        # read-modify-write - _process_by/_process_file_with_json_paths always
+        # read from main_branch, so a second touch to this file would
+        # silently clobber whichever change landed first)
+        self._process_file_with_json_paths(
             gitlab_cli=gitlab_cli,
             path="data/services/app-interface/cicd/ci-int/saas-qontract-api.yaml",
-            search_text="$.resourceTemplates[?(@.url == 'https://github.com/app-sre/qontract-reconcile')].targets[?(@.name == 'qontract-api-production')].ref",
-            replace_text=self.commit_sha,
+            replacements=[
+                (
+                    "$.resourceTemplates[?(@.url == 'https://github.com/app-sre/qontract-reconcile')].targets[?(@.name == 'qontract-api-production')].ref",
+                    self.commit_sha,
+                ),
+                *self._resolve_opa_image_pin_replacements(),
+            ],
         )
-
-        # data/services/app-interface/cicd/ci-int/saas-qontract-api.yaml (OPA sidecar digest pin)
-        self._update_opa_image_pin(gitlab_cli)
 
         # data/services/app-interface/terraform-repo/cicd/ci-int/saas-terraform-repo.yaml
         self._process_by(


### PR DESCRIPTION
Mirror the qontract-reconcile digest-pinning pattern (87002705) for qontract-api: add IMAGE_DIGEST and OPA_IMAGE_DIGEST parameters and reference images as ${IMAGE}:${IMAGE_TAG}@${IMAGE_DIGEST}, so deployments are pinned to an immutable digest rather than a mutable tag.

Companion app-interface change: [MR !197387](https://gitlab.cee.redhat.com/service/app-interface/-/merge_requests/197387) adds `REGISTRY_IMG` (auto-resolves `IMAGE_DIGEST` for the main image per commit, same mechanism as qontract-reconcile) and an initial static pin for `OPA_IMAGE_TAG`/`OPA_IMAGE_DIGEST`. That app-interface MR must merge first, since the new template parameters default to `''` and an empty digest would otherwise produce an invalid `image:tag@` reference.

Also extends `PromoteQontractReconcileCommercial` (`reconcile/utils/mr/promote_qontract.py`) — the automation that already bumps `qontract-api-production`'s `ref` on every push — to resolve and refresh `OPA_IMAGE_TAG`/`OPA_IMAGE_DIGEST` in the same promotion MR. The OPA sidecar is rebuilt from this repo on every commit (unlike qontract-reconcile's busybox/fluentd sidecars, which are stable third-party images), so a static pin alone would go stale immediately; this keeps it fresh automatically instead of requiring manual bumps. The resolution is best-effort — a failed lookup (e.g. image not mirrored yet) is skipped rather than raised, so it can't block the other unrelated bumps in the same promotion MR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional image digest parameters to the deployment template to support pinning API and OPA images to immutable digests.
  * During the promotion workflow, the OPA image digest is resolved and applied to the generated configuration when available.
* **Bug Fixes**
  * Made OPA digest pinning best-effort: digest resolution or update issues no longer block the promotion process.
* **Tests**
  * Added unit tests and a mocked configuration fixture to cover successful digest pinning and safe skipping on failures or missing results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->