### PR TITLE
fix(aus): skip 400 errors on channel switch for org-less SAs

### DIFF
--- a/reconcile/aus/base.py
+++ b/reconcile/aus/base.py
@@ -1445,7 +1445,11 @@ def act_channel_switches(
             update_cluster_channel(ocm_api, switch.cluster.id, switch.to_channel)
         except HTTPError as e:
             detail = e.response.text if e.response is not None else ""
-            if e.response is not None and e.response.status_code == 400:
+            if (
+                e.response is not None
+                and e.response.status_code == 400
+                and "could not locate organization" in detail.lower()
+            ):
                 # OCM returns 400 for org-less service accounts (ROSAENG-62340)
                 logging.warning(
                     f"{switch.cluster.name}: channel switch failed: {e}: {detail}"

--- a/reconcile/aus/base.py
+++ b/reconcile/aus/base.py
@@ -1445,6 +1445,12 @@ def act_channel_switches(
             update_cluster_channel(ocm_api, switch.cluster.id, switch.to_channel)
         except HTTPError as e:
             detail = e.response.text if e.response is not None else ""
+            if e.response is not None and e.response.status_code == 400:
+                # OCM returns 400 for org-less service accounts (ROSAENG-62340)
+                logging.warning(
+                    f"{switch.cluster.name}: channel switch failed: {e}: {detail}"
+                )
+                continue
             logging.error(
                 f"{switch.cluster.name}: channel switch failed: {e}: {detail}"
             )

--- a/reconcile/test/ocm/aus/test_channel_switch.py
+++ b/reconcile/test/ocm/aus/test_channel_switch.py
@@ -317,6 +317,37 @@ def test_act_http_non_400_error_raises(
     response.status_code = 403
     mock_update.side_effect = HTTPError(response=response)
     cluster1 = build_ocm_cluster(name="c1", version="4.20.10", channel="stable-4.20")
+    cluster2 = build_ocm_cluster(name="c2", version="4.20.10", channel="stable-4.20")
+    switches = [
+        ChannelSwitchAction(
+            cluster=c,
+            from_channel="stable-4.20",
+            to_channel="stable-4.21",
+            org_id="org1",
+        )
+        for c in [cluster1, cluster2]
+    ]
+    with pytest.raises(ExceptionGroup, match="Channel switch errors") as exc_info:
+        act_channel_switches(
+            dry_run=False,
+            channel_switches=switches,
+            ocm_api=MagicMock(),
+        )
+    assert mock_update.call_count == 2
+    assert len(exc_info.value.exceptions) == 2
+    mock_metrics.set_gauge.assert_not_called()
+
+
+@patch("reconcile.aus.base.update_cluster_channel")
+@patch("reconcile.aus.base.metrics")
+def test_act_http_400_unrelated_error_raises(
+    mock_metrics: MagicMock, mock_update: MagicMock
+) -> None:
+    response = MagicMock()
+    response.text = "invalid channel name"
+    response.status_code = 400
+    mock_update.side_effect = HTTPError(response=response)
+    cluster1 = build_ocm_cluster(name="c1", version="4.20.10", channel="stable-4.20")
     switches = [
         ChannelSwitchAction(
             cluster=cluster1,

--- a/reconcile/test/ocm/aus/test_channel_switch.py
+++ b/reconcile/test/ocm/aus/test_channel_switch.py
@@ -280,11 +280,12 @@ def test_act_success_emits_gauge(
 
 @patch("reconcile.aus.base.update_cluster_channel")
 @patch("reconcile.aus.base.metrics")
-def test_act_http_error_skips_gauge_continues(
+def test_act_http_400_warns_and_continues(
     mock_metrics: MagicMock, mock_update: MagicMock
 ) -> None:
     response = MagicMock()
-    response.text = "error"
+    response.text = "Could not locate organization id"
+    response.status_code = 400
     mock_update.side_effect = HTTPError(response=response)
     cluster1 = build_ocm_cluster(name="c1", version="4.20.10", channel="stable-4.20")
     cluster2 = build_ocm_cluster(name="c2", version="4.20.10", channel="stable-4.20")
@@ -297,12 +298,37 @@ def test_act_http_error_skips_gauge_continues(
         )
         for c in [cluster1, cluster2]
     ]
-    with pytest.raises(ExceptionGroup, match="Channel switch errors") as exc_info:
+    act_channel_switches(
+        dry_run=False,
+        channel_switches=switches,
+        ocm_api=MagicMock(),
+    )
+    assert mock_update.call_count == 2
+    mock_metrics.set_gauge.assert_not_called()
+
+
+@patch("reconcile.aus.base.update_cluster_channel")
+@patch("reconcile.aus.base.metrics")
+def test_act_http_non_400_error_raises(
+    mock_metrics: MagicMock, mock_update: MagicMock
+) -> None:
+    response = MagicMock()
+    response.text = "forbidden"
+    response.status_code = 403
+    mock_update.side_effect = HTTPError(response=response)
+    cluster1 = build_ocm_cluster(name="c1", version="4.20.10", channel="stable-4.20")
+    switches = [
+        ChannelSwitchAction(
+            cluster=cluster1,
+            from_channel="stable-4.20",
+            to_channel="stable-4.21",
+            org_id="org1",
+        )
+    ]
+    with pytest.raises(ExceptionGroup, match="Channel switch errors"):
         act_channel_switches(
             dry_run=False,
             channel_switches=switches,
             ocm_api=MagicMock(),
         )
-    assert mock_update.call_count == 2
-    assert len(exc_info.value.exceptions) == 2
     mock_metrics.set_gauge.assert_not_called()


### PR DESCRIPTION
## Summary

- OCM returns HTTP 400 when patching clusters via org-less service accounts (e.g. `service-account-sre-capabilities`) because `toggle.IsEnabled()` calls `GetUserOrganization()` which fails for SAs with no AMS org association
- Log warning and continue for 400 errors so valid cluster upgrades are not blocked
- Other HTTP errors still raise `ExceptionGroup` as before
- Workaround for [ROSAENG-62340](https://redhat.atlassian.net/browse/ROSAENG-62340). Change not intended to be pemanent. Once fixed from OCM side, it would be removed

## Affected clusters

| Cluster | ID | Org |
|---|---|---|
| acs-int-us-02 | 2htvo09targ1l3otirsiqu5v7q2sg1ld | 2NgB6hzFyCWU2EvO2Ro3MX4jEfF |
| acs-stage-dp-03 | 2jttjr1htmkbe3sora28m2ajiorpqc0a | 29ygxhJzgKUzhNUWXqHYE3yYXHC |
| acs-stage-eu-03 | 2juifeo25dqfq6lqpfbcf9gh2nu9r685 | 29ygxhJzgKUzhNUWXqHYE3yYXHC |
| acs-prod-dp-02 | 2jujdvh2nfbc05p1ltfjc12racnhnnkd | 2BBslZacVIVbOgyxTC35q6XCbMR |
| acs-prod-eu-02 | 2juk90j7c2aomkqeg5d5m5nhjvfp7kkf | 2BBslZacVIVbOgyxTC35q6XCbMR |

## Test plan

- [x] `test_act_http_400_warns_and_continues` — 400 errors warn and continue processing
- [x] `test_act_http_non_400_error_raises` — non-400 errors (e.g. 403) still raise ExceptionGroup
- [x] All 29 channel switch tests pass
- [x] `make linter-test` passes
- [x] `make types-test` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of HTTP 400 errors during channel switching so affected switches continue without triggering an aggregated failure.
  * Preserved error reporting for other HTTP failures, which continue to be surfaced after processing.
  * Updated monitoring behavior so skipped 400 errors do not emit gauge metrics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->