### PR TITLE
feat(qontract-cli): add aws_account_id and availability_zone_ids to clusters_network output

### DIFF
--- a/reconcile/utils/aws_api.py
+++ b/reconcile/utils/aws_api.py
@@ -1005,7 +1005,11 @@ class AWSApi:
             if subnets:
                 vpc_subnets = self.get_vpc_subnets(vpc_id, assumed_ec2)
                 subnets_id_az = [
-                    {"id": s["SubnetId"], "az": s["AvailabilityZone"]}
+                    {
+                        "id": s["SubnetId"],
+                        "az": s["AvailabilityZone"],
+                        "az_id": s["AvailabilityZoneId"],
+                    }
                     for s in vpc_subnets
                 ]
             if hcp_vpc_endpoint_sg:

--- a/tools/qontract_cli.py
+++ b/tools/qontract_cli.py
@@ -120,6 +120,7 @@ from reconcile.utils import (
     promtool,
 )
 from reconcile.utils.aws_api import AWSApi
+from reconcile.utils.aws_helper import get_account_uid_from_arn
 from reconcile.utils.binary import (
     binary,
     binary_version,
@@ -1013,10 +1014,12 @@ def clusters_network(ctx: click.Context, name: str) -> None:
 
     columns = [
         "name",
+        "aws_account_id",
         "vpc_id",
         "network.vpc",
         "network.service",
         "network.pod",
+        "availability_zone_ids",
         "egress_ips",
     ]
     ocm_map = OCMMap(clusters=clusters, settings=settings)
@@ -1039,6 +1042,7 @@ def clusters_network(ctx: click.Context, name: str) -> None:
                 "assume_region": cluster["spec"]["region"],
                 "assume_cidr": cluster["network"]["vpc"],
             })
+            cluster["aws_account_id"] = account["uid"]
         else:
             account = tfvpc._build_infrastructure_assume_role(
                 management_account,
@@ -1052,10 +1056,15 @@ def clusters_network(ctx: click.Context, name: str) -> None:
             account["resourcesDefaultRegion"] = management_account[
                 "resourcesDefaultRegion"
             ]
+            cluster["aws_account_id"] = get_account_uid_from_arn(account["assume_role"])
         with AWSApi(1, [account], settings=settings, init_users=False) as aws_api:
-            vpc_id, _, _, _ = aws_api.get_cluster_vpc_details(account)
+            vpc_id, _, subnets_id_az, _ = aws_api.get_cluster_vpc_details(
+                account, subnets=True
+            )
             assert vpc_id
             cluster["vpc_id"] = vpc_id
+            az_ids = sorted({s["az_id"] for s in subnets_id_az or [] if s["az_id"]})
+            cluster["availability_zone_ids"] = ", ".join(az_ids)
             egress_ips = aws_api.get_cluster_nat_gateways_egress_ips(account, vpc_id)
             cluster["egress_ips"] = ", ".join(sorted(egress_ips))
 


### PR DESCRIPTION
## Summary
- Adds `aws_account_id` column to the `clusters_network` CLI command output
  - For CCS/ROSA clusters: uses `account["uid"]` directly from the cluster spec
  - For non-CCS clusters: extracts the account ID from the assume role ARN via `get_account_uid_from_arn`
- Adds `availability_zone_ids` column showing the AZ IDs (e.g. `use1-az1`) for each cluster's VPC subnets
- Extends `get_cluster_vpc_details` to include `az_id` in the subnet data

## Test plan
- [x] Run `qontract-cli get clusters-network` and verify both new columns appear
- [x] Compare `aws_account_id` output with `qontract-cli get clusters-aws-account-ids` — account IDs match
- [x] Verify `availability_zone_ids` shows correct AZ IDs per cluster

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - The cluster network report now includes the AWS account ID associated with each cluster.
  - Availability Zone IDs are displayed alongside cluster network information as a sorted, comma-separated list.
  - VPC subnet details now include both Availability Zone names and their corresponding IDs, providing clearer regional placement information.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->