### PR TITLE
feat(automated-actions): compile owner argument for action-detail/action-cancel

### DIFF
--- a/reconcile/automated_actions/config/integration.py
+++ b/reconcile/automated_actions/config/integration.py
@@ -13,6 +13,8 @@ from pydantic import BaseModel
 
 import reconcile.openshift_base as ob
 from reconcile.gql_definitions.automated_actions.instance import (
+    AutomatedActionActionCancelV1,
+    AutomatedActionActionDetailV1,
     AutomatedActionActionListV1,
     AutomatedActionExternalResourceFlushElastiCacheV1,
     AutomatedActionExternalResourceRdsRebootV1,
@@ -171,6 +173,18 @@ class AutomatedActionsConfigIntegration(
         for action in actions:
             parameters: list[dict[str, str]] = []
             match action:
+                case AutomatedActionActionCancelV1():
+                    # no special handling needed, just dump the values
+                    parameters.extend(
+                        arg.model_dump(exclude_none=True, exclude_defaults=True)
+                        for arg in action.action_cancel_arguments or []
+                    )
+                case AutomatedActionActionDetailV1():
+                    # no special handling needed, just dump the values
+                    parameters.extend(
+                        arg.model_dump(exclude_none=True, exclude_defaults=True)
+                        for arg in action.action_detail_arguments or []
+                    )
                 case AutomatedActionActionListV1():
                     # no special handling needed, just dump the values
                     parameters.extend(

--- a/reconcile/gql_definitions/automated_actions/instance.gql
+++ b/reconcile/gql_definitions/automated_actions/instance.gql
@@ -26,6 +26,16 @@ query AutomatedActionsInstances {
         }
       }
       maxOps
+      ... on AutomatedActionActionCancel_v1 {
+        action_cancel_arguments: arguments {
+          owner
+        }
+      }
+      ... on AutomatedActionActionDetail_v1 {
+        action_detail_arguments: arguments {
+          owner
+        }
+      }
       ... on AutomatedActionActionList_v1 {
         action_list_arguments: arguments {
           action_user

--- a/reconcile/gql_definitions/automated_actions/instance.py
+++ b/reconcile/gql_definitions/automated_actions/instance.py
@@ -70,6 +70,16 @@ query AutomatedActionsInstances {
         }
       }
       maxOps
+      ... on AutomatedActionActionCancel_v1 {
+        action_cancel_arguments: arguments {
+          owner
+        }
+      }
+      ... on AutomatedActionActionDetail_v1 {
+        action_detail_arguments: arguments {
+          owner
+        }
+      }
       ... on AutomatedActionActionList_v1 {
         action_list_arguments: arguments {
           action_user
@@ -236,6 +246,22 @@ class AutomatedActionV1(ConfiguredBaseModel):
     q_type: str = Field(..., alias="type")
     permissions: Optional[list[PermissionAutomatedActionsV1]] = Field(..., alias="permissions")
     max_ops: int = Field(..., alias="maxOps")
+
+
+class AutomatedActionActionCancelArgumentV1(ConfiguredBaseModel):
+    owner: Optional[str] = Field(..., alias="owner")
+
+
+class AutomatedActionActionCancelV1(AutomatedActionV1):
+    action_cancel_arguments: Optional[list[AutomatedActionActionCancelArgumentV1]] = Field(..., alias="action_cancel_arguments")
+
+
+class AutomatedActionActionDetailArgumentV1(ConfiguredBaseModel):
+    owner: Optional[str] = Field(..., alias="owner")
+
+
+class AutomatedActionActionDetailV1(AutomatedActionV1):
+    action_detail_arguments: Optional[list[AutomatedActionActionDetailArgumentV1]] = Field(..., alias="action_detail_arguments")
 
 
 class AutomatedActionActionListArgumentV1(ConfiguredBaseModel):
@@ -450,7 +476,7 @@ class AutomatedActionOpenshiftWorkloadRestartV1(AutomatedActionV1):
 class AutomatedActionsInstanceV1(ConfiguredBaseModel):
     name: str = Field(..., alias="name")
     deployment: NamespaceV1 = Field(..., alias="deployment")
-    actions: Optional[list[Union[AutomatedActionActionListV1, AutomatedActionExternalResourceFlushElastiCacheV1, AutomatedActionExternalResourceRdsRebootV1, AutomatedActionExternalResourceRdsSnapshotV1, AutomatedActionExternalResourceRdsStartV1, AutomatedActionExternalResourceRdsStopV1, AutomatedActionOpenshiftTriggerCronjobV1, AutomatedActionOpenshiftWorkloadDeleteV1, AutomatedActionOpenshiftWorkloadRestartV1, AutomatedActionV1]]] = Field(..., alias="actions")
+    actions: Optional[list[Union[AutomatedActionActionCancelV1, AutomatedActionActionDetailV1, AutomatedActionActionListV1, AutomatedActionExternalResourceFlushElastiCacheV1, AutomatedActionExternalResourceRdsRebootV1, AutomatedActionExternalResourceRdsSnapshotV1, AutomatedActionExternalResourceRdsStartV1, AutomatedActionExternalResourceRdsStopV1, AutomatedActionOpenshiftTriggerCronjobV1, AutomatedActionOpenshiftWorkloadDeleteV1, AutomatedActionOpenshiftWorkloadRestartV1, AutomatedActionV1]]] = Field(..., alias="actions")
 
 
 class AutomatedActionsInstancesQueryData(ConfiguredBaseModel):

--- a/reconcile/gql_definitions/introspection.json
+++ b/reconcile/gql_definitions/introspection.json
@@ -1113,6 +1113,16 @@
                         },
                         {
                             "kind": "OBJECT",
+                            "name": "AutomatedActionActionCancel_v1",
+                            "ofType": null
+                        },
+                        {
+                            "kind": "OBJECT",
+                            "name": "AutomatedActionActionDetail_v1",
+                            "ofType": null
+                        },
+                        {
+                            "kind": "OBJECT",
                             "name": "AutomatedActionActionList_v1",
                             "ofType": null
                         },
@@ -29947,7 +29957,7 @@
                             "deprecationReason": null
                         },
                         {
-                            "name": "limit",
+                            "name": "rebase_limit",
                             "description": null,
                             "args": [],
                             "type": {
@@ -36547,6 +36557,208 @@
                 },
                 {
                     "kind": "OBJECT",
+                    "name": "QuayRepository_v1",
+                    "description": null,
+                    "fields": [
+                        {
+                            "name": "name",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "NON_NULL",
+                                "name": null,
+                                "ofType": {
+                                    "name": "String",
+                                    "kind": "SCALAR",
+                                    "ofType": null
+                                }
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "permission",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "NON_NULL",
+                                "name": null,
+                                "ofType": {
+                                    "name": "String",
+                                    "kind": "SCALAR",
+                                    "ofType": null
+                                }
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        }
+                    ],
+                    "inputFields": null,
+                    "interfaces": [],
+                    "enumValues": null,
+                    "possibleTypes": null
+                },
+                {
+                    "kind": "OBJECT",
+                    "name": "QuayRobot_v1",
+                    "description": null,
+                    "fields": [
+                        {
+                            "name": "schema",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "NON_NULL",
+                                "name": null,
+                                "ofType": {
+                                    "name": "String",
+                                    "kind": "SCALAR",
+                                    "ofType": null
+                                }
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "path",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "NON_NULL",
+                                "name": null,
+                                "ofType": {
+                                    "name": "String",
+                                    "kind": "SCALAR",
+                                    "ofType": null
+                                }
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "labels",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "SCALAR",
+                                "name": "JSON",
+                                "ofType": null
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "name",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "NON_NULL",
+                                "name": null,
+                                "ofType": {
+                                    "name": "String",
+                                    "kind": "SCALAR",
+                                    "ofType": null
+                                }
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "description",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "SCALAR",
+                                "name": "String",
+                                "ofType": null
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "quay_username",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "SCALAR",
+                                "name": "String",
+                                "ofType": null
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "quay_org",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "OBJECT",
+                                "name": "QuayOrg_v1",
+                                "ofType": null
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "repositories",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "LIST",
+                                "name": null,
+                                "ofType": {
+                                    "name": null,
+                                    "kind": "NON_NULL",
+                                    "ofType": {
+                                        "name": "QuayRepository_v1",
+                                        "kind": "OBJECT",
+                                        "ofType": null
+                                    }
+                                }
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "teams",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "LIST",
+                                "name": null,
+                                "ofType": {
+                                    "name": null,
+                                    "kind": "NON_NULL",
+                                    "ofType": {
+                                        "name": "String",
+                                        "kind": "SCALAR",
+                                        "ofType": null
+                                    }
+                                }
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "delete",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "SCALAR",
+                                "name": "Boolean",
+                                "ofType": null
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        }
+                    ],
+                    "inputFields": null,
+                    "interfaces": [],
+                    "enumValues": null,
+                    "possibleTypes": null
+                },
+                {
+                    "kind": "OBJECT",
                     "name": "Bot_v1",
                     "description": null,
                     "fields": [
@@ -37193,6 +37405,30 @@
                                         "kind": "NON_NULL",
                                         "ofType": {
                                             "name": "ExternalUser_v1",
+                                            "kind": "OBJECT",
+                                            "ofType": null
+                                        }
+                                    }
+                                }
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "quay_robots",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "NON_NULL",
+                                "name": null,
+                                "ofType": {
+                                    "name": null,
+                                    "kind": "LIST",
+                                    "ofType": {
+                                        "name": null,
+                                        "kind": "NON_NULL",
+                                        "ofType": {
+                                            "name": "QuayRobot_v1",
                                             "kind": "OBJECT",
                                             "ofType": null
                                         }
@@ -41176,6 +41412,47 @@
                                     "kind": "NON_NULL",
                                     "ofType": {
                                         "name": "Bot_v1",
+                                        "kind": "OBJECT",
+                                        "ofType": null
+                                    }
+                                }
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "quay_robots_v1",
+                            "description": null,
+                            "args": [
+                                {
+                                    "name": "path",
+                                    "description": null,
+                                    "type": {
+                                        "kind": "SCALAR",
+                                        "name": "String",
+                                        "ofType": null
+                                    },
+                                    "defaultValue": null
+                                },
+                                {
+                                    "name": "filter",
+                                    "description": null,
+                                    "type": {
+                                        "kind": "SCALAR",
+                                        "name": "JSON",
+                                        "ofType": null
+                                    },
+                                    "defaultValue": null
+                                }
+                            ],
+                            "type": {
+                                "kind": "LIST",
+                                "name": null,
+                                "ofType": {
+                                    "name": null,
+                                    "kind": "NON_NULL",
+                                    "ofType": {
+                                        "name": "QuayRobot_v1",
                                         "kind": "OBJECT",
                                         "ofType": null
                                     }
@@ -52343,6 +52620,16 @@
                     "possibleTypes": [
                         {
                             "kind": "OBJECT",
+                            "name": "AutomatedActionActionCancel_v1",
+                            "ofType": null
+                        },
+                        {
+                            "kind": "OBJECT",
+                            "name": "AutomatedActionActionDetail_v1",
+                            "ofType": null
+                        },
+                        {
+                            "kind": "OBJECT",
                             "name": "AutomatedActionActionList_v1",
                             "ofType": null
                         },
@@ -52520,6 +52807,376 @@
                             "ofType": null
                         }
                     ],
+                    "enumValues": null,
+                    "possibleTypes": null
+                },
+                {
+                    "kind": "OBJECT",
+                    "name": "AutomatedActionActionCancel_v1",
+                    "description": null,
+                    "fields": [
+                        {
+                            "name": "schema",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "NON_NULL",
+                                "name": null,
+                                "ofType": {
+                                    "name": "String",
+                                    "kind": "SCALAR",
+                                    "ofType": null
+                                }
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "path",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "NON_NULL",
+                                "name": null,
+                                "ofType": {
+                                    "name": "String",
+                                    "kind": "SCALAR",
+                                    "ofType": null
+                                }
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "type",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "NON_NULL",
+                                "name": null,
+                                "ofType": {
+                                    "name": "String",
+                                    "kind": "SCALAR",
+                                    "ofType": null
+                                }
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "description",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "SCALAR",
+                                "name": "String",
+                                "ofType": null
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "maxOps",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "NON_NULL",
+                                "name": null,
+                                "ofType": {
+                                    "name": "Int",
+                                    "kind": "SCALAR",
+                                    "ofType": null
+                                }
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "instances",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "NON_NULL",
+                                "name": null,
+                                "ofType": {
+                                    "name": null,
+                                    "kind": "LIST",
+                                    "ofType": {
+                                        "name": null,
+                                        "kind": "NON_NULL",
+                                        "ofType": {
+                                            "name": "AutomatedActionsInstance_v1",
+                                            "kind": "OBJECT",
+                                            "ofType": null
+                                        }
+                                    }
+                                }
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "permissions",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "LIST",
+                                "name": null,
+                                "ofType": {
+                                    "name": null,
+                                    "kind": "NON_NULL",
+                                    "ofType": {
+                                        "name": "PermissionAutomatedActions_v1",
+                                        "kind": "OBJECT",
+                                        "ofType": null
+                                    }
+                                }
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "arguments",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "LIST",
+                                "name": null,
+                                "ofType": {
+                                    "name": null,
+                                    "kind": "NON_NULL",
+                                    "ofType": {
+                                        "name": "AutomatedActionActionCancelArgument_v1",
+                                        "kind": "OBJECT",
+                                        "ofType": null
+                                    }
+                                }
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        }
+                    ],
+                    "inputFields": null,
+                    "interfaces": [
+                        {
+                            "kind": "INTERFACE",
+                            "name": "AutomatedAction_v1",
+                            "ofType": null
+                        },
+                        {
+                            "kind": "INTERFACE",
+                            "name": "DatafileObject_v1",
+                            "ofType": null
+                        }
+                    ],
+                    "enumValues": null,
+                    "possibleTypes": null
+                },
+                {
+                    "kind": "OBJECT",
+                    "name": "AutomatedActionActionCancelArgument_v1",
+                    "description": null,
+                    "fields": [
+                        {
+                            "name": "owner",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "SCALAR",
+                                "name": "String",
+                                "ofType": null
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        }
+                    ],
+                    "inputFields": null,
+                    "interfaces": [],
+                    "enumValues": null,
+                    "possibleTypes": null
+                },
+                {
+                    "kind": "OBJECT",
+                    "name": "AutomatedActionActionDetail_v1",
+                    "description": null,
+                    "fields": [
+                        {
+                            "name": "schema",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "NON_NULL",
+                                "name": null,
+                                "ofType": {
+                                    "name": "String",
+                                    "kind": "SCALAR",
+                                    "ofType": null
+                                }
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "path",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "NON_NULL",
+                                "name": null,
+                                "ofType": {
+                                    "name": "String",
+                                    "kind": "SCALAR",
+                                    "ofType": null
+                                }
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "type",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "NON_NULL",
+                                "name": null,
+                                "ofType": {
+                                    "name": "String",
+                                    "kind": "SCALAR",
+                                    "ofType": null
+                                }
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "description",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "SCALAR",
+                                "name": "String",
+                                "ofType": null
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "maxOps",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "NON_NULL",
+                                "name": null,
+                                "ofType": {
+                                    "name": "Int",
+                                    "kind": "SCALAR",
+                                    "ofType": null
+                                }
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "instances",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "NON_NULL",
+                                "name": null,
+                                "ofType": {
+                                    "name": null,
+                                    "kind": "LIST",
+                                    "ofType": {
+                                        "name": null,
+                                        "kind": "NON_NULL",
+                                        "ofType": {
+                                            "name": "AutomatedActionsInstance_v1",
+                                            "kind": "OBJECT",
+                                            "ofType": null
+                                        }
+                                    }
+                                }
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "permissions",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "LIST",
+                                "name": null,
+                                "ofType": {
+                                    "name": null,
+                                    "kind": "NON_NULL",
+                                    "ofType": {
+                                        "name": "PermissionAutomatedActions_v1",
+                                        "kind": "OBJECT",
+                                        "ofType": null
+                                    }
+                                }
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "arguments",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "LIST",
+                                "name": null,
+                                "ofType": {
+                                    "name": null,
+                                    "kind": "NON_NULL",
+                                    "ofType": {
+                                        "name": "AutomatedActionActionDetailArgument_v1",
+                                        "kind": "OBJECT",
+                                        "ofType": null
+                                    }
+                                }
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        }
+                    ],
+                    "inputFields": null,
+                    "interfaces": [
+                        {
+                            "kind": "INTERFACE",
+                            "name": "AutomatedAction_v1",
+                            "ofType": null
+                        },
+                        {
+                            "kind": "INTERFACE",
+                            "name": "DatafileObject_v1",
+                            "ofType": null
+                        }
+                    ],
+                    "enumValues": null,
+                    "possibleTypes": null
+                },
+                {
+                    "kind": "OBJECT",
+                    "name": "AutomatedActionActionDetailArgument_v1",
+                    "description": null,
+                    "fields": [
+                        {
+                            "name": "owner",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "SCALAR",
+                                "name": "String",
+                                "ofType": null
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        }
+                    ],
+                    "inputFields": null,
+                    "interfaces": [],
                     "enumValues": null,
                     "possibleTypes": null
                 },

--- a/reconcile/test/automated_actions/config/test_automated_actions_config_integration.py
+++ b/reconcile/test/automated_actions/config/test_automated_actions_config_integration.py
@@ -129,6 +129,44 @@ def test_automated_actions_config_get_automated_actions_instances(
                             }
                         ],
                     },
+                    {
+                        "type": "action-detail",
+                        "permissions": [
+                            {
+                                "roles": [
+                                    {
+                                        "name": "app-sre",
+                                        "users": [
+                                            {"org_username": "user1"},
+                                            {"org_username": "user2"},
+                                        ],
+                                        "bots": [{"org_username": "bot1"}],
+                                    }
+                                ]
+                            }
+                        ],
+                        "maxOps": 0,
+                        "action_detail_arguments": [{"owner": ".*"}],
+                    },
+                    {
+                        "type": "action-cancel",
+                        "permissions": [
+                            {
+                                "roles": [
+                                    {
+                                        "name": "app-sre",
+                                        "users": [
+                                            {"org_username": "user1"},
+                                            {"org_username": "user2"},
+                                        ],
+                                        "bots": [{"org_username": "bot1"}],
+                                    }
+                                ]
+                            }
+                        ],
+                        "maxOps": 0,
+                        "action_cancel_arguments": [{"owner": ".*"}],
+                    },
                 ],
             },
         )

