### PR TITLE
chore(renovate): group uv bumps in .tool-versions with pyproject.toml

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,4 +1,14 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["github>app-sre/shared-pipelines//renovate/default.json"]
+  "extends": ["github>app-sre/shared-pipelines//renovate/default.json"],
+  "customManagers": [
+    {
+      "customType": "regex",
+      "description": "Update uv version in .tool-versions",
+      "fileMatch": ["(^|/)\\.tool-versions$"],
+      "matchStrings": ["uv (?<currentValue>[\\d.]+)"],
+      "depNameTemplate": "ghcr.io/astral-sh/uv",
+      "datasourceTemplate": "docker"
+    }
+  ]
 }


### PR DESCRIPTION
## Summary
- Add a customManager for `.tool-versions` reusing the `ghcr.io/astral-sh/uv` / `docker` dependency identity already used by the `pyproject.toml` uv manager (added upstream in app-sre/shared-pipelines#384), so Renovate bundles both version bumps into a single PR instead of two.

## Test plan
- [ ] Confirm Renovate picks up both `pyproject.toml` and `.tool-versions` uv references in one grouped PR on the next dependency dashboard run

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved automated dependency update handling for `uv` versions.
  * `uv` updates are now detected and maintained consistently from project version settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->