### PR TITLE
fix(alert-report): handle bot messages without a username field

### DIFF
--- a/tools/alert_report.py
+++ b/tools/alert_report.py
@@ -5,6 +5,8 @@ from dataclasses import dataclass
 
 QONTRACT_INTEGRATION = "alert-report"
 
+CLUSTER_PREFIX_RE = re.compile(r"^\[(?P<cluster>[^\]]+)\]")
+
 
 @dataclass
 class Alert:
@@ -79,6 +81,16 @@ def group_alerts(messages: list[dict]) -> dict[str, list[Alert]]:
                 logging.debug(f"no alert name in title {at['title']}. Skipping")
                 continue
 
+            # Classic incoming-webhook posts carry a per-cluster "username"; bot
+            # OAuth app posts (used since the webhook was rotated) only carry
+            # "bot_id", which is the same for every cluster. Prefer the cluster
+            # name from the title prefix (present since the 2026-05-18 template
+            # change) to keep grouping/dedup per-cluster; fall back to bot_id
+            # only when neither is available.
+            cluster_match = CLUSTER_PREFIX_RE.match(at["title"])
+            cluster = cluster_match.group("cluster") if cluster_match else None
+            username = m.get("username") or cluster or m.get("bot_id", "unknown")
+
             # If there's only one alert related to the alert_name, message will be part
             # of the title. If not, alert messages will be part of the text under
             # "Alerts Firing" / "Alerts Resolved"
@@ -89,7 +101,7 @@ def group_alerts(messages: list[dict]) -> dict[str, list[Alert]]:
                         state=alert_state,
                         message=alert_message,
                         timestamp=timestamp,
-                        username=m["username"],
+                        username=username,
                         responsed=responsed,
                     )
                 )
@@ -104,7 +116,7 @@ def group_alerts(messages: list[dict]) -> dict[str, list[Alert]]:
                             state=alert_state,
                             message="placeholder",
                             timestamp=timestamp,
-                            username=m["username"],
+                            username=username,
                             responsed=responsed,
                         )
                     )
@@ -126,7 +138,7 @@ def group_alerts(messages: list[dict]) -> dict[str, list[Alert]]:
                                 state=alert_state,
                                 message=alert_message,
                                 timestamp=timestamp,
-                                username=m["username"],
+                                username=username,
                                 responsed=responsed,
                             )
                         )

--- a/tools/test/test_alert_report.py
+++ b/tools/test/test_alert_report.py
@@ -34,6 +34,49 @@ CLUSTER_PREFIXED_MESSAGES = [
     },
 ]
 
+# Bot OAuth app messages (used since the incoming-webhook was rotated on
+# 2026-05-14) have no "username" field at all, only "bot_id" — which is the
+# same for every cluster. Cluster identity now only comes from the title
+# prefix, so two different clusters firing the same alert/message must stay
+# separate.
+BOT_ONLY_MULTI_CLUSTER_MESSAGES = [
+    {
+        "subtype": "bot_message",
+        "bot_id": "B0B3Y3X62AW",
+        "ts": "1750000400.000000",
+        "attachments": [
+            {"title": "[clusterB]Alert: SharedAlert [RESOLVED]  same message"}
+        ],
+    },
+    {
+        "subtype": "bot_message",
+        "bot_id": "B0B3Y3X62AW",
+        "ts": "1750000300.000000",
+        "attachments": [
+            {"title": "[clusterB]Alert: SharedAlert [FIRING:1]  same message"}
+        ],
+    },
+    {
+        "subtype": "bot_message",
+        "bot_id": "B0B3Y3X62AW",
+        "ts": "1750000100.000000",
+        "attachments": [
+            {"title": "[clusterA]Alert: SharedAlert [FIRING:1]  same message"}
+        ],
+    },
+]
+
+# Bot message without a cluster-prefixed title (defensive edge case): falls
+# back to bot_id rather than raising KeyError.
+BOT_ONLY_NO_CLUSTER_PREFIX_MESSAGES = [
+    {
+        "subtype": "bot_message",
+        "bot_id": "B0B3Y3X62AW",
+        "ts": "1750000500.000000",
+        "attachments": [{"title": "Alert: NoUsernameAlert [FIRING:1]  message text"}],
+    },
+]
+
 messages = Fixtures("slack_api").get_anymarkup("conversations_history_messages.yaml")
 
 
