### PR TITLE
feat(aws-account-manager): automate ROSA HCP marketplace enablement

### DIFF
--- a/qontract_utils/qontract_utils/aws_api_typed/api.py
+++ b/qontract_utils/qontract_utils/aws_api_typed/api.py
@@ -14,6 +14,7 @@ from qontract_utils.aws_api_typed.cloudformation import AWSApiCloudFormation
 from qontract_utils.aws_api_typed.dynamodb import AWSApiDynamoDB
 from qontract_utils.aws_api_typed.iam import AWSApiIam
 from qontract_utils.aws_api_typed.logs import AWSApiLogs
+from qontract_utils.aws_api_typed.marketplace import AWSApiMarketplace
 from qontract_utils.aws_api_typed.organization import AWSApiOrganizations
 from qontract_utils.aws_api_typed.s3 import AWSApiS3
 from qontract_utils.aws_api_typed.service_quotas import AWSApiServiceQuotas
@@ -212,6 +213,23 @@ class AWSApi:
         client = self.session.client("sts", config=DEFAULT_CONFIG)
         self._session_clients.append(client)
         return AWSApiSts(client)
+
+    @cached_property
+    def marketplace(self) -> AWSApiMarketplace:
+        """Return an AWS Marketplace Api client for agreement and discovery."""
+        agreement_client = self.session.client(
+            "marketplace-agreement",
+            config=DEFAULT_CONFIG,
+            region_name="us-east-1",
+        )
+        discovery_client = self.session.client(
+            "marketplace-discovery",
+            config=DEFAULT_CONFIG,
+            region_name="us-east-1",
+        )
+        self._session_clients.append(agreement_client)
+        self._session_clients.append(discovery_client)
+        return AWSApiMarketplace(agreement_client, discovery_client)
 
     @cached_property
     def support(self) -> AWSApiSupport:

--- a/qontract_utils/qontract_utils/aws_api_typed/marketplace.py
+++ b/qontract_utils/qontract_utils/aws_api_typed/marketplace.py
@@ -1,0 +1,116 @@
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from pydantic import BaseModel
+
+from qontract_utils.aws_api_typed._hooks import AWS_DEFAULT_HOOKS, AWSApiCallContext
+from qontract_utils.hooks import Hooks, invoke_with_hooks, with_hooks
+
+ROSA_HCP_PRODUCT_ID = "bfdca560-2c78-4e64-8193-794c159e6d30"
+
+log = logging.getLogger(__name__)
+
+
+class RosaOffer(BaseModel):
+    offer_id: str
+    agreement_proposal_id: str
+    term_ids: list[str]
+
+
+@with_hooks(hooks=AWS_DEFAULT_HOOKS)
+class AWSApiMarketplace:
+    _hooks: Hooks
+
+    def __init__(
+        self,
+        agreement_client: Any,
+        discovery_client: Any,
+        hooks: Hooks | None = None,
+    ) -> None:  # ruff: ignore[unused-method-argument]
+        self.agreement_client = agreement_client
+        self.discovery_client = discovery_client
+
+    @invoke_with_hooks(
+        lambda: AWSApiCallContext(
+            method="has_rosa_subscription", service="marketplace-agreement"
+        )
+    )
+    def has_rosa_subscription(self) -> bool:
+        resp = self.agreement_client.search_agreements(
+            catalog="AWSMarketplace",
+            filters=[
+                {"name": "ResourceIdentifier", "values": [ROSA_HCP_PRODUCT_ID]}
+            ],
+        )
+        return bool(resp.get("agreementViewSummaries"))
+
+    @invoke_with_hooks(
+        lambda: AWSApiCallContext(
+            method="discover_rosa_offer", service="marketplace-discovery"
+        )
+    )
+    def discover_rosa_offer(self) -> RosaOffer:
+        resp = self.discovery_client.list_purchase_options(
+            filters=[
+                {
+                    "filterType": "PRODUCT_ID",
+                    "filterValues": [ROSA_HCP_PRODUCT_ID],
+                }
+            ],
+        )
+        options = resp.get("purchaseOptions", [])
+        if not options:
+            msg = "No purchase options found for ROSA HCP product"
+            raise RuntimeError(msg)
+
+        offer_id = None
+        for entity in options[0].get("associatedEntities", []):
+            if oid := entity.get("offer", {}).get("offerId"):
+                offer_id = oid
+                break
+        if not offer_id:
+            offer_id = options[0].get("purchaseOptionId")
+        if not offer_id:
+            msg = "Could not determine offer ID for ROSA HCP product"
+            raise RuntimeError(msg)
+
+        offer = self.discovery_client.get_offer(offerId=offer_id)
+        agreement_proposal_id = offer.get("agreementProposalIdentifier")
+        if not agreement_proposal_id:
+            msg = f"No agreementProposalIdentifier found for offer {offer_id}"
+            raise RuntimeError(msg)
+
+        terms_resp = self.discovery_client.get_offer_terms(offerId=offer_id)
+        term_ids = [term["termId"] for term in terms_resp.get("terms", [])]
+        if not term_ids:
+            msg = f"No terms found for ROSA HCP offer {offer_id}"
+            raise RuntimeError(msg)
+
+        return RosaOffer(
+            offer_id=offer_id,
+            agreement_proposal_id=agreement_proposal_id,
+            term_ids=term_ids,
+        )
+
+    @invoke_with_hooks(
+        lambda: AWSApiCallContext(
+            method="subscribe_rosa", service="marketplace-agreement"
+        )
+    )
+    def subscribe_rosa(
+        self, agreement_proposal_id: str, term_ids: list[str]
+    ) -> str:
+        create_resp = self.agreement_client.create_agreement_request(
+            catalog="AWSMarketplace",
+            agreementProposalIdentifier=agreement_proposal_id,
+            intent="NEW",
+            requestedTerms=[{"termId": tid} for tid in term_ids],
+        )
+        agreement_request_id = create_resp["agreementRequestId"]
+
+        accept_resp = self.agreement_client.accept_agreement_request(
+            agreementRequestId=agreement_request_id,
+        )
+        return accept_resp.get("agreementId", agreement_request_id)

