### PR TITLE
fix(qontract-api): bound gzip request decompression to prevent decompression bombs

### DIFF
--- a/qontract_api/qontract_api/constants.py
+++ b/qontract_api/qontract_api/constants.py
@@ -2,3 +2,7 @@
 
 # HTTP Headers
 REQUEST_ID_HEADER = "X-Request-ID"
+
+# Gzip request decompression limits (protect against decompression bombs)
+MAX_GZIP_COMPRESSED_SIZE = 10 * 1024 * 1024  # 10 MB
+MAX_GZIP_DECOMPRESSED_SIZE = 100 * 1024 * 1024  # 100 MB

--- a/qontract_api/qontract_api/middleware.py
+++ b/qontract_api/qontract_api/middleware.py
@@ -11,6 +11,7 @@ import structlog
 from fastapi import Request, Response
 from starlette import status
 from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.requests import ClientDisconnect
 from starlette.types import Receive
 
 from qontract_api.auth import (
@@ -55,6 +56,8 @@ async def _read_compressed_body(
     compressed_size = 0
     while True:
         message = await original_receive()
+        if message["type"] == "http.disconnect":
+            raise ClientDisconnect
         if message["type"] == "http.request":
             body_chunk = message.get("body", b"")
             if body_chunk:
@@ -74,22 +77,35 @@ def _decompress_gzip_bounded(
 
     Uses zlib's streaming API (rather than gzip.decompress()) so an oversized
     (gzip bomb) payload is rejected without fully materializing the decompressed
-    output in memory.
+    output in memory. Like gzip.decompress(), concatenated gzip members are all
+    decompressed; a stream that doesn't end with a complete member (truncated
+    input) raises gzip.BadGzipFile instead of silently returning partial data.
     """
-    decompressor = zlib.decompressobj(wbits=zlib.MAX_WBITS | 16)
     output = bytearray()
     pending = compressed_body
     while pending:
+        decompressor = zlib.decompressobj(wbits=zlib.MAX_WBITS | 16)
         chunk = decompressor.decompress(
             pending, max_decompressed_size + 1 - len(output)
         )
         output.extend(chunk)
         if len(output) > max_decompressed_size:
             raise GzipDecompressedSizeExceededError(max_decompressed_size)
-        pending = decompressor.unconsumed_tail
-    output.extend(decompressor.flush(max_decompressed_size + 1 - len(output)))
-    if len(output) > max_decompressed_size:
-        raise GzipDecompressedSizeExceededError(max_decompressed_size)
+        while decompressor.unconsumed_tail:
+            chunk = decompressor.decompress(
+                decompressor.unconsumed_tail, max_decompressed_size + 1 - len(output)
+            )
+            output.extend(chunk)
+            if len(output) > max_decompressed_size:
+                raise GzipDecompressedSizeExceededError(max_decompressed_size)
+        output.extend(decompressor.flush(max_decompressed_size + 1 - len(output)))
+        if len(output) > max_decompressed_size:
+            raise GzipDecompressedSizeExceededError(max_decompressed_size)
+        if not decompressor.eof:
+            raise gzip.BadGzipFile(
+                "Compressed file ended before the end-of-stream marker was reached"
+            )
+        pending = decompressor.unused_data
     return bytes(output)
 
 
@@ -231,6 +247,9 @@ class GzipRequestMiddleware(BaseHTTPMiddleware):
                     compressed_body, MAX_GZIP_DECOMPRESSED_SIZE
                 )
                 _install_decompressed_body(request, compressed_body, decompressed)
+            except ClientDisconnect:
+                # Client is gone; propagate so no response is wasted building one.
+                raise
             except GzipCompressedSizeExceededError as e:
                 logger.warning(
                     "Compressed gzip request exceeds size limit",

--- a/qontract_api/qontract_api/middleware.py
+++ b/qontract_api/qontract_api/middleware.py
@@ -4,19 +4,118 @@ import contextlib
 import gzip
 import time
 import uuid
+import zlib
 from collections.abc import Awaitable, Callable
 
 import structlog
 from fastapi import Request, Response
+from starlette import status
 from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.types import Receive
 
 from qontract_api.auth import (
     decode_token,
 )
-from qontract_api.constants import REQUEST_ID_HEADER
+from qontract_api.constants import (
+    MAX_GZIP_COMPRESSED_SIZE,
+    MAX_GZIP_DECOMPRESSED_SIZE,
+    REQUEST_ID_HEADER,
+)
 from qontract_api.logger import get_logger
 
 logger = get_logger(__name__)
+
+
+class GzipCompressedSizeExceededError(Exception):
+    """Raised when a gzip request body's compressed size exceeds the size limit."""
+
+    def __init__(self, max_size: int) -> None:
+        """Initialize with the exceeded size limit."""
+        super().__init__(f"Compressed request body exceeds {max_size} bytes limit")
+
+
+class GzipDecompressedSizeExceededError(Exception):
+    """Raised when decompressing a gzip request body would exceed the size limit."""
+
+    def __init__(self, max_size: int) -> None:
+        """Initialize with the exceeded size limit."""
+        super().__init__(f"Decompressed size exceeds {max_size} bytes")
+
+
+async def _read_compressed_body(
+    original_receive: Receive, max_compressed_size: int
+) -> bytes:
+    """Read chunks from the ASGI receive channel, bounding the total size.
+
+    Rejects early (without buffering further chunks) once the total exceeds
+    max_compressed_size, so an oversized upload can't exhaust memory even
+    before decompression is attempted.
+    """
+    compressed_chunks: list[bytes] = []
+    compressed_size = 0
+    while True:
+        message = await original_receive()
+        if message["type"] == "http.request":
+            body_chunk = message.get("body", b"")
+            if body_chunk:
+                compressed_size += len(body_chunk)
+                if compressed_size > max_compressed_size:
+                    raise GzipCompressedSizeExceededError(max_compressed_size)
+                compressed_chunks.append(body_chunk)
+            if not message.get("more_body", False):
+                break
+    return b"".join(compressed_chunks)
+
+
+def _decompress_gzip_bounded(
+    compressed_body: bytes, max_decompressed_size: int
+) -> bytes:
+    """Decompress gzip data, aborting as soon as the output exceeds max_decompressed_size.
+
+    Uses zlib's streaming API (rather than gzip.decompress()) so an oversized
+    (gzip bomb) payload is rejected without fully materializing the decompressed
+    output in memory.
+    """
+    decompressor = zlib.decompressobj(wbits=zlib.MAX_WBITS | 16)
+    output = bytearray()
+    pending = compressed_body
+    while pending:
+        chunk = decompressor.decompress(
+            pending, max_decompressed_size + 1 - len(output)
+        )
+        output.extend(chunk)
+        if len(output) > max_decompressed_size:
+            raise GzipDecompressedSizeExceededError(max_decompressed_size)
+        pending = decompressor.unconsumed_tail
+    output.extend(decompressor.flush(max_decompressed_size + 1 - len(output)))
+    if len(output) > max_decompressed_size:
+        raise GzipDecompressedSizeExceededError(max_decompressed_size)
+    return bytes(output)
+
+
+def _install_decompressed_body(
+    request: Request, compressed_body: bytes, decompressed: bytes
+) -> None:
+    """Swap the request's receive channel to return the decompressed body and log details."""
+
+    async def receive() -> dict[str, str | bytes | bool]:  # ruff: ignore[unused-async]
+        return {
+            "type": "http.request",
+            "body": decompressed,
+            "more_body": False,
+        }
+
+    request._receive = receive  # ruff: ignore[private-member-access]
+
+    logger.debug(
+        "Decompressed gzip request",
+        compressed_size=len(compressed_body),
+        decompressed_size=len(decompressed),
+        compression_ratio=round((1 - len(compressed_body) / len(decompressed)) * 100, 1)
+        if len(decompressed) > 0
+        else 0,
+        request_id=request.state.request_id,
+    )
 
 
 class RequestIDMiddleware(BaseHTTPMiddleware):
@@ -123,46 +222,34 @@ class GzipRequestMiddleware(BaseHTTPMiddleware):
     ) -> Response:
         """Decompress gzip request body if Content-Encoding header present."""
         if request.headers.get("content-encoding") == "gzip":
-            try:  # ruff: ignore[too-many-statements-in-try-clause]
-                # Read all chunks from original receive
-                compressed_chunks: list[bytes] = []
+            try:
                 original_receive = request._receive  # ruff: ignore[private-member-access]
-
-                while True:
-                    message = await original_receive()
-                    if message["type"] == "http.request":
-                        body_chunk = message.get("body", b"")
-                        if body_chunk:
-                            compressed_chunks.append(body_chunk)
-                        if not message.get("more_body", False):
-                            break
-
-                # Concatenate and decompress
-                compressed_body = b"".join(compressed_chunks)
-                decompressed = gzip.decompress(compressed_body)
-
-                # Create new receive that returns decompressed body
-                async def receive() -> dict[str, str | bytes | bool]:  # ruff: ignore[unused-async]
-                    return {
-                        "type": "http.request",
-                        "body": decompressed,
-                        "more_body": False,
-                    }
-
-                request._receive = receive  # ruff: ignore[private-member-access]
-
-                logger.debug(
-                    "Decompressed gzip request",
-                    compressed_size=len(compressed_body),
-                    decompressed_size=len(decompressed),
-                    compression_ratio=round(
-                        (1 - len(compressed_body) / len(decompressed)) * 100, 1
-                    )
-                    if len(decompressed) > 0
-                    else 0,
+                compressed_body = await _read_compressed_body(
+                    original_receive, MAX_GZIP_COMPRESSED_SIZE
+                )
+                decompressed = _decompress_gzip_bounded(
+                    compressed_body, MAX_GZIP_DECOMPRESSED_SIZE
+                )
+                _install_decompressed_body(request, compressed_body, decompressed)
+            except GzipCompressedSizeExceededError as e:
+                logger.warning(
+                    "Compressed gzip request exceeds size limit",
+                    max_compressed_size=MAX_GZIP_COMPRESSED_SIZE,
                     request_id=request.state.request_id,
                 )
-            except gzip.BadGzipFile as e:
+                return Response(
+                    content=str(e), status_code=status.HTTP_413_CONTENT_TOO_LARGE
+                )
+            except GzipDecompressedSizeExceededError as e:
+                logger.warning(
+                    "Decompressed gzip request exceeds size limit",
+                    max_decompressed_size=MAX_GZIP_DECOMPRESSED_SIZE,
+                    request_id=request.state.request_id,
+                )
+                return Response(
+                    content=str(e), status_code=status.HTTP_413_CONTENT_TOO_LARGE
+                )
+            except (gzip.BadGzipFile, zlib.error) as e:
                 logger.exception(
                     "Failed to decompress gzip request",
                     request_id=request.state.request_id,

--- a/qontract_api/tests/test_middleware.py
+++ b/qontract_api/tests/test_middleware.py
@@ -7,6 +7,7 @@ from http import HTTPStatus
 import pytest
 from fastapi.testclient import TestClient
 
+import qontract_api.middleware as middleware_module
 from qontract_api.auth import create_access_token
 from qontract_api.constants import REQUEST_ID_HEADER
 from qontract_api.models import TokenData
@@ -98,6 +99,51 @@ def test_gzip_request_with_invalid_data(client_with_cache: TestClient) -> None:
     # Should return 400 Bad Request
     assert response.status_code == HTTPStatus.BAD_REQUEST
     assert "gzip" in response.text.lower()
+
+
+def test_gzip_request_exceeds_max_compressed_size(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Test that an oversized compressed request body is rejected before decompression."""
+    monkeypatch.setattr(middleware_module, "MAX_GZIP_COMPRESSED_SIZE", 1_000)
+
+    # Body itself doesn't need to be valid gzip - the size check runs
+    # while collecting chunks, before gzip decompression is attempted.
+    oversized_body = b"x" * 2_000
+
+    response = client.post(
+        "/api/v1/integrations/slack-usergroups/reconcile",
+        content=oversized_body,
+        headers={
+            "Content-Type": "application/json",
+            "Content-Encoding": "gzip",
+        },
+    )
+
+    assert response.status_code == HTTPStatus.REQUEST_ENTITY_TOO_LARGE
+    assert "compressed" in response.text.lower()
+
+
+def test_gzip_bomb_exceeds_max_decompressed_size(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Test that a gzip bomb (small compressed, huge decompressed) is rejected."""
+    monkeypatch.setattr(middleware_module, "MAX_GZIP_DECOMPRESSED_SIZE", 1_024)
+
+    # Highly compressible payload: tiny compressed size, large decompressed size.
+    bomb = gzip.compress(b"A" * 100_000)
+
+    response = client.post(
+        "/api/v1/integrations/slack-usergroups/reconcile",
+        content=bomb,
+        headers={
+            "Content-Type": "application/json",
+            "Content-Encoding": "gzip",
+        },
+    )
+
+    assert response.status_code == HTTPStatus.REQUEST_ENTITY_TOO_LARGE
+    assert "decompress" in response.text.lower()
 
 
 def test_uncompressed_request_still_works(

--- a/qontract_api/tests/test_middleware.py
+++ b/qontract_api/tests/test_middleware.py
@@ -2,14 +2,17 @@
 
 import gzip
 import json
+import zlib
 from http import HTTPStatus
 
 import pytest
 from fastapi.testclient import TestClient
+from starlette.requests import ClientDisconnect
 
 import qontract_api.middleware as middleware_module
 from qontract_api.auth import create_access_token
 from qontract_api.constants import REQUEST_ID_HEADER
+from qontract_api.middleware import _decompress_gzip_bounded, _read_compressed_body
 from qontract_api.models import TokenData
 
 
@@ -144,6 +147,47 @@ def test_gzip_bomb_exceeds_max_decompressed_size(
 
     assert response.status_code == HTTPStatus.REQUEST_ENTITY_TOO_LARGE
     assert "decompress" in response.text.lower()
+
+
+@pytest.mark.asyncio
+async def test_read_compressed_body_raises_on_client_disconnect() -> None:
+    """Test that an http.disconnect message raises ClientDisconnect instead of looping forever."""
+
+    async def fake_receive() -> dict[str, object]:  # ruff: ignore[unused-async]
+        return {"type": "http.disconnect"}
+
+    with pytest.raises(ClientDisconnect):
+        await _read_compressed_body(fake_receive, max_compressed_size=1_000)
+
+
+def test_decompress_gzip_bounded_concatenated_members() -> None:
+    """Test that concatenated gzip members are all decompressed, like gzip.decompress()."""
+    payload = gzip.compress(b"first") + gzip.compress(b"second")
+
+    result = _decompress_gzip_bounded(payload, max_decompressed_size=1_000)
+
+    assert result == b"firstsecond"
+
+
+def test_decompress_gzip_bounded_truncated_data() -> None:
+    """Test that truncated gzip input raises instead of silently returning partial data."""
+    truncated = gzip.compress(b"first")[:-8]
+
+    with pytest.raises(gzip.BadGzipFile):
+        _decompress_gzip_bounded(truncated, max_decompressed_size=1_000)
+
+
+def test_decompress_gzip_bounded_trailing_garbage() -> None:
+    """Test that trailing non-gzip data after a valid member raises instead of being dropped.
+
+    Raises zlib.error (from parsing the invalid gzip header of the trailing
+    data) rather than gzip.BadGzipFile - the middleware's dispatch() already
+    catches both identically and maps them to a 400 "Invalid gzip data" response.
+    """
+    payload = gzip.compress(b"first") + b"garbage-not-gzip"
+
+    with pytest.raises((gzip.BadGzipFile, zlib.error)):
+        _decompress_gzip_bounded(payload, max_decompressed_size=1_000)
 
 
 def test_uncompressed_request_still_works(

--- a/qontract_api/tests/test_middleware.py
+++ b/qontract_api/tests/test_middleware.py
@@ -152,8 +152,13 @@ def test_gzip_bomb_exceeds_max_decompressed_size(
 @pytest.mark.asyncio
 async def test_read_compressed_body_raises_on_client_disconnect() -> None:
     """Test that an http.disconnect message raises ClientDisconnect instead of looping forever."""
+    calls = 0
 
     async def fake_receive() -> dict[str, object]:  # ruff: ignore[unused-async]
+        nonlocal calls
+        calls += 1
+        if calls > 1:
+            raise AssertionError("reader did not stop after disconnect")
         return {"type": "http.disconnect"}
 
     with pytest.raises(ClientDisconnect):


### PR DESCRIPTION
## Summary
- `GzipRequestMiddleware` decompressed request bodies with `gzip.decompress()` without any size checks, letting a small compressed payload expand to gigabytes and exhaust memory ([APPSRE-14302](https://redhat.atlassian.net/browse/APPSRE-14302))
- Add `MAX_GZIP_COMPRESSED_SIZE` (10MB) / `MAX_GZIP_DECOMPRESSED_SIZE` (100MB) constants
- Reject compressed bodies over the size limit during chunk collection, before decompression is attempted (413)
- Replace `gzip.decompress()` with bounded streaming decompression via `zlib.decompressobj`, aborting as soon as the decompressed output exceeds the limit (413) - so a bomb payload is never fully materialized in memory
- Follow-up (review feedback): `_read_compressed_body` now raises `starlette.requests.ClientDisconnect` on `http.disconnect` instead of looping forever awaiting a client that's gone; `_decompress_gzip_bounded` now correctly decompresses concatenated gzip members (matching `gzip.decompress()`) and raises `gzip.BadGzipFile` for truncated/corrupt input instead of silently returning partial data
- Follow-up (review feedback): hardened the client-disconnect regression test so a future regression fails fast with a clear assertion instead of hanging the test run

## Test plan
- Added `test_gzip_request_exceeds_max_compressed_size` and `test_gzip_bomb_exceeds_max_decompressed_size` to `qontract_api/tests/test_middleware.py`, reproducing both limits
- Added regression tests for the client-disconnect hang and the multi-member/truncated gzip handling; confirmed each failed against the previous code (the disconnect test hung entirely) before fixing
- `make test` in `qontract_api/` passes (ruff check, ruff format, mypy strict, pytest - 617 passed)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added safeguards for compressed request bodies larger than 10 MB.
  * Added safeguards for decompressed request bodies larger than 100 MB.
  * Oversized requests now return HTTP 413 responses instead of being processed.
  * Improved protection against highly compressed payloads (“gzip bombs”) while preserving existing invalid-request handling.
  * Improved handling of interrupted, truncated, concatenated, or malformed compressed request data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->