### PR TITLE
chore: add uv-lock-test target to all-tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help build push rc build-test test-app test clean
+.PHONY: help build push rc build-test test-app test clean all-tests uv-lock-test linter-test types-test qenerate-test helm-test unittest
 
 CONTAINER_ENGINE ?= $(shell which podman >/dev/null 2>&1 && echo podman || echo docker)
 CONTAINER_UID ?= $(shell id -u)
@@ -86,7 +86,10 @@ qenerate: gql-introspection gql-query-classes
 localstack:
 	@$(CONTAINER_ENGINE) compose -f dev/localstack/docker-compose.yml up
 
-all-tests: linter-test types-test qenerate-test helm-test unittest
+all-tests: uv-lock-test linter-test types-test qenerate-test helm-test unittest
+
+uv-lock-test:
+	uv lock --check
 
 linter-test:
 	uv run ruff check --no-fix


### PR DESCRIPTION
## Summary
- Adds a `uv-lock-test` target running `uv lock --check` to `all-tests`, catching out-of-sync lockfiles in CI.

## Test plan
- [ ] CI passes with `make all-tests`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded the complete test suite to verify that the dependency lockfile is up to date.
  * Added a dedicated lockfile validation check.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->