### PR TITLE
fix(dashdotdb): acquire token before posting DORA metrics

### DIFF
--- a/reconcile/dashdotdb_dora.py
+++ b/reconcile/dashdotdb_dora.py
@@ -339,11 +339,7 @@ class DashdotdbDORA(DashdotdbBase):
         ]
 
         if deployments:
-            self._get_token()
-            try:
-                self.post({"deployments": deployments})
-            finally:
-                self._close_token()
+            self._post_deployments(deployments)
 
     def get_saastargets(self) -> list[SaasTarget]:
         targets = []
@@ -482,6 +478,20 @@ class DashdotdbDORA(DashdotdbBase):
             Commit(rc.repo_url, commit.sha, commit.commit.committer.date)
             for commit in self.gh_api(repo).compare(rc.ref_from, rc.ref_to)
         ]
+
+    def _post_deployments(self, deployments: list[dict[str, Any]]) -> None:
+        self._get_token()
+        if not self.dry_run and not self.dashdotdb_token:
+            LOG.error(
+                "%s failed to acquire token for %s data, skipping POST",
+                self.logmarker,
+                self.scope,
+            )
+            return
+        try:
+            self.post({"deployments": deployments})
+        finally:
+            self._close_token()
 
     def post(self, data: Mapping[str, Any]) -> None:
         endpoint = f"{self.dashdotdb_url}/api/v1/dora"

--- a/reconcile/dashdotdb_dora.py
+++ b/reconcile/dashdotdb_dora.py
@@ -339,7 +339,11 @@ class DashdotdbDORA(DashdotdbBase):
         ]
 
         if deployments:
-            self.post({"deployments": deployments})
+            self._get_token()
+            try:
+                self.post({"deployments": deployments})
+            finally:
+                self._close_token()
 
     def get_saastargets(self) -> list[SaasTarget]:
         targets = []

--- a/reconcile/test/test_dashdotdb_dora.py
+++ b/reconcile/test/test_dashdotdb_dora.py
@@ -252,3 +252,26 @@ def test_get_repo_changes(mocker: MockerFixture) -> None:
     assert exp_saas_target == saastarget
     assert exp_deployment == deployment
     assert repo_changes == RepoChanges("repo1", "commitA", "commitB")
+
+
+def test_post_deployments_skips_when_get_token_fails(
+    mocker: MockerFixture,
+) -> None:
+    mocker.patch(
+        "reconcile.dashdotdb_dora.DashdotdbDORA.__init__"
+    ).return_value = None
+    d = DashdotdbDORA(False, "1", 1)
+    d.dry_run = False
+    d.dashdotdb_token = None
+    d.logmarker = "DORA"
+    d.scope = "dora"
+
+    d._get_token = MagicMock()  # type: ignore[method-assign]
+    d.post = MagicMock()  # type: ignore[method-assign]
+    d._close_token = MagicMock()  # type: ignore[method-assign]
+
+    d._post_deployments([{"some": "deployment"}])
+
+    d._get_token.assert_called_once()
+    d.post.assert_not_called()
+    d._close_token.assert_not_called()

--- a/reconcile/test/test_dashdotdb_dora.py
+++ b/reconcile/test/test_dashdotdb_dora.py
@@ -257,9 +257,7 @@ def test_get_repo_changes(mocker: MockerFixture) -> None:
 def test_post_deployments_skips_when_get_token_fails(
     mocker: MockerFixture,
 ) -> None:
-    mocker.patch(
-        "reconcile.dashdotdb_dora.DashdotdbDORA.__init__"
-    ).return_value = None
+    mocker.patch("reconcile.dashdotdb_dora.DashdotdbDORA.__init__").return_value = None
     d = DashdotdbDORA(False, "1", 1)
     d.dry_run = False
     d.dashdotdb_token = None


### PR DESCRIPTION
## Summary

- The DORA integration was the only dashdotdb client that skipped `_get_token()` / `_close_token()` around its POST call, sending requests without an `X-Auth` header.
- This was harmless because the server endpoint also lacked auth enforcement, but the server side is being fixed to require `TokenAuth` (matching all other write endpoints).
- Follows the SLO pattern: `_get_token()` with try/finally `_close_token()`.

**Must merge before** the corresponding server-side PR (app-sre/dashdotdb) to avoid 401s during the rollout window.

## Test plan

- [ ] Verify DORA metrics are still ingested successfully in staging after deploy
- [ ] Confirm `X-Auth` header is present in POST requests (check dashdotdb logs)
- [ ] Verify dry-run mode still skips token acquisition (existing base class behavior)

Ref: APPSRE-14999

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved deployment reporting reliability by ensuring authentication is established before submissions and properly closed afterward.
  * Prevented unnecessary submission attempts when no deployments are available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->