### PR TITLE
fix(rhidp): correct grafana dashboard queries after qontract-api migration

### DIFF
--- a/grafana-dashboards/sre-capability-idp.configmap.yaml
+++ b/grafana-dashboards/sre-capability-idp.configmap.yaml
@@ -137,7 +137,7 @@ data:
                 "uid": "P7B77307D2CE073BC"
               },
               "editorMode": "code",
-              "expr": "sum(rhidp_managed_clusters{integration=~\"rhidp-sso-client.*\"})",
+              "expr": "sum(max by (org_id, ocm_environment) (rhidp_managed_clusters{integration=~\"rhidp-sso-client.*\"}))",
               "interval": "10m",
               "legendFormat": "rhidp-sso-client integration",
               "range": true,
@@ -149,7 +149,7 @@ data:
                 "uid": "P7B77307D2CE073BC"
               },
               "editorMode": "code",
-              "expr": "sum(rhidp_managed_clusters{integration=~\"ocm-oidc-idp.*\"})",
+              "expr": "sum(max by (org_id, ocm_environment) (rhidp_managed_clusters{integration=~\"ocm-oidc-idp.*\"}))",
               "hide": false,
               "interval": "10m",
               "legendFormat": "ocm-oidc-idp integration",
@@ -248,7 +248,7 @@ data:
                 "uid": "P7B77307D2CE073BC"
               },
               "editorMode": "code",
-              "expr": "sum(rhidp_sso_client_number_of_clients{integration=~\"rhidp-sso-client.*\"})",
+              "expr": "sum(max by (ocm_environment) (rhidp_sso_client_number_of_clients{integration=~\"rhidp-sso-client.*\"}))",
               "interval": "10m",
               "legendFormat": "__auto",
               "range": true,
@@ -263,7 +263,7 @@ data:
             "type": "prometheus",
             "uid": "P7B77307D2CE073BC"
           },
-          "description": "Expiration date for auth.stage.redhat.com initial-access-token (IAT)",
+          "description": "Expiration date for prod initial-access-token (IAT)",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -315,14 +315,14 @@ data:
                 "uid": "P7B77307D2CE073BC"
               },
               "editorMode": "code",
-              "expr": "rhidp_sso_client_inital_access_token_expiration{integration=\"rhidp-sso-client\", path=\"app-sre/creds/rhidp/auth.redhat.com\"} * 1000",
+              "expr": "max(rhidp_sso_client_inital_access_token_expiration{integration=\"rhidp-sso-client\", path=\"apps/sso-iat/share-with/app/ai-app-sre/iat\"}) * 1000",
               "interval": "5m",
               "legendFormat": "__auto",
               "range": true,
               "refId": "A"
             }
           ],
-          "title": "IAT Expiration Date (auth.redhat.com)",
+          "title": "IAT Expiration Date (keycloak prod)",
           "type": "stat"
         },
         {
@@ -330,7 +330,7 @@ data:
             "type": "prometheus",
             "uid": "P7B77307D2CE073BC"
           },
-          "description": "Expiration date for auth.stage.redhat.com initial-access-token (IAT)",
+          "description": "Expiration date for stage initial-access-token (IAT)",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -382,14 +382,14 @@ data:
                 "uid": "P7B77307D2CE073BC"
               },
               "editorMode": "code",
-              "expr": "rhidp_sso_client_inital_access_token_expiration{integration=\"rhidp-sso-client\", path=\"app-sre/creds/rhidp/auth.stage.redhat.com\"} * 1000",
+              "expr": "max(rhidp_sso_client_inital_access_token_expiration{integration=\"rhidp-sso-client\", path=\"apps/sso-iat/share-with/app/ai-app-sre/iat-stage\"}) * 1000",
               "interval": "5m",
               "legendFormat": "__auto",
               "range": true,
               "refId": "A"
             }
           ],
-          "title": "IAT Expiration Date (auth.stage.redhat.com)",
+          "title": "IAT Expiration Date (keycloak stage)",
           "type": "stat"
         }
       ],
@@ -406,6 +406,6 @@ data:
       "timezone": "",
       "title": "RedHat SSO IDP Overview",
       "uid": "0lZiDarVz",
-      "version": 5,
+      "version": 6,
       "weekStart": ""
     }

--- a/opa/Dockerfile
+++ b/opa/Dockerfile
@@ -13,7 +13,7 @@ COPY opa/authz /authz
 # Test image
 #
 FROM base AS test
-COPY --from=ghcr.io/styrainc/regal:0.35.1@sha256:7caf9953f1c49054c94030ec7be087b46ae501fc347cdaace9557a57abd3f4ff /ko-app/regal /bin/regal
+COPY --from=ghcr.io/open-policy-agent/regal:0.42.0@sha256:07984036043f772a1f921bd0ad9045b8bd9dc58460a1d76f476c458dc8a98b16 /ko-app/regal /bin/regal
 
 USER 0
 RUN microdnf install -y make


### PR DESCRIPTION
## Summary
- The `rhidp-sso-client` integration now runs as multiple `qontract-api-worker` replicas instead of a single `reconcile` pod, so `rhidp_managed_clusters` and `rhidp_sso_client_number_of_clients` were being summed once per replica, inflating the numbers on the dashboard. Queries now dedupe with `max by (...)` before summing, so the panels are correct regardless of replica count.
- Updated the `rhidp_sso_client_inital_access_token_expiration` panels to match the new Vault `path` values for the prod/stage Keycloak IAT secrets (the old `app-sre/creds/rhidp/auth*.redhat.com` paths no longer exist).
- Bumped the dashboard `version`.

## Test plan
- [x] Validated the ConfigMap YAML/embedded dashboard JSON parses correctly
- [x] Manually verified new PromQL expressions against a live Prometheus query dump from both the old (`reconcile`) and new (`qontract-api`) integration

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Dashboard Updates**
  * Improved Grafana metrics for managed clusters and SSO clients by environment and organization.
  * Renamed IAT expiration panels for clearer identification of production and staging data.
  * Updated metric paths used by the IAT expiration panels.
  * Incremented the dashboard version.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->