### PR TITLE
fix(helm): quote extra_args/extraArgs env values to prevent broken YAML

### DIFF
--- a/helm/qontract-reconcile/templates/template.yaml
+++ b/helm/qontract-reconcile/templates/template.yaml
@@ -368,7 +368,7 @@ objects:
             value: {{ $integration.name }}
           {{- with $shard.extra_args }}
           - name: INTEGRATION_EXTRA_ARGS
-            value: "{{ $shard.extra_args }}"
+            value: {{ $shard.extra_args | quote }}
           {{- end }}
           - name: SLEEP_DURATION_SECS
             {{- if $integration.sleepDurationSecs }}
@@ -693,7 +693,7 @@ objects:
                 value: {{ $integration.name }}
               {{- with $integration.extraArgs }}
               - name: INTEGRATION_EXTRA_ARGS
-                value: "{{ $integration.extraArgs }}"
+                value: {{ $integration.extraArgs | quote }}
               {{- end }}
               - name: GITHUB_API
                 valueFrom:

--- a/reconcile/test/fixtures/helm/extra_args_with_embedded_quotes.yml
+++ b/reconcile/test/fixtures/helm/extra_args_with_embedded_quotes.yml
@@ -1,0 +1,317 @@
+---
+# Source: qontract-reconcile/templates/template.yaml
+apiVersion: template.openshift.io/v1
+kind: Template
+metadata:
+  name: qontract-reconcile
+objects:
+- apiVersion: apps/v1
+  kind: Deployment
+  metadata:
+    labels:
+      app: qontract-reconcile-integ
+    annotations:
+      ignore-check.kube-linter.io/minimum-three-replicas: "qontract-reconcile integrations are sharded and not replicated"
+      ignore-check.kube-linter.io/no-readiness-probe: "qontract-reconcile integrations are not getting traffic"
+      ignore-check.kube-linter.io/no-liveness-probe: "qontract-reconcile integrations are monitored for being stuck"
+      ignore-check.kube-linter.io/unset-cpu-requirements: "no cpu limits"
+    name: qontract-reconcile-integ
+  spec:
+    revisionHistoryLimit: 5
+    replicas: 1
+    selector:
+      matchLabels:
+        app: qontract-reconcile-integ
+    template:
+      metadata:
+        labels:
+          app: qontract-reconcile-integ
+          component: qontract-reconcile
+      spec:
+        serviceAccountName: qontract-reconcile
+        initContainers:
+        - name: config
+          image: ${BUSYBOX_IMAGE}:${BUSYBOX_IMAGE_TAG}@${BUSYBOX_IMAGE_DIGEST}
+          imagePullPolicy: ${BUSYBOX_IMAGE_PULL_POLICY}
+          resources:
+            requests:
+              memory: 10Mi
+              cpu: 15m
+            limits:
+              memory: 20Mi
+          env:
+          - name: LOG_GROUP_NAME
+            valueFrom:
+              secretKeyRef:
+                name: ${CLOUDWATCH_SECRET}
+                key: log_group_name
+          command: ["/bin/sh", "-c"]
+          args:
+          - |
+            # generate fluent.conf
+            cat > /fluentd/etc/fluent.conf <<EOF
+            <source>
+              @type tail
+              path /fluentd/log/integration.log
+              read_from_head true
+              pos_file /fluentd/log/integration.log.pos
+              tag integration
+              <parse>
+                @type none
+              </parse>
+            </source>
+
+            <filter integration>
+              @type grep
+              <exclude>
+                key message
+                pattern /using gql endpoint/
+              </exclude>
+            </filter>
+
+            <filter integration>
+              @type grep
+              <exclude>
+                key message
+                pattern /request_id: /
+              </exclude>
+            </filter>
+
+            <filter integration>
+              @type grep
+              <exclude>
+                key message
+                pattern /Certificate did not match expected hostname/
+              </exclude>
+            </filter>
+
+            <match integration>
+              @type copy
+              <store>
+                @type cloudwatch_logs
+                log_group_name ${LOG_GROUP_NAME}
+                log_stream_name integ
+                auto_create_stream true
+              </store>
+            </match>
+            EOF
+          volumeMounts:
+          - name: fluentd-config
+            mountPath: /fluentd/etc/
+        containers:
+        - name: int
+          image: ${IMAGE}:${IMAGE_TAG}@${IMAGE_DIGEST}
+          ports:
+            - name: http
+              containerPort: 9090
+          env:
+          - name: SHARDS
+            value: "1"
+          - name: SHARD_ID
+            value: "0"
+          - name: DRY_RUN
+            value: ${DRY_RUN}
+          - name: INTEGRATION_NAME
+            value: integ
+          - name: INTEGRATION_EXTRA_ARGS
+            value: "--keycloak-instances '[{\"url\": \"https://sso.example.com\", \"secret\": {\"secret_manager_url\": \"https://vault.example.com:8200\", \"path\": \"some/path\"}}]'"
+          - name: SLEEP_DURATION_SECS
+            value: ${SLEEP_DURATION_SECS}
+          - name: GITHUB_API
+            valueFrom:
+              configMapKeyRef:
+                name: app-interface
+                key: GITHUB_API
+          - name: SENTRY_DSN
+            valueFrom:
+              configMapKeyRef:
+                name: app-interface
+                key: SENTRY_DSN
+          - name: LOG_FILE
+            value: "${LOG_FILE}"
+          - name: UNLEASH_API_URL
+            valueFrom:
+              secretKeyRef:
+                name: unleash
+                key: API_URL
+                optional: true
+          - name: UNLEASH_CLIENT_ACCESS_TOKEN
+            valueFrom:
+              secretKeyRef:
+                name: unleash
+                key: CLIENT_ACCESS_TOKEN
+                optional: true
+          - name: SLOW_OC_RECONCILE_THRESHOLD
+            value: "${SLOW_OC_RECONCILE_THRESHOLD}"
+          - name: LOG_SLOW_OC_RECONCILE
+            value: "${LOG_SLOW_OC_RECONCILE}"
+          - name: USE_NATIVE_CLIENT
+            value: "${USE_NATIVE_CLIENT}"
+          - name: KUBE_SA_TOKEN_PATH
+            value: "${KUBE_SA_TOKEN_MOUNT_PATH}/${KUBE_SA_TOKEN_FILENAME}"
+          - name: USED_FOR_SECURITY
+            value: "${USED_FOR_SECURITY}"
+          resources:
+            limits:
+              memory: ${INTEG_MEMORY_LIMIT}
+            requests:
+              cpu: ${INTEG_CPU_REQUEST}
+              memory: ${INTEG_MEMORY_REQUEST}
+          volumeMounts:
+          - name: tmp-dir
+            mountPath: /tmp
+          - name: qontract-reconcile-toml
+            mountPath: /config
+          - name: logs
+            mountPath: /fluentd/log/
+          - name: qontract-reconcile-sa-token
+            mountPath: ${KUBE_SA_TOKEN_MOUNT_PATH}
+        - name: fluentd
+          image: ${FLUENTD_IMAGE}:${FLUENTD_IMAGE_TAG}@${FLUENTD_IMAGE_DIGEST}
+          imagePullPolicy: ${FLUENTD_IMAGE_PULL_POLICY}
+          env:
+          - name: AWS_REGION
+            valueFrom:
+              secretKeyRef:
+                name: ${CLOUDWATCH_SECRET}
+                key: aws_region
+          - name: AWS_ACCESS_KEY_ID
+            valueFrom:
+              secretKeyRef:
+                name: ${CLOUDWATCH_SECRET}
+                key: aws_access_key_id
+          - name: AWS_SECRET_ACCESS_KEY
+            valueFrom:
+              secretKeyRef:
+                name: ${CLOUDWATCH_SECRET}
+                key: aws_secret_access_key
+          resources:
+            requests:
+              memory: 30Mi
+              cpu: 15m
+            limits:
+              memory: 120Mi
+          volumeMounts:
+          - name: logs
+            mountPath: /fluentd/log/
+          - name: fluentd-config
+            mountPath: /fluentd/etc/
+        volumes:
+        - name: qontract-reconcile-sa-token
+          projected:
+            sources:
+            - serviceAccountToken:
+                expirationSeconds: 1800
+                path: ${KUBE_SA_TOKEN_FILENAME}
+        - name: qontract-reconcile-toml
+          secret:
+            secretName: ${QONTRACT_RECONCILE_TOML_SECRET_NAME}
+        - name: logs
+          emptyDir: {}
+        - name: fluentd-config
+          emptyDir: {}
+        - name: tmp-dir
+          emptyDir: { }
+- apiVersion: v1
+  kind: Service
+  metadata:
+    name: qontract-reconcile
+    labels:
+      app: qontract-reconcile
+  spec:
+    ports:
+      - protocol: TCP
+        port: 80
+        targetPort: 9090
+        name: http
+    selector:
+      component: qontract-reconcile
+parameters:
+- name: IMAGE
+  value: quay.io/app-sre/qontract-reconcile
+- name: IMAGE_TAG
+  value: latest
+- name: IMAGE_DIGEST
+  value: ''
+- name: BUSYBOX_IMAGE
+  value: registry.access.redhat.com/ubi8/ubi-minimal
+- name: BUSYBOX_IMAGE_TAG
+  value: 8.10-1781701121
+- name: BUSYBOX_IMAGE_DIGEST
+  value: 'sha256:5d76d0cedabd7d7893b28bec684d7a3412dd8d95d186e7d4b6eeed4ea28c327b'
+- name: BUSYBOX_IMAGE_PULL_POLICY
+  value: Always
+- name: FLUENTD_IMAGE
+  value: quay.io/redhat-services-prod/app-sre-tenant/fluentd-master/fluentd-master
+- name: FLUENTD_IMAGE_TAG
+  value: d0d1812
+- name: FLUENTD_IMAGE_DIGEST
+  value: 'sha256:4868ac49b42f14ff0878216cd2c618413209f634a5c9a6c004e353e1b0805e60'
+- name: FLUENTD_IMAGE_PULL_POLICY
+  value: Always
+- name: ENVIRONMENT_NAME
+  value: app-interface
+- name: DRY_RUN
+  value: --dry-run
+- name: MANAGER_DRY_RUN
+  value: --dry-run
+- name: SLEEP_DURATION_SECS
+  value: "300"
+- name: QONTRACT_RECONCILE_TOML_SECRET_NAME
+  value: qontract-reconcile-toml
+- name: APP_INTERFACE_SQS_SECRET_NAME
+  value: app-interface-sqs
+- name: APP_INTERFACE_STATE_BUCKET_ACCOUNT
+  value: app-sre
+- name: AWS_CONFIG_SECRET_NAME
+  value: app-interface-aws-config
+- name: APP_INTERFACE_PROJECT_ID
+  value: "0"
+- name: USER_ID
+  value: dummy
+- name: KUBE_SA_TOKEN_MOUNT_PATH
+  value: '/var/run/secrets/kubernetes.io/serviceaccount'
+- name: KUBE_SA_TOKEN_FILENAME
+  value: 'token'
+- name: LOG_FILE
+  value: "/fluentd/log/integration.log"
+- name: SLACK_CHANNEL
+  value: "sd-app-sre-reconcile-stage"
+- name: SLACK_CHANNEL_TRIGGER
+  value: "sd-app-sre-triggers-stage"
+- name: SLACK_ICON_EMOJI
+  value: ":bust_in_silhouette:"
+- name: GITHUB_API
+  value: 'http://github-mirror.github-mirror-stage.svc.cluster.local'
+- name: CLOUDWATCH_SECRET
+  value: app-interface-cloudwatch
+- name: SENTRY_DSN
+  value: ""
+- name: SLOW_OC_RECONCILE_THRESHOLD
+  value: "600"
+- name: LOG_SLOW_OC_RECONCILE
+  value: "false"
+- name: USE_NATIVE_CLIENT
+  value: ""
+- name: INTERNAL_CERTIFICATES_IMAGE
+  value: quay.io/app-sre/internal-redhat-ca
+- name: INTERNAL_CERTIFICATES_IMAGE_TAG
+  value: latest
+- name: INTERNAL_CERTIFICATES_IMAGE_PULL_POLICY
+  value: Always
+- name: INTEGRATIONS_MANAGER_UPSTREAM
+  value: ''
+- name: INTEGRATIONS_MANAGER_IMAGE
+  value: ''
+- name: INTEGRATIONS_MANAGER_IMAGE_TAG_FROM_REF
+  value: ''
+- name: PUSHGATEWAY_SECRET_NAME
+  value: push-gateway-auth-url
+- name: USED_FOR_SECURITY
+  value: ''
+- name: INTEG_MEMORY_LIMIT
+  value: 90Mi
+- name: INTEG_CPU_REQUEST
+  value: 123
+- name: INTEG_MEMORY_REQUEST
+  value: 45Mi

