### PR TITLE
Revert fix(aus): skip 400 errors on channel switch for org-less SAs

### DIFF
--- a/reconcile/aus/base.py
+++ b/reconcile/aus/base.py
@@ -1445,16 +1445,6 @@ def act_channel_switches(
             update_cluster_channel(ocm_api, switch.cluster.id, switch.to_channel)
         except HTTPError as e:
             detail = e.response.text if e.response is not None else ""
-            if (
-                e.response is not None
-                and e.response.status_code == 400
-                and "could not locate organization" in detail.lower()
-            ):
-                # OCM returns 400 for org-less service accounts (ROSAENG-62340)
-                logging.warning(
-                    f"{switch.cluster.name}: channel switch failed: {e}: {detail}"
-                )
-                continue
             logging.error(
                 f"{switch.cluster.name}: channel switch failed: {e}: {detail}"
             )

--- a/reconcile/test/ocm/aus/test_channel_switch.py
+++ b/reconcile/test/ocm/aus/test_channel_switch.py
@@ -280,41 +280,11 @@ def test_act_success_emits_gauge(
 
 @patch("reconcile.aus.base.update_cluster_channel")
 @patch("reconcile.aus.base.metrics")
-def test_act_http_400_warns_and_continues(
+def test_act_http_error_skips_gauge_continues(
     mock_metrics: MagicMock, mock_update: MagicMock
 ) -> None:
     response = MagicMock()
-    response.text = "Could not locate organization id"
-    response.status_code = 400
-    mock_update.side_effect = HTTPError(response=response)
-    cluster1 = build_ocm_cluster(name="c1", version="4.20.10", channel="stable-4.20")
-    cluster2 = build_ocm_cluster(name="c2", version="4.20.10", channel="stable-4.20")
-    switches = [
-        ChannelSwitchAction(
-            cluster=c,
-            from_channel="stable-4.20",
-            to_channel="stable-4.21",
-            org_id="org1",
-        )
-        for c in [cluster1, cluster2]
-    ]
-    act_channel_switches(
-        dry_run=False,
-        channel_switches=switches,
-        ocm_api=MagicMock(),
-    )
-    assert mock_update.call_count == 2
-    mock_metrics.set_gauge.assert_not_called()
-
-
-@patch("reconcile.aus.base.update_cluster_channel")
-@patch("reconcile.aus.base.metrics")
-def test_act_http_non_400_error_raises(
-    mock_metrics: MagicMock, mock_update: MagicMock
-) -> None:
-    response = MagicMock()
-    response.text = "forbidden"
-    response.status_code = 403
+    response.text = "error"
     mock_update.side_effect = HTTPError(response=response)
     cluster1 = build_ocm_cluster(name="c1", version="4.20.10", channel="stable-4.20")
     cluster2 = build_ocm_cluster(name="c2", version="4.20.10", channel="stable-4.20")
@@ -335,31 +305,4 @@ def test_act_http_non_400_error_raises(
         )
     assert mock_update.call_count == 2
     assert len(exc_info.value.exceptions) == 2
-    mock_metrics.set_gauge.assert_not_called()
-
-
-@patch("reconcile.aus.base.update_cluster_channel")
-@patch("reconcile.aus.base.metrics")
-def test_act_http_400_unrelated_error_raises(
-    mock_metrics: MagicMock, mock_update: MagicMock
-) -> None:
-    response = MagicMock()
-    response.text = "invalid channel name"
-    response.status_code = 400
-    mock_update.side_effect = HTTPError(response=response)
-    cluster1 = build_ocm_cluster(name="c1", version="4.20.10", channel="stable-4.20")
-    switches = [
-        ChannelSwitchAction(
-            cluster=cluster1,
-            from_channel="stable-4.20",
-            to_channel="stable-4.21",
-            org_id="org1",
-        )
-    ]
-    with pytest.raises(ExceptionGroup, match="Channel switch errors"):
-        act_channel_switches(
-            dry_run=False,
-            channel_switches=switches,
-            ocm_api=MagicMock(),
-        )
     mock_metrics.set_gauge.assert_not_called()


### PR DESCRIPTION
## Summary
- Reverts #5695 — the 400 error workaround for org-less service accounts on channel switch
- OCM fixed the underlying issue (ROSAENG-62340) server-side, so the client-side workaround is no longer needed
- The workaround was masking a channel flip-flop loop between AUS and OSD Fleet Manager

## Test plan
- [ ] CI passes (lint, types, unit tests)
- [ ] Verify channel switches return 200 without the workaround (OCM fix deployed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling during channel switching so all HTTP errors are consistently reported.
  * Failed channel-switch operations now contribute to the final error result instead of being silently ignored.
  * Processing continues for other channel switches, while affected operations are clearly surfaced.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->