--- a/qontract_utils/qontract_utils/aws_api_typed/marketplace.py
+++ b/qontract_utils/qontract_utils/aws_api_typed/marketplace.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import logging
+from collections.abc import Iterable
 from typing import Any
 
 from pydantic import BaseModel
@@ -27,8 +28,8 @@ class AWSApiMarketplace:
         self,
         agreement_client: Any,
         discovery_client: Any,
-        hooks: Hooks | None = None,
-    ) -> None:  # ruff: ignore[unused-method-argument]
+        hooks: Hooks | None = None,  # ruff: ignore[unused-method-argument]
+    ) -> None:
         self.agreement_client = agreement_client
         self.discovery_client = discovery_client
 
@@ -41,7 +42,9 @@ class AWSApiMarketplace:
         resp = self.agreement_client.search_agreements(
             catalog="AWSMarketplace",
             filters=[
-                {"name": "ResourceIdentifier", "values": [ROSA_HCP_PRODUCT_ID]}
+                {"name": "PartyType", "values": ["Acceptor"]},
+                {"name": "AgreementType", "values": ["PurchaseAgreement"]},
+                {"name": "ResourceIdentifier", "values": [ROSA_HCP_PRODUCT_ID]},
             ],
         )
         return bool(resp.get("agreementViewSummaries"))
@@ -65,25 +68,31 @@ class AWSApiMarketplace:
             msg = "No purchase options found for ROSA HCP product"
             raise RuntimeError(msg)
 
-        offer_id = None
-        for entity in options[0].get("associatedEntities", []):
-            if oid := entity.get("offer", {}).get("offerId"):
-                offer_id = oid
-                break
-        if not offer_id:
-            offer_id = options[0].get("purchaseOptionId")
+        offer_id = next(
+            (
+                entity["offer"]["offerId"]
+                for entity in options[0].get("associatedEntities", [])
+                if entity.get("offer", {}).get("offerId")
+            ),
+            options[0].get("purchaseOptionId"),
+        )
         if not offer_id:
             msg = "Could not determine offer ID for ROSA HCP product"
             raise RuntimeError(msg)
 
         offer = self.discovery_client.get_offer(offerId=offer_id)
-        agreement_proposal_id = offer.get("agreementProposalIdentifier")
+        agreement_proposal_id = offer.get("agreementProposalId")
         if not agreement_proposal_id:
-            msg = f"No agreementProposalIdentifier found for offer {offer_id}"
+            msg = f"No agreementProposalId found for offer {offer_id}"
             raise RuntimeError(msg)
 
         terms_resp = self.discovery_client.get_offer_terms(offerId=offer_id)
-        term_ids = [term["termId"] for term in terms_resp.get("terms", [])]
+        term_ids = [
+            term_data["id"]
+            for term_wrapper in terms_resp.get("offerTerms", [])
+            for term_data in term_wrapper.values()
+            if isinstance(term_data, dict) and "id" in term_data
+        ]
         if not term_ids:
             msg = f"No terms found for ROSA HCP offer {offer_id}"
             raise RuntimeError(msg)
