### PR TITLE
feat: add /rcs analyze chatops trigger for release-confidence-score

### DIFF
--- a/reconcile/cli.py
+++ b/reconcile/cli.py
@@ -3200,6 +3200,66 @@ def gitlab_fork_compliance(
 
 
 @integration.command(
+    short_help="Triggers release-confidence-score analysis on /rcs analyze MR comments."
+)
+@click.argument("gitlab-project-id")
+@click.argument("gitlab-merge-request-id")
+@click.option(
+    "--comparison-sha",
+    help="bundle sha to compare to to find changed component refs",
+    required=True,
+)
+@click.option(
+    "--job-controller-cluster",
+    help="The cluster holding the job-controller namespace",
+    required=True,
+    envvar="JOB_CONTROLLER_CLUSTER",
+)
+@click.option(
+    "--job-controller-namespace",
+    help="The namespace used to run RCS analysis jobs",
+    required=True,
+    envvar="JOB_CONTROLLER_NAMESPACE",
+)
+@click.option(
+    "--rcs-job-image",
+    help="The release-confidence-score container image to run",
+    required=True,
+    envvar="RCS_JOB_IMAGE",
+)
+@click.option(
+    "--rcs-secrets-path",
+    help="Vault path holding the RCS_* secrets passed to the RCS container",
+    required=True,
+    envvar="RCS_SECRETS_PATH",
+)
+@click.pass_context
+def rcs_analyze_trigger(
+    ctx: click.Context,
+    gitlab_project_id: str,
+    gitlab_merge_request_id: str,
+    comparison_sha: str,
+    job_controller_cluster: str,
+    job_controller_namespace: str,
+    rcs_job_image: str,
+    rcs_secrets_path: str,
+) -> None:
+    import reconcile.rcs_analyze_trigger
+
+    run_integration(
+        reconcile.rcs_analyze_trigger,
+        ctx,
+        gitlab_project_id,
+        gitlab_merge_request_id,
+        comparison_sha,
+        job_controller_cluster,
+        job_controller_namespace,
+        rcs_job_image,
+        rcs_secrets_path,
+    )
+
+
+@integration.command(
     short_help="Collects the DeploymentValidations from all the clusters "
     "and posts them to Dashdotdb."
 )

--- a/reconcile/openshift_saas_deploy_change_tester.py
+++ b/reconcile/openshift_saas_deploy_change_tester.py
@@ -1,25 +1,22 @@
 from __future__ import annotations
 
-import logging
 import sys
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING
 
-from pydantic import BaseModel
 from sretoolbox.utils import threaded
 
 import reconcile.openshift_saas_deploy as osd
 from reconcile import queries
-from reconcile.gql_definitions.common.saas_files import (
-    DeployResourcesV1,
-    SaasResourceTemplateTargetUpstreamV1,
-)
-from reconcile.gql_definitions.fragments.vault_secret import VaultSecret
 from reconcile.typed_queries.saas_files import (
-    SaasFile,
     SaasFileList,
 )
 from reconcile.utils import gql
 from reconcile.utils.gitlab_api import GitLabApi
+from reconcile.utils.saas_diff import (
+    State,
+    collect_state,
+    find_ref_diffs,
+)
 from reconcile.utils.semver_helper import make_semver
 
 if TYPE_CHECKING:
@@ -27,31 +24,6 @@ if TYPE_CHECKING:
 
 QONTRACT_INTEGRATION = "openshift-saas-deploy-change-tester"
 QONTRACT_INTEGRATION_VERSION = make_semver(0, 1, 0)
-
-
-class Definition(BaseModel):
-    managed_resource_types: list[str]
-    image_patterns: list[str]
-    use_channel_in_image_tag: bool
-
-
-class State(BaseModel):
-    saas_file_path: str
-    saas_file_name: str
-    saas_file_deploy_resources: DeployResourcesV1 | None = None
-    resource_template_name: str
-    cluster: str
-    namespace: str
-    environment: str
-    url: str
-    ref: str
-    parameters: dict[str, Any]
-    secret_parameters: dict[str, VaultSecret]
-    saas_file_definitions: Definition
-    upstream: SaasResourceTemplateTargetUpstreamV1 | None = None
-    disable: bool | None = None
-    delete: bool | None = None
-    target_path: str | None = None
 
 
 def osd_run_wrapper(
@@ -81,54 +53,6 @@ def init_gitlab(gitlab_project_id: str) -> GitLabApi:
     return GitLabApi(instance, project_id=gitlab_project_id, settings=settings)
 
 
-def collect_state(saas_files: list[SaasFile]) -> list[State]:
-    state = []
-    for saas_file in saas_files:
-        definitions = Definition(
-            managed_resource_types=saas_file.managed_resource_types,
-            image_patterns=saas_file.image_patterns,
-            use_channel_in_image_tag=saas_file.use_channel_in_image_tag or False,
-        )
-
-        for resource_template in saas_file.resource_templates:
-            for target in resource_template.targets:
-                parameters: dict[str, Any] = {}
-                parameters.update(saas_file.parameters or {})
-                parameters.update(resource_template.parameters or {})
-                parameters.update(target.parameters or {})
-                secret_parameters: dict[str, VaultSecret] = {}
-                secret_parameters.update({
-                    s.name: s.secret for s in saas_file.secret_parameters or []
-                })
-                secret_parameters.update({
-                    s.name: s.secret for s in resource_template.secret_parameters or []
-                })
-                secret_parameters.update({
-                    s.name: s.secret for s in target.secret_parameters or []
-                })
-                state.append(
-                    State(
-                        saas_file_path=saas_file.path,
-                        saas_file_name=saas_file.name,
-                        saas_file_deploy_resources=saas_file.deploy_resources,
-                        resource_template_name=resource_template.name,
-                        cluster=target.namespace.cluster.name,
-                        namespace=target.namespace.name,
-                        environment=target.namespace.environment.name,
-                        url=resource_template.url,
-                        ref=target.ref,
-                        parameters=parameters,
-                        secret_parameters=secret_parameters,
-                        saas_file_definitions=definitions,
-                        upstream=target.upstream,
-                        disable=target.disable,
-                        delete=target.delete,
-                        target_path=target.path,
-                    )
-                )
-    return state
-
-
 def collect_compare_diffs(
     current_state: Iterable[State],
     desired_state: Iterable[State],
@@ -136,37 +60,10 @@ def collect_compare_diffs(
 ) -> set[str]:
     """Collect a list of URLs in a git diff format
     for each change in the merge request"""
-    compare_diffs = set()
-    for d in desired_state:
-        # check if this diff was actually changed in the current MR
-        changed_path_matches = [
-            c for c in changed_paths if c.endswith(d.saas_file_path)
-        ]
-        if not changed_path_matches:
-            # this diff was found in the graphql endpoint comparison
-            # but is not a part of the changed paths.
-            # the only known case for this currently is if a previous MR
-            # that changes another saas file was merged but is not yet
-            # reflected in the baseline graphql endpoint.
-            # https://issues.redhat.com/browse/APPSRE-3029
-            logging.debug(f"Diff not found in changed paths, skipping: {d!s}")
-            continue
-        for c in current_state:
-            if d.saas_file_name != c.saas_file_name:
-                continue
-            if d.resource_template_name != c.resource_template_name:
-                continue
-            if d.environment != c.environment:
-                continue
-            if d.cluster != c.cluster:
-                continue
-            if d.namespace != c.namespace:
-                continue
-            if d.ref == c.ref:
-                continue
-            compare_diffs.add(f"{d.url}/compare/{c.ref}...{d.ref}")
-
-    return compare_diffs
+    return {
+        f"{d.url}/compare/{c.ref}...{d.ref}"
+        for d, c in find_ref_diffs(current_state, desired_state, changed_paths)
+    }
 
 
 def update_mr_with_ref_diffs(

--- a/reconcile/rcs_analyze_trigger.py
+++ b/reconcile/rcs_analyze_trigger.py
@@ -296,6 +296,39 @@ def run(
     rcs_job_image: str,
     rcs_secrets_path: str,
 ) -> None:
+    try:
+        _run(
+            dry_run,
+            gitlab_project_id,
+            gitlab_merge_request_id,
+            comparison_sha,
+            job_controller_cluster,
+            job_controller_namespace,
+            rcs_job_image,
+            rcs_secrets_path,
+        )
+    except Exception:
+        # RCS is a manual, non-blocking, best-effort trigger: no unexpected
+        # failure anywhere in this flow (GitLab/GQL access, Vault reads,
+        # controller construction, job execution) may fail the calling
+        # pr_check pipeline.
+        LOG.exception(
+            "Unexpected failure while processing %s trigger for MR !%s",
+            TRIGGER_COMMAND,
+            gitlab_merge_request_id,
+        )
+
+
+def _run(
+    dry_run: bool,
+    gitlab_project_id: str,
+    gitlab_merge_request_id: str,
+    comparison_sha: str,
+    job_controller_cluster: str,
+    job_controller_namespace: str,
+    rcs_job_image: str,
+    rcs_secrets_path: str,
+) -> None:
     instance = queries.get_gitlab_instance()
     vault_settings = get_app_interface_vault_settings()
     secret_reader = create_secret_reader(use_vault=vault_settings.vault)
@@ -428,7 +461,13 @@ def run(
                 "!%s, deleting it",
                 gitlab_merge_request_id,
             )
-            controller.delete_job(job.name())
+            try:
+                controller.delete_job(job.name())
+            except Exception:
+                LOG.exception(
+                    "Failed to delete timed-out RCS analysis job for MR !%s",
+                    gitlab_merge_request_id,
+                )
             return
         except Exception:
             # RCS is a manual, non-blocking, best-effort trigger: any
@@ -447,4 +486,10 @@ def run(
                 status,
                 gitlab_merge_request_id,
             )
-            controller.get_job_logs(job.name(), output=sys.stdout)
+            try:
+                controller.get_job_logs(job.name(), output=sys.stdout)
+            except Exception:
+                LOG.exception(
+                    "Failed to retrieve logs for RCS analysis job for MR !%s",
+                    gitlab_merge_request_id,
+                )

--- a/reconcile/rcs_analyze_trigger.py
+++ b/reconcile/rcs_analyze_trigger.py
@@ -1,0 +1,420 @@
+from __future__ import annotations
+
+import json
+import logging
+import sys
+from operator import attrgetter
+from typing import TYPE_CHECKING, Any
+
+from kubernetes.client import (
+    V1Container,
+    V1EnvVar,
+    V1JobSpec,
+    V1LocalObjectReference,
+    V1ObjectMeta,
+    V1PodSpec,
+    V1PodTemplateSpec,
+    V1ResourceRequirements,
+)
+from pydantic import BaseModel
+
+from reconcile import queries
+from reconcile.change_owners.bundle import (
+    BundleFileType,
+    QontractServerFileDiffResolver,
+)
+from reconcile.change_owners.change_owners import (
+    cover_changes,
+    fetch_change_type_processors,
+)
+from reconcile.change_owners.changes import fetch_bundle_changes
+from reconcile.typed_queries.app_interface_vault_settings import (
+    get_app_interface_vault_settings,
+)
+from reconcile.typed_queries.saas_files import SaasFileList
+from reconcile.utils import gql
+from reconcile.utils.gitlab_api import GitLabApi
+from reconcile.utils.jobcontroller.controller import (
+    JobConcurrencyPolicy,
+    JobStatus,
+    build_job_controller,
+)
+from reconcile.utils.jobcontroller.models import K8sJob
+from reconcile.utils.saas_diff import State, collect_state, find_ref_diffs
+from reconcile.utils.secret_reader import create_secret_reader
+from reconcile.utils.semver_helper import make_semver
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
+
+    from reconcile.change_owners.bundle import FileRef
+    from reconcile.utils.gitlab_api import Comment
+
+LOG = logging.getLogger(__name__)
+
+QONTRACT_INTEGRATION = "rcs-analyze-trigger"
+QONTRACT_INTEGRATION_VERSION = make_semver(0, 1, 0)
+
+# Exact-match trigger comment. RCS itself parses "/rcs note ..." and
+# "/rcs override ..." on the same MR - those are not our concern and are
+# never matched by this exact comparison.
+TRIGGER_COMMAND = "/rcs analyze"
+
+JOB_CHECK_INTERVAL_SECONDS = 30
+JOB_TIMEOUT_SECONDS = 1800
+
+# RCS is a thin client that mostly calls the GitLab/GitHub/Vertex AI APIs and
+# waits on network I/O rather than doing heavy local computation, so these
+# are deliberately modest. Tune if real usage shows otherwise.
+JOB_CPU_REQUEST = "100m"
+JOB_CPU_LIMIT = "500m"
+JOB_MEMORY_REQUEST = "256Mi"
+JOB_MEMORY_LIMIT = "512Mi"
+
+
+class ComponentDiff(BaseModel):
+    repo_url: str
+    old_ref: str
+    new_ref: str
+
+
+def find_trigger_comment(comments: Iterable[Comment]) -> Comment | None:
+    """
+    Return the most recent comment matching the exact trigger line, or None
+    if the trigger was never posted.
+    """
+    matches = []
+    for c in comments:
+        for line in c.body.split("\n") if c.body else []:
+            if line.strip() == TRIGGER_COMMAND:
+                matches.append(c)
+                break
+    if not matches:
+        return None
+    return max(matches, key=attrgetter("created_at"))
+
+
+def _repo_relative_path(file_ref: FileRef) -> str:
+    """
+    Bundle-relative paths (FileRef.path, e.g. "/services/foo/app.yml") map
+    1:1 onto app-interface's git repo layout by prepending "data/" for
+    datafiles or "resources/" for resourcefiles - the same root directories
+    the bundle itself is built from. Reconstructing the real repo path lets
+    us exact-match against GitLab's changed_paths instead of using a
+    suffix-match (endswith) that could accidentally match an unrelated file
+    whose bundle path happens to be a trailing substring of another path.
+    """
+    root = "data" if file_ref.file_type == BundleFileType.DATAFILE else "resources"
+    return f"{root}/{file_ref.path.lstrip('/')}"
+
+
+def is_authorized_approver(
+    username: str,
+    comparison_gql_api: gql.GqlApi,
+    comparison_sha: str,
+    changed_paths: Iterable[str],
+) -> bool:
+    """
+    True if `username` is an authorized approver of every diff of every
+    changed bundle file relevant to changed_paths, using the same
+    change-type/self-service-role coverage machinery reconcile.change_owners
+    uses to decide who may /lgtm or /hold an MR. Requiring coverage of every
+    diff (not just one, and not just one file out of a batch) matches
+    /lgtm's own all-diffs-covered bar (BundleFileChange.all_changes_covered),
+    so a batched MR touching multiple components - or a single file with
+    multiple independently-owned fields - can't be triggered by someone who
+    only approves part of it.
+
+    Unlike a real /lgtm admission, which different approvers can jointly
+    satisfy across diffs, this requires the single commenting `username` to
+    cover everything - there's no multi-comment approval history to draw
+    from for a one-shot trigger.
+    """
+    file_diff_resolver = QontractServerFileDiffResolver(comparison_sha=comparison_sha)
+    change_type_processors = fetch_change_type_processors(
+        comparison_gql_api, file_diff_resolver
+    )
+    changes = fetch_bundle_changes(comparison_sha)
+    cover_changes(changes, change_type_processors, comparison_gql_api)
+
+    changed_paths_set = set(changed_paths)
+    relevant_changes = [
+        bc for bc in changes if _repo_relative_path(bc.fileref) in changed_paths_set
+    ]
+    if not relevant_changes:
+        return False
+
+    for bc in relevant_changes:
+        if not bc.diff_coverage:
+            return False
+        for dc in bc.diff_coverage:
+            if not any(
+                ctx.includes_approver(username)
+                for ctx in dc.coverage
+                if not ctx.disabled
+            ):
+                return False
+    return True
+
+
+def collect_component_diffs(
+    current_state: Iterable[State],
+    desired_state: Iterable[State],
+    changed_paths: Iterable[str],
+) -> list[ComponentDiff]:
+    """
+    Compute per-component (repo_url, old_ref, new_ref) diffs for the
+    promotion batch, using the shared ref-matching logic in
+    reconcile.utils.saas_diff.find_ref_diffs (also used by
+    openshift_saas_deploy_change_tester.collect_compare_diffs).
+    """
+    diffs = {
+        (d.url, c.ref, d.ref)
+        for d, c in find_ref_diffs(current_state, desired_state, changed_paths)
+    }
+    return [
+        ComponentDiff(repo_url=repo_url, old_ref=old_ref, new_ref=new_ref)
+        for repo_url, old_ref, new_ref in sorted(diffs)
+    ]
+
+
+class RcsAnalyzeJob(K8sJob, BaseModel, frozen=True):
+    """
+    Wraps a single release-confidence-score (RCS) analysis run into a
+    Kubernetes Job. RCS reads the diffs and posts its own report comment on
+    the MR using its own GitLab token - this job only runs the container and
+    is not responsible for relaying any result.
+    """
+
+    gitlab_project_id: str
+    gitlab_merge_request_iid: str
+    trigger_comment_id: int
+    triggered_by: str
+    triggered_at: str
+    diffs: list[ComponentDiff]
+    rcs_job_image: str
+    rcs_secrets: dict[str, str]
+
+    def name_prefix(self) -> str:
+        return "rcs-analyze"
+
+    def unit_of_work_identity(self) -> Any:
+        # Keying on the specific triggering comment (not the MR's head sha)
+        # means each /rcs analyze comment causes exactly one job, regardless
+        # of how many times pr_check reruns or how many more commits get
+        # pushed to the MR afterwards. A rerun requires a genuinely new
+        # comment.
+        return (
+            self.gitlab_project_id,
+            self.gitlab_merge_request_iid,
+            self.trigger_comment_id,
+        )
+
+    def secret_data(self) -> dict[str, str]:
+        return self.rcs_secrets
+
+    def job_spec(self) -> V1JobSpec:
+        container = V1Container(
+            name="rcs-analyze",
+            image=self.rcs_job_image,
+            image_pull_policy="Always",
+            resources=V1ResourceRequirements(
+                requests={"cpu": JOB_CPU_REQUEST, "memory": JOB_MEMORY_REQUEST},
+                limits={"cpu": JOB_CPU_LIMIT, "memory": JOB_MEMORY_LIMIT},
+            ),
+            env=[
+                V1EnvVar(
+                    name="RCS_APP_INTERFACE_PROJECT_ID",
+                    value=self.gitlab_project_id,
+                ),
+                V1EnvVar(
+                    name="RCS_APP_INTERFACE_MR_IID",
+                    value=self.gitlab_merge_request_iid,
+                ),
+                V1EnvVar(
+                    name="RCS_COMPONENT_DIFFS",
+                    value=json.dumps([d.model_dump() for d in self.diffs]),
+                ),
+                V1EnvVar(
+                    name="RCS_TRIGGERED_BY",
+                    value=self.triggered_by,
+                ),
+                V1EnvVar(
+                    name="RCS_TRIGGERED_AT",
+                    value=self.triggered_at,
+                ),
+                V1EnvVar(
+                    name="RCS_TRIGGER_COMMENT_ID",
+                    value=str(self.trigger_comment_id),
+                ),
+                *self.secret_data_to_env_vars_secret_refs(),
+            ],
+        )
+        return V1JobSpec(
+            backoff_limit=0,
+            # Bounds the pod's wall-clock runtime so a hung RCS container
+            # (e.g. stalled on an LLM API call) can't run in the cluster
+            # indefinitely, independent of whether run()'s own wait times out.
+            active_deadline_seconds=JOB_TIMEOUT_SECONDS,
+            ttl_seconds_after_finished=3600,
+            template=V1PodTemplateSpec(
+                metadata=V1ObjectMeta(
+                    annotations=self.annotations(), labels=self.labels()
+                ),
+                spec=V1PodSpec(
+                    containers=[container],
+                    image_pull_secrets=[V1LocalObjectReference(name="quay.io")],
+                    restart_policy="Never",
+                ),
+            ),
+        )
+
+
+def run(
+    dry_run: bool,
+    gitlab_project_id: str,
+    gitlab_merge_request_id: str,
+    comparison_sha: str,
+    job_controller_cluster: str,
+    job_controller_namespace: str,
+    rcs_job_image: str,
+    rcs_secrets_path: str,
+) -> None:
+    instance = queries.get_gitlab_instance()
+    vault_settings = get_app_interface_vault_settings()
+    secret_reader = create_secret_reader(use_vault=vault_settings.vault)
+
+    with GitLabApi(
+        instance, project_id=gitlab_project_id, secret_reader=secret_reader
+    ) as gl:
+        merge_request = gl.get_merge_request(gitlab_merge_request_id)
+        comments = gl.get_merge_request_comments(merge_request)
+
+        trigger_comment = find_trigger_comment(comments)
+        if trigger_comment is None:
+            return
+
+        changed_paths = gl.get_merge_request_changed_paths(merge_request)
+        comparison_gql_api = gql.get_api_for_sha(
+            comparison_sha, QONTRACT_INTEGRATION, validate_schemas=False
+        )
+
+        # Compute diffs before authorizing: it's cheaper (two SaasFileList
+        # queries vs. a full bundle diff plus change-type/role resolution),
+        # so the common "nothing relevant actually changed" case bails out
+        # without paying for the expensive authorization pass at all.
+        comparison_state = collect_state(
+            SaasFileList(query_func=comparison_gql_api.query).saas_files
+        )
+        desired_state = collect_state(SaasFileList().saas_files)
+        diffs = collect_component_diffs(comparison_state, desired_state, changed_paths)
+
+        if not diffs:
+            LOG.info(
+                "%s triggered by %s on MR !%s but no component ref changes were found",
+                TRIGGER_COMMAND,
+                trigger_comment.username,
+                gitlab_merge_request_id,
+            )
+            return
+
+        try:
+            authorized = is_authorized_approver(
+                trigger_comment.username,
+                comparison_gql_api,
+                comparison_sha,
+                changed_paths,
+            )
+        except BaseException:
+            # Fail-soft: a misconfigured change-type/role elsewhere in the
+            # bundle, unrelated to this MR, must not crash the pr_check.
+            # BaseException (not Exception) to match change_owners.py's own
+            # handling of this same cover_changes() call - scoped to just
+            # this call so it can't swallow unrelated exceptions.
+            LOG.exception(
+                "Failed to resolve approvers for MR !%s - ignoring %s trigger",
+                gitlab_merge_request_id,
+                TRIGGER_COMMAND,
+            )
+            return
+
+        if not authorized:
+            LOG.warning(
+                "%s triggered by %s on MR !%s, but they are not an "
+                "authorized approver of the changed paths - ignoring",
+                TRIGGER_COMMAND,
+                trigger_comment.username,
+                gitlab_merge_request_id,
+            )
+            return
+
+        # Log the plan identically in both modes; dry_run is only checked
+        # right at the execution point below, since (unlike its name
+        # suggests) build_job_controller's dry_run flag is not actually
+        # enforced anywhere in K8sJobController - we cannot rely on it to
+        # skip the real job launch, so we must never reach that call at all
+        # when dry_run is set.
+        LOG.info(
+            "Triggering RCS analysis for MR !%s (requested by %s) with %d "
+            "component diff(s)",
+            gitlab_merge_request_id,
+            trigger_comment.username,
+            len(diffs),
+        )
+        if dry_run:
+            return
+
+        rcs_secrets = secret_reader.read_all({"path": rcs_secrets_path})
+        job = RcsAnalyzeJob(
+            gitlab_project_id=gitlab_project_id,
+            gitlab_merge_request_iid=str(gitlab_merge_request_id),
+            trigger_comment_id=trigger_comment.id,
+            triggered_by=trigger_comment.username,
+            triggered_at=trigger_comment.created_at,
+            diffs=diffs,
+            rcs_job_image=rcs_job_image,
+            rcs_secrets=rcs_secrets,
+        )
+
+        controller = build_job_controller(
+            integration=QONTRACT_INTEGRATION,
+            integration_version=QONTRACT_INTEGRATION_VERSION,
+            cluster=job_controller_cluster,
+            namespace=job_controller_namespace,
+            secret_reader=secret_reader,
+            dry_run=dry_run,
+        )
+
+        try:
+            status = controller.enqueue_job_and_wait_for_completion(
+                job,
+                check_interval_seconds=JOB_CHECK_INTERVAL_SECONDS,
+                timeout_seconds=JOB_TIMEOUT_SECONDS,
+                concurrency_policy=JobConcurrencyPolicy.NO_REPLACE,
+            )
+        except TimeoutError:
+            LOG.warning(
+                "Timed out waiting for RCS analysis job to complete for MR "
+                "!%s, deleting it",
+                gitlab_merge_request_id,
+            )
+            controller.delete_job(job.name())
+            return
+        except Exception:
+            # RCS is a manual, non-blocking, best-effort trigger: any
+            # failure launching/monitoring it (e.g. a transient job-uid
+            # lookup error in the controller) must not fail the calling
+            # pr_check pipeline.
+            LOG.exception(
+                "Failed to launch or monitor RCS analysis job for MR !%s",
+                gitlab_merge_request_id,
+            )
+            return
+
+        if status != JobStatus.SUCCESS:
+            LOG.warning(
+                "RCS analysis job did not succeed (status=%s) for MR !%s",
+                status,
+                gitlab_merge_request_id,
+            )
+            controller.get_job_logs(job.name(), output=sys.stdout)

--- a/reconcile/rcs_analyze_trigger.py
+++ b/reconcile/rcs_analyze_trigger.py
@@ -47,6 +47,8 @@ from reconcile.utils.semver_helper import make_semver
 if TYPE_CHECKING:
     from collections.abc import Iterable
 
+    from gitlab.v4.objects import ProjectMergeRequestNote
+
     from reconcile.change_owners.bundle import FileRef
     from reconcile.utils.gitlab_api import Comment
 
@@ -59,6 +61,12 @@ QONTRACT_INTEGRATION_VERSION = make_semver(0, 1, 0)
 # "/rcs override ..." on the same MR - those are not our concern and are
 # never matched by this exact comparison.
 TRIGGER_COMMAND = "/rcs analyze"
+
+# Awarded to the trigger comment itself. This is the durable record of
+# whether a comment already launched (or finished) an analysis - it never
+# expires and needs no separate storage.
+EMOJI_LAUNCHED = "eyes"
+EMOJI_COMPLETED = "white_check_mark"
 
 JOB_CHECK_INTERVAL_SECONDS = 30
 JOB_TIMEOUT_SECONDS = 1800
@@ -92,6 +100,14 @@ def find_trigger_comment(comments: Iterable[Comment]) -> Comment | None:
     if not matches:
         return None
     return max(matches, key=attrgetter("created_at"))
+
+
+def _has_award_emoji(note: ProjectMergeRequestNote, emoji_name: str) -> bool:
+    return any(e.name == emoji_name for e in note.awardemojis.list(iterator=True))
+
+
+def _award_emoji(note: ProjectMergeRequestNote, emoji_name: str) -> None:
+    note.awardemojis.create({"name": emoji_name})
 
 
 def _repo_relative_path(file_ref: FileRef) -> str:
@@ -291,7 +307,13 @@ def run(
         comments = gl.get_merge_request_comments(merge_request)
 
         trigger_comment = find_trigger_comment(comments)
-        if trigger_comment is None:
+        if trigger_comment is None or trigger_comment.note is None:
+            return
+        note = trigger_comment.note
+
+        if _has_award_emoji(note, EMOJI_LAUNCHED):
+            # Already launched (regardless of outcome) by a prior pr_check
+            # run for this exact comment.
             return
 
         changed_paths = gl.get_merge_request_changed_paths(merge_request)
@@ -386,12 +408,20 @@ def run(
         )
 
         try:
-            status = controller.enqueue_job_and_wait_for_completion(
-                job,
-                check_interval_seconds=JOB_CHECK_INTERVAL_SECONDS,
-                timeout_seconds=JOB_TIMEOUT_SECONDS,
-                concurrency_policy=JobConcurrencyPolicy.NO_REPLACE,
+            controller.enqueue_job(
+                job, concurrency_policy=JobConcurrencyPolicy.NO_REPLACE
             )
+            _award_emoji(note, EMOJI_LAUNCHED)
+            status = (
+                JobStatus.SUCCESS
+                if controller.wait_for_job_completion(
+                    job.name(),
+                    check_interval_seconds=JOB_CHECK_INTERVAL_SECONDS,
+                    timeout_seconds=JOB_TIMEOUT_SECONDS,
+                )
+                else JobStatus.ERROR
+            )
+            _award_emoji(note, EMOJI_COMPLETED)
         except TimeoutError:
             LOG.warning(
                 "Timed out waiting for RCS analysis job to complete for MR "

--- a/reconcile/rcs_analyze_trigger.py
+++ b/reconcile/rcs_analyze_trigger.py
@@ -102,8 +102,16 @@ def find_trigger_comment(comments: Iterable[Comment]) -> Comment | None:
     return max(matches, key=attrgetter("created_at"))
 
 
-def _has_award_emoji(note: ProjectMergeRequestNote, emoji_name: str) -> bool:
-    return any(e.name == emoji_name for e in note.awardemojis.list(iterator=True))
+def _has_award_emoji(
+    note: ProjectMergeRequestNote, emoji_name: str, bot_username: str
+) -> bool:
+    # Scoped to our own account: a third party reacting to the trigger
+    # comment with the same emoji name must not be mistaken for our own
+    # durable "already launched/completed" marker.
+    return any(
+        e.name == emoji_name and e.user["username"] == bot_username
+        for e in note.awardemojis.list(iterator=True)
+    )
 
 
 def _award_emoji(note: ProjectMergeRequestNote, emoji_name: str) -> None:
@@ -344,7 +352,7 @@ def _run(
             return
         note = trigger_comment.note
 
-        if _has_award_emoji(note, EMOJI_LAUNCHED):
+        if _has_award_emoji(note, EMOJI_LAUNCHED, gl.user.username):
             # Already launched (regardless of outcome) by a prior pr_check
             # run for this exact comment.
             return

--- a/reconcile/test/test_rcs_analyze_trigger.py
+++ b/reconcile/test/test_rcs_analyze_trigger.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from typing import TYPE_CHECKING
+from unittest.mock import MagicMock
 
 from reconcile.gql_definitions.change_owners.queries.change_types import (
     ChangeTypeImplicitOwnershipJsonPathProviderV1,
@@ -9,6 +10,8 @@ from reconcile.gql_definitions.change_owners.queries.self_service_roles import (
     DatafileObjectV1,
 )
 from reconcile.rcs_analyze_trigger import (
+    EMOJI_COMPLETED,
+    EMOJI_LAUNCHED,
     TRIGGER_COMMAND,
     ComponentDiff,
     RcsAnalyzeJob,
@@ -23,12 +26,10 @@ from reconcile.test.change_owners.fixtures import (
     build_test_datafile,
 )
 from reconcile.utils.gitlab_api import Comment
-from reconcile.utils.jobcontroller.models import JobConcurrencyPolicy, JobStatus
+from reconcile.utils.jobcontroller.models import JobConcurrencyPolicy
 from reconcile.utils.saas_diff import Definition, State
 
 if TYPE_CHECKING:
-    from unittest.mock import MagicMock
-
     import pytest
     from pytest_mock import MockerFixture
 
@@ -39,13 +40,31 @@ if TYPE_CHECKING:
     )
 
 
+def _emoji_award(name: str) -> MagicMock:
+    # MagicMock(name=...) sets the mock's own repr, not a "name" attribute,
+    # so it must be assigned separately to be readable as award.name.
+    award = MagicMock()
+    award.name = name
+    return award
+
+
 def _comment(
     body: str,
     username: str = "someuser",
     comment_id: int = 1,
     created_at: str = "2026-01-01T00:00:00Z",
+    awarded_emojis: tuple[str, ...] = (),
+    note: MagicMock | None = None,
 ) -> Comment:
-    return Comment(id=comment_id, username=username, body=body, created_at=created_at)
+    # Accepting an externally-built note lets callers keep a MagicMock-typed
+    # handle to assert on award calls later - going through comment.note
+    # would statically resolve to the real (non-mock) gitlab-lib type.
+    if note is None:
+        note = MagicMock()
+    note.awardemojis.list.return_value = [_emoji_award(n) for n in awarded_emojis]
+    return Comment(
+        id=comment_id, username=username, body=body, created_at=created_at, note=note
+    )
 
 
 def _state(
@@ -562,7 +581,8 @@ def _mock_run_dependencies(
         side_effect=[[_state(ref="old-sha")], [_state(ref="new-sha")]],
     )
     mock_controller = mocker.MagicMock()
-    mock_controller.enqueue_job_and_wait_for_completion.return_value = JobStatus.SUCCESS
+    mock_controller.enqueue_job.return_value = True
+    mock_controller.wait_for_job_completion.return_value = True
     mocker.patch(
         "reconcile.rcs_analyze_trigger.build_job_controller",
         return_value=mock_controller,
@@ -588,7 +608,7 @@ def test_run_skips_when_no_trigger_comment(mocker: MockerFixture) -> None:
         rcs_secrets_path="app-sre/rcs/secrets",
     )
 
-    mocks["controller"].enqueue_job_and_wait_for_completion.assert_not_called()
+    mocks["controller"].enqueue_job.assert_not_called()
 
 
 def test_run_skips_authorization_check_when_no_diffs(mocker: MockerFixture) -> None:
@@ -614,7 +634,7 @@ def test_run_skips_authorization_check_when_no_diffs(mocker: MockerFixture) -> N
     )
 
     mocks["is_authorized_approver"].assert_not_called()
-    mocks["controller"].enqueue_job_and_wait_for_completion.assert_not_called()
+    mocks["controller"].enqueue_job.assert_not_called()
 
 
 def test_run_skips_when_trigger_comment_not_authorized_approver(
@@ -639,7 +659,7 @@ def test_run_skips_when_trigger_comment_not_authorized_approver(
         rcs_secrets_path="app-sre/rcs/secrets",
     )
 
-    mocks["controller"].enqueue_job_and_wait_for_completion.assert_not_called()
+    mocks["controller"].enqueue_job.assert_not_called()
 
 
 def test_run_does_not_raise_when_authorization_check_fails(
@@ -664,14 +684,13 @@ def test_run_does_not_raise_when_authorization_check_fails(
         rcs_secrets_path="app-sre/rcs/secrets",
     )
 
-    mocks["controller"].enqueue_job_and_wait_for_completion.assert_not_called()
+    mocks["controller"].enqueue_job.assert_not_called()
 
 
 def test_run_launches_job_when_triggered(mocker: MockerFixture) -> None:
-    mocks = _mock_run_dependencies(
-        mocker,
-        comments=[_comment(TRIGGER_COMMAND, username="alice", comment_id=42)],
-    )
+    note = MagicMock()
+    comment = _comment(TRIGGER_COMMAND, username="alice", comment_id=42, note=note)
+    mocks = _mock_run_dependencies(mocker, comments=[comment])
 
     run(
         dry_run=False,
@@ -684,19 +703,39 @@ def test_run_launches_job_when_triggered(mocker: MockerFixture) -> None:
         rcs_secrets_path="app-sre/rcs/secrets",
     )
 
-    mocks["controller"].enqueue_job_and_wait_for_completion.assert_called_once()
-    call_args = mocks["controller"].enqueue_job_and_wait_for_completion.call_args
+    mocks["controller"].enqueue_job.assert_called_once()
+    call_args = mocks["controller"].enqueue_job.call_args
     job = call_args[0][0]
     assert call_args[1]["concurrency_policy"] == JobConcurrencyPolicy.NO_REPLACE
     assert job.trigger_comment_id == 42
     assert job.triggered_by == "alice"
+    note.awardemojis.create.assert_any_call({"name": EMOJI_LAUNCHED})
+    note.awardemojis.create.assert_any_call({"name": EMOJI_COMPLETED})
+
+
+def test_run_skips_when_already_launched(mocker: MockerFixture) -> None:
+    comment = _comment(TRIGGER_COMMAND, awarded_emojis=(EMOJI_LAUNCHED,))
+    mocks = _mock_run_dependencies(mocker, comments=[comment])
+
+    run(
+        dry_run=False,
+        gitlab_project_id="123",
+        gitlab_merge_request_id="456",
+        comparison_sha="deadbeef",
+        job_controller_cluster="cluster",
+        job_controller_namespace="namespace",
+        rcs_job_image="quay.io/example/rcs:latest",
+        rcs_secrets_path="app-sre/rcs/secrets",
+    )
+
+    mocks["controller"].enqueue_job.assert_not_called()
 
 
 def test_run_does_not_raise_on_non_success_job_status(mocker: MockerFixture) -> None:
-    mocks = _mock_run_dependencies(mocker, comments=[_comment(TRIGGER_COMMAND)])
-    mocks[
-        "controller"
-    ].enqueue_job_and_wait_for_completion.return_value = JobStatus.ERROR
+    note = MagicMock()
+    comment = _comment(TRIGGER_COMMAND, note=note)
+    mocks = _mock_run_dependencies(mocker, comments=[comment])
+    mocks["controller"].wait_for_job_completion.return_value = False
 
     run(
         dry_run=False,
@@ -710,11 +749,16 @@ def test_run_does_not_raise_on_non_success_job_status(mocker: MockerFixture) -> 
     )
 
     mocks["controller"].get_job_logs.assert_called_once()
+    # Awarded regardless of outcome - the marker means "already handled",
+    # not "succeeded".
+    note.awardemojis.create.assert_any_call({"name": EMOJI_COMPLETED})
 
 
 def test_run_deletes_job_on_timeout(mocker: MockerFixture) -> None:
-    mocks = _mock_run_dependencies(mocker, comments=[_comment(TRIGGER_COMMAND)])
-    mocks["controller"].enqueue_job_and_wait_for_completion.side_effect = TimeoutError
+    note = MagicMock()
+    comment = _comment(TRIGGER_COMMAND, note=note)
+    mocks = _mock_run_dependencies(mocker, comments=[comment])
+    mocks["controller"].wait_for_job_completion.side_effect = TimeoutError
 
     run(
         dry_run=False,
@@ -728,13 +772,15 @@ def test_run_deletes_job_on_timeout(mocker: MockerFixture) -> None:
     )
 
     mocks["controller"].delete_job.assert_called_once()
+    assert comment.note is not None
+    note.awardemojis.create.assert_called_once_with({"name": EMOJI_LAUNCHED})
 
 
 def test_run_does_not_raise_on_unexpected_job_controller_error(
     mocker: MockerFixture,
 ) -> None:
     mocks = _mock_run_dependencies(mocker, comments=[_comment(TRIGGER_COMMAND)])
-    mocks["controller"].enqueue_job_and_wait_for_completion.side_effect = Exception(
+    mocks["controller"].wait_for_job_completion.side_effect = Exception(
         "Failed to lookup job uid for rcs-analyze-xyz"
     )
 
@@ -773,7 +819,7 @@ def test_run_skips_job_launch_in_dry_run(mocker: MockerFixture) -> None:
     # dry_run must never reach the point of launching a real job, since
     # K8sJobController's own dry_run flag is not actually enforced.
     mock_build_job_controller.assert_not_called()
-    mocks["controller"].enqueue_job_and_wait_for_completion.assert_not_called()
+    mocks["controller"].enqueue_job.assert_not_called()
 
 
 def test_run_logs_same_plan_message_in_both_dry_run_modes(

--- a/reconcile/test/test_rcs_analyze_trigger.py
+++ b/reconcile/test/test_rcs_analyze_trigger.py
@@ -1,0 +1,804 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from reconcile.gql_definitions.change_owners.queries.change_types import (
+    ChangeTypeImplicitOwnershipJsonPathProviderV1,
+)
+from reconcile.gql_definitions.change_owners.queries.self_service_roles import (
+    DatafileObjectV1,
+)
+from reconcile.rcs_analyze_trigger import (
+    TRIGGER_COMMAND,
+    ComponentDiff,
+    RcsAnalyzeJob,
+    collect_component_diffs,
+    find_trigger_comment,
+    is_authorized_approver,
+    run,
+)
+from reconcile.test.change_owners.fixtures import (
+    build_change_type,
+    build_role,
+    build_test_datafile,
+)
+from reconcile.utils.gitlab_api import Comment
+from reconcile.utils.jobcontroller.models import JobConcurrencyPolicy, JobStatus
+from reconcile.utils.saas_diff import Definition, State
+
+if TYPE_CHECKING:
+    from unittest.mock import MagicMock
+
+    import pytest
+    from pytest_mock import MockerFixture
+
+    from reconcile.change_owners.change_types import ChangeTypeProcessor
+    from reconcile.change_owners.changes import BundleFileChange
+    from reconcile.gql_definitions.change_owners.queries.self_service_roles import (
+        RoleV1,
+    )
+
+
+def _comment(
+    body: str,
+    username: str = "someuser",
+    comment_id: int = 1,
+    created_at: str = "2026-01-01T00:00:00Z",
+) -> Comment:
+    return Comment(id=comment_id, username=username, body=body, created_at=created_at)
+
+
+def _state(
+    saas_file_path: str = "/path.yml",
+    saas_file_name: str = "saas-file-name",
+    resource_template_name: str = "tmpl",
+    cluster: str = "cluster",
+    namespace: str = "namespace",
+    environment: str = "env-name",
+    url: str = "https://github.com/some-org/some-repo.git",
+    ref: str = "master",
+) -> State:
+    return State(
+        saas_file_path=saas_file_path,
+        saas_file_name=saas_file_name,
+        resource_template_name=resource_template_name,
+        cluster=cluster,
+        namespace=namespace,
+        environment=environment,
+        url=url,
+        ref=ref,
+        parameters={},
+        secret_parameters={},
+        saas_file_definitions=Definition(
+            managed_resource_types=[], image_patterns=[], use_channel_in_image_tag=False
+        ),
+    )
+
+
+def test_find_trigger_comment_exact_match() -> None:
+    comment = _comment(TRIGGER_COMMAND)
+    assert find_trigger_comment([comment]) == comment
+
+
+def test_find_trigger_comment_among_other_lines() -> None:
+    comment = _comment(f"some text\n{TRIGGER_COMMAND}\nmore")
+    assert find_trigger_comment([comment]) == comment
+
+
+def test_find_trigger_comment_ignores_rcs_note() -> None:
+    assert find_trigger_comment([_comment("/rcs note this is fine")]) is None
+
+
+def test_find_trigger_comment_ignores_rcs_override() -> None:
+    assert find_trigger_comment([_comment("/rcs override justification")]) is None
+
+
+def test_find_trigger_comment_ignores_unrelated_comment() -> None:
+    assert find_trigger_comment([_comment("lgtm, nice work")]) is None
+
+
+def test_find_trigger_comment_empty_comments() -> None:
+    assert find_trigger_comment([]) is None
+
+
+def test_find_trigger_comment_returns_most_recent_match() -> None:
+    older = _comment(TRIGGER_COMMAND, comment_id=1, created_at="2026-01-01T00:00:00Z")
+    newer = _comment(TRIGGER_COMMAND, comment_id=2, created_at="2026-01-02T00:00:00Z")
+    assert find_trigger_comment([older, newer]) == newer
+    assert find_trigger_comment([newer, older]) == newer
+
+
+def test_collect_component_diffs_finds_ref_change() -> None:
+    desired = [_state(ref="new-sha")]
+    current = [_state(ref="old-sha")]
+    diffs = collect_component_diffs(
+        current, desired, changed_paths=[desired[0].saas_file_path]
+    )
+    assert diffs == [
+        ComponentDiff(
+            repo_url="https://github.com/some-org/some-repo.git",
+            old_ref="old-sha",
+            new_ref="new-sha",
+        )
+    ]
+
+
+def test_collect_component_diffs_ignores_paths_not_changed() -> None:
+    desired = [_state(ref="new-sha")]
+    current = [_state(ref="old-sha")]
+    diffs = collect_component_diffs(
+        current, desired, changed_paths=["/some/other-path.yml"]
+    )
+    assert diffs == []
+
+
+def test_collect_component_diffs_ignores_unchanged_ref() -> None:
+    desired = [_state(ref="same-sha")]
+    current = [_state(ref="same-sha")]
+    diffs = collect_component_diffs(
+        current, desired, changed_paths=[desired[0].saas_file_path]
+    )
+    assert diffs == []
+
+
+def _mock_change_owners_fetch(
+    mocker: MockerFixture,
+    change_type_processors: list[ChangeTypeProcessor],
+    roles: list[RoleV1],
+    bundle_changes: list[BundleFileChange],
+) -> None:
+    # Mocked only at the fetch/query boundary (fetch_bundle_changes /
+    # fetch_self_service_roles / gql.get_api hit a live qontract-server) -
+    # the real coverage-resolution logic (cover_changes,
+    # ChangeTypeContext.includes_approver) runs against the fixtures built
+    # above. fetch_self_service_roles/gql.get_api are patched inside
+    # change_owners.change_owners, since that's where cover_changes (called
+    # directly by is_authorized_approver) resolves them.
+    mocker.patch(
+        "reconcile.rcs_analyze_trigger.fetch_change_type_processors",
+        return_value=change_type_processors,
+    )
+    mocker.patch(
+        "reconcile.change_owners.change_owners.fetch_self_service_roles",
+        return_value=roles,
+    )
+    mocker.patch(
+        "reconcile.rcs_analyze_trigger.fetch_bundle_changes",
+        return_value=bundle_changes,
+    )
+    # Configured with a well-shaped empty result (rather than left as a bare
+    # unconfigured MagicMock) so that if cover_changes' implicit-ownership
+    # pathway ever queries it, it gets a clean "no approver found" instead
+    # of confusing MagicMock-shaped garbage.
+    mock_gql_get_api = mocker.MagicMock()
+    mock_gql_get_api.query.return_value = {"user": [], "bot": []}
+    mocker.patch("reconcile.utils.gql.get_api", return_value=mock_gql_get_api)
+
+
+def _build_scoped_change_type_and_role(
+    name: str, schema: str, path: str, users: list[str]
+) -> tuple[ChangeTypeProcessor, RoleV1]:
+    change_type = build_change_type(
+        name=name, change_selectors=["$"], change_schema=schema
+    )
+    role = build_role(
+        name=f"{name}-role",
+        change_type_name=name,
+        datafiles=[DatafileObjectV1(datafileSchema=schema, path=path)],
+        users=users,
+    )
+    return change_type, role
+
+
+def test_is_authorized_approver_true_for_the_files_approver(
+    mocker: MockerFixture,
+) -> None:
+    schema = "/schema-1.yml"
+    path = "/services/app-a/app.yml"
+    change_type, role = _build_scoped_change_type_and_role(
+        "ct-a", schema, path, users=["alice"]
+    )
+    datafile = build_test_datafile(
+        content={"ref": "old-sha"}, filepath=path, schema=schema
+    )
+    bundle_change = datafile.create_bundle_change({"ref": "new-sha"})
+    _mock_change_owners_fetch(mocker, [change_type], [role], [bundle_change])
+
+    assert is_authorized_approver(
+        "alice",
+        mocker.MagicMock(),
+        "comparisonsha",
+        changed_paths=["data/services/app-a/app.yml"],
+    )
+
+
+def test_is_authorized_approver_false_for_a_different_user(
+    mocker: MockerFixture,
+) -> None:
+    schema = "/schema-1.yml"
+    path = "/services/app-a/app.yml"
+    change_type, role = _build_scoped_change_type_and_role(
+        "ct-a", schema, path, users=["alice"]
+    )
+    datafile = build_test_datafile(
+        content={"ref": "old-sha"}, filepath=path, schema=schema
+    )
+    bundle_change = datafile.create_bundle_change({"ref": "new-sha"})
+    _mock_change_owners_fetch(mocker, [change_type], [role], [bundle_change])
+
+    assert not is_authorized_approver(
+        "mallory",
+        mocker.MagicMock(),
+        "comparisonsha",
+        changed_paths=["data/services/app-a/app.yml"],
+    )
+
+
+def test_is_authorized_approver_requires_covering_every_changed_file(
+    mocker: MockerFixture,
+) -> None:
+    # Regression test for a batched MR touching two unrelated components:
+    # an approver of only one of them must NOT be authorized to trigger
+    # analysis of the whole MR.
+    schema = "/schema-1.yml"
+    path_a = "/services/app-a/app.yml"
+    path_b = "/services/app-b/app.yml"
+    change_type_a, role_a = _build_scoped_change_type_and_role(
+        "ct-a", schema, path_a, users=["alice"]
+    )
+    change_type_b, role_b = _build_scoped_change_type_and_role(
+        "ct-b", schema, path_b, users=["bob"]
+    )
+    datafile_a = build_test_datafile(
+        content={"ref": "old-sha"}, filepath=path_a, schema=schema
+    )
+    datafile_b = build_test_datafile(
+        content={"ref": "old-sha"}, filepath=path_b, schema=schema
+    )
+    bundle_changes = [
+        datafile_a.create_bundle_change({"ref": "new-sha"}),
+        datafile_b.create_bundle_change({"ref": "new-sha"}),
+    ]
+    _mock_change_owners_fetch(
+        mocker, [change_type_a, change_type_b], [role_a, role_b], bundle_changes
+    )
+    changed_paths = ["data/services/app-a/app.yml", "data/services/app-b/app.yml"]
+
+    assert not is_authorized_approver(
+        "alice", mocker.MagicMock(), "comparisonsha", changed_paths
+    )
+    assert not is_authorized_approver(
+        "bob", mocker.MagicMock(), "comparisonsha", changed_paths
+    )
+
+
+def test_is_authorized_approver_requires_covering_every_diff_in_a_file(
+    mocker: MockerFixture,
+) -> None:
+    # Regression test for a single file with two independently-owned
+    # fields: an approver of only one of them must NOT be authorized to
+    # trigger analysis of the whole file, even though it's a single
+    # relevant_changes entry (not a multi-file batch like the test above).
+    schema = "/schema-1.yml"
+    path = "/services/app-a/app.yml"
+    ref_change_type = build_change_type(
+        name="ct-ref", change_selectors=["ref"], change_schema=schema
+    )
+    ref_role = build_role(
+        name="ref-role",
+        change_type_name="ct-ref",
+        datafiles=[DatafileObjectV1(datafileSchema=schema, path=path)],
+        users=["alice"],
+    )
+    permissions_change_type = build_change_type(
+        name="ct-permissions", change_selectors=["permissions"], change_schema=schema
+    )
+    permissions_role = build_role(
+        name="permissions-role",
+        change_type_name="ct-permissions",
+        datafiles=[DatafileObjectV1(datafileSchema=schema, path=path)],
+        users=["bob"],
+    )
+    datafile = build_test_datafile(
+        content={"ref": "old-sha", "permissions": "old-perms"},
+        filepath=path,
+        schema=schema,
+    )
+    bundle_change = datafile.create_bundle_change({
+        "ref": "new-sha",
+        "permissions": "new-perms",
+    })
+    _mock_change_owners_fetch(
+        mocker,
+        [ref_change_type, permissions_change_type],
+        [ref_role, permissions_role],
+        [bundle_change],
+    )
+    changed_paths = ["data/services/app-a/app.yml"]
+
+    assert not is_authorized_approver(
+        "alice", mocker.MagicMock(), "comparisonsha", changed_paths
+    )
+    assert not is_authorized_approver(
+        "bob", mocker.MagicMock(), "comparisonsha", changed_paths
+    )
+
+
+def test_is_authorized_approver_true_when_covering_every_diff_in_a_file(
+    mocker: MockerFixture,
+) -> None:
+    # Positive counterpart: a user who owns BOTH independently-owned
+    # fields in the same file must still be authorized.
+    schema = "/schema-1.yml"
+    path = "/services/app-a/app.yml"
+    ref_change_type = build_change_type(
+        name="ct-ref", change_selectors=["ref"], change_schema=schema
+    )
+    ref_role = build_role(
+        name="ref-role",
+        change_type_name="ct-ref",
+        datafiles=[DatafileObjectV1(datafileSchema=schema, path=path)],
+        users=["alice"],
+    )
+    permissions_change_type = build_change_type(
+        name="ct-permissions", change_selectors=["permissions"], change_schema=schema
+    )
+    permissions_role = build_role(
+        name="permissions-role",
+        change_type_name="ct-permissions",
+        datafiles=[DatafileObjectV1(datafileSchema=schema, path=path)],
+        users=["alice"],
+    )
+    datafile = build_test_datafile(
+        content={"ref": "old-sha", "permissions": "old-perms"},
+        filepath=path,
+        schema=schema,
+    )
+    bundle_change = datafile.create_bundle_change({
+        "ref": "new-sha",
+        "permissions": "new-perms",
+    })
+    _mock_change_owners_fetch(
+        mocker,
+        [ref_change_type, permissions_change_type],
+        [ref_role, permissions_role],
+        [bundle_change],
+    )
+
+    assert is_authorized_approver(
+        "alice",
+        mocker.MagicMock(),
+        "comparisonsha",
+        changed_paths=["data/services/app-a/app.yml"],
+    )
+
+
+def test_is_authorized_approver_covers_implicit_ownership(
+    mocker: MockerFixture,
+) -> None:
+    # Exercises the implicit-ownership coverage pathway (unlike every other
+    # is_authorized_approver test, which only covers self-service roles) -
+    # cover_changes runs this branch on every call in production, so it
+    # must be tested against the real GqlApproverResolver, not skipped.
+    schema = "/schema-1.yml"
+    path = "/services/app-a/app.yml"
+    change_type = build_change_type(
+        name="ct-implicit", change_selectors=["ref"], change_schema=schema
+    )
+    change_type.implicit_ownership = [
+        ChangeTypeImplicitOwnershipJsonPathProviderV1(
+            provider="jsonPath",
+            jsonPathSelector="$.owner",
+        )
+    ]
+    datafile = build_test_datafile(
+        content={"ref": "old-sha", "owner": "/user/alice.yml"},
+        filepath=path,
+        schema=schema,
+    )
+    bundle_change = datafile.create_bundle_change({"ref": "new-sha"})
+    # No self-service roles at all - coverage must come purely from the
+    # implicit-ownership pathway being exercised.
+    _mock_change_owners_fetch(mocker, [change_type], [], [bundle_change])
+
+    comparison_gql_api = mocker.MagicMock()
+    comparison_gql_api.query.return_value = {
+        "user": [{"org_username": "alice", "tag_on_merge_requests": False}],
+        "bot": [],
+    }
+    changed_paths = ["data/services/app-a/app.yml"]
+
+    assert is_authorized_approver(
+        "alice", comparison_gql_api, "comparisonsha", changed_paths
+    )
+    assert not is_authorized_approver(
+        "mallory", comparison_gql_api, "comparisonsha", changed_paths
+    )
+
+
+def test_is_authorized_approver_false_when_no_relevant_changes(
+    mocker: MockerFixture,
+) -> None:
+    schema = "/schema-1.yml"
+    path = "/services/app-a/app.yml"
+    change_type, role = _build_scoped_change_type_and_role(
+        "ct-a", schema, path, users=["alice"]
+    )
+    datafile = build_test_datafile(
+        content={"ref": "old-sha"}, filepath=path, schema=schema
+    )
+    bundle_change = datafile.create_bundle_change({"ref": "new-sha"})
+    _mock_change_owners_fetch(mocker, [change_type], [role], [bundle_change])
+
+    assert not is_authorized_approver(
+        "alice",
+        mocker.MagicMock(),
+        "comparisonsha",
+        changed_paths=["data/some/unrelated/path.yml"],
+    )
+
+
+def test_is_authorized_approver_does_not_match_on_path_suffix_collision(
+    mocker: MockerFixture,
+) -> None:
+    # Regression test: a changed path that merely ENDS with the bundle
+    # file's path (but isn't actually it) must not be treated as a match -
+    # exact-match on the reconstructed repo path, not endswith.
+    schema = "/schema-1.yml"
+    path = "/team-a/app.yml"
+    change_type, role = _build_scoped_change_type_and_role(
+        "ct-a", schema, path, users=["alice"]
+    )
+    datafile = build_test_datafile(
+        content={"ref": "old-sha"}, filepath=path, schema=schema
+    )
+    bundle_change = datafile.create_bundle_change({"ref": "new-sha"})
+    _mock_change_owners_fetch(mocker, [change_type], [role], [bundle_change])
+
+    # "data/team-b/nested/team-a/app.yml" ends with "/team-a/app.yml" - an
+    # endswith-based match would have wrongly treated this as the same file.
+    assert not is_authorized_approver(
+        "alice",
+        mocker.MagicMock(),
+        "comparisonsha",
+        changed_paths=["data/team-b/nested/team-a/app.yml"],
+    )
+
+
+def _job(**overrides: object) -> RcsAnalyzeJob:
+    defaults: dict[str, object] = {
+        "gitlab_project_id": "123",
+        "gitlab_merge_request_iid": "456",
+        "trigger_comment_id": 789,
+        "triggered_by": "someuser",
+        "triggered_at": "2026-01-01T00:00:00Z",
+        "diffs": [],
+        "rcs_job_image": "quay.io/example/rcs:latest",
+        "rcs_secrets": {"RCS_GITLAB_TOKEN": "token"},
+    }
+    defaults.update(overrides)
+    return RcsAnalyzeJob(**defaults)
+
+
+def test_rcs_analyze_job_unit_of_work_identity() -> None:
+    job = _job()
+    assert job.unit_of_work_identity() == ("123", "456", 789)
+
+
+def test_rcs_analyze_job_identity_depends_only_on_trigger_comment() -> None:
+    # Same trigger comment, different "who" fields recorded for audit
+    # purposes only, must not change job identity - it's the comment that
+    # defines the unit of work, not who posted it or when it was processed.
+    job_a = _job(triggered_by="alice", triggered_at="2026-01-01T00:00:00Z")
+    job_b = _job(triggered_by="bob", triggered_at="2026-06-01T00:00:00Z")
+    assert job_a.unit_of_work_identity() == job_b.unit_of_work_identity()
+
+    # A different trigger comment must produce a different identity, even
+    # for the exact same MR.
+    job_c = _job(trigger_comment_id=999)
+    assert job_c.unit_of_work_identity() != job_a.unit_of_work_identity()
+
+
+def test_rcs_analyze_job_secret_data() -> None:
+    job = _job()
+    assert job.secret_data() == {"RCS_GITLAB_TOKEN": "token"}
+
+
+def test_rcs_analyze_job_spec_contains_expected_env_vars() -> None:
+    job = _job(
+        triggered_by="alice",
+        triggered_at="2026-01-01T00:00:00Z",
+        trigger_comment_id=789,
+        diffs=[
+            ComponentDiff(
+                repo_url="https://github.com/some-org/some-repo.git",
+                old_ref="old-sha",
+                new_ref="new-sha",
+            )
+        ],
+    )
+    spec = job.job_spec()
+    container = spec.template.spec.containers[0]
+    assert container.image == "quay.io/example/rcs:latest"
+    env_by_name = {e.name: e.value for e in container.env if e.value is not None}
+    assert env_by_name["RCS_APP_INTERFACE_PROJECT_ID"] == "123"
+    assert env_by_name["RCS_APP_INTERFACE_MR_IID"] == "456"
+    assert env_by_name["RCS_TRIGGERED_BY"] == "alice"
+    assert env_by_name["RCS_TRIGGERED_AT"] == "2026-01-01T00:00:00Z"
+    assert env_by_name["RCS_TRIGGER_COMMENT_ID"] == "789"
+    assert "RCS_COMPONENT_DIFFS" in env_by_name
+    assert spec.ttl_seconds_after_finished is not None
+    assert spec.active_deadline_seconds is not None
+    assert container.resources.requests
+    assert container.resources.limits
+
+
+def _mock_run_dependencies(
+    mocker: MockerFixture, comments: list[Comment]
+) -> dict[str, MagicMock]:
+    mock_gl = mocker.MagicMock()
+    mock_gl.__enter__.return_value = mock_gl
+    mock_gl.get_merge_request_comments.return_value = comments
+    mock_gl.get_merge_request_changed_paths.return_value = ["/path.yml"]
+    mocker.patch("reconcile.rcs_analyze_trigger.GitLabApi", return_value=mock_gl)
+    mocker.patch("reconcile.rcs_analyze_trigger.queries.get_gitlab_instance")
+    mocker.patch("reconcile.rcs_analyze_trigger.get_app_interface_vault_settings")
+    # By default, authorize the trigger commenter - tests of the
+    # authorization gate itself override this.
+    mock_is_authorized_approver = mocker.patch(
+        "reconcile.rcs_analyze_trigger.is_authorized_approver",
+        return_value=True,
+    )
+    mock_secret_reader = mocker.MagicMock()
+    mock_secret_reader.read_all.return_value = {"RCS_GITLAB_TOKEN": "token"}
+    mocker.patch(
+        "reconcile.rcs_analyze_trigger.create_secret_reader",
+        return_value=mock_secret_reader,
+    )
+    mocker.patch("reconcile.rcs_analyze_trigger.gql.get_api_for_sha")
+    mocker.patch("reconcile.rcs_analyze_trigger.SaasFileList")
+    mocker.patch(
+        "reconcile.rcs_analyze_trigger.collect_state",
+        side_effect=[[_state(ref="old-sha")], [_state(ref="new-sha")]],
+    )
+    mock_controller = mocker.MagicMock()
+    mock_controller.enqueue_job_and_wait_for_completion.return_value = JobStatus.SUCCESS
+    mocker.patch(
+        "reconcile.rcs_analyze_trigger.build_job_controller",
+        return_value=mock_controller,
+    )
+    return {
+        "gl": mock_gl,
+        "controller": mock_controller,
+        "is_authorized_approver": mock_is_authorized_approver,
+    }
+
+
+def test_run_skips_when_no_trigger_comment(mocker: MockerFixture) -> None:
+    mocks = _mock_run_dependencies(mocker, comments=[_comment("lgtm")])
+
+    run(
+        dry_run=False,
+        gitlab_project_id="123",
+        gitlab_merge_request_id="456",
+        comparison_sha="deadbeef",
+        job_controller_cluster="cluster",
+        job_controller_namespace="namespace",
+        rcs_job_image="quay.io/example/rcs:latest",
+        rcs_secrets_path="app-sre/rcs/secrets",
+    )
+
+    mocks["controller"].enqueue_job_and_wait_for_completion.assert_not_called()
+
+
+def test_run_skips_authorization_check_when_no_diffs(mocker: MockerFixture) -> None:
+    # Diffs are computed before authorization, so the expensive
+    # authorization pass is skipped entirely when there's nothing to
+    # trigger anyway - same identical (old-sha -> old-sha) state means no
+    # ref actually changed.
+    mocks = _mock_run_dependencies(mocker, comments=[_comment(TRIGGER_COMMAND)])
+    mocker.patch(
+        "reconcile.rcs_analyze_trigger.collect_state",
+        side_effect=[[_state(ref="same-sha")], [_state(ref="same-sha")]],
+    )
+
+    run(
+        dry_run=False,
+        gitlab_project_id="123",
+        gitlab_merge_request_id="456",
+        comparison_sha="deadbeef",
+        job_controller_cluster="cluster",
+        job_controller_namespace="namespace",
+        rcs_job_image="quay.io/example/rcs:latest",
+        rcs_secrets_path="app-sre/rcs/secrets",
+    )
+
+    mocks["is_authorized_approver"].assert_not_called()
+    mocks["controller"].enqueue_job_and_wait_for_completion.assert_not_called()
+
+
+def test_run_skips_when_trigger_comment_not_authorized_approver(
+    mocker: MockerFixture,
+) -> None:
+    mocks = _mock_run_dependencies(
+        mocker, comments=[_comment(TRIGGER_COMMAND, username="rando")]
+    )
+    mocker.patch(
+        "reconcile.rcs_analyze_trigger.is_authorized_approver",
+        return_value=False,
+    )
+
+    run(
+        dry_run=False,
+        gitlab_project_id="123",
+        gitlab_merge_request_id="456",
+        comparison_sha="deadbeef",
+        job_controller_cluster="cluster",
+        job_controller_namespace="namespace",
+        rcs_job_image="quay.io/example/rcs:latest",
+        rcs_secrets_path="app-sre/rcs/secrets",
+    )
+
+    mocks["controller"].enqueue_job_and_wait_for_completion.assert_not_called()
+
+
+def test_run_does_not_raise_when_authorization_check_fails(
+    mocker: MockerFixture,
+) -> None:
+    mocks = _mock_run_dependencies(mocker, comments=[_comment(TRIGGER_COMMAND)])
+    mocker.patch(
+        "reconcile.rcs_analyze_trigger.is_authorized_approver",
+        side_effect=Exception("broken role file elsewhere in the bundle"),
+    )
+
+    # Must not raise - an unrelated bundle misconfiguration must not crash
+    # the calling pr_check pipeline.
+    run(
+        dry_run=False,
+        gitlab_project_id="123",
+        gitlab_merge_request_id="456",
+        comparison_sha="deadbeef",
+        job_controller_cluster="cluster",
+        job_controller_namespace="namespace",
+        rcs_job_image="quay.io/example/rcs:latest",
+        rcs_secrets_path="app-sre/rcs/secrets",
+    )
+
+    mocks["controller"].enqueue_job_and_wait_for_completion.assert_not_called()
+
+
+def test_run_launches_job_when_triggered(mocker: MockerFixture) -> None:
+    mocks = _mock_run_dependencies(
+        mocker,
+        comments=[_comment(TRIGGER_COMMAND, username="alice", comment_id=42)],
+    )
+
+    run(
+        dry_run=False,
+        gitlab_project_id="123",
+        gitlab_merge_request_id="456",
+        comparison_sha="deadbeef",
+        job_controller_cluster="cluster",
+        job_controller_namespace="namespace",
+        rcs_job_image="quay.io/example/rcs:latest",
+        rcs_secrets_path="app-sre/rcs/secrets",
+    )
+
+    mocks["controller"].enqueue_job_and_wait_for_completion.assert_called_once()
+    call_args = mocks["controller"].enqueue_job_and_wait_for_completion.call_args
+    job = call_args[0][0]
+    assert call_args[1]["concurrency_policy"] == JobConcurrencyPolicy.NO_REPLACE
+    assert job.trigger_comment_id == 42
+    assert job.triggered_by == "alice"
+
+
+def test_run_does_not_raise_on_non_success_job_status(mocker: MockerFixture) -> None:
+    mocks = _mock_run_dependencies(mocker, comments=[_comment(TRIGGER_COMMAND)])
+    mocks[
+        "controller"
+    ].enqueue_job_and_wait_for_completion.return_value = JobStatus.ERROR
+
+    run(
+        dry_run=False,
+        gitlab_project_id="123",
+        gitlab_merge_request_id="456",
+        comparison_sha="deadbeef",
+        job_controller_cluster="cluster",
+        job_controller_namespace="namespace",
+        rcs_job_image="quay.io/example/rcs:latest",
+        rcs_secrets_path="app-sre/rcs/secrets",
+    )
+
+    mocks["controller"].get_job_logs.assert_called_once()
+
+
+def test_run_deletes_job_on_timeout(mocker: MockerFixture) -> None:
+    mocks = _mock_run_dependencies(mocker, comments=[_comment(TRIGGER_COMMAND)])
+    mocks["controller"].enqueue_job_and_wait_for_completion.side_effect = TimeoutError
+
+    run(
+        dry_run=False,
+        gitlab_project_id="123",
+        gitlab_merge_request_id="456",
+        comparison_sha="deadbeef",
+        job_controller_cluster="cluster",
+        job_controller_namespace="namespace",
+        rcs_job_image="quay.io/example/rcs:latest",
+        rcs_secrets_path="app-sre/rcs/secrets",
+    )
+
+    mocks["controller"].delete_job.assert_called_once()
+
+
+def test_run_does_not_raise_on_unexpected_job_controller_error(
+    mocker: MockerFixture,
+) -> None:
+    mocks = _mock_run_dependencies(mocker, comments=[_comment(TRIGGER_COMMAND)])
+    mocks["controller"].enqueue_job_and_wait_for_completion.side_effect = Exception(
+        "Failed to lookup job uid for rcs-analyze-xyz"
+    )
+
+    # Must not raise - RCS is a best-effort, non-blocking trigger and must
+    # never fail the calling pr_check pipeline.
+    run(
+        dry_run=False,
+        gitlab_project_id="123",
+        gitlab_merge_request_id="456",
+        comparison_sha="deadbeef",
+        job_controller_cluster="cluster",
+        job_controller_namespace="namespace",
+        rcs_job_image="quay.io/example/rcs:latest",
+        rcs_secrets_path="app-sre/rcs/secrets",
+    )
+
+
+def test_run_skips_job_launch_in_dry_run(mocker: MockerFixture) -> None:
+    mocks = _mock_run_dependencies(mocker, comments=[_comment(TRIGGER_COMMAND)])
+    mock_build_job_controller = mocker.patch(
+        "reconcile.rcs_analyze_trigger.build_job_controller",
+        return_value=mocks["controller"],
+    )
+
+    run(
+        dry_run=True,
+        gitlab_project_id="123",
+        gitlab_merge_request_id="456",
+        comparison_sha="deadbeef",
+        job_controller_cluster="cluster",
+        job_controller_namespace="namespace",
+        rcs_job_image="quay.io/example/rcs:latest",
+        rcs_secrets_path="app-sre/rcs/secrets",
+    )
+
+    # dry_run must never reach the point of launching a real job, since
+    # K8sJobController's own dry_run flag is not actually enforced.
+    mock_build_job_controller.assert_not_called()
+    mocks["controller"].enqueue_job_and_wait_for_completion.assert_not_called()
+
+
+def test_run_logs_same_plan_message_in_both_dry_run_modes(
+    mocker: MockerFixture, caplog: pytest.LogCaptureFixture
+) -> None:
+    caplog.set_level("INFO")
+
+    for dry_run in (True, False):
+        caplog.clear()
+        _mock_run_dependencies(
+            mocker, comments=[_comment(TRIGGER_COMMAND, username="alice")]
+        )
+
+        run(
+            dry_run=dry_run,
+            gitlab_project_id="123",
+            gitlab_merge_request_id="456",
+            comparison_sha="deadbeef",
+            job_controller_cluster="cluster",
+            job_controller_namespace="namespace",
+            rcs_job_image="quay.io/example/rcs:latest",
+            rcs_secrets_path="app-sre/rcs/secrets",
+        )
+
+        assert (
+            "Triggering RCS analysis for MR !456 (requested by alice) with "
+            "1 component diff(s)" in caplog.text
+        )

--- a/reconcile/test/test_rcs_analyze_trigger.py
+++ b/reconcile/test/test_rcs_analyze_trigger.py
@@ -798,6 +798,67 @@ def test_run_does_not_raise_on_unexpected_job_controller_error(
     )
 
 
+def test_run_does_not_raise_on_unexpected_error_before_job_launch(
+    mocker: MockerFixture,
+) -> None:
+    mocks = _mock_run_dependencies(mocker, comments=[_comment(TRIGGER_COMMAND)])
+    # Anything outside the two inner try/except blocks - GitLab access, GQL
+    # access, Vault reads, controller construction - must also be caught by
+    # the outer boundary rather than crashing the calling pr_check.
+    mocks["gl"].get_merge_request_changed_paths.side_effect = Exception(
+        "GitLab API unavailable"
+    )
+
+    run(
+        dry_run=False,
+        gitlab_project_id="123",
+        gitlab_merge_request_id="456",
+        comparison_sha="deadbeef",
+        job_controller_cluster="cluster",
+        job_controller_namespace="namespace",
+        rcs_job_image="quay.io/example/rcs:latest",
+        rcs_secrets_path="app-sre/rcs/secrets",
+    )
+
+
+def test_run_does_not_raise_when_deleting_timed_out_job_fails(
+    mocker: MockerFixture,
+) -> None:
+    mocks = _mock_run_dependencies(mocker, comments=[_comment(TRIGGER_COMMAND)])
+    mocks["controller"].wait_for_job_completion.side_effect = TimeoutError
+    mocks["controller"].delete_job.side_effect = Exception("job already gone")
+
+    run(
+        dry_run=False,
+        gitlab_project_id="123",
+        gitlab_merge_request_id="456",
+        comparison_sha="deadbeef",
+        job_controller_cluster="cluster",
+        job_controller_namespace="namespace",
+        rcs_job_image="quay.io/example/rcs:latest",
+        rcs_secrets_path="app-sre/rcs/secrets",
+    )
+
+
+def test_run_does_not_raise_when_fetching_job_logs_fails(
+    mocker: MockerFixture,
+) -> None:
+    mocks = _mock_run_dependencies(mocker, comments=[_comment(TRIGGER_COMMAND)])
+    mocks["controller"].wait_for_job_completion.return_value = False
+    mocks["controller"].get_job_logs.side_effect = Exception("log stream error")
+
+    run(
+        dry_run=False,
+        gitlab_project_id="123",
+        gitlab_merge_request_id="456",
+        comparison_sha="deadbeef",
+        job_controller_cluster="cluster",
+        job_controller_namespace="namespace",
+        rcs_job_image="quay.io/example/rcs:latest",
+        rcs_secrets_path="app-sre/rcs/secrets",
+    )
+
+
 def test_run_skips_job_launch_in_dry_run(mocker: MockerFixture) -> None:
     mocks = _mock_run_dependencies(mocker, comments=[_comment(TRIGGER_COMMAND)])
     mock_build_job_controller = mocker.patch(

--- a/reconcile/test/test_rcs_analyze_trigger.py
+++ b/reconcile/test/test_rcs_analyze_trigger.py
@@ -40,11 +40,15 @@ if TYPE_CHECKING:
     )
 
 
-def _emoji_award(name: str) -> MagicMock:
+BOT_USERNAME = "rcs-analyze-bot"
+
+
+def _emoji_award(name: str, username: str = BOT_USERNAME) -> MagicMock:
     # MagicMock(name=...) sets the mock's own repr, not a "name" attribute,
     # so it must be assigned separately to be readable as award.name.
     award = MagicMock()
     award.name = name
+    award.user = {"username": username}
     return award
 
 
@@ -54,6 +58,7 @@ def _comment(
     comment_id: int = 1,
     created_at: str = "2026-01-01T00:00:00Z",
     awarded_emojis: tuple[str, ...] = (),
+    awarded_emojis_by: str = BOT_USERNAME,
     note: MagicMock | None = None,
 ) -> Comment:
     # Accepting an externally-built note lets callers keep a MagicMock-typed
@@ -61,7 +66,9 @@ def _comment(
     # would statically resolve to the real (non-mock) gitlab-lib type.
     if note is None:
         note = MagicMock()
-    note.awardemojis.list.return_value = [_emoji_award(n) for n in awarded_emojis]
+    note.awardemojis.list.return_value = [
+        _emoji_award(n, username=awarded_emojis_by) for n in awarded_emojis
+    ]
     return Comment(
         id=comment_id, username=username, body=body, created_at=created_at, note=note
     )
@@ -557,6 +564,7 @@ def _mock_run_dependencies(
 ) -> dict[str, MagicMock]:
     mock_gl = mocker.MagicMock()
     mock_gl.__enter__.return_value = mock_gl
+    mock_gl.user.username = BOT_USERNAME
     mock_gl.get_merge_request_comments.return_value = comments
     mock_gl.get_merge_request_changed_paths.return_value = ["/path.yml"]
     mocker.patch("reconcile.rcs_analyze_trigger.GitLabApi", return_value=mock_gl)
@@ -729,6 +737,31 @@ def test_run_skips_when_already_launched(mocker: MockerFixture) -> None:
     )
 
     mocks["controller"].enqueue_job.assert_not_called()
+
+
+def test_run_launches_job_when_launched_emoji_was_awarded_by_someone_else(
+    mocker: MockerFixture,
+) -> None:
+    # The "eyes" emoji is only our durable marker when we're the one who
+    # awarded it - a reviewer or bystander reacting to the trigger comment
+    # with the same emoji must not be mistaken for a prior launch.
+    comment = _comment(
+        TRIGGER_COMMAND, awarded_emojis=(EMOJI_LAUNCHED,), awarded_emojis_by="rando"
+    )
+    mocks = _mock_run_dependencies(mocker, comments=[comment])
+
+    run(
+        dry_run=False,
+        gitlab_project_id="123",
+        gitlab_merge_request_id="456",
+        comparison_sha="deadbeef",
+        job_controller_cluster="cluster",
+        job_controller_namespace="namespace",
+        rcs_job_image="quay.io/example/rcs:latest",
+        rcs_secrets_path="app-sre/rcs/secrets",
+    )
+
+    mocks["controller"].enqueue_job.assert_called_once()
 
 
 def test_run_does_not_raise_on_non_success_job_status(mocker: MockerFixture) -> None:

--- a/reconcile/utils/saas_diff.py
+++ b/reconcile/utils/saas_diff.py
@@ -1,0 +1,138 @@
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING, Any
+
+from pydantic import BaseModel
+
+from reconcile.gql_definitions.common.saas_files import (
+    DeployResourcesV1,
+    SaasResourceTemplateTargetUpstreamV1,
+)
+from reconcile.gql_definitions.fragments.vault_secret import VaultSecret
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
+
+    from reconcile.typed_queries.saas_files import SaasFile
+
+
+class Definition(BaseModel):
+    managed_resource_types: list[str]
+    image_patterns: list[str]
+    use_channel_in_image_tag: bool
+
+
+class State(BaseModel):
+    saas_file_path: str
+    saas_file_name: str
+    saas_file_deploy_resources: DeployResourcesV1 | None = None
+    resource_template_name: str
+    cluster: str
+    namespace: str
+    environment: str
+    url: str
+    ref: str
+    parameters: dict[str, Any]
+    secret_parameters: dict[str, VaultSecret]
+    saas_file_definitions: Definition
+    upstream: SaasResourceTemplateTargetUpstreamV1 | None = None
+    disable: bool | None = None
+    delete: bool | None = None
+    target_path: str | None = None
+
+
+def collect_state(saas_files: list[SaasFile]) -> list[State]:
+    state = []
+    for saas_file in saas_files:
+        definitions = Definition(
+            managed_resource_types=saas_file.managed_resource_types,
+            image_patterns=saas_file.image_patterns,
+            use_channel_in_image_tag=saas_file.use_channel_in_image_tag or False,
+        )
+
+        for resource_template in saas_file.resource_templates:
+            for target in resource_template.targets:
+                parameters: dict[str, Any] = {}
+                parameters.update(saas_file.parameters or {})
+                parameters.update(resource_template.parameters or {})
+                parameters.update(target.parameters or {})
+                secret_parameters: dict[str, VaultSecret] = {}
+                secret_parameters.update({
+                    s.name: s.secret for s in saas_file.secret_parameters or []
+                })
+                secret_parameters.update({
+                    s.name: s.secret for s in resource_template.secret_parameters or []
+                })
+                secret_parameters.update({
+                    s.name: s.secret for s in target.secret_parameters or []
+                })
+                state.append(
+                    State(
+                        saas_file_path=saas_file.path,
+                        saas_file_name=saas_file.name,
+                        saas_file_deploy_resources=saas_file.deploy_resources,
+                        resource_template_name=resource_template.name,
+                        cluster=target.namespace.cluster.name,
+                        namespace=target.namespace.name,
+                        environment=target.namespace.environment.name,
+                        url=resource_template.url,
+                        ref=target.ref,
+                        parameters=parameters,
+                        secret_parameters=secret_parameters,
+                        saas_file_definitions=definitions,
+                        upstream=target.upstream,
+                        disable=target.disable,
+                        delete=target.delete,
+                        target_path=target.path,
+                    )
+                )
+    return state
+
+
+def find_ref_diffs(
+    current_state: Iterable[State],
+    desired_state: Iterable[State],
+    changed_paths: Iterable[str],
+) -> list[tuple[State, State]]:
+    """
+    Match desired-state targets against current-state targets by
+    (saas_file_name, resource_template_name, environment, cluster,
+    namespace), skipping targets whose saas file is not part of
+    changed_paths and targets whose ref did not actually change.
+
+    Returns (desired, current) State pairs for each detected ref change.
+    Shared by openshift_saas_deploy_change_tester.collect_compare_diffs and
+    rcs_analyze_trigger.collect_component_diffs so a fix to the matching
+    rule only has to be made in one place.
+    """
+    matches: list[tuple[State, State]] = []
+    for d in desired_state:
+        # check if this diff was actually changed in the current MR
+        changed_path_matches = [
+            c for c in changed_paths if c.endswith(d.saas_file_path)
+        ]
+        if not changed_path_matches:
+            # this diff was found in the graphql endpoint comparison
+            # but is not a part of the changed paths.
+            # the only known case for this currently is if a previous MR
+            # that changes another saas file was merged but is not yet
+            # reflected in the baseline graphql endpoint.
+            # https://issues.redhat.com/browse/APPSRE-3029
+            logging.debug(f"Diff not found in changed paths, skipping: {d!s}")
+            continue
+        for c in current_state:
+            if d.saas_file_name != c.saas_file_name:
+                continue
+            if d.resource_template_name != c.resource_template_name:
+                continue
+            if d.environment != c.environment:
+                continue
+            if d.cluster != c.cluster:
+                continue
+            if d.namespace != c.namespace:
+                continue
+            if d.ref == c.ref:
+                continue
+            matches.append((d, c))
+    return matches


### PR DESCRIPTION
## Summary

Implements the qontract-reconcile side of the `/rcs analyze` chatops trigger for [release-confidence-score (RCS)](https://github.com/RedHatInsights/release-confidence-score): commenting `/rcs analyze` on an app-interface promotion MR launches RCS, which independently analyzes the diffs of the promoted components and posts its own AI-based confidence report back on the MR using its own GitLab token.

`/rcs analyze` is an optional, manually-triggered, non-blocking analysis — it never gates merging and never fails the calling pr_check pipeline (see Approach below). This MR has no impact on any existing qontract-reconcile process: `cli.py` only adds a new command, `openshift_saas_deploy_change_tester.py`'s behavior is unchanged (its logic was moved to a shared module, not modified — see below), and the new integration doesn't run anywhere yet, since it isn't wired into app-interface's `pr_check` config in this PR.

RHCLOUD-49397

## Approach

- **New integration**: `reconcile/rcs_analyze_trigger.py`, registered as a `pr_check`-style CLI command (`rcs-analyze-trigger`) in `reconcile/cli.py`, following the same `def run(dry_run, ...)` pattern as sibling integrations like `gitlab_fork_compliance.py`.
- **Trigger detection**: exact-match on `/rcs analyze` comment lines (`find_trigger_comment`), explicitly distinct from RCS's own `/rcs note`/`/rcs override` commands, which RCS parses itself. The most recent matching comment is used, and the job's identity is keyed on that specific comment's id, so a concurrent pr_check rerun can't double-launch a job while the original is still in the cluster.
- **Durable dedup**: launching a job awards its trigger comment a GitLab emoji, checked before launching; a second emoji marks completion once the job reaches a terminal state. This is deliberately independent of the Kubernetes Job's own lifetime: the Job is deleted `ttl_seconds_after_finished` after finishing, but the emoji never expires, so a pr_check rerun days later (e.g. from an unrelated new commit) can't re-trigger an analysis for a comment that already ran, just because the original Job is gone by then.
- **Authorization**: only proceeds if the commenter is an authorized approver of *every diff* of every changed bundle file relevant to the MR, reusing `reconcile.change_owners.change_owners.cover_changes()` directly and `ChangeTypeContext.includes_approver()` — the same primitives `/lgtm`/`/hold` use. This is a deliberately stricter, single-actor bar than `/lgtm`'s joint multi-approver model, since there's no multi-comment history to aggregate for a one-shot trigger.
- **`reconcile/utils/saas_diff.py` is a straight move, not a rewrite.** `Definition`, `State`, and `collect_state` are byte-for-byte identical to their originals in `openshift_saas_deploy_change_tester.py` (diffed against `upstream/master` to confirm). The matching logic itself — every field comparison, the debug log, and the APPSRE-3029 comment — is also byte-for-byte identical; the only change is the final line inside the loop, which now returns the matched `(desired, current)` `State` pair instead of building a formatted compare-URL string directly, so a second caller can format it differently. `openshift_saas_deploy_change_tester.py`'s `collect_compare_diffs` is now a one-line wrapper around that shared function that reconstructs the exact original output.
- **Job execution**: RCS runs as a Kubernetes Job via the existing `reconcile/utils/jobcontroller` (`K8sJobController`), the same mechanism already used by the external-resources reconciler and the `ocm-clusters` pr_check integration. `active_deadline_seconds` bounds pod runtime, `resources` requests/limits are set (deliberately modest — RCS is network/API-bound, not compute-heavy), and a timed-out job is explicitly deleted rather than left running.
- **Audit metadata**: the triggering comment's author, timestamp, and id are passed to the RCS container as `RCS_TRIGGERED_BY` / `RCS_TRIGGERED_AT` / `RCS_TRIGGER_COMMENT_ID`, alongside `RCS_APP_INTERFACE_PROJECT_ID` / `RCS_APP_INTERFACE_MR_IID` / `RCS_COMPONENT_DIFFS`.
- **Failure handling**: the plan is logged identically whether `dry_run` is true or false, and `dry_run` is checked as late as possible — since `K8sJobController`'s own `dry_run` flag is not actually enforced anywhere in that module. `run()` is a thin top-level exception boundary around the actual logic (`_run()`), on top of the narrower authorization and job launch/monitoring handlers inside it — and the timed-out-job deletion and non-success job log retrieval each have their own guard, so a failure in either best-effort cleanup/diagnostic step can't itself crash the pipeline. Nothing in this integration can fail the calling pr_check.
- App-interface-side wiring (the `pr_check` declaration, Vault secrets, docs) is tracked separately in RHCLOUD-49397 and is out of scope here.

## Test plan

- `uv run pytest reconcile/test/test_rcs_analyze_trigger.py reconcile/test/test_openshift_saas_deploy_change_tester.py reconcile/test/change_owners` — 194 tests pass, no regressions.
- `uv run mypy` / `ruff check` / `ruff format --check` — clean.
- Authorization is tested against real `change_owners` fixtures (not mocked out), including per-diff coverage, multi-file batches, and the implicit-ownership pathway.
- The durable dedup path is covered directly: already-launched comments are skipped, both emojis are awarded on a normal success/failure completion, and a timeout awards only the launched marker (the job was killed, not completed).
- The fail-soft boundary is covered directly: an unexpected failure anywhere before job launch, a failing job deletion on timeout, and a failing log fetch on a non-success job status each fail soft rather than propagating.
- Verified `rcs-analyze-trigger`'s Click registration directly against the command tree, without requiring a live qontract-server connection.

## Issues identified during review and dismissed

- **`reconcile/` vs. the newer `qontract_api` architecture**: deferred — migrating this integration properly would require building net-new platform infrastructure (a GitLab client with comment/diff/post support, and a Kubernetes-Job-launching subsystem) that doesn't exist yet in `qontract_api`. `AGENTS.md`'s own "Integration Structure" section still documents the classic pattern used here as valid.
- **Missing `service_account_name` on the pod spec**: investigated and dismissed — the target namespace's RBAC is scoped specifically to `external-resources-sa`, and RCS makes no Kubernetes API calls at all, so running under the default SA is strictly more restrictive, not a privilege-escalation risk.
- **`reconcile/utils/saas_diff.py` placement**: `AGENTS.md` states shared code goes to `qontract_utils/`, and no new module has landed in `reconcile/utils/` in roughly 9 months. Kept here deliberately: per ADR-007, migration to `qontract_utils/` is driven by what `qontract_api` actually needs, and `saas_diff.py` has no `qontract_api` consumer today — only two `reconcile/`-side integrations.
- **Multiple full-bundle GraphQL fetches per trigger check**: real overhead, but no worse than costs already accepted at higher frequency elsewhere — `openshift_saas_deploy_change_tester.py` already does the same double fetch on every MR touching a saas file, and `change_owners.py` already performs the identical coverage computation on every MR's pr_check run.

Also noted but out of scope here: `K8sJobController`'s `dry_run` flag (`reconcile/utils/jobcontroller/controller.py`) is stored but never actually enforced anywhere in that module — a pre-existing issue in shared code, not introduced by this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## New Features
- Added an RCS analysis command for GitLab merge requests.
- Added `/rcs analyze` support to detect relevant component changes and validate approval coverage.
- Authorized analyses launch configurable jobs using comparison, execution, container image, and secret settings.
- Added dry-run support, progress markers, timeout handling, and failure reporting.

## Refactor
- Improved consistency and reliability of SAAS deployment change comparisons through shared processing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

