### PR TITLE
fix(aus): fetch available_channels from cluster GET instead of versions API

### DIFF
--- a/reconcile/aus/base.py
+++ b/reconcile/aus/base.py
@@ -1180,9 +1180,7 @@ def _get_available_channels(
         return cache[version_id]
     try:
         data = ocm_api.get(api_path=build_cluster_url(cluster_id))
-        channels = set(
-            (data.get("version") or {}).get("available_channels") or []
-        )
+        channels = set((data.get("version") or {}).get("available_channels") or [])
     except HTTPError as e:
         detail = e.response.text if e.response is not None else ""
         logging.warning(

--- a/reconcile/aus/base.py
+++ b/reconcile/aus/base.py
@@ -88,6 +88,7 @@ from reconcile.utils.ocm.clusters import (
 )
 from reconcile.utils.ocm.upgrades import (
     OCMVersionGate,
+    build_cluster_url,
     create_control_plane_upgrade_policy,
     create_node_pool_upgrade_policy,
     create_upgrade_policy,
@@ -1162,25 +1163,31 @@ class ChannelSwitchAction(BaseModel):
 
 def _get_available_channels(
     ocm_api: OCMBaseClient,
+    cluster_id: str,
     version_id: str,
     cache: dict[str, set[str]],
 ) -> set[str]:
-    """Fetch available_channels from the versions API, cached by version ID.
+    """Fetch available_channels via individual cluster GET, cached by version ID.
 
-    The cluster list API omits available_channels (OCM-24287), so we fetch
-    from /api/clusters_mgmt/v1/versions/{version_id} instead. Since
-    available_channels is a property of the version (not the cluster),
-    multiple clusters on the same version share one API call.
+    The cluster list API omits available_channels (OCM-24287) and the
+    versions API returns 403 for org-less service accounts on non-stable
+    channel groups.  Individual cluster GET populates
+    version.available_channels without the 403 restriction.  Results are
+    cached by version_id so only the first cluster per version pays an
+    API call.
     """
     if version_id in cache:
         return cache[version_id]
     try:
-        data = ocm_api.get(api_path=f"/api/clusters_mgmt/v1/versions/{version_id}")
-        channels = set(data.get("available_channels") or [])
+        data = ocm_api.get(api_path=build_cluster_url(cluster_id))
+        channels = set(
+            (data.get("version") or {}).get("available_channels") or []
+        )
     except HTTPError as e:
         detail = e.response.text if e.response is not None else ""
         logging.warning(
-            f"failed to fetch available_channels for version {version_id}: {e}: {detail}"
+            f"failed to fetch available_channels for cluster {cluster_id} "
+            f"(version {version_id}): {e}: {detail}"
         )
         channels = set()
     cache[version_id] = channels
@@ -1230,7 +1237,7 @@ def _try_channel_switch(
     available_channels = set(
         spec.cluster.version.available_channels
     ) or _get_available_channels(
-        ocm_api, spec.cluster.version.id, available_channels_cache
+        ocm_api, spec.cluster.id, spec.cluster.version.id, available_channels_cache
     )
     channel_switch = check_y_stream_channel_switch_needed(spec, available_channels)
     if channel_switch:

--- a/reconcile/test/ocm/aus/test_channel_switch.py
+++ b/reconcile/test/ocm/aus/test_channel_switch.py
@@ -154,24 +154,28 @@ def test_check_y1_blocked_still_switches() -> None:
 # --- _get_available_channels tests ---
 
 
-def test_get_available_channels_from_versions_api() -> None:
+def test_get_available_channels_from_cluster_api() -> None:
     ocm_api = MagicMock()
     ocm_api.get.return_value = {
-        "available_channels": ["stable-4.20", "stable-4.21"],
+        "version": {
+            "available_channels": ["stable-4.20", "stable-4.21"],
+        },
     }
     cache: dict[str, set[str]] = {}
-    result = aus_base._get_available_channels(ocm_api, "openshift-v4.20.10", cache)
-    assert result == {"stable-4.20", "stable-4.21"}
-    ocm_api.get.assert_called_once_with(
-        api_path="/api/clusters_mgmt/v1/versions/openshift-v4.20.10"
+    result = aus_base._get_available_channels(
+        ocm_api, "c1_id", "openshift-v4.20.10", cache
     )
+    assert result == {"stable-4.20", "stable-4.21"}
+    ocm_api.get.assert_called_once_with(api_path="/api/clusters_mgmt/v1/clusters/c1_id")
     assert cache["openshift-v4.20.10"] == {"stable-4.20", "stable-4.21"}
 
 
 def test_get_available_channels_cache_hit() -> None:
     ocm_api = MagicMock()
     cache = {"openshift-v4.20.10": {"stable-4.20", "stable-4.21"}}
-    result = aus_base._get_available_channels(ocm_api, "openshift-v4.20.10", cache)
+    result = aus_base._get_available_channels(
+        ocm_api, "c1_id", "openshift-v4.20.10", cache
+    )
     assert result == {"stable-4.20", "stable-4.21"}
     ocm_api.get.assert_not_called()
 
@@ -182,7 +186,9 @@ def test_get_available_channels_http_error() -> None:
     response.text = "not found"
     ocm_api.get.side_effect = HTTPError(response=response)
     cache: dict[str, set[str]] = {}
-    result = aus_base._get_available_channels(ocm_api, "openshift-v4.20.10", cache)
+    result = aus_base._get_available_channels(
+        ocm_api, "c1_id", "openshift-v4.20.10", cache
+    )
     assert result == set()
     assert cache["openshift-v4.20.10"] == set()
 
@@ -201,7 +207,7 @@ def test_try_channel_switch_skips_addon() -> None:
     assert switches == []
 
 
-def test_try_channel_switch_uses_versions_api_fallback() -> None:
+def test_try_channel_switch_uses_cluster_get_fallback() -> None:
     spec = build_cluster_upgrade_spec(
         name="c1",
         current_version="4.20.10",
@@ -209,7 +215,9 @@ def test_try_channel_switch_uses_versions_api_fallback() -> None:
     )
     ocm_api = MagicMock()
     ocm_api.get.return_value = {
-        "available_channels": ["stable-4.20", "stable-4.21"],
+        "version": {
+            "available_channels": ["stable-4.20", "stable-4.21"],
+        },
     }
     switches: list[ChannelSwitchAction] = []
     cache: dict[str, set[str]] = {}


### PR DESCRIPTION
## Summary

- The versions API (`/api/clusters_mgmt/v1/versions/{id}`) returns 403 for org-less service accounts on non-stable channel groups (candidate, nightly), blocking Y-stream channel switching for AUS clusters
- Switch `_get_available_channels` to use individual cluster GET (`/api/clusters_mgmt/v1/clusters/{id}`) which populates `version.available_channels` without the 403 restriction
- Results remain cached by `version_id` — only the first cluster per version pays an API call

Ref: ROSAENG-62163

## Test plan

- [x] All 28 channel switch tests pass
- [x] All 252 AUS tests pass
- [x] mypy clean
- [ ] Verify in integration/staging with org-less SA that cluster GET returns `available_channels` for candidate versions

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved automatic channel switching by retrieving available channels from the cluster’s current version information.
  * Updated fallback behavior to use the correct cluster details when determining eligible channels.
  * Enhanced handling of channel-discovery errors, including more informative diagnostics.

* **Tests**
  * Updated coverage to validate cluster-based channel discovery, caching, error handling, and fallback behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->