@@ -100,11 +109,11 @@ class AWSApiMarketplace:
         )
     )
     def subscribe_rosa(
-        self, agreement_proposal_id: str, term_ids: list[str]
+        self, agreement_proposal_id: str, term_ids: Iterable[str]
     ) -> str:
         create_resp = self.agreement_client.create_agreement_request(
             catalog="AWSMarketplace",
-            agreementProposalIdentifier=agreement_proposal_id,
+            agreementProposalId=agreement_proposal_id,
             intent="NEW",
             requestedTerms=[{"termId": tid} for tid in term_ids],
         )

--- a/qontract_utils/tests/aws_api_typed/test_aws_api_typed_marketplace.py
+++ b/qontract_utils/tests/aws_api_typed/test_aws_api_typed_marketplace.py
@@ -1,0 +1,210 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+from qontract_utils.aws_api_typed.marketplace import (
+    ROSA_HCP_PRODUCT_ID,
+    AWSApiMarketplace,
+    RosaOffer,
+)
+from qontract_utils.hooks import Hooks
+
+if TYPE_CHECKING:
+    from unittest.mock import MagicMock
+
+    from pytest_mock import MockerFixture
+    from qontract_utils.aws_api_typed._hooks import AWSApiCallContext
+
+
+@pytest.fixture
+def agreement_client(mocker: MockerFixture) -> MagicMock:
+    return mocker.Mock()
+
+
+@pytest.fixture
+def discovery_client(mocker: MockerFixture) -> MagicMock:
+    return mocker.Mock()
+
+
+@pytest.fixture
+def marketplace_api(
+    agreement_client: MagicMock, discovery_client: MagicMock
+) -> AWSApiMarketplace:
+    return AWSApiMarketplace(
+        agreement_client=agreement_client, discovery_client=discovery_client
+    )
+
+
+def test_has_rosa_subscription_true(
+    marketplace_api: AWSApiMarketplace, agreement_client: MagicMock
+) -> None:
+    agreement_client.search_agreements.return_value = {
+        "agreementViewSummaries": [{"agreementId": "agr-123"}]
+    }
+    assert marketplace_api.has_rosa_subscription() is True
+    agreement_client.search_agreements.assert_called_once_with(
+        catalog="AWSMarketplace",
+        filters=[{"name": "ResourceIdentifier", "values": [ROSA_HCP_PRODUCT_ID]}],
+    )
+
+
+def test_has_rosa_subscription_false(
+    marketplace_api: AWSApiMarketplace, agreement_client: MagicMock
+) -> None:
+    agreement_client.search_agreements.return_value = {
+        "agreementViewSummaries": []
+    }
+    assert marketplace_api.has_rosa_subscription() is False
+
+
+def test_discover_rosa_offer(
+    marketplace_api: AWSApiMarketplace, discovery_client: MagicMock
+) -> None:
+    discovery_client.list_purchase_options.return_value = {
+        "purchaseOptions": [
+            {
+                "purchaseOptionId": "po-123",
+                "associatedEntities": [
+                    {"offer": {"offerId": "offer-abc"}}
+                ],
+            }
+        ]
+    }
+    discovery_client.get_offer.return_value = {
+        "agreementProposalIdentifier": "prop-xyz",
+    }
+    discovery_client.get_offer_terms.return_value = {
+        "terms": [{"termId": "term-1"}, {"termId": "term-2"}]
+    }
+
+    offer = marketplace_api.discover_rosa_offer()
+
+    assert offer == RosaOffer(
+        offer_id="offer-abc",
+        agreement_proposal_id="prop-xyz",
+        term_ids=["term-1", "term-2"],
+    )
+    discovery_client.list_purchase_options.assert_called_once()
+    discovery_client.get_offer.assert_called_once_with(offerId="offer-abc")
+    discovery_client.get_offer_terms.assert_called_once_with(offerId="offer-abc")
+
+
+def test_discover_rosa_offer_fallback_to_purchase_option_id(
+    marketplace_api: AWSApiMarketplace, discovery_client: MagicMock
+) -> None:
+    discovery_client.list_purchase_options.return_value = {
+        "purchaseOptions": [
+            {
+                "purchaseOptionId": "po-fallback",
+                "associatedEntities": [],
+            }
+        ]
+    }
+    discovery_client.get_offer.return_value = {
+        "agreementProposalIdentifier": "prop-xyz",
+    }
+    discovery_client.get_offer_terms.return_value = {
+        "terms": [{"termId": "term-1"}]
+    }
+
+    offer = marketplace_api.discover_rosa_offer()
+    assert offer.offer_id == "po-fallback"
+    discovery_client.get_offer.assert_called_once_with(offerId="po-fallback")
+
+
+def test_discover_rosa_offer_no_purchase_options(
+    marketplace_api: AWSApiMarketplace, discovery_client: MagicMock
+) -> None:
+    discovery_client.list_purchase_options.return_value = {"purchaseOptions": []}
+    with pytest.raises(RuntimeError, match="No purchase options"):
+        marketplace_api.discover_rosa_offer()
+
+
+def test_discover_rosa_offer_no_proposal_id(
+    marketplace_api: AWSApiMarketplace, discovery_client: MagicMock
+) -> None:
+    discovery_client.list_purchase_options.return_value = {
+        "purchaseOptions": [
+            {"purchaseOptionId": "po-1", "associatedEntities": []}
+        ]
+    }
+    discovery_client.get_offer.return_value = {}
+    with pytest.raises(RuntimeError, match="No agreementProposalIdentifier"):
+        marketplace_api.discover_rosa_offer()
+
+
+def test_discover_rosa_offer_no_terms(
+    marketplace_api: AWSApiMarketplace, discovery_client: MagicMock
+) -> None:
+    discovery_client.list_purchase_options.return_value = {
+        "purchaseOptions": [
+            {"purchaseOptionId": "po-1", "associatedEntities": []}
+        ]
+    }
+    discovery_client.get_offer.return_value = {
+        "agreementProposalIdentifier": "prop-1",
+    }
+    discovery_client.get_offer_terms.return_value = {"terms": []}
+    with pytest.raises(RuntimeError, match="No terms found"):
+        marketplace_api.discover_rosa_offer()
+
+
+def test_subscribe_rosa(
+    marketplace_api: AWSApiMarketplace, agreement_client: MagicMock
+) -> None:
+    agreement_client.create_agreement_request.return_value = {
+        "agreementRequestId": "req-123"
+    }
+    agreement_client.accept_agreement_request.return_value = {
+        "agreementId": "agr-456"
+    }
+
+    result = marketplace_api.subscribe_rosa(
+        agreement_proposal_id="prop-xyz",
+        term_ids=["term-1", "term-2"],
+    )
+
+    assert result == "agr-456"
+    agreement_client.create_agreement_request.assert_called_once_with(
+        catalog="AWSMarketplace",
+        agreementProposalIdentifier="prop-xyz",
+        intent="NEW",
+        requestedTerms=[{"termId": "term-1"}, {"termId": "term-2"}],
+    )
+    agreement_client.accept_agreement_request.assert_called_once_with(
+        agreementRequestId="req-123",
+    )
+
+
+def test_subscribe_rosa_fallback_to_request_id(
+    marketplace_api: AWSApiMarketplace, agreement_client: MagicMock
+) -> None:
+    agreement_client.create_agreement_request.return_value = {
+        "agreementRequestId": "req-123"
+    }
+    agreement_client.accept_agreement_request.return_value = {}
+
+    result = marketplace_api.subscribe_rosa(
+        agreement_proposal_id="prop-xyz",
+        term_ids=["term-1"],
+    )
+    assert result == "req-123"
+
+
+def test_hooks_fire_on_method_call(
+    agreement_client: MagicMock, discovery_client: MagicMock
+) -> None:
+    contexts: list[AWSApiCallContext] = []
+    api = AWSApiMarketplace(
+        agreement_client=agreement_client,
+        discovery_client=discovery_client,
+        hooks=Hooks(pre_hooks=[contexts.append]),
+    )
+    agreement_client.search_agreements.return_value = {"agreementViewSummaries": []}
+
+    api.has_rosa_subscription()
+
+    assert len(contexts) == 1
+    assert contexts[0].method == "has_rosa_subscription"
+    assert contexts[0].service == "marketplace-agreement"

