### PR TITLE
chore: set desired uv version in .tool-versions

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -4,4 +4,4 @@ terraform 1.6.6
 oc 4.19.0
 helm 3.21.3
 sloth 0.12.0
-uv latest
+uv 0.12.1

--- a/.tool-versions
+++ b/.tool-versions
@@ -4,4 +4,4 @@ terraform 1.6.6
 oc 4.19.0
 helm 3.21.3
 sloth 0.12.0
-uv
+uv latest


### PR DESCRIPTION
Without a version this does not work when using `mise`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Pinned the project’s `uv` tool version to 0.12.1 for more consistent development environments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->