### PR TITLE
fix(ocm): migrate service log severities to HCC labels

### DIFF
--- a/reconcile/aus/advanced_upgrade_service.py
+++ b/reconcile/aus/advanced_upgrade_service.py
@@ -622,7 +622,7 @@ def _signal_validation_issues_for_org(
                 ocm_api=ocm_api,
                 service_log=OCMClusterServiceLogCreateModel(
                     cluster_uuid=cluster.cluster_uuid,
-                    severity=OCMServiceLogSeverity.Warning,
+                    severity=OCMServiceLogSeverity.Moderate,
                     summary="AUS configuration error on organization",
                     description=org_error_msg,
                     service_name=QONTRACT_INTEGRATION,
@@ -643,7 +643,7 @@ def _expose_cluster_validation_errors_as_service_log(
         ocm_api=ocm_api,
         service_log=OCMClusterServiceLogCreateModel(
             cluster_uuid=cluster_uuid,
-            severity=OCMServiceLogSeverity.Warning,
+            severity=OCMServiceLogSeverity.Moderate,
             summary="Cluster upgrade policy validation errors",
             description=description,
             service_name=QONTRACT_INTEGRATION,

--- a/reconcile/dynatrace_token_provider/integration.py
+++ b/reconcile/dynatrace_token_provider/integration.py
@@ -696,7 +696,7 @@ def _expose_errors_as_service_log(
     ocm_api.create_service_log(
         service_log=OCMClusterServiceLogCreateModel(
             cluster_uuid=cluster_uuid,
-            severity=OCMServiceLogSeverity.Warning,
+            severity=OCMServiceLogSeverity.Moderate,
             summary="Dynatrace Token Provider Errors",
             description=f"\n {error}",
             service_name=QONTRACT_INTEGRATION,

--- a/reconcile/oum/standalone.py
+++ b/reconcile/oum/standalone.py
@@ -70,7 +70,7 @@ class OCMStandaloneUserManagementIntegration(OCMUserManagementIntegration):
             ocm_api=ocm_api,
             service_log=OCMClusterServiceLogCreateModel(
                 cluster_uuid=spec.cluster.ocm_cluster.external_id,
-                severity=OCMServiceLogSeverity.Info,
+                severity=OCMServiceLogSeverity.Low,
                 summary="Reconciled cluster groups",
                 description=message,
                 service_name=self.name,
@@ -101,7 +101,7 @@ class OCMStandaloneUserManagementIntegration(OCMUserManagementIntegration):
             ocm_api=ocm_api,
             service_log=OCMClusterServiceLogCreateModel(
                 cluster_uuid=spec.cluster.ocm_cluster.external_id,
-                severity=OCMServiceLogSeverity.Error,
+                severity=OCMServiceLogSeverity.Critical,
                 summary="Failed to reconcile cluster user group configuration",
                 description=str(error),
                 service_name=self.name,

--- a/reconcile/test/ocm/test_utils_ocm_service_log.py
+++ b/reconcile/test/ocm/test_utils_ocm_service_log.py
@@ -41,7 +41,7 @@ def build_service_log(
     description: str = "",
     cluster_uuid: str = "",
     service_name: str = "some-service",
-    severity: OCMServiceLogSeverity = OCMServiceLogSeverity.Info,
+    severity: OCMServiceLogSeverity = OCMServiceLogSeverity.Low,
     timestamp: datetime = datetime(2020, 1, 2, 0, 0, 0, 0, tzinfo=UTC),
 ) -> OCMClusterServiceLog:
     return OCMClusterServiceLog(
@@ -67,7 +67,7 @@ def example_service_log(
         "some error",
         "description",
         "cluster_uuid",
-        severity=OCMServiceLogSeverity.Error,
+        severity=OCMServiceLogSeverity.Critical,
     )
     register_ocm_url_responses([
         OcmUrl(method="GET", uri=CLUSTER_SERVICE_LOGS_LIST_ENDPOINT).add_list_response([
@@ -133,7 +133,7 @@ def test_create_service_log(
                     summary="something happened",
                     description="something happenes",
                     service_name="some-service",
-                    severity=OCMServiceLogSeverity.Info,
+                    severity=OCMServiceLogSeverity.Low,
                     timestamp=timestamp,
                 ),
             ],
@@ -146,7 +146,7 @@ def test_create_service_log(
             summary="something happened",
             description="something happenes",
             service_name="some-service",
-            severity=OCMServiceLogSeverity.Info,
+            severity=OCMServiceLogSeverity.Low,
         ),
     )
     assert result is not None
@@ -165,7 +165,7 @@ def test_create_service_log_dedup_timedelta_filter(
             "some error",
             "description",
             "cluster_uuid",
-            severity=OCMServiceLogSeverity.Error,
+            severity=OCMServiceLogSeverity.Critical,
         )
     ])
 
@@ -177,7 +177,7 @@ def test_create_service_log_dedup_timedelta_filter(
             summary="something happened",
             description="something happenes",
             service_name="some-service",
-            severity=OCMServiceLogSeverity.Info,
+            severity=OCMServiceLogSeverity.Low,
         ),
         dedup_interval=dedup_interval,
     )
@@ -207,7 +207,7 @@ def test_create_service_log_dedup(
             summary="something happened",
             description="something happenes",
             service_name="some-service",
-            severity=OCMServiceLogSeverity.Info,
+            severity=OCMServiceLogSeverity.Low,
         ),
         dedup_interval=timedelta(days=1),
     )
@@ -238,7 +238,7 @@ def test_create_service_log_dedup_no_dup(
             summary="SOMETHING ELSE HAPPENED",
             description="something happenes",
             service_name="some-service",
-            severity=OCMServiceLogSeverity.Info,
+            severity=OCMServiceLogSeverity.Low,
         ),
         dedup_interval=timedelta(days=1),
     )

--- a/reconcile/utils/ocm/base.py
+++ b/reconcile/utils/ocm/base.py
@@ -439,11 +439,11 @@ class OCMServiceLogSeverity(StrEnum):
     Represents the severity of a service log.
     """
 
+    Low = "Low"
+    Moderate = "Moderate"
+    Important = "Important"
+    Critical = "Critical"
     Debug = "Debug"
-    Info = "Info"
-    Warning = "Warning"
-    Error = "Error"
-    Fatal = "Fatal"
 
 
 class OCMClusterServiceLogCreateModel(BaseModel):


### PR DESCRIPTION
## Summary
Replaced deprecated OCM severity labels with HCC-compatible labels:
- `Info` → `Low`
- `Warning` → `Moderate`
- `Error` → `Critical`
- `Fatal` → removed (not used in codebase)

Updated all OCM service log calls across:
- `reconcile/aus/advanced_upgrade_service.py`
- `reconcile/dynatrace_token_provider/integration.py`
- `reconcile/oum/standalone.py`
- Tests in `reconcile/test/ocm/test_utils_ocm_service_log.py`

## Test plan
- [x] All existing tests pass (`reconcile/test/ocm/test_utils_ocm_service_log.py`)
- [x] Changed severity values in tests reflect the new HCC labels
- [x] No behavioral changes, only label migration

Resolves: APPSRE-15049

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Changes**
  * Updated service log severity levels to provide clearer distinctions between low-impact notices, moderate issues, important events, and critical failures.
  * Advanced upgrade and token-provider validation messages now use moderate severity.
  * Successful standalone user-management reconciliations are recorded as low-severity events.
  * Validation failures are now recorded as critical events, improving visibility and prioritization.
  * Related service-log records and test coverage were updated to reflect the revised severity classifications.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->