### PR TITLE
ci: retrigger pipelines for #5706

### DIFF
--- a/reconcile/gitlab_housekeeping.py
+++ b/reconcile/gitlab_housekeeping.py
@@ -321,7 +321,7 @@ def check_pipeline_health(
     """Return True if MR is healthy (should stay in queue).
 
     Return False if last `consecutive_failure_limit` pipelines all
-    ended in a non-success terminal state (FAILED).
+    ended in a non-success terminal state, (FAILED or CANCELLED).
     """
     pipeline_failure_window = pipelines[:consecutive_failure_limit]
     if len(pipeline_failure_window) < consecutive_failure_limit:


### PR DESCRIPTION
## Summary
- Empty commit to retrigger clean on-push Konflux builds for #5706 

## Context
The previous push (`b1808ccd`) has a failed "pr group" Enterprise Contract check caused by running `/retest` post-merge, which triggered a group snapshot EC validation for the first time. The group EC test fails on `qontract-reconcile-fips-master` because the `ecosystem-cert-preflight-checks` task's `IMAGES_PROCESSED` does not include the image-index digest.

This empty commit produces a fresh push to master with clean on-push builds, unblocking the promotion MR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified that cancelled pipelines, in addition to failed pipelines, are considered non-success outcomes when assessing pipeline health.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->