### PR TITLE
fix(qontract-api): bind OPA sidecar to localhost, close unauthenticated policy API exposure

### DIFF
--- a/opa/Dockerfile
+++ b/opa/Dockerfile
@@ -1,3 +1,9 @@
+# ubi-minimal (not ubi-micro) is required here: OPA runs as a sidecar bound to
+# 127.0.0.1 only (see openshift/qontract-api.yaml), so kubelet's httpGet/tcpSocket
+# probes can't reach it from outside the pod netns. Liveness/readiness/startup
+# probes instead exec `curl` inside this container against 127.0.0.1:8181 —
+# provided by ubi-minimal's curl-minimal package. Do not slim this image down
+# without replacing that probe mechanism.
 FROM registry.access.redhat.com/ubi10/ubi-minimal@sha256:ceaad73890ea88685eeb1b40a502b7983f2cfac6f1aa10915d1176d51eb90124 AS base
 COPY --from=openpolicyagent/opa:1.19.0-static@sha256:2f42ca765bb739b40fc23ee625b3287012acdf8120ad4fcbdab68433a17be144 /opa /opa
 

--- a/openshift/qontract-api.yaml
+++ b/openshift/qontract-api.yaml
@@ -177,22 +177,30 @@ objects:
                   command:
                     - curl
                     - -sf
+                    - --max-time
+                    - "4"
                     - http://127.0.0.1:8181/health
                 initialDelaySeconds: 5
                 periodSeconds: 60
+                timeoutSeconds: 5
               readinessProbe:
                 exec:
                   command:
                     - curl
                     - -sf
+                    - --max-time
+                    - "4"
                     - http://127.0.0.1:8181/health?bundle=true
                 initialDelaySeconds: 5
                 periodSeconds: 10
+                timeoutSeconds: 5
               startupProbe:
                 exec:
                   command:
                     - curl
                     - -sf
+                    - --max-time
+                    - "4"
                     - http://127.0.0.1:8181/health
                 initialDelaySeconds: 1
                 periodSeconds: 5

--- a/openshift/qontract-api.yaml
+++ b/openshift/qontract-api.yaml
@@ -154,7 +154,7 @@ objects:
                 - --server
                 - --log-level=info
                 - --disable-telemetry
-                - --addr=0.0.0.0:8181
+                - --addr=127.0.0.1:8181
                 - --set=decision_logs.console=true
                 - --watch
                 - /authz
@@ -169,21 +169,31 @@ objects:
                       - sh
                       - "-c"
                       - sleep 2
+              # httpGet/tcpSocket probes can't reach a loopback-only port from
+              # the kubelet (outside the pod's network namespace), so probes
+              # exec curl from inside the container instead.
               livenessProbe:
-                httpGet:
-                  path: /health
-                  port: 8181
+                exec:
+                  command:
+                    - curl
+                    - -sf
+                    - http://127.0.0.1:8181/health
                 initialDelaySeconds: 5
                 periodSeconds: 60
               readinessProbe:
-                httpGet:
-                  path: /health?bundle=true
-                  port: 8181
+                exec:
+                  command:
+                    - curl
+                    - -sf
+                    - http://127.0.0.1:8181/health?bundle=true
                 initialDelaySeconds: 5
                 periodSeconds: 10
               startupProbe:
-                tcpSocket:
-                  port: 8181
+                exec:
+                  command:
+                    - curl
+                    - -sf
+                    - http://127.0.0.1:8181/health
                 initialDelaySeconds: 1
                 periodSeconds: 5
                 timeoutSeconds: 5


### PR DESCRIPTION
## Summary
- OPA runs as a sidecar in the `qontract-api` pod but was bound with `--addr=0.0.0.0:8181` and ships no auth or NetworkPolicy — any co-tenant pod in the same namespace could reach its unauthenticated policy-management REST API (`PUT`/`DELETE` on `/v1/policies/*` and `/v1/data/*`), since OpenShift's default NetworkPolicies only block cross-namespace traffic.
- Bind OPA to `127.0.0.1:8181` instead, so it's only reachable from the `api` container in the same pod.
- `httpGet`/`tcpSocket` probes can no longer reach a loopback-only port from outside the pod's network namespace, so the `opa` container's liveness/readiness/startup probes are switched to `exec curl` from inside the container instead — same approach applied in `app-sre/automated-actions#721` for the sibling finding (APPSRE-14970).
- All three exec probes get an explicit `timeoutSeconds: 5` and `curl --max-time 4`, since exec probes default to a 1s timeout in Kubernetes which is tight for spawning a process.

## Test plan
- [x] `openshift/qontract-api.yaml` parses as valid YAML
- [x] Verified no other references to the old `0.0.0.0:8181` bind address in the repo
- [ ] Deploy to a test namespace and confirm the `opa` container passes liveness/readiness/startup probes and the `api` container can still reach OPA at `http://localhost:8181`

Jira: https://redhat.atlassian.net/browse/APPSRE-14981

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved OPA health monitoring by running liveness, readiness, and startup checks from within the container.
  * Restricted OPA access to the local container interface for improved security.
  * Added explicit health-check timing controls to improve startup and probe reliability.
  * Maintained dependable health checks while using the minimal runtime image.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->