@@ -115,3 +158,27 @@ def test_alert_stats_cluster_prefixed_title() -> None:
     assert stat.triggered_alerts == 1
     assert stat.resolved_alerts == 1
     assert len(stat.elapsed_times) == 1
+
+
+def test_group_alerts_bot_message_without_username() -> None:
+    """Bot OAuth app messages have no 'username' field and must not raise KeyError."""
+    alerts = group_alerts(BOT_ONLY_MULTI_CLUSTER_MESSAGES)
+    assert "SharedAlert" in alerts
+    assert len(alerts["SharedAlert"]) == 3
+    # The shared bot_id must not be used as the grouping key when a cluster
+    # name is available from the title prefix.
+    assert {a.username for a in alerts["SharedAlert"]} == {"clusterA", "clusterB"}
+
+
+def test_alert_stats_bot_message_without_username_keeps_clusters_separate() -> None:
+    stat = gen_alert_stats(group_alerts(BOT_ONLY_MULTI_CLUSTER_MESSAGES))["SharedAlert"]
+    # Both clusters fired, but only clusterB resolved.
+    assert stat.triggered_alerts == 2
+    assert stat.resolved_alerts == 1
+    assert stat.elapsed_times == [100.0]
+
+
+def test_group_alerts_bot_message_falls_back_to_bot_id() -> None:
+    """Without a cluster-prefixed title either, fall back to bot_id."""
+    alerts = group_alerts(BOT_ONLY_NO_CLUSTER_PREFIX_MESSAGES)
+    assert alerts["NoUsernameAlert"][0].username == "B0B3Y3X62AW"


### PR DESCRIPTION
## Problem

The `alert-report` Jenkins jobs (`alert-report-1-day`, `alert-report-7-days`, `alert-report-30-days`) have failed every run since ~2026-05-14 with:

```
File "/work/tools/alert_report.py", line 129, in group_alerts
    username=m["username"],
             ~^^^^^^^^^^^^
KeyError: 'username'
```

## Root cause

`group_alerts()` unconditionally reads `m["username"]` on bot Slack messages. That field only exists on classic incoming-webhook messages. The incoming-webhook integration on `#sd-app-sre-alert` was disabled on 2026-05-14 (webhook URL had leaked), and alerts have since posted via a Bot OAuth app whose messages carry `bot_id` but no `username`. Every qualifying message has crashed the script since, so no report has been produced for ~2 months.

## Fix

Fall back from `username` to the cluster name parsed out of the alert title's `[cluster]` prefix (added in the 2026-05-18 Alertmanager Slack template change), and only fall back to `bot_id` if neither is present.

The cluster-prefix fallback matters because `bot_id` is identical across every cluster now — using it directly as the `gen_alert_stats()` grouping/dedup key would silently merge different clusters' alerts together instead of just fixing the crash. The cluster name recovers the same per-cluster distinction the old `username` value used to provide.

## Testing

Added tests in `tools/test/test_alert_report.py`:
- bot message without `username` groups/parses without raising
- two clusters firing the same alert/message stay separate in `gen_alert_stats()` (not merged via shared `bot_id`)
- fallback to `bot_id` when no cluster-prefixed title is present either

All existing + new tests pass, ruff and mypy clean.

Ref: APPSRE-14865

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved alert grouping for Slack bot messages that lack a username.
  * Keeps alerts from different clusters separated using cluster labels in attachment titles.
  * Falls back to the bot ID when no username or cluster label is available.
  * Preserves accurate alert statistics, including triggered and resolved counts and elapsed times.

* **Tests**
  * Added coverage for multi-cluster bot messages and messages without cluster prefixes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->