### PR TITLE
add optional gov slack username field q-r logic

### DIFF
--- a/reconcile/gql_definitions/common/users.py
+++ b/reconcile/gql_definitions/common/users.py
@@ -27,6 +27,7 @@ fragment User on User_v1 {
   github_username
   pagerduty_username
   tag_on_merge_requests
+  gov_slack_username
 }
 
 query Users {

--- a/reconcile/gql_definitions/common/users.py
+++ b/reconcile/gql_definitions/common/users.py
@@ -27,7 +27,7 @@ fragment User on User_v1 {
   github_username
   pagerduty_username
   tag_on_merge_requests
-  gov_slack_username
+  gov_slack_email_local_part
 }
 
 query Users {

--- a/reconcile/gql_definitions/fragments/user.gql
+++ b/reconcile/gql_definitions/fragments/user.gql
@@ -5,4 +5,5 @@ fragment User on User_v1 {
   github_username
   pagerduty_username
   tag_on_merge_requests
+  gov_slack_username
 }

--- a/reconcile/gql_definitions/fragments/user.gql
+++ b/reconcile/gql_definitions/fragments/user.gql
@@ -5,5 +5,5 @@ fragment User on User_v1 {
   github_username
   pagerduty_username
   tag_on_merge_requests
-  gov_slack_username
+  gov_slack_email_local_part
 }

--- a/reconcile/gql_definitions/fragments/user.py
+++ b/reconcile/gql_definitions/fragments/user.py
@@ -30,3 +30,4 @@ class User(ConfiguredBaseModel):
     github_username: str = Field(..., alias="github_username")
     pagerduty_username: Optional[str] = Field(..., alias="pagerduty_username")
     tag_on_merge_requests: Optional[bool] = Field(..., alias="tag_on_merge_requests")
+    gov_slack_username: Optional[str] = Field(..., alias="gov_slack_username")

--- a/reconcile/gql_definitions/fragments/user.py
+++ b/reconcile/gql_definitions/fragments/user.py
@@ -30,4 +30,4 @@ class User(ConfiguredBaseModel):
     github_username: str = Field(..., alias="github_username")
     pagerduty_username: Optional[str] = Field(..., alias="pagerduty_username")
     tag_on_merge_requests: Optional[bool] = Field(..., alias="tag_on_merge_requests")
-    gov_slack_username: Optional[str] = Field(..., alias="gov_slack_username")
+    gov_slack_email_local_part: Optional[str] = Field(..., alias="gov_slack_email_local_part")

--- a/reconcile/gql_definitions/introspection.json
+++ b/reconcile/gql_definitions/introspection.json
@@ -36346,6 +36346,18 @@
                             "deprecationReason": null
                         },
                         {
+                            "name": "gov_slack_username",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "SCALAR",
+                                "name": "String",
+                                "ofType": null
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
                             "name": "cloudflare_user",
                             "description": null,
                             "args": [],

--- a/reconcile/gql_definitions/introspection.json
+++ b/reconcile/gql_definitions/introspection.json
@@ -11371,6 +11371,18 @@
                             "deprecationReason": null
                         },
                         {
+                            "name": "gov_slack_email_local_part",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "SCALAR",
+                                "name": "String",
+                                "ofType": null
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
                             "name": "cloudflare_user",
                             "description": null,
                             "args": [],

--- a/reconcile/gql_definitions/ocm_groups_api/roles.py
+++ b/reconcile/gql_definitions/ocm_groups_api/roles.py
@@ -27,6 +27,7 @@ fragment User on User_v1 {
   github_username
   pagerduty_username
   tag_on_merge_requests
+  gov_slack_email_local_part
 }
 
 query OcmGroupsApiRoles {

--- a/reconcile/gql_definitions/openshift_groups/managed_roles.py
+++ b/reconcile/gql_definitions/openshift_groups/managed_roles.py
@@ -27,6 +27,7 @@ fragment User on User_v1 {
   github_username
   pagerduty_username
   tag_on_merge_requests
+  gov_slack_username
 }
 
 query OpenshiftGroupsManagedRoles {

--- a/reconcile/gql_definitions/openshift_groups/managed_roles.py
+++ b/reconcile/gql_definitions/openshift_groups/managed_roles.py
@@ -27,7 +27,7 @@ fragment User on User_v1 {
   github_username
   pagerduty_username
   tag_on_merge_requests
-  gov_slack_username
+  gov_slack_email_local_part
 }
 
 query OpenshiftGroupsManagedRoles {

--- a/reconcile/gql_definitions/slack_usergroups_api/permissions.py
+++ b/reconcile/gql_definitions/slack_usergroups_api/permissions.py
@@ -28,6 +28,7 @@ fragment User on User_v1 {
   github_username
   pagerduty_username
   tag_on_merge_requests
+  gov_slack_username
 }
 
 fragment VaultSecret on VaultSecret_v1 {

--- a/reconcile/gql_definitions/slack_usergroups_api/permissions.py
+++ b/reconcile/gql_definitions/slack_usergroups_api/permissions.py
@@ -28,7 +28,7 @@ fragment User on User_v1 {
   github_username
   pagerduty_username
   tag_on_merge_requests
-  gov_slack_username
+  gov_slack_email_local_part
 }
 
 fragment VaultSecret on VaultSecret_v1 {

--- a/reconcile/gql_definitions/slack_usergroups_api/roles.py
+++ b/reconcile/gql_definitions/slack_usergroups_api/roles.py
@@ -27,6 +27,7 @@ fragment User on User_v1 {
   github_username
   pagerduty_username
   tag_on_merge_requests
+  gov_slack_username
 }
 
 query SlackUsergroupsApiRoles {

--- a/reconcile/gql_definitions/slack_usergroups_api/roles.py
+++ b/reconcile/gql_definitions/slack_usergroups_api/roles.py
@@ -27,7 +27,7 @@ fragment User on User_v1 {
   github_username
   pagerduty_username
   tag_on_merge_requests
-  gov_slack_username
+  gov_slack_email_local_part
 }
 
 query SlackUsergroupsApiRoles {

--- a/reconcile/gql_definitions/slack_usergroups_api/users.py
+++ b/reconcile/gql_definitions/slack_usergroups_api/users.py
@@ -27,6 +27,7 @@ fragment User on User_v1 {
   github_username
   pagerduty_username
   tag_on_merge_requests
+  gov_slack_username
 }
 
 query SlackUsergroupApiClusterUser {

--- a/reconcile/gql_definitions/slack_usergroups_api/users.py
+++ b/reconcile/gql_definitions/slack_usergroups_api/users.py
@@ -27,7 +27,7 @@ fragment User on User_v1 {
   github_username
   pagerduty_username
   tag_on_merge_requests
-  gov_slack_username
+  gov_slack_email_local_part
 }
 
 query SlackUsergroupApiClusterUser {

--- a/reconcile/slack_usergroups_api.py
+++ b/reconcile/slack_usergroups_api.py
@@ -89,16 +89,16 @@ DATE_FORMAT = "%Y-%m-%d %H:%M"
 
 class _UserWithSlackIdentity(Protocol):
     org_username: str
-    gov_slack_username: str | None
+    gov_slack_email_local_part: str | None
 
 
 def slack_username(user: _UserWithSlackIdentity) -> str:
     """Return the Slack identity for an app-interface user.
 
-    Prefer gov_slack_username when set (gov Slack email local-part), otherwise
+    Prefer gov_slack_email_local_part when set (gov Slack email local-part), otherwise
     fall back to org_username (commercial Slack / LDAP).
     """
-    return user.gov_slack_username or user.org_username
+    return user.gov_slack_email_local_part or user.org_username
 
 
 class SlackWorkspace(BaseModel, arbitrary_types_allowed=True):

--- a/reconcile/slack_usergroups_api.py
+++ b/reconcile/slack_usergroups_api.py
@@ -18,7 +18,7 @@ import logging
 import sys
 from collections import defaultdict
 from datetime import datetime
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Protocol
 
 from pydantic import BaseModel
 from qontract_api_client.client import (
@@ -85,6 +85,20 @@ if TYPE_CHECKING:
 QONTRACT_INTEGRATION = "slack-usergroups-api"
 INTEGRATION_VERSION = "0.1.0"
 DATE_FORMAT = "%Y-%m-%d %H:%M"
+
+
+class _UserWithSlackIdentity(Protocol):
+    org_username: str
+    gov_slack_username: str | None
+
+
+def slack_username(user: _UserWithSlackIdentity) -> str:
+    """Return the Slack identity for an app-interface user.
+
+    Prefer gov_slack_username when set (gov Slack email local-part), otherwise
+    fall back to org_username (commercial Slack / LDAP).
+    """
+    return user.gov_slack_username or user.org_username
 
 
 class SlackWorkspace(BaseModel, arbitrary_types_allowed=True):
@@ -210,7 +224,7 @@ class SlackUsergroupsIntegration(
             start = ensure_utc(datetime.strptime(entry.start, DATE_FORMAT))  # ruff: ignore[call-datetime-strptime-without-zone]
             end = ensure_utc(datetime.strptime(entry.end, DATE_FORMAT))  # ruff: ignore[call-datetime-strptime-without-zone]
             if start <= now <= end:
-                all_usernames.extend(u.org_username for u in entry.users)
+                all_usernames.extend(slack_username(u) for u in entry.users)
         return all_usernames
 
     @staticmethod
@@ -224,7 +238,9 @@ class SlackUsergroupsIntegration(
             List of usernames from roles
         """
 
-        return [user.org_username for role in roles or [] for user in role.users or []]
+        return [
+            slack_username(user) for role in roles or [] for user in role.users or []
+        ]
 
     async def fetch_owners(
         self,
@@ -261,7 +277,7 @@ class SlackUsergroupsIntegration(
             if org_username and org_username in users_map:
                 user = users_map[org_username]
                 if user.tag_on_merge_requests is not False:
-                    result.append(user.org_username)
+                    result.append(slack_username(user))
         return result
 
     async def compile_users_from_git_owners(
@@ -550,7 +566,7 @@ class SlackUsergroupsIntegration(
                     continue
 
                 cluster_users.setdefault(cluster_name, set()).update([
-                    user.org_username
+                    slack_username(user)
                     for user in role.users
                     if self.include_user_to_cluster_usergroup(user, role)
                 ])

--- a/reconcile/slack_usergroups_api.py
+++ b/reconcile/slack_usergroups_api.py
@@ -92,7 +92,7 @@ class _UserWithSlackIdentity(Protocol):
     gov_slack_email_local_part: str | None
 
 
-def slack_username(user: _UserWithSlackIdentity) -> str:
+def slack_identity(user: _UserWithSlackIdentity) -> str:
     """Return the Slack identity for an app-interface user.
 
     Prefer gov_slack_email_local_part when set (gov Slack email local-part), otherwise
@@ -224,7 +224,7 @@ class SlackUsergroupsIntegration(
             start = ensure_utc(datetime.strptime(entry.start, DATE_FORMAT))  # ruff: ignore[call-datetime-strptime-without-zone]
             end = ensure_utc(datetime.strptime(entry.end, DATE_FORMAT))  # ruff: ignore[call-datetime-strptime-without-zone]
             if start <= now <= end:
-                all_usernames.extend(slack_username(u) for u in entry.users)
+                all_usernames.extend(slack_identity(u) for u in entry.users)
         return all_usernames
 
     @staticmethod
@@ -239,7 +239,7 @@ class SlackUsergroupsIntegration(
         """
 
         return [
-            slack_username(user) for role in roles or [] for user in role.users or []
+            slack_identity(user) for role in roles or [] for user in role.users or []
         ]
 
     async def fetch_owners(
@@ -277,7 +277,7 @@ class SlackUsergroupsIntegration(
             if org_username and org_username in users_map:
                 user = users_map[org_username]
                 if user.tag_on_merge_requests is not False:
-                    result.append(slack_username(user))
+                    result.append(slack_identity(user))
         return result
 
     async def compile_users_from_git_owners(
@@ -566,7 +566,7 @@ class SlackUsergroupsIntegration(
                     continue
 
                 cluster_users.setdefault(cluster_name, set()).update([
-                    slack_username(user)
+                    slack_identity(user)
                     for user in role.users
                     if self.include_user_to_cluster_usergroup(user, role)
                 ])

--- a/reconcile/test/test_gitlab_members.py
+++ b/reconcile/test/test_gitlab_members.py
@@ -102,6 +102,7 @@ def user() -> User:
         name="name",
         pagerduty_username="pagerduty_username",
         tag_on_merge_requests=None,
+        gov_slack_username=None,
     )
 
 

--- a/reconcile/test/test_gitlab_members.py
+++ b/reconcile/test/test_gitlab_members.py
@@ -102,7 +102,7 @@ def user() -> User:
         name="name",
         pagerduty_username="pagerduty_username",
         tag_on_merge_requests=None,
-        gov_slack_username=None,
+        gov_slack_email_local_part=None,
     )
 
 

--- a/reconcile/test/utils/test_mr.py
+++ b/reconcile/test/utils/test_mr.py
@@ -403,6 +403,7 @@ def users() -> list[User]:
             github_username="github_user",
             pagerduty_username=None,
             tag_on_merge_requests=None,
+            gov_slack_username=None,
         )
     ]
 

--- a/reconcile/test/utils/test_mr.py
+++ b/reconcile/test/utils/test_mr.py
@@ -403,7 +403,7 @@ def users() -> list[User]:
             github_username="github_user",
             pagerduty_username=None,
             tag_on_merge_requests=None,
-            gov_slack_username=None,
+            gov_slack_email_local_part=None,
         )
     ]
 


### PR DESCRIPTION
As the current code stands, users within the FedRAMP environment are not able to utilize the qontract-api slack-usergroups-api qontract-reconcile integration due to how GovSlack user handles are assigned compared to commercial Slack. The comparison differentiation comes from `qontract_api/qontract_api/slack/slack_workspace_client.py`:

```
        valid_org_names = {
            user.org_username for user in self.get_users().values() if not user.deleted
        }
```

As it stands, because the code is currently looking for and validating only `org_username`, a new field will be needed in-boundary to ensure users are seen as valid users within gov slack.

This pull request allows either the `org_username` field value or the `gov_slack_email_local_part` field value to be used in order to assign users to various slack user groups. If the optional `gov_slack_email_local_part` field is present within the user file, that value will be used instead of `org_username`.

Note the field `gov_slack_email_local_part` will only utilize the management of Slack user groups and not utilize services like PagerDuty, as it is not approved to use in-boundary.

qontract-schemas logic: https://github.com/app-sre/qontract-schemas/pull/1039

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for retrieving users’ government Slack usernames.
  * Slack identity matching now prefers the government Slack username when available, with fallback to the existing username.
  * User reconciliation across schedules, roles, ownership, and access now uses improved identity resolution.
* **Bug Fixes**
  * Ensured government Slack usernames are included in reconciliation data when available.
* **Chores**
  * Updated supporting data and test coverage for the new optional username field.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->