--- a/reconcile/test/automated_actions/conftest.py
+++ b/reconcile/test/automated_actions/conftest.py
@@ -12,6 +12,10 @@ from reconcile.automated_actions.config.integration import (
     AutomatedActionsUser,
 )
 from reconcile.gql_definitions.automated_actions.instance import (
+    AutomatedActionActionCancelArgumentV1,
+    AutomatedActionActionCancelV1,
+    AutomatedActionActionDetailArgumentV1,
+    AutomatedActionActionDetailV1,
     AutomatedActionActionListArgumentV1,
     AutomatedActionActionListV1,
     AutomatedActionOpenshiftWorkloadRestartArgumentV1,
@@ -119,6 +123,40 @@ def actions() -> list[AutomatedActionV1]:
                 )
             ],
         ),
+        AutomatedActionActionDetailV1(
+            type="action-detail",
+            maxOps=0,
+            permissions=[
+                PermissionAutomatedActionsV1(
+                    roles=[
+                        RoleV1(
+                            name="role-2",
+                            users=[UserV1(org_username="user1")],
+                            bots=[],
+                            expirationDate=None,
+                        )
+                    ],
+                )
+            ],
+            action_detail_arguments=[AutomatedActionActionDetailArgumentV1(owner=".*")],
+        ),
+        AutomatedActionActionCancelV1(
+            type="action-cancel",
+            maxOps=0,
+            permissions=[
+                PermissionAutomatedActionsV1(
+                    roles=[
+                        RoleV1(
+                            name="role-2",
+                            users=[UserV1(org_username="user1")],
+                            bots=[],
+                            expirationDate=None,
+                        )
+                    ],
+                )
+            ],
+            action_cancel_arguments=[AutomatedActionActionCancelArgumentV1(owner=".*")],
+        ),
         AutomatedActionOpenshiftWorkloadRestartV1(
             type="openshift-workload-restart",
             maxOps=5,
@@ -172,6 +210,16 @@ def automated_actions_roles() -> AutomatedActionRoles:
                 params={"action_user": ".*"},
             ),
             AutomatedActionsPolicy(
+                obj="action-detail",
+                max_ops=0,
+                params={"owner": ".*"},
+            ),
+            AutomatedActionsPolicy(
+                obj="action-cancel",
+                max_ops=0,
+                params={"owner": ".*"},
+            ),
+            AutomatedActionsPolicy(
                 obj="openshift-workload-restart",
                 max_ops=5,
                 params={
@@ -197,6 +245,14 @@ def policy_file() -> str:
     obj: action-list
     params:
       action_user: .*
+  - max_ops: 0
+    obj: action-detail
+    params:
+      owner: .*
+  - max_ops: 0
+    obj: action-cancel
+    params:
+      owner: .*
   - max_ops: 5
     obj: openshift-workload-restart
     params:

--- a/reconcile/test/fixtures/automated_actions/instances.yml
+++ b/reconcile/test/fixtures/automated_actions/instances.yml
@@ -78,6 +78,32 @@ automated_actions_instances_v1:
     action_list_arguments:
     - action_user: user1
 
+  - type: action-detail
+    maxOps: 0
+    permissions:
+    - roles:
+      - name: app-sre
+        users:
+        - org_username: user1
+        - org_username: user2
+        bots:
+        - org_username: bot1
+    action_detail_arguments:
+    - owner: .*
+
+  - type: action-cancel
+    maxOps: 0
+    permissions:
+    - roles:
+      - name: app-sre
+        users:
+        - org_username: user1
+        - org_username: user2
+        bots:
+        - org_username: bot1
+    action_cancel_arguments:
+    - owner: .*
+
   # no permissions
   - type: create-token
     maxOps: 0


### PR DESCRIPTION
## Summary

- Adds GraphQL fragments for the new `action-detail`/`action-cancel` automated-action types (`app-sre/qontract-schemas#1045`) to `instance.gql`, regenerates `instance.py`.
- Adds `AutomatedActionActionDetailV1`/`AutomatedActionActionCancelV1` cases to `compile_roles()`, turning the `owner` argument into `AutomatedActionsPolicy.params`, mirroring the existing `action-list`/`action_user` handling.

## Why

Without this, both new types would silently fall through `compile_roles()`'s unmatched-type case to an unconstrained `params: {}` (the same fallback `create-token`/`no-op` intentionally rely on) — meaning whichever role references them would get full access regardless of the configured `owner` pattern. That's not correct for the intended use: app-sre needs a real `owner: .*` grant (broad, but explicit and auditable), not an accidental unconstrained one.

Part of fixing an IDOR in `app-sre/automated-actions` (APPSRE-14974): any authenticated user can currently view/cancel any other user's action. Once `automated-actions` restricts the default role's `action-detail`/`action-cancel` to each action's own owner, app-sre support staff need this `owner` argument to keep their existing cross-user visibility for incident response.

## Dependencies / sequencing

- Depends on `app-sre/qontract-schemas#1045` (adds the schema types) being available wherever this integration's GraphQL queries run against.
- `app-interface` MR https://gitlab.cee.redhat.com/service/app-interface/-/merge_requests/200360 grants app-sre `owner: .*` for both types.
- `automated-actions` PR https://github.com/app-sre/automated-actions/pull/726 adds the actual enforcement — must deploy **last**, after this integration has regenerated OPA's role data with app-sre's grant in place.

## Test plan

TDD: fixtures extended first (new `action-detail`/`action-cancel` entries with `owner: ".*"`), confirmed `test_automated_actions_config_compile_roles` failed against the unmatched-type fallback, then added the match cases and confirmed green.

- [x] `uv run pytest reconcile/test/automated_actions/` — 13/13 pass.
- [x] `ruff check`/`ruff format --check`/`mypy` clean on the non-generated files touched.
- [x] `instance.py` regenerated via `qenerate` from the updated `.gql`; `introspection.json` diff is scoped exactly to the two new types.

Jira: APPSRE-14974

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for automated action detail and cancel actions.
  * These actions can now specify an owner and be included in automated-action policies.
  * Policy parameters now preserve configured action arguments while omitting empty or default values.
* **Bug Fixes**
  * Automated-action instances now correctly expose owner information for detail and cancel actions.
* **Tests**
  * Added coverage and fixtures for owner matching, permissions, and operation limits.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->