### PR TITLE
Fix User and Group resource kind

### DIFF
--- a/reconcile/utils/oc.py
+++ b/reconcile/utils/oc.py
@@ -66,6 +66,8 @@ urllib3.disable_warnings()
 GET_REPLICASET_MAX_ATTEMPTS = 20
 DEFAULT_GROUP = ""
 PROJECT_KIND = "Project.project.openshift.io"
+USER_KIND = "User.user.openshift.io"
+GROUP_KIND = "Group.user.openshift.io"
 POD_RECYCLE_SUPPORTED_TRIGGER_KINDS = [
     "ConfigMap",
     "Secret",
@@ -657,7 +659,7 @@ class OCCli:
 
     def get_group_if_exists(self, name: str) -> dict[str, Any] | None:
         try:
-            return self.get(None, "Group", name)
+            return self.get(None, GROUP_KIND, name)
         except StatusCodeError as e:
             if "NotFound" in str(e):
                 return None
@@ -674,10 +676,10 @@ class OCCli:
         self._run(cmd)
 
     def get_users(self) -> Iterable[dict[str, Any]]:
-        return self.get_all("User")["items"]
+        return self.get_all(USER_KIND)["items"]
 
     def delete_user(self, user_name: str) -> None:
-        user = self.get(None, "User", user_name)
+        user = self.get(None, USER_KIND, user_name)
         cmd = ["delete", "user", user_name]
         self._run(cmd)
         for identity in user["identities"]:

--- a/reconcile/utils/oc.py
+++ b/reconcile/utils/oc.py
@@ -680,7 +680,7 @@ class OCCli:
 
     def delete_user(self, user_name: str) -> None:
         user = self.get(None, USER_KIND, user_name)
-        cmd = ["delete", "user", user_name]
+        cmd = ["delete", USER_KIND, user_name]
         self._run(cmd)
         for identity in user["identities"]:
             cmd = ["delete", "identity", identity]


### PR DESCRIPTION
Within the FedRAMP environment, `openshift-users` and `openshift-groups` integrations crash with `AmbiguousResourceTypeError` on any cluster that has a second `User` or `Group` kind registered (e.g. from the OpenStack Resource Controller CRDs).

The code in reconcile/utils/oc.py calls:

`get_all("User") in get_users()`
`get(None, "User", ...) in delete_user()`
`get(None, "Group", ...) in get_group_if_exists()`

These need to be qualified:

`User -> User.user.openshift.io`
`Group -> Group.user.openshift.io`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved consistency when managing OpenShift users and groups.
  * User and group operations now use standardized resource types for more reliable lookups and deletions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->