### PR TITLE
fix(git): allow print-to-file paths that are gitignored

### DIFF
--- a/reconcile/utils/git.py
+++ b/reconcile/utils/git.py
@@ -67,7 +67,12 @@ def is_file_in_git_repo(file_path: str) -> bool:
     dir_path = os.path.dirname(real_path)
     cmd = ["git", "rev-parse", "--is-inside-work-tree"]
     result = subprocess.run(cmd, cwd=dir_path, capture_output=True, check=False)
-    return result.returncode == 0
+    if result.returncode != 0:
+        return False
+    # If git check-ignore returns 0, the path is gitignored — allow it
+    cmd = ["git", "check-ignore", "-q", real_path]
+    result = subprocess.run(cmd, cwd=dir_path, capture_output=True, check=False)
+    return result.returncode != 0
 
 
 def has_uncommited_changes() -> bool:


### PR DESCRIPTION
## Summary
- `is_file_in_git_repo` previously blocked all paths inside a git work tree, even gitignored ones
- Now uses `git check-ignore` to allow gitignored paths, since they won't be accidentally committed
- Affects all `print_to_file` safety checks in CLI and terraform config client

## Test plan
- [ ] Verify `is_file_in_git_repo` returns `False` for a path listed in `.gitignore`
- [ ] Verify `is_file_in_git_repo` returns `True` for a tracked/unignored path inside a repo
- [ ] Verify `is_file_in_git_repo` returns `False` for a path outside any git repo

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved file detection so paths outside Git repositories are correctly excluded.
  * Ignored files are no longer treated as tracked repository files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->