### PR TITLE
feat(housekeeping): read rebase_limit instead of limit

### DIFF
--- a/reconcile/gitlab_housekeeping.py
+++ b/reconcile/gitlab_housekeeping.py
@@ -1593,8 +1593,7 @@ def publish_access_token_expiration_metrics(gl: GitLabApi) -> None:
 
 def run(dry_run: bool, wait_for_pipeline: bool) -> None:
     default_days_interval = 15
-    default_limit = 8
-    default_merge_limit = 8
+    default_rebase_limit = 8
     default_consecutive_failure_limit = 3
     default_enable_closing = False
     instance = queries.get_gitlab_instance()
@@ -1612,8 +1611,8 @@ def run(dry_run: bool, wait_for_pipeline: bool) -> None:
         project_url = repo["url"]
         days_interval = hk.get("days_interval") or default_days_interval
         enable_closing = hk.get("enable_closing") or default_enable_closing
-        limit = hk.get("limit") or default_limit
-        merge_limit = hk.get("merge_limit") or default_merge_limit
+        rebase_limit = hk.get("rebase_limit") or default_rebase_limit
+        merge_limit = hk.get("merge_limit") or rebase_limit
         consecutive_failure_limit = (
             hk.get("consecutive_failure_limit") or default_consecutive_failure_limit
         )
@@ -1709,7 +1708,7 @@ def run(dry_run: bool, wait_for_pipeline: bool) -> None:
                 rebase_merge_requests(
                     dry_run=dry_run,
                     gl=gl,
-                    rebase_limit=limit,
+                    rebase_limit=rebase_limit,
                     state=state,
                     pipeline_timeout=pipeline_timeout,
                     wait_for_pipeline=wait_for_pipeline,

--- a/reconcile/queries.py
+++ b/reconcile/queries.py
@@ -1750,7 +1750,7 @@ APPS_QUERY = """
         enabled
         rebase
         days_interval
-        limit
+        rebase_limit
         merge_limit
         enable_closing
         pipeline_timeout


### PR DESCRIPTION
## Summary

- Update GraphQL query to fetch `rebase_limit` instead of `limit`
- Update `run()` to read `rebase_limit` from config
- `merge_limit` now defaults to `rebase_limit` when unset (was a separate default)

Step 3b of APPSRE-14266 (reconcile side). Depends on the schema PR (app-sre/qontract-schemas#1041) merging first.

## Test plan

- [x] ruff passes
- [x] Existing tests already use `rebase_limit` parameter name throughout

APPSRE-14266

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Rebase and merge operations can now use separate concurrency limits.
  - Repositories can set a dedicated rebase concurrency limit, with merge concurrency continuing to be configurable independently.
  - When limits aren’t specified, the system applies sensible default and fallback behavior automatically.

- **Bug Fixes**
  - Housekeeping settings are now interpreted consistently so rebase operations reliably use the intended concurrency limit.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->