--- a/reconcile/test/utils/test_helm.py
+++ b/reconcile/test/utils/test_helm.py
@@ -118,6 +118,22 @@ def test_template_extra_args(
     assert template == expected
 
 
+def test_template_extra_args_with_embedded_quotes(
+    helm_integration_specs: Sequence[HelmIntegrationSpec],
+) -> None:
+    """extra_args values containing literal double quotes (e.g. embedded JSON, as used
+    by --keycloak-instances) must not break the rendered YAML."""
+    extra_args = (
+        '--keycloak-instances \'[{"url": "https://sso.example.com", '
+        '"secret": {"secret_manager_url": "https://vault.example.com:8200", '
+        '"path": "some/path"}}]\''
+    )
+    helm_integration_specs[0].shard_specs[0].extra_args = extra_args
+    template = helm.template(build_helm_values(helm_integration_specs))
+    expected = yaml.safe_load(fxt.get("extra_args_with_embedded_quotes.yml"))
+    assert template == expected
+
+
 def test_template_extra_env(
     helm_integration_specs: Sequence[HelmIntegrationSpec],
 ) -> None:


### PR DESCRIPTION
## Summary
- `INTEGRATION_EXTRA_ARGS` was interpolated in the Helm chart as `value: "{{ ... }}"` without escaping. Any `extra_args`/`extraArgs` value containing a literal double quote (e.g. a JSON payload passed to `--keycloak-instances` for `rhidp-sso-client-api`) produced invalid YAML, causing `helm template` to fail with `did not find expected key`.
- Fixed both occurrences (`$shard.extra_args` for regular Deployments, `$integration.extraArgs` for CronJob-based integrations) to use the `quote` template function, which properly escapes embedded quotes.

## Test plan
- Added `test_template_extra_args_with_embedded_quotes` in `reconcile/test/utils/test_helm.py`, reproducing an `extra_args` value with embedded JSON/double quotes.
- Verified the test fails with the old (unfixed) template (`HelmTemplateError: ... did not find expected key`) and passes with the fix.
- `uv run pytest reconcile/test/utils/test_helm.py` — 29 passed.
- `uv run ruff check` / `ruff format --check` clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Helm rendering of `INTEGRATION_EXTRA_ARGS` to handle values containing embedded double quotes, avoiding incorrect YAML escaping in generated Deployments/StatefulSets and CronJobs.
* **Tests**
  * Added a new Helm fixture covering JSON-like `extra_args` with embedded quotes.
  * Added a pytest that asserts rendered manifests match the fixture output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->