### PR TITLE
Revert "chore(glhk): log CANNOT_BE_MERGED checks"

### DIFF
--- a/reconcile/gitlab_housekeeping.py
+++ b/reconcile/gitlab_housekeeping.py
@@ -531,13 +531,6 @@ def preprocess_merge_requests(
             MRStatus.CANNOT_BE_MERGED,
             MRStatus.CANNOT_BE_MERGED_RECHECK,
         }:
-            logging.info([
-                "preprocess",
-                gl.project.name,
-                mr.iid,
-                "skip-cannot-be-merged",
-                mr.merge_status,
-            ])
             continue
         if mr.draft:
             continue
@@ -1479,13 +1472,6 @@ def run_error_healthcheck(
             MRStatus.CANNOT_BE_MERGED,
             MRStatus.CANNOT_BE_MERGED_RECHECK,
         }:
-            logging.info([
-                "error-healthcheck",
-                gl.project.name,
-                mr.iid,
-                "skip-cannot-be-merged",
-                mr.merge_status,
-            ])
             continue
 
         if not is_good_to_merge(mr.labels):


### PR DESCRIPTION
Reverts app-sre/qontract-reconcile#5733

Logs were extremely noisy, needed to be reverted

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed informational log messages when certain unmergeable merge requests are skipped.
  * Skipping behavior remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->