### PR TITLE
fix(glhk): handle canceled pipelines and transient merge errors

### DIFF
--- a/reconcile/gitlab_housekeeping.py
+++ b/reconcile/gitlab_housekeeping.py
@@ -873,7 +873,7 @@ def _is_omm_window_open(lead: ProjectMergeRequest, max_interval: timedelta) -> b
 
 
 def _check_post_merge_ci(gl: GitLabApi, lead: ProjectMergeRequest) -> bool:
-    """Return True if post-merge CI is healthy (not failed).
+    """Return True if post-merge CI is healthy (not failed or canceled).
 
     Only considers pipelines created after the lead was merged so that
     a stale pre-merge failure doesn't cancel a new OMM group.
@@ -1149,26 +1149,18 @@ def _process_omm_member(
             try:
                 squash = (gl.project.squash_option == SQUASH_OPTION_ALWAYS) or mr.squash
                 mr.merge(squash=squash)
-                labels = mr.labels
-                merged_merge_requests.labels(
-                    project_id=mr.target_project_id,
-                    self_service=SELF_SERVICEABLE in labels,
-                    auto_merge=AUTO_MERGE in labels,
-                    app_sre=mr.author["username"] in app_sre_usernames,
-                    onboarding=ONBOARDING in labels,
-                ).inc()
-                optimistic_merges.labels(project_id=mr.target_project_id).inc()
-                gl.remove_label(mr, OMM_PENDING)
-                approval_info = _get_approval_info(gl, mr)
-                if approval_info:
-                    priority, approved_at = approval_info
-                    time_to_merge.labels(
-                        project_id=mr.target_project_id, priority=priority
-                    ).observe(_calculate_time_since_approval(approved_at))
             except gitlab.exceptions.GitlabMRClosedError as e:
                 logging.error(f"unable to merge {mr.iid}: {e}")
-                gl.add_label_to_merge_request(mr, MERGE_ERROR)
-                gl.remove_label(mr, OMM_PENDING)
+                try:
+                    gl.add_label_to_merge_request(mr, MERGE_ERROR)
+                    gl.remove_label(mr, OMM_PENDING)
+                except gitlab.exceptions.GitlabError:
+                    logging.warning([
+                        "omm-group",
+                        "label-cleanup-failed",
+                        gl.project.name,
+                        mr.iid,
+                    ])
                 optimistic_merge_rejected.labels(
                     project_id=mr.target_project_id, reason="merge_rejected"
                 ).inc()
@@ -1181,11 +1173,44 @@ def _process_omm_member(
                     mr.iid,
                     str(e),
                 ])
-                gl.remove_label(mr, OMM_PENDING)
+                try:
+                    gl.remove_label(mr, OMM_PENDING)
+                except gitlab.exceptions.GitlabError:
+                    logging.warning([
+                        "omm-group",
+                        "label-cleanup-failed",
+                        gl.project.name,
+                        mr.iid,
+                    ])
                 optimistic_merge_rejected.labels(
                     project_id=mr.target_project_id, reason="merge_error"
                 ).inc()
                 return _MemberResult()
+
+            labels = mr.labels
+            merged_merge_requests.labels(
+                project_id=mr.target_project_id,
+                self_service=SELF_SERVICEABLE in labels,
+                auto_merge=AUTO_MERGE in labels,
+                app_sre=mr.author["username"] in app_sre_usernames,
+                onboarding=ONBOARDING in labels,
+            ).inc()
+            optimistic_merges.labels(project_id=mr.target_project_id).inc()
+            try:
+                gl.remove_label(mr, OMM_PENDING)
+            except gitlab.exceptions.GitlabError:
+                logging.warning([
+                    "omm-group",
+                    "label-cleanup-failed",
+                    gl.project.name,
+                    mr.iid,
+                ])
+            approval_info = _get_approval_info(gl, mr)
+            if approval_info:
+                priority, approved_at = approval_info
+                time_to_merge.labels(
+                    project_id=mr.target_project_id, priority=priority
+                ).observe(_calculate_time_since_approval(approved_at))
         return _MemberResult(merged=True)
 
     # Not rebased + SUCCESS: skip-ci rebase to bring MR up to date

--- a/reconcile/gitlab_housekeeping.py
+++ b/reconcile/gitlab_housekeeping.py
@@ -889,7 +889,7 @@ def _check_post_merge_ci(gl: GitLabApi, lead: ProjectMergeRequest) -> bool:
     for pipeline in pipelines:
         if from_utc_iso_format(pipeline.created_at) < merged_at:
             break