--- a/qontract_utils/tests/aws_api_typed/test_aws_api_typed_marketplace.py
+++ b/qontract_utils/tests/aws_api_typed/test_aws_api_typed_marketplace.py
@@ -45,16 +45,18 @@ def test_has_rosa_subscription_true(
     assert marketplace_api.has_rosa_subscription() is True
     agreement_client.search_agreements.assert_called_once_with(
         catalog="AWSMarketplace",
-        filters=[{"name": "ResourceIdentifier", "values": [ROSA_HCP_PRODUCT_ID]}],
+        filters=[
+            {"name": "PartyType", "values": ["Acceptor"]},
+            {"name": "AgreementType", "values": ["PurchaseAgreement"]},
+            {"name": "ResourceIdentifier", "values": [ROSA_HCP_PRODUCT_ID]},
+        ],
     )
 
 
 def test_has_rosa_subscription_false(
     marketplace_api: AWSApiMarketplace, agreement_client: MagicMock
 ) -> None:
-    agreement_client.search_agreements.return_value = {
-        "agreementViewSummaries": []
-    }
+    agreement_client.search_agreements.return_value = {"agreementViewSummaries": []}
     assert marketplace_api.has_rosa_subscription() is False
 
 
@@ -65,17 +67,23 @@ def test_discover_rosa_offer(
         "purchaseOptions": [
             {
                 "purchaseOptionId": "po-123",
-                "associatedEntities": [
-                    {"offer": {"offerId": "offer-abc"}}
-                ],
+                "associatedEntities": [{"offer": {"offerId": "offer-abc"}}],
             }
         ]
     }
     discovery_client.get_offer.return_value = {
-        "agreementProposalIdentifier": "prop-xyz",
+        "agreementProposalId": "prop-xyz",
     }
     discovery_client.get_offer_terms.return_value = {
-        "terms": [{"termId": "term-1"}, {"termId": "term-2"}]
+        "offerTerms": [
+            {
+                "usageBasedPricingTerm": {
+                    "id": "term-1",
+                    "type": "UsageBasedPricingTerm",
+                }
+            },
+            {"legalTerm": {"id": "term-2", "type": "LegalTerm"}},
+        ]
     }
 
     offer = marketplace_api.discover_rosa_offer()
@@ -102,10 +110,12 @@ def test_discover_rosa_offer_fallback_to_purchase_option_id(
         ]
     }
     discovery_client.get_offer.return_value = {
-        "agreementProposalIdentifier": "prop-xyz",
+        "agreementProposalId": "prop-xyz",
     }
     discovery_client.get_offer_terms.return_value = {
-        "terms": [{"termId": "term-1"}]
+        "offerTerms": [
+            {"supportTerm": {"id": "term-1", "type": "SupportTerm"}},
+        ]
     }
 
     offer = marketplace_api.discover_rosa_offer()
