### PR TITLE
fix(glhk) filter terminal pipeline statuses

### DIFF
--- a/reconcile/gitlab_housekeeping.py
+++ b/reconcile/gitlab_housekeeping.py
@@ -1502,8 +1502,18 @@ def run_error_healthcheck(
         if not pipelines:
             continue
 
+        terminal_pipelines = [
+            p
+            for p in pipelines
+            if p.status not in {PipelineStatus.RUNNING, PipelineStatus.PENDING}
+        ]
+        if not terminal_pipelines:
+            continue
+
         has_pipeline_error = PIPELINE_ERROR in labels
-        is_healthy = check_pipeline_health(pipelines, consecutive_failure_limit)
+        is_healthy = check_pipeline_health(
+            terminal_pipelines, consecutive_failure_limit
+        )
 
         if not is_healthy and not has_pipeline_error:
             logging.warning([

--- a/reconcile/gitlab_housekeeping.py
+++ b/reconcile/gitlab_housekeeping.py
@@ -1505,7 +1505,13 @@ def run_error_healthcheck(
         terminal_pipelines = [
             p
             for p in pipelines
-            if p.status not in {PipelineStatus.RUNNING, PipelineStatus.PENDING}
+            if p.status
+            in {
+                PipelineStatus.SUCCESS,
+                PipelineStatus.FAILED,
+                PipelineStatus.CANCELED,
+                PipelineStatus.SKIPPED,
+            }
         ]
         if not terminal_pipelines:
             continue

--- a/reconcile/test/test_gitlab_housekeeping.py
+++ b/reconcile/test/test_gitlab_housekeeping.py
@@ -1132,11 +1132,12 @@ def _make_healthcheck_mr(
 def test_pipeline_error_label_applied_on_consecutive_failures(
     project: Project,
 ) -> None:
-    """Consecutive pipeline failures apply pipeline-error label."""
+    """Consecutive pipeline failures apply pipeline-error label, even with a running pipeline."""
     mr = _make_healthcheck_mr(labels=["lgtm"])
     mocked_gl = create_autospec(GitLabApi)
     mocked_gl.project = project
     mocked_gl.get_merge_request_pipelines.return_value = _make_pipelines([
+        "running",
         "failed",
         "failed",
         "failed",
@@ -1156,11 +1157,12 @@ def test_pipeline_error_label_applied_on_consecutive_failures(
 def test_pipeline_error_label_auto_removed_on_recovery(
     project: Project,
 ) -> None:
-    """A successful pipeline removes the pipeline-error label."""
+    """A successful terminal pipeline removes the pipeline-error label, even with a running pipeline."""
     mr = _make_healthcheck_mr(labels=["lgtm", "pipeline-error"])
     mocked_gl = create_autospec(GitLabApi)
     mocked_gl.project = project
     mocked_gl.get_merge_request_pipelines.return_value = _make_pipelines([
+        "running",
         "success",
         "failed",
         "failed",
@@ -1174,6 +1176,31 @@ def test_pipeline_error_label_auto_removed_on_recovery(
     )
 
     mocked_gl.remove_label.assert_called_once_with(mr, "pipeline-error")
+    mocked_gl.add_label_to_merge_request.assert_not_called()
+
+
+def test_pipeline_error_not_removed_while_pipeline_running(
+    project: Project,
+) -> None:
+    """A running pipeline alone does not clear the label; terminal failures still dominate."""
+    mr = _make_healthcheck_mr(labels=["lgtm", "pipeline-error"])
+    mocked_gl = create_autospec(GitLabApi)
+    mocked_gl.project = project
+    mocked_gl.get_merge_request_pipelines.return_value = _make_pipelines([
+        "running",
+        "failed",
+        "failed",
+        "failed",
+    ])
+
+    gl_h.run_error_healthcheck(
+        dry_run=False,
+        gl=mocked_gl,
+        project_merge_requests=[mr],
+        consecutive_failure_limit=3,
+    )
+
+    mocked_gl.remove_label.assert_not_called()
     mocked_gl.add_label_to_merge_request.assert_not_called()
 
 


### PR DESCRIPTION
## What

Filter out `running` and `pending` pipelines in `run_error_healthcheck` before evaluating pipeline health. Only completed (terminal) pipelines are now considered when deciding whether to add or remove the `pipeline-error` label.

## Why

MRs with long-running external pipelines (~50 min) and frequent pushes/rebases can have multiple in-progress pipelines at any given time. `check_pipeline_health` checks whether the 3 most recent pipelines are all `failed`, but in-progress pipelines dilute the window — the check sees `[running, running, running]` instead of the underlying `[failed, failed, failed]` and returns "healthy."

This was observed on app-interface MR 198355 (RHOBS config promotion): 31 consecutive failed pipelines over 5 hours, but `pipeline-error` was never applied because the external CI pipelines took ~50 minutes each, ensuring there were always in-progress pipelines in the top 3 when the healthcheck ran. Meanwhile, glhk rebased the MR 50 times unnecessarily.

A comparable MR (198373) with the same labels but faster pipelines (~5 min) correctly received `pipeline-error` within 30 minutes.

## How

Added a terminal pipeline allowlist filter before the existing `check_pipeline_health` call in `run_error_healthcheck`:

```python
terminal_pipelines = [
    p
    for p in pipelines
    if p.status
    in {
        PipelineStatus.SUCCESS,
        PipelineStatus.FAILED,
        PipelineStatus.CANCELED,
        PipelineStatus.SKIPPED,
    }
]
if not terminal_pipelines:
    continue
```

Uses an explicit allowlist of completed statuses rather than a denylist, so non-terminal states like `CREATED`, `PREPARING`, `WAITING_FOR_RESOURCE`, `MANUAL`, and `SCHEDULED` are also excluded. Both the ADD and REMOVE paths use the same filtered list. This means:

- **ADD**: consecutive failures are detected regardless of in-progress pipelines
- **REMOVE**: the label clears only when a completed pipeline breaks the failure streak (e.g., a `success`), not merely when a new pipeline starts running

The `check_pipeline_health` function itself is unchanged.

## Side effects

- The `pipeline-error` label no longer auto-clears the instant a new pipeline starts running. It clears when a pipeline **completes** with a non-failure status. For fast pipelines (~5 min) this is a negligible delay. For slow pipelines (~50 min), this is a feature — it prevents label flapping and stops unnecessary rebase storms while failures persist.
- MRs with only in-progress pipelines (no terminal history) are skipped entirely — no false positives.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Bug Fixes**
  * Pipeline error health checks now consider only completed pipeline states, preventing in-progress pipelines from influencing consecutive-failure detection.
  * The `pipeline-error` label is left intact during in-progress activity and is updated based on terminal outcomes.

* **Tests**
  * Expanded coverage for scenarios that mix running pipelines with consecutive failures and recovery, including a new case ensuring the label isn’t cleared while pipelines are still running.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->