### PR TITLE
Add aws partition awareness to route53-zone IAM policy

### DIFF
--- a/reconcile/utils/terrascript_aws_client.py
+++ b/reconcile/utils/terrascript_aws_client.py
@@ -6224,7 +6224,7 @@ class TerrascriptClient:
                         "route53:Get*",
                         "route53:List*",
                     ],
-                    "Resource": "arn:aws:route53:::hostedzone/"
+                    "Resource": f"arn:{self._get_partition(account)}:route53:::hostedzone/"
                     + f"${{{zone_tf_resource.zone_id}}}",
                 },
                 {"Effect": "Allow", "Action": ["route53:List*"], "Resource": "*"},


### PR DESCRIPTION
### Summary
Refactor ARN reference in IAM policy created by `route53_zone` provider to be partition-aware. This is necessary for GovCloud usage of the provider.

ROSAENG-61395

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated Route53 IAM policy resource ARNs to support the account’s AWS partition, improving compatibility across AWS environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->