@@ -125,12 +135,10 @@ def test_discover_rosa_offer_no_proposal_id(
     marketplace_api: AWSApiMarketplace, discovery_client: MagicMock
 ) -> None:
     discovery_client.list_purchase_options.return_value = {
-        "purchaseOptions": [
-            {"purchaseOptionId": "po-1", "associatedEntities": []}
-        ]
+        "purchaseOptions": [{"purchaseOptionId": "po-1", "associatedEntities": []}]
     }
     discovery_client.get_offer.return_value = {}
-    with pytest.raises(RuntimeError, match="No agreementProposalIdentifier"):
+    with pytest.raises(RuntimeError, match="No agreementProposalId found"):
         marketplace_api.discover_rosa_offer()
 
 
@@ -138,14 +146,12 @@ def test_discover_rosa_offer_no_terms(
     marketplace_api: AWSApiMarketplace, discovery_client: MagicMock
 ) -> None:
     discovery_client.list_purchase_options.return_value = {
-        "purchaseOptions": [
-            {"purchaseOptionId": "po-1", "associatedEntities": []}
-        ]
+        "purchaseOptions": [{"purchaseOptionId": "po-1", "associatedEntities": []}]
     }
     discovery_client.get_offer.return_value = {
-        "agreementProposalIdentifier": "prop-1",
+        "agreementProposalId": "prop-1",
     }
-    discovery_client.get_offer_terms.return_value = {"terms": []}
+    discovery_client.get_offer_terms.return_value = {"offerTerms": []}
     with pytest.raises(RuntimeError, match="No terms found"):
         marketplace_api.discover_rosa_offer()
 
