### PR TITLE
fix(change-owners): render Diff.path without jsonpath_ng 1.8.0 parens

### DIFF
--- a/reconcile/change_owners/diff.py
+++ b/reconcile/change_owners/diff.py
@@ -12,7 +12,7 @@ from deepdiff.helper import CannotCompare
 from deepdiff.path import parse_path
 
 from reconcile.utils.json import json_dumps
-from reconcile.utils.jsonpath import remove_prefix_from_path
+from reconcile.utils.jsonpath import jsonpath_parts, remove_prefix_from_path
 
 if TYPE_CHECKING:
     from deepdiff.model import DiffLevel
@@ -22,6 +22,46 @@ class DiffType(Enum):
     ADDED = "added"
     REMOVED = "removed"
     CHANGED = "changed"
+
+
+class _DottedChild(jsonpath_ng.Child):
+    """
+    Same as `jsonpath_ng.Child`, but renders as a plain dotted path, e.g.
+    `resourceTemplates.[0].targets.[0].parameters.A`.
+
+    jsonpath_ng 1.8.0 wraps every `Child` in parentheses when stringified
+    (e.g. `(((a.b).c).d)`) to disambiguate operator precedence for
+    re-parsing. `Diff.path` is only ever rendered for display (MR check
+    output, logs, error messages), never re-parsed, so the parens just
+    hurt readability.
+    """
+
+    def __str__(self) -> str:
+        return f"{self.left}.{self.right}"
+
+
+def _join_for_display(
+    left: jsonpath_ng.JSONPath, right: jsonpath_ng.JSONPath
+) -> jsonpath_ng.JSONPath:
+    if isinstance(left, jsonpath_ng.This | jsonpath_ng.Root):
+        return right
+    if isinstance(right, jsonpath_ng.This):
+        return left
+    if isinstance(right, jsonpath_ng.Root):
+        return right
+    return _DottedChild(left, right)
+
+
+def _normalize_for_display(path: jsonpath_ng.JSONPath) -> jsonpath_ng.JSONPath:
+    """
+    Rebuild `path` using `_DottedChild` so it always renders as a plain
+    dotted string, regardless of how it was originally constructed. This
+    matters because jsonpath_ng's own `find()` traversal also builds
+    `Child` chains internally (e.g. when resolving a change-type's
+    self-service path against actual file content), so we can't rely on
+    controlling every path's construction site.
+    """
+    return reduce(_join_for_display, jsonpath_parts(path))
 
 
 @dataclass
@@ -34,6 +74,9 @@ class Diff:
     diff_type: DiffType
     old: Any | None
     new: Any | None
+
+    def __post_init__(self) -> None:
+        self.path = _normalize_for_display(self.path)
 
     def create_subdiff(self, sub_path: jsonpath_ng.JSONPath) -> Diff:
         if sub_path == self.path:

--- a/reconcile/test/change_owners/test_change_type_diff.py
+++ b/reconcile/test/change_owners/test_change_type_diff.py
@@ -11,6 +11,7 @@ from reconcile.test.change_owners.fixtures import (
     build_bundle_datafile_change,
     build_bundle_resourcefile_change,
 )
+from reconcile.utils.output import format_table
 
 #
 # deep diff path translation
