### PR TITLE
qontract-utils k8s: fix project creation

### DIFF
--- a/qontract_utils/qontract_utils/kubernetes/client.py
+++ b/qontract_utils/qontract_utils/kubernetes/client.py
@@ -29,7 +29,12 @@ _Project = create_global_resource(
     kind="Project",
     plural="projects",
 )
-
+_ProjectRequest = create_global_resource(
+    group="project.openshift.io",
+    version="v1",
+    kind="ProjectRequest",
+    plural="projectrequests",
+)
 logger = structlog.get_logger(__name__)
 
 kubernetes_request = Counter(
@@ -258,10 +263,10 @@ class KubernetesApi:
         return self._create_namespace(name)
 
     def _create_project(self, name: str) -> Namespace:
-        """Create via OpenShift Project API, return as Namespace."""
-        project = _Project(metadata=ObjectMeta(name=name))
+        """Create via OpenShift ProjectRequest API, return as Namespace."""
+        project_request = _ProjectRequest(metadata=ObjectMeta(name=name))
         try:
-            self._client.create(project)
+            self._client.create(project_request)
         except ApiError as e:
             if e.status.code != _HTTP_CONFLICT:
                 raise from_api_error(e) from e

--- a/qontract_utils/tests/kubernetes/test_client.py
+++ b/qontract_utils/tests/kubernetes/test_client.py
@@ -359,7 +359,7 @@ def test_create_namespace_uses_project_on_openshift(
 ) -> None:
     """On OpenShift, create_namespace creates a Project then returns Namespace."""
     httpserver.expect_ordered_request(
-        "/apis/project.openshift.io/v1/projects",
+        "/apis/project.openshift.io/v1/projectrequests",
         method="POST",
     ).respond_with_json(k8s_project_json("new-ns"), status=201)
     httpserver.expect_ordered_request(
@@ -377,7 +377,7 @@ def test_create_namespace_project_idempotent_409(
 ) -> None:
     """On OpenShift, 409 on Project create is handled (idempotent)."""
     httpserver.expect_ordered_request(
-        "/apis/project.openshift.io/v1/projects",
+        "/apis/project.openshift.io/v1/projectrequests",
         method="POST",
     ).respond_with_json(
         k8s_status_json(409, "AlreadyExists", 'projects "exists" already exists'),


### PR DESCRIPTION
$TITLE

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved OpenShift namespace/project creation by switching to the supported project request workflow.
  * Preserved idempotent behavior when projects already exist, including conflict handling, and continued to reliably retrieve the resulting namespace.
* **Tests**
  * Updated automated tests to use the new OpenShift project request endpoint for namespace/project creation requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->