### PR TITLE
fix(glhk) hold labels apply within OMM group

### DIFF
--- a/reconcile/gitlab_housekeeping.py
+++ b/reconcile/gitlab_housekeeping.py
@@ -1050,6 +1050,23 @@ def _process_omm_member(
         ).inc()
         return _MemberResult()
 
+    hold_labels = set(HOLD_LABELS).intersection(mr.labels)
+    if hold_labels:
+        logging.info([
+            "omm-group",
+            "eject-hold-label",
+            gl.project.name,
+            mr.iid,
+            sorted(hold_labels),
+        ])
+        if not dry_run:
+            gl.remove_label(mr, OMM_PENDING)
+        optimistic_merge_rejected.labels(
+            project_id=mr.target_project_id,
+            reason="hold_label",
+        ).inc()
+        return _MemberResult()
+
     pipelines = gl.get_merge_request_pipelines(mr)
 
     if pipeline_timeout is not None and pipelines:

--- a/reconcile/test/test_gitlab_housekeeping.py
+++ b/reconcile/test/test_gitlab_housekeeping.py
@@ -2382,6 +2382,55 @@ def test_omm_group_ejects_error_labeled_mr(
 
 
 @pytest.mark.parametrize(
+    "hold_label",
+    [
+        "awaiting-approval",
+        "blocked/bot-access",
+        "changes-requested",
+        "do-not-merge/hold",
+        "do-not-merge/pending-review",
+        "bot/hold",
+        "needs-rebase",
+    ],
+)
+def test_omm_group_ejects_hold_labeled_mr(
+    mocker: MockerFixture,
+    hold_label: str,
+) -> None:
+    """MRs with any hold label added after group formation are ejected
+    from OMM groups without pipeline fetches or merge attempts."""
+    _setup_omm_group_mocks(mocker)
+    mocker.patch("reconcile.gitlab_housekeeping.clear_omm_group")
+
+    lead = create_autospec(ProjectMergeRequest)
+    lead.merge_commit_sha = "abc123"
+    lead.squash_commit_sha = None
+    lead.target_branch = "master"
+
+    mr = _make_merge_mr(11, ["approved", "tenant-bar", "omm-pending", hold_label])
+
+    mocker.patch(
+        "reconcile.gitlab_housekeeping.get_omm_pending_mrs",
+        return_value=[mr],
+    )
+
+    mocked_gl = _make_omm_gl(head_sha="abc123")
+
+    merges = gl_h._process_omm_group(
+        dry_run=False,
+        gl=mocked_gl,
+        lead=lead,
+        app_sre_usernames=set(),
+    )
+
+    assert merges == 0
+    mocked_gl.remove_label.assert_called_once_with(mr, "omm-pending")
+    mocked_gl.get_merge_request_pipelines.assert_not_called()
+    mr.merge.assert_not_called()
+    mr.rebase.assert_not_called()
+
+
+@pytest.mark.parametrize(
     "merge_sha, squash_sha",
     [("abc123", None), (None, "abc123")],
     ids=["merge-commit", "squash-commit"],


### PR DESCRIPTION
## Summary

- Eject MRs from an active OMM group if a hold label (`/hold`, `changes-requested`, `do-not-merge/hold`, etc.) is added after group formation
- Previously, hold labels were only checked during `preprocess_merge_requests` (serial merge path) — once an MR entered an OMM group, it could merge even if a reviewer flagged it

## Context

The OMM group processes pending members in a loop, checking for error labels and pipeline state. Hold labels were not checked, meaning a reviewer's `/hold` would be silently ignored until the OMM window either expires or the MR merges.

## Test plan

- [x] Parametrized test covering all 7 hold labels — verifies ejection, no pipeline fetch, no merge/rebase attempt
- [x] Existing OMM test suite passes (46 tests)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Members marked with a configured hold label are now removed from optimistic merge processing.
  * Hold-labeled members no longer trigger pipeline checks, merge attempts, or rebase attempts.
  * The `omm-pending` label is removed when applicable, while other labels remain unchanged.
  * Rejections caused by hold labels are now tracked accurately.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->