### PR TITLE
fix(external-resources): honor clusterAdmin when syncing output secrets

### DIFF
--- a/reconcile/external_resources/secrets_sync.py
+++ b/reconcile/external_resources/secrets_sync.py
@@ -214,10 +214,9 @@ class SecretsReconciler:
             if spec.cluster_admin
         }
         privileged_clusters = {ns.cluster for ns in self._privileged_namespaces}
+        spec_cluster_names = {spec.cluster_name for spec in specs}
         clusters_by_name = {
-            c.name: c
-            for c in get_clusters_minimal()
-            if c.name in {spec.cluster_name for spec in specs}
+            c.name: c for c in get_clusters_minimal() if c.name in spec_cluster_names
         }
         namespaces = [
             _ClusterAdminNamespace(

--- a/reconcile/external_resources/secrets_sync.py
+++ b/reconcile/external_resources/secrets_sync.py
@@ -6,7 +6,7 @@ import logging
 from abc import abstractmethod
 from dataclasses import dataclass
 from hashlib import shake_128
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, NamedTuple
 
 from pydantic import BaseModel
 from qontract_utils.differ import diff_mappings
@@ -138,12 +138,14 @@ class OutputSecretsFormatter:
         }
 
 
+class ClusterNamespace(NamedTuple):
+    cluster: str
+    namespace: str
+
+
 @dataclass
 class _ClusterAdminNamespace:
-    """Minimal stand-in satisfying the `oc_connection_parameters.Namespace`
-    protocol, so we can request a privileged (cluster-admin) OC client for
-    clusters that host at least one clusterAdmin: true namespace among the
-    specs being synced."""
+    """Satisfies the `oc_connection_parameters.Namespace` protocol."""
 
     cluster: ClusterV1
     cluster_admin: bool | None
@@ -161,10 +163,8 @@ class SecretsReconciler:
         self.ri = ri
         self.thread_pool_size = thread_pool_size
         self.dry_run = dry_run
-        # (cluster_name, namespace_name) pairs that require the privileged
-        # cluster-admin OC client to read/write their output Secret.
-        # Populated per sync_secrets() call. See _init_ocmap().
-        self._privileged_namespaces: set[tuple[str, str]] = set()
+        # Namespaces requiring the privileged cluster-admin OC client. Set by _init_ocmap().
+        self._privileged_namespaces: set[ClusterNamespace] = set()
 
     @abstractmethod
     def _populate_secret_data(self, specs: Iterable[ExternalResourceSpec]) -> None:
@@ -207,18 +207,13 @@ class SecretsReconciler:
 
     def _init_ocmap(self, specs: Iterable[ExternalResourceSpec]) -> OCMap:
         specs = list(specs)
-        # A namespace with clusterAdmin: true (e.g. an output secret that must
-        # land in a platform-protected namespace such as openshift-ingress)
-        # needs the privileged cluster-admin token to read/write its Secret -
-        # the standard dedicated-admin automation token is forbidden there.
-        # Track it here so reconcile_data()/apply_action() know which
-        # (cluster, namespace) pairs must use the privileged OC client.
+        # clusterAdmin: true namespaces (e.g. openshift-ingress) need the privileged token.
         self._privileged_namespaces = {
-            (spec.cluster_name, spec.namespace_name)
+            ClusterNamespace(spec.cluster_name, spec.namespace_name)
             for spec in specs
             if spec.cluster_admin
         }
-        privileged_cluster_names = {cluster for cluster, _ in self._privileged_namespaces}
+        privileged_clusters = {ns.cluster for ns in self._privileged_namespaces}
         clusters_by_name = {
             c.name: c
             for c in get_clusters_minimal()
@@ -226,10 +221,9 @@ class SecretsReconciler:
         }
         namespaces = [
             _ClusterAdminNamespace(
-                cluster=cluster,
-                cluster_admin=cluster_name in privileged_cluster_names,
+                cluster=cluster, cluster_admin=name in privileged_clusters
             )
-            for cluster_name, cluster in clusters_by_name.items()
+            for name, cluster in clusters_by_name.items()
         ]
         return init_oc_map_from_namespaces(
             namespaces=namespaces,
@@ -286,7 +280,7 @@ class SecretsReconciler:
         ocmap: OCMap,
     ) -> None:
         cluster, namespace, kind, data = ri_item
-        privileged = (cluster, namespace) in self._privileged_namespaces
+        privileged = ClusterNamespace(cluster, namespace) in self._privileged_namespaces
         oc = ocmap.get_cluster(cluster, privileged)
         names = list(data["desired"].keys())
 

--- a/reconcile/external_resources/secrets_sync.py
+++ b/reconcile/external_resources/secrets_sync.py
@@ -4,6 +4,7 @@ import base64
 import json
 import logging
 from abc import abstractmethod
+from dataclasses import dataclass
 from hashlib import shake_128
 from typing import TYPE_CHECKING, Any
 
@@ -23,11 +24,16 @@ from reconcile.external_resources.meta import (
 from reconcile.external_resources.model import (
     ExternalResourceKey,
 )
+from reconcile.gql_definitions.common.clusters_minimal import ClusterV1
 from reconcile.openshift_base import ApplyOptions, apply_action
 from reconcile.typed_queries.clusters_minimal import get_clusters_minimal
 from reconcile.utils.datetime_util import to_utc_seconds_iso_format, utc_now
 from reconcile.utils.json import json_dumps
-from reconcile.utils.oc_map import OCMap, init_oc_map_from_clusters
+from reconcile.utils.oc_map import (
+    OCMap,
+    init_oc_map_from_clusters,
+    init_oc_map_from_namespaces,
+)
 from reconcile.utils.openshift_resource import OpenshiftResource, ResourceInventory
 from reconcile.utils.secret_reader import SecretNotFoundError, SecretReaderBase
 from reconcile.utils.three_way_diff_strategy import three_way_diff_using_hash
@@ -132,6 +138,17 @@ class OutputSecretsFormatter:
         }
 
 
+@dataclass
+class _ClusterAdminNamespace:
+    """Minimal stand-in satisfying the `oc_connection_parameters.Namespace`
+    protocol, so we can request a privileged (cluster-admin) OC client for
+    clusters that host at least one clusterAdmin: true namespace among the
+    specs being synced."""
+
+    cluster: ClusterV1
+    cluster_admin: bool | None
+
+
 class SecretsReconciler:
     def __init__(
         self,
@@ -144,6 +161,10 @@ class SecretsReconciler:
         self.ri = ri
         self.thread_pool_size = thread_pool_size
         self.dry_run = dry_run
+        # (cluster_name, namespace_name) pairs that require the privileged
+        # cluster-admin OC client to read/write their output Secret.
+        # Populated per sync_secrets() call. See _init_ocmap().
+        self._privileged_namespaces: set[tuple[str, str]] = set()
 
     @abstractmethod
     def _populate_secret_data(self, specs: Iterable[ExternalResourceSpec]) -> None:
@@ -185,12 +206,33 @@ class SecretsReconciler:
         )
 
     def _init_ocmap(self, specs: Iterable[ExternalResourceSpec]) -> OCMap:
-        return init_oc_map_from_clusters(
-            clusters=[
-                c
-                for c in get_clusters_minimal()
-                if c.name in [o.cluster_name for o in specs]
-            ],
+        specs = list(specs)
+        # A namespace with clusterAdmin: true (e.g. an output secret that must
+        # land in a platform-protected namespace such as openshift-ingress)
+        # needs the privileged cluster-admin token to read/write its Secret -
+        # the standard dedicated-admin automation token is forbidden there.
+        # Track it here so reconcile_data()/apply_action() know which
+        # (cluster, namespace) pairs must use the privileged OC client.
+        self._privileged_namespaces = {
+            (spec.cluster_name, spec.namespace_name)
+            for spec in specs
+            if spec.cluster_admin
+        }
+        privileged_cluster_names = {cluster for cluster, _ in self._privileged_namespaces}
+        clusters_by_name = {
+            c.name: c
+            for c in get_clusters_minimal()
+            if c.name in {spec.cluster_name for spec in specs}
+        }
+        namespaces = [
+            _ClusterAdminNamespace(
+                cluster=cluster,
+                cluster_admin=cluster_name in privileged_cluster_names,
+            )
+            for cluster_name, cluster in clusters_by_name.items()
+        ]
+        return init_oc_map_from_namespaces(
+            namespaces=namespaces,
             secret_reader=self.secrets_reader,
             integration=QONTRACT_INTEGRATION,
         )
@@ -244,7 +286,8 @@ class SecretsReconciler:
         ocmap: OCMap,
     ) -> None:
         cluster, namespace, kind, data = ri_item
-        oc = ocmap.get_cluster(cluster)
+        privileged = (cluster, namespace) in self._privileged_namespaces
+        oc = ocmap.get_cluster(cluster, privileged)
         names = list(data["desired"].keys())
 
         logging.debug(
@@ -271,7 +314,7 @@ class SecretsReconciler:
             diff.add.values()
         )
 
-        self.apply_action(ocmap, cluster, namespace, items_to_update)
+        self.apply_action(ocmap, cluster, namespace, items_to_update, privileged)
 
     def apply_action(
         self,
@@ -279,6 +322,7 @@ class SecretsReconciler:
         cluster: str,
         namespace: str,
         items: Iterable[OpenshiftResource],
+        privileged: bool = False,
     ) -> None:
         options = ApplyOptions(
             dry_run=self.dry_run,
@@ -289,7 +333,7 @@ class SecretsReconciler:
             override_enable_deletion=False,
             caller=None,
             all_callers=None,
-            privileged=None,
+            privileged=privileged,
             enable_deletion=None,
         )
         for item in items:

--- a/reconcile/test/external_resources/test_secrets_sync.py
+++ b/reconcile/test/external_resources/test_secrets_sync.py
@@ -12,6 +12,7 @@ from reconcile.external_resources.meta import (
 )
 from reconcile.external_resources.secrets_sync import (
     SECRET_UPDATED_AT,
+    ClusterNamespace,
     SecretHelper,
     VaultSecretsReconciler,
 )
@@ -81,7 +82,9 @@ def test_init_ocmap_requests_privileged_client_for_cluster_admin_namespace(
     ocmap = reconciler._init_ocmap(specs)
 
     assert ocmap == "fake-ocmap"
-    assert reconciler._privileged_namespaces == {("cluster-a", "protected-ns")}
+    assert reconciler._privileged_namespaces == {
+        ClusterNamespace("cluster-a", "protected-ns")
+    }
     admin_by_cluster = {ns.cluster.name: ns.cluster_admin for ns in captured_namespaces}
     assert admin_by_cluster == {"cluster-a": True, "cluster-b": False}
 

--- a/reconcile/test/external_resources/test_secrets_sync.py
+++ b/reconcile/test/external_resources/test_secrets_sync.py
@@ -1,9 +1,10 @@
 import copy
 from dataclasses import dataclass
 from datetime import UTC, datetime
-from typing import Any
+from typing import TYPE_CHECKING, Any
 from unittest.mock import MagicMock, create_autospec
 
+import pytest
 from pytest import MonkeyPatch, fixture
 
 from reconcile.external_resources.meta import (
@@ -19,6 +20,9 @@ from reconcile.external_resources.secrets_sync import (
 from reconcile.utils.external_resource_spec import ExternalResourceSpec
 from reconcile.utils.openshift_resource import OpenshiftResource, ResourceInventory
 from reconcile.utils.secret_reader import SecretReaderBase
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping
 
 
 @dataclass
@@ -124,6 +128,42 @@ def test_apply_action_threads_privileged_flag_into_apply_options(
     )
 
     assert captured_options[-1].privileged is True
+
+
+@pytest.mark.parametrize(
+    ("privileged_namespaces", "expected_privileged"),
+    [
+        ({ClusterNamespace("cluster-a", "protected-ns")}, True),
+        (set(), False),
+    ],
+)
+def test_reconcile_data_threads_privileged_flag_from_lookup(
+    reconciler: VaultSecretsReconciler,
+    privileged_namespaces: set[ClusterNamespace],
+    expected_privileged: bool,
+) -> None:
+    """reconcile_data() must look up the (cluster, namespace) pair set by
+    _init_ocmap() and thread it through to both ocmap.get_cluster() and
+    apply_action(), otherwise the privileged client computed at init time
+    never reaches the code that actually talks to the cluster."""
+    reconciler._privileged_namespaces = privileged_namespaces
+    reconciler.apply_action = MagicMock()  # type: ignore[method-assign]
+
+    ocmap = MagicMock()
+    ocmap.get_cluster.return_value.get_items.return_value = []
+
+    ri_item: tuple[str, str, str, Mapping[str, Any]] = (
+        "cluster-a",
+        "protected-ns",
+        "Secret",
+        {"desired": {}, "current": {}},
+    )
+    reconciler.reconcile_data(ri_item, ocmap)
+
+    ocmap.get_cluster.assert_called_once_with("cluster-a", expected_privileged)
+    reconciler.apply_action.assert_called_once_with(
+        ocmap, "cluster-a", "protected-ns", [], expected_privileged
+    )
 
 
 @fixture

--- a/reconcile/test/external_resources/test_secrets_sync.py
+++ b/reconcile/test/external_resources/test_secrets_sync.py
@@ -26,7 +26,8 @@ class _FakeCluster:
     name: str
 
 
-def _reconciler() -> VaultSecretsReconciler:
+@fixture
+def reconciler() -> VaultSecretsReconciler:
     return VaultSecretsReconciler(
         ri=ResourceInventory(),
         secrets_reader=create_autospec(SecretReaderBase),
@@ -50,12 +51,12 @@ def _spec(cluster: str, namespace: str, cluster_admin: bool) -> ExternalResource
 
 def test_init_ocmap_requests_privileged_client_for_cluster_admin_namespace(
     monkeypatch: MonkeyPatch,
+    reconciler: VaultSecretsReconciler,
 ) -> None:
     """A namespace with clusterAdmin: true (e.g. a protected namespace like
     openshift-ingress) must get a privileged OC client - otherwise the
     secret sync 403s, since the standard dedicated-admin token is forbidden
     there."""
-    reconciler = _reconciler()
     specs = [
         _spec("cluster-a", "protected-ns", cluster_admin=True),
         _spec("cluster-b", "regular-ns", cluster_admin=False),
@@ -91,8 +92,8 @@ def test_init_ocmap_requests_privileged_client_for_cluster_admin_namespace(
 
 def test_apply_action_threads_privileged_flag_into_apply_options(
     monkeypatch: MonkeyPatch,
+    reconciler: VaultSecretsReconciler,
 ) -> None:
-    reconciler = _reconciler()
     captured_options: list[Any] = []
 
     def fake_apply_action(

--- a/reconcile/test/external_resources/test_secrets_sync.py
+++ b/reconcile/test/external_resources/test_secrets_sync.py
@@ -1,8 +1,10 @@
 import copy
+from dataclasses import dataclass
 from datetime import UTC, datetime
-from unittest.mock import create_autospec
+from typing import Any
+from unittest.mock import MagicMock, create_autospec
 
-from pytest import fixture
+from pytest import MonkeyPatch, fixture
 
 from reconcile.external_resources.meta import (
     QONTRACT_INTEGRATION,
@@ -16,6 +18,108 @@ from reconcile.external_resources.secrets_sync import (
 from reconcile.utils.external_resource_spec import ExternalResourceSpec
 from reconcile.utils.openshift_resource import OpenshiftResource, ResourceInventory
 from reconcile.utils.secret_reader import SecretReaderBase
+
+
+@dataclass
+class _FakeCluster:
+    name: str
+
+
+def _reconciler() -> VaultSecretsReconciler:
+    return VaultSecretsReconciler(
+        ri=ResourceInventory(),
+        secrets_reader=create_autospec(SecretReaderBase),
+        vault_path="test-path",
+        thread_pool_size=1,
+        dry_run=True,
+    )
+
+
+def _spec(cluster: str, namespace: str, cluster_admin: bool) -> ExternalResourceSpec:
+    namespace_data: dict = {"name": namespace, "cluster": {"name": cluster}}
+    if cluster_admin:
+        namespace_data["clusterAdmin"] = True
+    return ExternalResourceSpec(
+        provision_provider="aws",
+        provisioner={"name": "provisioner"},
+        resource={"identifier": f"{namespace}-id", "provider": "vpc-endpoint-service"},
+        namespace=namespace_data,
+    )
+
+
+def test_init_ocmap_requests_privileged_client_for_cluster_admin_namespace(
+    monkeypatch: MonkeyPatch,
+) -> None:
+    """A namespace with clusterAdmin: true (e.g. a protected namespace like
+    openshift-ingress) must get a privileged OC client - otherwise the
+    secret sync 403s, since the standard dedicated-admin token is forbidden
+    there."""
+    reconciler = _reconciler()
+    specs = [
+        _spec("cluster-a", "protected-ns", cluster_admin=True),
+        _spec("cluster-b", "regular-ns", cluster_admin=False),
+    ]
+
+    captured_namespaces: list[Any] = []
+
+    def fake_get_clusters_minimal() -> list[_FakeCluster]:
+        return [_FakeCluster("cluster-a"), _FakeCluster("cluster-b")]
+
+    def fake_init_oc_map_from_namespaces(namespaces: Any, **_kwargs: Any) -> str:
+        captured_namespaces.extend(namespaces)
+        return "fake-ocmap"
+
+    monkeypatch.setattr(
+        "reconcile.external_resources.secrets_sync.get_clusters_minimal",
+        fake_get_clusters_minimal,
+    )
+    monkeypatch.setattr(
+        "reconcile.external_resources.secrets_sync.init_oc_map_from_namespaces",
+        fake_init_oc_map_from_namespaces,
+    )
+
+    ocmap = reconciler._init_ocmap(specs)
+
+    assert ocmap == "fake-ocmap"
+    assert reconciler._privileged_namespaces == {("cluster-a", "protected-ns")}
+    admin_by_cluster = {ns.cluster.name: ns.cluster_admin for ns in captured_namespaces}
+    assert admin_by_cluster == {"cluster-a": True, "cluster-b": False}
+
+
+def test_apply_action_threads_privileged_flag_into_apply_options(
+    monkeypatch: MonkeyPatch,
+) -> None:
+    reconciler = _reconciler()
+    captured_options: list[Any] = []
+
+    def fake_apply_action(
+        oc_map: Any,
+        ri: Any,
+        cluster: Any,
+        namespace: Any,
+        resource_type: Any,
+        resource: Any,
+        options: Any,
+    ) -> None:
+        captured_options.append(options)
+
+    monkeypatch.setattr(
+        "reconcile.external_resources.secrets_sync.apply_action",
+        fake_apply_action,
+    )
+
+    fake_item = MagicMock(spec=OpenshiftResource)
+    fake_item.name = "secret-a"
+
+    reconciler.apply_action(
+        ocmap=MagicMock(),
+        cluster="cluster-a",
+        namespace="protected-ns",
+        items=[fake_item],
+        privileged=True,
+    )
+
+    assert captured_options[-1].privileged is True
 
 
 @fixture

--- a/reconcile/test/utils/test_external_resource_spec.py
+++ b/reconcile/test/utils/test_external_resource_spec.py
@@ -31,24 +31,21 @@ def test_identifier_creation_from_spec() -> None:
     assert id.provisioner_name == "a"
 
 
-def test_cluster_admin_true() -> None:
+@pytest.mark.parametrize(
+    ("namespace", "expected"),
+    [
+        ({"name": "n", "cluster": {"name": "c"}, "clusterAdmin": True}, True),
+        ({"name": "n", "cluster": {"name": "c"}}, False),
+    ],
+)
+def test_cluster_admin(namespace: dict[str, Any], expected: bool) -> None:
     spec = ExternalResourceSpec(
         provision_provider="p",
         provisioner={"name": "a"},
         resource={"identifier": "i", "provider": "p"},
-        namespace={"name": "n", "cluster": {"name": "c"}, "clusterAdmin": True},
+        namespace=namespace,
     )
-    assert spec.cluster_admin is True
-
-
-def test_cluster_admin_false_when_absent() -> None:
-    spec = ExternalResourceSpec(
-        provision_provider="p",
-        provisioner={"name": "a"},
-        resource={"identifier": "i", "provider": "p"},
-        namespace={"name": "n", "cluster": {"name": "c"}},
-    )
-    assert spec.cluster_admin is False
+    assert spec.cluster_admin is expected
 
 
 def test_identifier_missing() -> None:

--- a/reconcile/test/utils/test_external_resource_spec.py
+++ b/reconcile/test/utils/test_external_resource_spec.py
@@ -31,6 +31,26 @@ def test_identifier_creation_from_spec() -> None:
     assert id.provisioner_name == "a"
 
 
+def test_cluster_admin_true() -> None:
+    spec = ExternalResourceSpec(
+        provision_provider="p",
+        provisioner={"name": "a"},
+        resource={"identifier": "i", "provider": "p"},
+        namespace={"name": "n", "cluster": {"name": "c"}, "clusterAdmin": True},
+    )
+    assert spec.cluster_admin is True
+
+
+def test_cluster_admin_false_when_absent() -> None:
+    spec = ExternalResourceSpec(
+        provision_provider="p",
+        provisioner={"name": "a"},
+        resource={"identifier": "i", "provider": "p"},
+        namespace={"name": "n", "cluster": {"name": "c"}},
+    )
+    assert spec.cluster_admin is False
+
+
 def test_identifier_missing() -> None:
     with pytest.raises(ValidationError):
         ExternalResourceUniqueKey.from_spec(

--- a/reconcile/utils/external_resource_spec.py
+++ b/reconcile/utils/external_resource_spec.py
@@ -119,6 +119,10 @@ class ExternalResourceSpec:
         return self.namespace["cluster"]["name"]
 
     @property
+    def cluster_admin(self) -> bool:
+        return bool(self.namespace.get("clusterAdmin"))
+
+    @property
     def environment_type(self) -> str:
         labels = json.loads(self.namespace["environment"]["labels"])
         return labels.get("type", "production")


### PR DESCRIPTION
## Summary
- `external_resources/secrets_sync.py` always built its OCMap via `init_oc_map_from_clusters()`, which only ever requests the standard `dedicated-admin` automation token, regardless of the target namespace's `clusterAdmin` setting.
- Namespaces flagged `clusterAdmin: true` in app-interface (e.g. platform-protected core namespaces like `openshift-ingress`, needed for things like the `vpc-endpoint-service` module's output secret) require the privileged cluster-admin token instead. Without it, reading/writing the output Secret fails with a 403 Forbidden (`cannot get resource "secrets" ... in the namespace "openshift-ingress"`), and the integration keeps retrying every reconcile loop.
- The legacy `terraform_resources.py` flow already threads `privileged=namespace.get("clusterAdmin")` through when applying output secrets. This PR brings the erv2 secrets-sync path to parity:
  - `_init_ocmap()` now builds the OCMap via `init_oc_map_from_namespaces()`, requesting a privileged client for any cluster hosting at least one `clusterAdmin: true` namespace among the specs being synced.
  - `reconcile_data()` reads the current Secret using the privileged client when applicable.
  - `apply_action()` now threads the `privileged` flag into `ApplyOptions` instead of hardcoding `None`.
  - Added `ExternalResourceSpec.cluster_admin`, mirroring the existing `cluster_name`/`namespace_name` properties.

## Test plan
- [x] `ruff check` clean on all changed files
- [x] `mypy` clean on all changed files
- [x] `pytest reconcile/test/external_resources/ reconcile/test/utils/test_external_resource_spec.py` — 106 passed
- [x] Added unit tests covering: `cluster_admin` property (true/absent), `_init_ocmap` correctly marking only the `clusterAdmin` cluster as privileged, `apply_action` threading `privileged=True` into `ApplyOptions`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added recognition of namespace-level “cluster admin” requirements during secret synchronization.
  * Secret sync now initializes and uses cluster access with namespace awareness (elevated access only where required).
* **Bug Fixes**
  * Fixed propagation of the privileged access flag during secret apply operations.
* **Tests**
  * Added/expanded tests covering privileged namespace detection, privileged access selection, and forwarding of the privileged option.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->