-        return pipeline.status != PipelineStatus.FAILED
+        return pipeline.status not in {PipelineStatus.FAILED, PipelineStatus.CANCELED}
     return True
 
 
@@ -1171,6 +1171,19 @@ def _process_omm_member(
                 gl.remove_label(mr, OMM_PENDING)
                 optimistic_merge_rejected.labels(
                     project_id=mr.target_project_id, reason="merge_rejected"
+                ).inc()
+                return _MemberResult()
+            except gitlab.exceptions.GitlabError as e:
+                logging.warning([
+                    "omm-group",
+                    "eject-merge-error",
+                    gl.project.name,
+                    mr.iid,
+                    str(e),
+                ])
+                gl.remove_label(mr, OMM_PENDING)
+                optimistic_merge_rejected.labels(
+                    project_id=mr.target_project_id, reason="merge_error"
                 ).inc()
                 return _MemberResult()
         return _MemberResult(merged=True)

--- a/reconcile/test/test_gitlab_housekeeping.py
+++ b/reconcile/test/test_gitlab_housekeeping.py
@@ -17,6 +17,7 @@ import pytest
 from gitlab import Gitlab
 from gitlab.const import PipelineStatus
 from gitlab.exceptions import (
+    GitlabError,
     GitlabGetError,
     GitlabMRClosedError,
     GitlabMRRebaseError,
@@ -2478,6 +2479,57 @@ def test_omm_group_merge_rejected_applies_merge_error(
     mr.merge.assert_called_once()
     mocked_gl.add_label_to_merge_request.assert_called_once_with(mr, "merge-error")
     mocked_gl.remove_label.assert_called_once_with(mr, "omm-pending")
+
+
+@pytest.mark.parametrize(
+    "merge_sha, squash_sha",
+    [("abc123", None), (None, "abc123")],
+    ids=["merge-commit", "squash-commit"],
+)
+def test_omm_group_transient_merge_error_ejects_without_merge_error_label(
+    mocker: MockerFixture,
+    merge_sha: str | None,
+    squash_sha: str | None,
+) -> None:
+    """A generic GitlabError (e.g. 500) on merge ejects the member from the
+    OMM group but does NOT apply merge-error label, allowing retry via serial path."""
+    _setup_omm_group_mocks(mocker)
+    mocker.patch(
+        "reconcile.gitlab_housekeeping.is_rebased",
+        return_value=True,
+    )
+    clear_mock = mocker.patch(
+        "reconcile.gitlab_housekeeping.clear_omm_group",
+    )
+
+    lead = create_autospec(ProjectMergeRequest)
+    lead.merge_commit_sha = merge_sha
+    lead.squash_commit_sha = squash_sha
+    lead.target_branch = "master"
+
+    mr = _make_merge_mr(11, ["approved", "tenant-bar", "omm-pending"])
+    mr.merge.side_effect = GitlabError("500 Internal Server Error")
+
+    mocker.patch(
+        "reconcile.gitlab_housekeeping.get_omm_pending_mrs",
+        return_value=[mr],
+    )
+
+    mocked_gl = _make_omm_gl(head_sha="abc123")
+    mocked_gl.get_merge_request_pipelines.return_value = [_success_pipeline()]
+
+    merges = gl_h._process_omm_group(
+        dry_run=False,
+        gl=mocked_gl,
+        lead=lead,
+        app_sre_usernames=set(),
+    )
+
+    assert merges == 0
+    mr.merge.assert_called_once()
+    mocked_gl.add_label_to_merge_request.assert_not_called()
+    mocked_gl.remove_label.assert_called_once_with(mr, "omm-pending")
+    clear_mock.assert_called_once()
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary
- `_check_post_merge_ci` now treats `CANCELED` pipelines as failures alongside `FAILED`, preventing stale MRs from blocking OMM group
- `_process_omm_member` catches broad `GitlabError` (e.g. 500 Internal Server Error) during merge — ejects member from OMM group gracefully with `omm-pending` label removed and `merge_error` metric incremented, instead of propagating exception

## Test plan
- [x] New test `test_omm_group_transient_merge_error_ejects_without_merge_error_label` covers GitlabError path for both merge-commit and squash-commit scenarios
- [x] Existing tests pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Canceled pipelines are now treated as unhealthy during post-merge health checks.
  * Improved handling of GitLab merge failures by clearing pending status and allowing affected merges to be retried.
  * Merge failures are now recorded for monitoring without applying an incorrect failure label.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->