### PR TITLE
fix(glhk) Re-fetch MR before is_rebased check in serial rebase paths

### DIFF
--- a/reconcile/gitlab_housekeeping.py
+++ b/reconcile/gitlab_housekeeping.py
@@ -1098,7 +1098,8 @@ def _process_omm_member(
         if not dry_run:
             gl.remove_label(mr, OMM_PENDING)
         optimistic_merge_rejected.labels(
-            project_id=mr.target_project_id, reason="pipeline_failed"
+            project_id=mr.target_project_id,
+            reason=f"pipeline_{latest_status.value}",
         ).inc()
         return _MemberResult()
 

--- a/reconcile/gitlab_housekeeping.py
+++ b/reconcile/gitlab_housekeeping.py
@@ -927,7 +927,8 @@ def _rebase_merge_requests_active_cap(
     for mr in merge_requests:
         pipelines = gl.get_merge_request_pipelines(mr)
         pipelines = [p for p in pipelines if p.status != PipelineStatus.SKIPPED]
-        if is_rebased(mr, gl):
+        fresh_mr = gl.get_merge_request(mr.iid)
+        if is_rebased(fresh_mr, gl):
             if pipelines and pipelines[0].status in {
                 PipelineStatus.RUNNING,
                 PipelineStatus.PENDING,
@@ -989,7 +990,8 @@ def _rebase_merge_requests_old_burst(
         if not item["error"]
     ]
     for mr in merge_requests:
-        if is_rebased(mr, gl):
+        fresh_mr = gl.get_merge_request(mr.iid)
+        if is_rebased(fresh_mr, gl):
             continue
 
         pipelines = gl.get_merge_request_pipelines(mr)

--- a/reconcile/gitlab_housekeeping.py
+++ b/reconcile/gitlab_housekeeping.py
@@ -1087,12 +1087,13 @@ def _process_omm_member(
 
     latest_status = pipelines[0].status
 
-    if latest_status == PipelineStatus.FAILED:
+    if latest_status in {PipelineStatus.FAILED, PipelineStatus.CANCELED}:
         logging.info([
             "omm-group",
             "eject-failed",
             gl.project.name,
             mr.iid,
+            latest_status,
         ])
         if not dry_run:
             gl.remove_label(mr, OMM_PENDING)

--- a/reconcile/test/test_gitlab_housekeeping.py
+++ b/reconcile/test/test_gitlab_housekeeping.py
@@ -15,6 +15,7 @@ from unittest.mock import (
 
 import pytest
 from gitlab import Gitlab
+from gitlab.const import PipelineStatus
 from gitlab.exceptions import (
     GitlabGetError,
     GitlabMRClosedError,
@@ -900,6 +901,50 @@ def test_rebase_stale_success_pipeline_does_not_block_rebase(
 
     assert merge_requests[0].rebase.call_count == 1
     assert merge_requests[1].rebase.call_count == 1
+
+
+@pytest.mark.parametrize(
+    "strategy",
+    [RebaseStrategy.ACTIVE_CAP, RebaseStrategy.OLD_BURST],
+    ids=["active-cap", "old-burst"],
+)
+def test_rebase_uses_refreshed_mr_not_stale_batch_object(
+    mocker: MockerFixture, gitlab_api: Mock, state: Mock, strategy: RebaseStrategy
+) -> None:
+    """Regression: is_rebased must receive the refreshed MR from
+    get_merge_request, not the stale batch-fetched object.  The stale
+    object has an old SHA that would make is_rebased return False
+    (triggering a redundant rebase), but the fresh object is up-to-date."""
+    stale_mr = _make_rebase_mr(1)
+    fresh_mr = _make_rebase_mr(1)
+
+    gitlab_api.get_merge_request_pipelines.return_value = []
+    gitlab_api.get_merge_request.return_value = fresh_mr
+    mocker.patch(
+        "reconcile.gitlab_housekeeping.get_merge_requests",
+        return_value=[{"mr": stale_mr, "error": False}],
+    )
+
+    def _is_rebased(mr, gl):
+        return mr is fresh_mr
+
+    mocker.patch(
+        "reconcile.gitlab_housekeeping.is_rebased",
+        side_effect=_is_rebased,
+    )
+
+    gl_h.rebase_merge_requests(
+        dry_run=False,
+        gl=gitlab_api,
+        rebase_limit=2,
+        state=state,
+        pipeline_timeout=None,
+        wait_for_pipeline=False,
+        strategy=strategy,
+    )
+
+    gitlab_api.get_merge_request.assert_called_once_with(1)
+    stale_mr.rebase.assert_not_called()
 
 
 @pytest.mark.parametrize(
@@ -3033,7 +3078,7 @@ def test_omm_group_all_skipped_pipelines_rebased_stays_active(
 def _canceled_pipeline(
     project_id: int = 1, sha: str = "pipeline-sha", source: str = "external"
 ) -> Mock:
-    p = create_autospec(ProjectMergeRequestPipeline, status="canceled")
+    p = create_autospec(ProjectMergeRequestPipeline, status=PipelineStatus.CANCELED)
     p.project_id = project_id
     p.sha = sha
     p.source = source
@@ -3138,6 +3183,7 @@ def test_omm_group_unhandled_status_rebased_stays_active(
 
     assert merges == 0
     mr.merge.assert_not_called()
+    mocked_gl.remove_label.assert_not_called()
     clear_mock.assert_not_called()
 
 

--- a/reconcile/test/test_gitlab_housekeeping.py
+++ b/reconcile/test/test_gitlab_housekeeping.py
@@ -925,7 +925,7 @@ def test_rebase_uses_refreshed_mr_not_stale_batch_object(
         return_value=[{"mr": stale_mr, "error": False}],
     )
 
-    def _is_rebased(mr, gl):
+    def _is_rebased(mr: Mock, gl: Mock) -> bool:
         return mr is fresh_mr
 
     mocker.patch(

--- a/reconcile/test/test_gitlab_housekeeping.py
+++ b/reconcile/test/test_gitlab_housekeeping.py
@@ -533,6 +533,8 @@ def _call_rebase(
     gitlab_api.get_merge_request_pipelines.side_effect = lambda mr: pipelines_map.get(
         mr.iid, []
     )
+    mr_by_iid = {mr.iid: mr for mr in merge_requests}
+    gitlab_api.get_merge_request.side_effect = lambda iid: mr_by_iid[iid]
     mocker.patch(
         "reconcile.gitlab_housekeeping.get_merge_requests",
         return_value=[

--- a/reconcile/test/test_gitlab_housekeeping.py
+++ b/reconcile/test/test_gitlab_housekeeping.py
@@ -3045,13 +3045,13 @@ def _canceled_pipeline(
     [("abc123", None), (None, "abc123")],
     ids=["merge-commit", "squash-commit"],
 )
-def test_omm_group_unhandled_status_rebased_stays_active(
+def test_omm_group_canceled_pipeline_ejects_member(
     mocker: MockerFixture,
     merge_sha: str | None,
     squash_sha: str | None,
 ) -> None:
-    """An unexpected pipeline status (e.g. 'canceled') on a rebased MR
-    should keep the group active rather than triggering adaptive-close."""
+    """A canceled pipeline ejects the member (same as failed). With no
+    active members remaining, adaptive-close fires."""
     _setup_omm_group_mocks(mocker)
     mocker.patch(
         "reconcile.gitlab_housekeeping.is_rebased",
@@ -3075,6 +3075,59 @@ def test_omm_group_unhandled_status_rebased_stays_active(
 
     mocked_gl = _make_omm_gl(head_sha="abc123")
     mocked_gl.get_merge_request_pipelines.return_value = [_canceled_pipeline()]
+
+    merges = gl_h._process_omm_group(
+        dry_run=False,
+        gl=mocked_gl,
+        lead=lead,
+        app_sre_usernames=set(),
+    )
+
+    assert merges == 0
+    mr.merge.assert_not_called()
+    mocked_gl.remove_label.assert_called_once_with(mr, gl_h.OMM_PENDING)
+    clear_mock.assert_called_once()
+
+
+@pytest.mark.parametrize(
+    "merge_sha, squash_sha",
+    [("abc123", None), (None, "abc123")],
+    ids=["merge-commit", "squash-commit"],
+)
+def test_omm_group_unhandled_status_rebased_stays_active(
+    mocker: MockerFixture,
+    merge_sha: str | None,
+    squash_sha: str | None,
+) -> None:
+    """An unexpected pipeline status (e.g. 'manual') on a rebased MR
+    should keep the group active rather than triggering adaptive-close."""
+    _setup_omm_group_mocks(mocker)
+    mocker.patch(
+        "reconcile.gitlab_housekeeping.is_rebased",
+        return_value=True,
+    )
+    clear_mock = mocker.patch(
+        "reconcile.gitlab_housekeeping.clear_omm_group",
+    )
+
+    lead = create_autospec(ProjectMergeRequest)
+    lead.merge_commit_sha = merge_sha
+    lead.squash_commit_sha = squash_sha
+    lead.target_branch = "master"
+
+    mr = _make_merge_mr(11, ["approved", "tenant-bar", "omm-pending"])
+
+    mocker.patch(
+        "reconcile.gitlab_housekeeping.get_omm_pending_mrs",
+        return_value=[mr],
+    )
+
+    mocked_gl = _make_omm_gl(head_sha="abc123")
+    unhandled = create_autospec(ProjectMergeRequestPipeline, status="manual")
+    unhandled.project_id = 1
+    unhandled.sha = "pipeline-sha"
+    unhandled.source = "external"
+    mocked_gl.get_merge_request_pipelines.return_value = [unhandled]
 
     merges = gl_h._process_omm_group(
         dry_run=False,


### PR DESCRIPTION
## [APPSRE-14948](https://redhat.atlassian.net/browse/APPSRE-14948)

## Problem

In `_rebase_merge_requests_active_cap` (line 896), the MR objects are fetched once via `get_merge_requests()` at the top of the function (line 909-918). When `is_rebased(mr, gl)` is called at line 930, it uses `mr.sha` from this batch-fetched object. If the previous cycle's async `mr.rebase()` hasn't been reflected yet in the list endpoint, `mr.sha` is stale, `is_rebased` returns False, and the MR gets rebased again unnecessarily.

This is the same bug fixed in #5712 for the OMM path, where `gl.get_merge_request(mr.iid)` is called to get a fresh object before checking `is_rebased` (line 1072-1073).

## Evidence from logs (8/3 production run)

MRs 199925 and 199917 are rebased in cycle 1, then rebased again in cycle 2 with no merge in between:

```
# Cycle 1 (13:37:24) - rebases issued
[2026-08-03 13:37:24] [INFO] [gitlab_housekeeping.py:_try_rebase:690] - ['rebase', 'app-interface', 199925]
[2026-08-03 13:37:24] [INFO] [gitlab_housekeeping.py:_try_rebase:690] - ['rebase', 'app-interface', 199917]
[2026-08-03 13:37:24] [INFO] [gitlab_housekeeping.py:_try_rebase:690] - ['rebase', 'app-interface', 199928]

# No merge log between cycles — only a skip:
[2026-08-03 13:38:32] [INFO] [gitlab_housekeeping.py:merge_merge_requests:1351] - ['skip merge', 'app-interface', 199729]

# Cycle 2 (13:38:49) - same MRs rebased again
[2026-08-03 13:38:49] [INFO] [gitlab_housekeeping.py:_try_rebase:690] - ['rebase', 'app-interface', 199947]
[2026-08-03 13:38:50] [INFO] [gitlab_housekeeping.py:_try_rebase:690] - ['rebase', 'app-interface', 199925]
[2026-08-03 13:38:50] [INFO] [gitlab_housekeeping.py:_try_rebase:690] - ['rebase', 'app-interface', 199917]
```

The GQL bundle SHA changes between cycles (`ce95c7a6...` -> `d105c7e4...`), but this reflects a data refresh, not necessarily a target-branch merge. Nothing in the logs shows a merge that would invalidate the prior rebases. The re-rebases are redundant — caused by `is_rebased` reading stale `mr.sha` from the batch-fetched MR list rather than re-fetching the individual MR object after the async rebase completed.

In `_process_omm_member`, a pipeline with status `canceled` falls into the catch-all `unhandled-status` branch, which returns `active=True` when the MR is rebased. This holds the OMM group hostage — the member can't merge (not SUCCESS) but prevents adaptive-close (active=True). The group spins until the 5-minute window expires.

## Fix
In [`reconcile/gitlab_housekeeping.py`](qontract-reconcile/reconcile/gitlab_housekeeping.py), change the `is_rebased` call at line 930 to re-fetch the MR first:

```python
# Before (line 930):
if is_rebased(mr, gl):

# After:
fresh_mr = gl.get_merge_request(mr.iid)
if is_rebased(fresh_mr, gl):
```

This adds one API call per MR in the loop, but it's the same pattern already used in the OMM path and is necessary to get an accurate `sha` value.

## Same fix for old-burst path

The `_rebase_merge_requests_old_burst` function (line 968) has the same pattern at line 992:

```python
if is_rebased(mr, gl):
```

Apply the same re-fetch there for consistency.

Treat `canceled` the same as `failed` — eject the member from the group so it returns to the serial queue for a fresh rebase + CI run.

## Test

- Verify existing tests pass (the `is_rebased` mock may need updating if tests supply MR objects directly)
- The log output should show fewer redundant rebase entries across consecutive cycles

Written by Claude

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Bug Fixes**
  * Merge request rebase checks now use the latest information from GitLab, improving accuracy when statuses change after initial retrieval.
  * Canceled pipelines are now handled like failed pipelines, removing affected members and performing the necessary cleanup.
  * Unrecognized pipeline statuses, such as manual, no longer incorrectly deactivate active groups.
* **Tests**
  * Expanded coverage for refreshed merge request details and pipeline status handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->