@@ -156,9 +162,7 @@ def test_subscribe_rosa(
     agreement_client.create_agreement_request.return_value = {
         "agreementRequestId": "req-123"
     }
-    agreement_client.accept_agreement_request.return_value = {
-        "agreementId": "agr-456"
-    }
+    agreement_client.accept_agreement_request.return_value = {"agreementId": "agr-456"}
 
     result = marketplace_api.subscribe_rosa(
         agreement_proposal_id="prop-xyz",
@@ -168,7 +172,7 @@ def test_subscribe_rosa(
     assert result == "agr-456"
     agreement_client.create_agreement_request.assert_called_once_with(
         catalog="AWSMarketplace",
-        agreementProposalIdentifier="prop-xyz",
+        agreementProposalId="prop-xyz",
         intent="NEW",
         requestedTerms=[{"termId": "term-1"}, {"termId": "term-2"}],
     )

--- a/reconcile/aws_account_manager/integration.py
+++ b/reconcile/aws_account_manager/integration.py
@@ -198,6 +198,14 @@ class AwsAccountMgmtIntegration(
                 ):
                     self.save_access_key(account_request.name, access_key)
 
+                if (
+                    account_request.additional_features
+                    and account_request.additional_features.get("rosa")
+                ):
+                    reconciler.enable_rosa_marketplace(
+                        aws_api=account_role_api, name=account_request.name
+                    )
+
             merge_request_manager.create_account_file(
                 title=f"{account_request.name}: AWS account template collection file",
                 account_tmpl_file_path=f"{self.params.template_collection_root_path}/{account_request.name}.yml",

--- a/reconcile/aws_account_manager/reconciler.py
+++ b/reconcile/aws_account_manager/reconciler.py
@@ -34,6 +34,7 @@ TASK_ENABLE_ENTERPRISE_SUPPORT = "enable-enterprise-support"
 TASK_CHECK_ENTERPRISE_SUPPORT_STATUS = "check-enterprise-support-status"
 TASK_SET_SECURITY_CONTACT = "set-security-contact"
 TASK_SET_SUPPORTED_REGIONS = "set-supported-regions"
+TASK_ENABLE_ROSA_MARKETPLACE = "enable-rosa-marketplace"
 
 
 class Quota(Protocol):
@@ -386,6 +387,32 @@ class AWSReconciler:
 
             state.value = regions
 
+    def _enable_rosa_marketplace(
+        self, aws_api: AWSApi, name: str
+    ) -> str | None:
+        with self.state.transaction(
+            state_key(name, TASK_ENABLE_ROSA_MARKETPLACE)
+        ) as state:
+            if state.exists:
+                return state.value
+
+            if aws_api.marketplace.has_rosa_subscription():
+                logging.info(f"{name}: ROSA HCP marketplace already subscribed")
+                state.value = "already-subscribed"
+                return None
+
+            logging.info(f"{name}: Enabling ROSA HCP marketplace subscription")
+            if self.dry_run:
+                raise AbortStateTransactionError("Dry run")
+
+            offer = aws_api.marketplace.discover_rosa_offer()
+            agreement_id = aws_api.marketplace.subscribe_rosa(
+                agreement_proposal_id=offer.agreement_proposal_id,
+                term_ids=offer.term_ids,
+            )
+            state.value = agreement_id
+            return agreement_id
+
     #
     # Public methods
     #
@@ -424,6 +451,9 @@ class AWSReconciler:
                 policy_arn=user_policy_arn,
             )
             return aws_api.iam.create_access_key(user_name=user_name)
+
+    def enable_rosa_marketplace(self, aws_api: AWSApi, name: str) -> None:
+        self._enable_rosa_marketplace(aws_api, name)
 
     def reconcile_organization_account(
         self,

--- a/reconcile/aws_account_manager/reconciler.py
+++ b/reconcile/aws_account_manager/reconciler.py
@@ -387,19 +387,17 @@ class AWSReconciler:
 
             state.value = regions
 
-    def _enable_rosa_marketplace(
-        self, aws_api: AWSApi, name: str
-    ) -> str | None:
+    def _enable_rosa_marketplace(self, aws_api: AWSApi, name: str) -> None:
         with self.state.transaction(
             state_key(name, TASK_ENABLE_ROSA_MARKETPLACE)
         ) as state:
             if state.exists:
-                return state.value
+                return
 
             if aws_api.marketplace.has_rosa_subscription():
                 logging.info(f"{name}: ROSA HCP marketplace already subscribed")
                 state.value = "already-subscribed"
-                return None
+                return
 
             logging.info(f"{name}: Enabling ROSA HCP marketplace subscription")
             if self.dry_run:
@@ -411,7 +409,6 @@ class AWSReconciler:
                 term_ids=offer.term_ids,
             )
             state.value = agreement_id
-            return agreement_id
 
     #
     # Public methods

--- a/reconcile/test/aws_account_manager/test_aws_account_manager_reconciler.py
+++ b/reconcile/test/aws_account_manager/test_aws_account_manager_reconciler.py
@@ -28,6 +28,8 @@ from qontract_utils.aws_api_typed.service_quotas import (
 )
 from qontract_utils.aws_api_typed.support import AWSCase, SupportPlan
 
+from qontract_utils.aws_api_typed.marketplace import RosaOffer
+
 from reconcile.aws_account_manager.reconciler import (
     TASK_ACCOUNT_ALIAS,
     TASK_CHECK_ENTERPRISE_SUPPORT_STATUS,
@@ -36,6 +38,7 @@ from reconcile.aws_account_manager.reconciler import (
     TASK_CREATE_IAM_USER,
     TASK_DESCRIBE_ACCOUNT,
     TASK_ENABLE_ENTERPRISE_SUPPORT,
+    TASK_ENABLE_ROSA_MARKETPLACE,
     TASK_MOVE_ACCOUNT,
     TASK_REQUEST_SERVICE_QUOTA,
     TASK_SET_SECURITY_CONTACT,
@@ -875,3 +878,65 @@ def test_aws_account_manager_reconcile_reconcile_account_no_initial_user(
     reconciler._request_quotas.assert_called_once()
     reconciler._check_quota_change_requests.assert_called_once()
     reconciler._set_security_contact.assert_called_once()
+
+
+#
+# ROSA Marketplace
+#
+
+
+def test_aws_account_manager_reconcile_enable_rosa_marketplace(
+    aws_api: MagicMock, reconciler: AWSReconciler
+) -> None:
+    aws_api.marketplace.has_rosa_subscription.return_value = False
+    aws_api.marketplace.discover_rosa_offer.return_value = RosaOffer(
+        offer_id="offer-1",
+        agreement_proposal_id="prop-1",
+        term_ids=["term-1", "term-2"],
+    )
+    aws_api.marketplace.subscribe_rosa.return_value = "agr-123"
+
+    assert reconciler._enable_rosa_marketplace(aws_api, "account") == "agr-123"
+    aws_api.marketplace.has_rosa_subscription.assert_called_once()
+    aws_api.marketplace.discover_rosa_offer.assert_called_once()
+    aws_api.marketplace.subscribe_rosa.assert_called_once_with(
+        agreement_proposal_id="prop-1",
+        term_ids=["term-1", "term-2"],
+    )
+
+
+def test_aws_account_manager_reconcile_enable_rosa_marketplace_already_subscribed(
+    aws_api: MagicMock, reconciler: AWSReconciler
+) -> None:
+    aws_api.marketplace.has_rosa_subscription.return_value = True
+
+    assert reconciler._enable_rosa_marketplace(aws_api, "account") is None
+    aws_api.marketplace.discover_rosa_offer.assert_not_called()
+    aws_api.marketplace.subscribe_rosa.assert_not_called()
+
+
+def test_aws_account_manager_reconcile_enable_rosa_marketplace_state_exists(
+    aws_api: MagicMock, reconciler: AWSReconciler, state_exists: Callable
+) -> None:
+    state_exists(state_key("account", TASK_ENABLE_ROSA_MARKETPLACE), "agr-123")
+
+    assert reconciler._enable_rosa_marketplace(aws_api, "account") == "agr-123"
+    aws_api.marketplace.has_rosa_subscription.assert_not_called()
+    aws_api.marketplace.subscribe_rosa.assert_not_called()
+
+
+def test_aws_account_manager_reconcile_enable_rosa_marketplace_dry_run(
+    aws_api: MagicMock, reconciler_dry_run: AWSReconciler
+) -> None:
+    aws_api.marketplace.has_rosa_subscription.return_value = False
+
+    assert reconciler_dry_run._enable_rosa_marketplace(aws_api, "account") is None
+    aws_api.marketplace.subscribe_rosa.assert_not_called()
+
+
+def test_aws_account_manager_reconcile_enable_rosa_marketplace_public(
+    aws_api: MagicMock, reconciler: AWSReconciler
+) -> None:
+    reconciler._enable_rosa_marketplace = MagicMock(return_value="agr-123")  # type: ignore
+    reconciler.enable_rosa_marketplace(aws_api, "account")
+    reconciler._enable_rosa_marketplace.assert_called_once_with(aws_api, "account")

--- a/reconcile/test/aws_account_manager/test_aws_account_manager_reconciler.py
+++ b/reconcile/test/aws_account_manager/test_aws_account_manager_reconciler.py
@@ -18,6 +18,7 @@ from qontract_utils.aws_api_typed.iam import (
     AWSAccessKey,
     AWSEntityAlreadyExistsError,
 )
+from qontract_utils.aws_api_typed.marketplace import RosaOffer
 from qontract_utils.aws_api_typed.organization import (
     AWSAccountStatus,
     AwsOrganizationOU,
@@ -27,8 +28,6 @@ from qontract_utils.aws_api_typed.service_quotas import (
     AWSRequestedServiceQuotaChange,
 )
 from qontract_utils.aws_api_typed.support import AWSCase, SupportPlan
-
-from qontract_utils.aws_api_typed.marketplace import RosaOffer
 
 from reconcile.aws_account_manager.reconciler import (
     TASK_ACCOUNT_ALIAS,
@@ -896,7 +895,7 @@ def test_aws_account_manager_reconcile_enable_rosa_marketplace(
     )
     aws_api.marketplace.subscribe_rosa.return_value = "agr-123"
 
-    assert reconciler._enable_rosa_marketplace(aws_api, "account") == "agr-123"
+    reconciler._enable_rosa_marketplace(aws_api, "account")
     aws_api.marketplace.has_rosa_subscription.assert_called_once()
     aws_api.marketplace.discover_rosa_offer.assert_called_once()
     aws_api.marketplace.subscribe_rosa.assert_called_once_with(
@@ -910,7 +909,7 @@ def test_aws_account_manager_reconcile_enable_rosa_marketplace_already_subscribe
 ) -> None:
     aws_api.marketplace.has_rosa_subscription.return_value = True
 
-    assert reconciler._enable_rosa_marketplace(aws_api, "account") is None
+    reconciler._enable_rosa_marketplace(aws_api, "account")
     aws_api.marketplace.discover_rosa_offer.assert_not_called()
     aws_api.marketplace.subscribe_rosa.assert_not_called()
 
@@ -920,7 +919,7 @@ def test_aws_account_manager_reconcile_enable_rosa_marketplace_state_exists(
 ) -> None:
     state_exists(state_key("account", TASK_ENABLE_ROSA_MARKETPLACE), "agr-123")
 
-    assert reconciler._enable_rosa_marketplace(aws_api, "account") == "agr-123"
+    reconciler._enable_rosa_marketplace(aws_api, "account")
     aws_api.marketplace.has_rosa_subscription.assert_not_called()
     aws_api.marketplace.subscribe_rosa.assert_not_called()
 
@@ -930,13 +929,13 @@ def test_aws_account_manager_reconcile_enable_rosa_marketplace_dry_run(
 ) -> None:
     aws_api.marketplace.has_rosa_subscription.return_value = False
 
-    assert reconciler_dry_run._enable_rosa_marketplace(aws_api, "account") is None
+    reconciler_dry_run._enable_rosa_marketplace(aws_api, "account")
     aws_api.marketplace.subscribe_rosa.assert_not_called()
 
 
 def test_aws_account_manager_reconcile_enable_rosa_marketplace_public(
     aws_api: MagicMock, reconciler: AWSReconciler
 ) -> None:
-    reconciler._enable_rosa_marketplace = MagicMock(return_value="agr-123")  # type: ignore
+    reconciler._enable_rosa_marketplace = MagicMock(return_value=None)  # type: ignore
     reconciler.enable_rosa_marketplace(aws_api, "account")
     reconciler._enable_rosa_marketplace.assert_called_once_with(aws_api, "account")


### PR DESCRIPTION
## Summary

Automates the manual SOP step of enabling ROSA HCP on AWS accounts during onboarding ([APPSRE-14982](https://redhat.atlassian.net/browse/APPSRE-14982)).

Currently, enabling ROSA HCP requires logging into the AWS console, searching for ROSA, and clicking "Enable ROSA with HCP" (per `openshift-rosa-clusters-prerequisites.md`). This PR replaces that manual step with programmatic marketplace subscription using the `marketplace-agreement` and `marketplace-discovery` boto3 APIs.

### Changes

- **New `qontract_utils/aws_api_typed/marketplace.py`** — Layer 1 client wrapping both marketplace services (pinned to `us-east-1`):
  - `has_rosa_subscription()` — idempotency check via `search_agreements` (filters: `PartyType=Acceptor`, `AgreementType=PurchaseAgreement`, `ResourceIdentifier`)
  - `discover_rosa_offer()` — discovers offer ID, proposal ID, and term IDs via `list_purchase_options` → `get_offer` → `get_offer_terms`
  - `subscribe_rosa()` — creates and accepts agreement request
- **Updated `aws_api_typed/api.py`** — Added `marketplace` cached property creating both clients
- **Updated `reconciler.py`** — Added `TASK_ENABLE_ROSA_MARKETPLACE` with state-tracked `_enable_rosa_marketplace()` method
- **Updated `integration.py`** — Wired into `create_accounts()` after IAM user creation, gated by `additionalFeatures.rosa: true`

### Design

- Uses hardcoded ROSA HCP product ID (`bfdca560-2c78-4e64-8193-794c159e6d30`) — stable AWS Marketplace identifier
- Dynamic offer/term discovery via `list_purchase_options` → `get_offer` → `get_offer_terms`
- Idempotent: checks existing agreements before subscribing, state-tracked to skip on re-runs
- No new dependencies — uses existing boto3 (no type stubs available for marketplace services, clients typed as `Any`)

### IAM permissions required on target account role

- `aws-marketplace-agreement:SearchAgreements`
- `aws-marketplace-agreement:CreateAgreementRequest`
- `aws-marketplace-agreement:AcceptAgreementRequest`
- `aws-marketplace-discovery:ListPurchaseOptions`
- `aws-marketplace-discovery:GetOffer`
- `aws-marketplace-discovery:GetOfferTerms`

## Test plan

- [x] Layer 1 marketplace client unit tests (10 tests)
- [x] Reconciler ROSA marketplace tests (5 tests): wet run, already-subscribed, state-exists, dry-run, public method
- [x] mypy passes on all changed files
- [x] Validated with dry-run against real AWS account using `AWSApiMarketplace` directly
- [ ] Verify IAM permissions are granted on the OrganizationAccountAccessRole