@@ -45,6 +46,90 @@ def test_deepdiff_path_to_jsonpath(
 def test_deepdiff_invalid() -> None:
     with pytest.raises(ValueError):
         deepdiff_path_to_jsonpath("something_invalid")
+
+
+@pytest.mark.parametrize(
+    "jsonpath_expression,expected_path_str",
+    [
+        ("field", "field"),
+        ("resourceTemplates.[0]", "resourceTemplates.[0]"),
+        (
+            "resourceTemplates.[0].targets.[0].parameters.A",
+            "resourceTemplates.[0].targets.[0].parameters.A",
+        ),
+        ("$", "$"),
+    ],
+)
+def test_diff_path_str_no_parentheses(
+    jsonpath_expression: str, expected_path_str: str
+) -> None:
+    """
+    jsonpath_ng 1.8.0 introduced parentheses into `Child.__str__`, e.g.
+    `(((a.b).c).d)`, to disambiguate operator precedence when re-parsing.
+    Diff.path_str() is used for display purposes (e.g. MR check output)
+    and must keep rendering plain dotted paths without parentheses.
+    """
+    diff = Diff(
+        path=jsonpath_ng.parse(jsonpath_expression),
+        diff_type=DiffType.CHANGED,
+        old="old",
+        new="new",
+    )
+    assert diff.path_str() == expected_path_str
+    # the underlying path object must render correctly by itself too, since
+    # e.g. change_owners.py puts raw Diff.path objects into report dicts
+    # that get stringified implicitly (via tabulate), never calling
+    # path_str() explicitly.
+    assert str(diff.path) == expected_path_str
+
+
+def test_diff_path_from_jsonpath_find_traversal_renders_without_parens() -> None:
+    """
+    jsonpath_ng's own `find()` traversal builds `Child` chains internally
+    (e.g. when a change-type's self-service path containing a wildcard gets
+    resolved against actual file content while splitting a diff for partial
+    coverage). Diff must normalize such externally-constructed paths too,
+    not just the ones it builds itself via deepdiff_path_to_jsonpath.
+    """
+    content = {"openshiftResources": [{"a": 1}, {"variables": {"var2": "x"}}]}
+    resolved_path = (
+        jsonpath_ng
+        .parse("openshiftResources.[*].variables.var2")
+        .find(content)[0]
+        .full_path
+    )
+    # sanity check: the raw, library-constructed path does have parens
+    assert "(" in str(resolved_path)
+
+    diff = Diff(
+        path=resolved_path,
+        diff_type=DiffType.CHANGED,
+        old="old",
+        new="new",
+    )
+    assert diff.path_str() == "openshiftResources.[1].variables.var2"
+    assert str(diff.path) == "openshiftResources.[1].variables.var2"
+
+
+def test_diff_path_renders_without_parens_in_mr_report_table() -> None:
+    """
+    change_owners.add_coverage_report_to_merge_request() and
+    write_coverage_report_to_stdout() put raw Diff.path objects into dicts
+    that reconcile.utils.output.format_table() renders via tabulate, without
+    ever calling path_str(). This must render cleanly without any change to
+    that display code.
+    """
+    diff = Diff(
+        path=deepdiff_path_to_jsonpath(
+            "root['resourceTemplates'][0]['targets'][0]['parameters']['A']"
+        ),
+        diff_type=DiffType.CHANGED,
+        old="old",
+        new="new",
+    )
+    table = format_table([{"change": diff.path}], ["change"])
+    assert "(" not in table
+    assert "resourceTemplates.[0].targets.[0].parameters.A" in table
 
 
 def test_deepdiff_path_element_with_dot() -> None:

--- a/reconcile/test/change_owners/test_change_type_diff.py
+++ b/reconcile/test/change_owners/test_change_type_diff.py
@@ -58,6 +58,9 @@ def test_deepdiff_invalid() -> None:
             "resourceTemplates.[0].targets.[0].parameters.A",
         ),
         ("$", "$"),
+        # an explicit "$." prefix is intentionally dropped too, for consistency
+        # with every other displayed path never showing a leading "$"
+        ("$.field", "field"),
     ],
 )
 def test_diff_path_str_no_parentheses(


### PR DESCRIPTION
## Summary
- jsonpath_ng 1.8.0 wraps every `Child` node in parentheses when stringified (e.g. `(((a.b).c).d)`) to disambiguate precedence for re-parsing. Since the change-owners MR check puts raw `Diff.path` objects into report tables that stringify them implicitly, this made the change coverage report unreadable, e.g. `(((((resourceTemplates.[0]).targets).[0]).parameters).A)` instead of `resourceTemplates.[0].targets.[0].parameters.A`.
  - Example MR comment **with** the parens (jsonpath-ng 1.8.0): https://gitlab.cee.redhat.com/service/app-interface/-/merge_requests/199516
  - Example MR comment **without** the parens (jsonpath-ng 1.7.0, before the bump): https://gitlab.cee.redhat.com/service/app-interface/-/merge_requests/199413
- `Diff` now normalizes its `path` once in `__post_init__`, rebuilding it with a private `Child` subclass that renders as a plain dotted string. This also covers paths built internally by jsonpath_ng's own `find()` traversal (used when resolving a change-type's self-service path against real file content for partial/split diff coverage), so no display call site needs to change.

## Test plan
- [x] `uv run pytest reconcile/test/change_owners/ reconcile/test/utils/test_jsonpath.py reconcile/test/runtime/test_utils_desired_state_diff.py` — 218 passed
- [x] Added tests reproducing the bug (verified they fail without the fix): rendering of nested paths, paths built via jsonpath_ng's `find()` traversal, and the actual `format_table`/tabulate rendering path used by the MR report
- [x] `mypy reconcile/change_owners/` — clean
- [x] `ruff check` / `ruff format --check` — clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved change report paths with clearer dotted notation.
  * Removed confusing nested parentheses from displayed JSON paths.
  * Ensured paths are formatted consistently across generated reports and merge-request tables.
  * Made nested fields easier to read and interpret in change summaries.

* **Tests**
  * Added coverage for parsed paths, traversed paths, nested field formatting, and report table output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->