### PR TITLE
refactor(qontract-api): remove too-many-statements-in-try-clause suppressions from tasks.py

### DIFF
--- a/qontract_api/qontract_api/integrations/github_owners/tasks.py
+++ b/qontract_api/qontract_api/integrations/github_owners/tasks.py
@@ -76,16 +76,15 @@ def reconcile_github_owners_task(
     """
     request_id = self.request.id
 
-    try:  # ruff: ignore[too-many-statements-in-try-clause]
+    try:
         cache = get_cache()
         secret_manager = get_secret_manager(cache=cache)
         event_manager = get_event_manager()
 
-        github_org_client_factory = GithubOrgClientFactory(
-            cache=cache, settings=settings
-        )
         service = GithubOwnersService(
-            github_org_client_factory=github_org_client_factory,
+            github_org_client_factory=GithubOrgClientFactory(
+                cache=cache, settings=settings
+            ),
             secret_manager=secret_manager,
             settings=settings,
         )
@@ -94,17 +93,26 @@ def reconcile_github_owners_task(
             organizations=organizations,
             dry_run=dry_run,
         )
-
-        logger.info(
-            f"Task {request_id} completed",
-            status=result.status,
-            total_actions=len(result.actions),
-            applied_count=len(result.applied_actions),
-            actions=[action.model_dump() for action in result.actions],
-            errors=result.errors,
+    except Exception as err:
+        logger.exception(f"Task {request_id} failed with error")
+        return GithubOwnersTaskResult(
+            status=TaskStatus.FAILED,
+            actions=[],
+            applied_count=0,
+            errors=[f"Unexpected {err=}"],
         )
 
-        if not dry_run and event_manager:
+    logger.info(
+        f"Task {request_id} completed",
+        status=result.status,
+        total_actions=len(result.actions),
+        applied_count=len(result.applied_actions),
+        actions=[action.model_dump() for action in result.actions],
+        errors=result.errors,
+    )
+
+    if not dry_run and event_manager:
+        try:
             # Publish one event per successfully applied action.
             # result.applied_actions excludes actions that failed to execute,
             # preventing spurious success events for partial failures.
@@ -131,14 +139,7 @@ def reconcile_github_owners_task(
                         datacontenttype="application/json",
                     )
                 )
+        except Exception:
+            logger.exception(f"Task {request_id} failed to publish events")
 
-        return result
-
-    except Exception as err:
-        logger.exception(f"Task {request_id} failed with error")
-        return GithubOwnersTaskResult(
-            status=TaskStatus.FAILED,
-            actions=[],
-            applied_count=0,
-            errors=[f"Unexpected {err=}"],
-        )
+    return result

--- a/qontract_api/qontract_api/integrations/glitchtip/tasks.py
+++ b/qontract_api/qontract_api/integrations/glitchtip/tasks.py
@@ -51,16 +51,15 @@ def reconcile_glitchtip_task(
     """
     request_id = self.request.id
 
-    try:  # ruff: ignore[too-many-statements-in-try-clause]
+    try:
         cache = get_cache()
         secret_manager = get_secret_manager(cache=cache)
         event_manager = get_event_manager()
 
-        glitchtip_client_factory = GlitchtipClientFactory(
-            cache=cache, settings=settings
-        )
         service = GlitchtipService(
-            glitchtip_client_factory=glitchtip_client_factory,
+            glitchtip_client_factory=GlitchtipClientFactory(
+                cache=cache, settings=settings
+            ),
             secret_manager=secret_manager,
             settings=settings,
         )
@@ -69,17 +68,26 @@ def reconcile_glitchtip_task(
             instances=instances,
             dry_run=dry_run,
         )
-
-        logger.info(
-            f"Task {request_id} completed",
-            status=result.status,
-            total_actions=len(result.actions),
-            applied_count=result.applied_count,
-            actions=[action.model_dump() for action in result.actions],
-            errors=result.errors,
+    except Exception as err:
+        logger.exception(f"Task {request_id} failed with error")
+        return GlitchtipTaskResult(
+            status=TaskStatus.FAILED,
+            actions=[],
+            applied_count=0,
+            errors=[f"Unexpected {err=}"],
         )
 
-        if not dry_run and event_manager:
+    logger.info(
+        f"Task {request_id} completed",
+        status=result.status,
+        total_actions=len(result.actions),
+        applied_count=result.applied_count,
+        actions=[action.model_dump() for action in result.actions],
+        errors=result.errors,
+    )
+
+    if not dry_run and event_manager:
+        try:
             for action in result.applied_actions:
                 event_manager.publish_event(
                     Event(
@@ -99,14 +107,7 @@ def reconcile_glitchtip_task(
                         datacontenttype="application/json",
                     )
                 )
+        except Exception:
+            logger.exception(f"Task {request_id} failed to publish events")
 
-        return result
-
-    except Exception as err:
-        logger.exception(f"Task {request_id} failed with error")
-        return GlitchtipTaskResult(
-            status=TaskStatus.FAILED,
-            actions=[],
-            applied_count=0,
-            errors=[f"Unexpected {err=}"],
-        )
+    return result

--- a/qontract_api/qontract_api/integrations/glitchtip_project_alerts/tasks.py
+++ b/qontract_api/qontract_api/integrations/glitchtip_project_alerts/tasks.py
@@ -80,18 +80,17 @@ def reconcile_glitchtip_project_alerts_task(
     """
     request_id = self.request.id
 
-    try:  # ruff: ignore[too-many-statements-in-try-clause]
+    try:
         # Get shared dependencies
         cache = get_cache()
         secret_manager = get_secret_manager(cache=cache)
         event_manager = get_event_manager()
 
-        # Create factory and service
-        glitchtip_client_factory = GlitchtipClientFactory(
-            cache=cache, settings=settings
-        )
+        # Create service
         service = GlitchtipProjectAlertsService(
-            glitchtip_client_factory=glitchtip_client_factory,
+            glitchtip_client_factory=GlitchtipClientFactory(
+                cache=cache, settings=settings
+            ),
             secret_manager=secret_manager,
             settings=settings,
         )
@@ -101,17 +100,26 @@ def reconcile_glitchtip_project_alerts_task(
             instances=instances,
             dry_run=dry_run,
         )
-
-        logger.info(
-            f"Task {request_id} completed",
-            status=result.status,
-            total_actions=len(result.actions),
-            applied_count=result.applied_count,
-            actions=[action.model_dump() for action in result.actions],
-            errors=result.errors,
+    except Exception as err:
+        logger.exception(f"Task {request_id} failed with error")
+        return GlitchtipProjectAlertsTaskResult(
+            status=TaskStatus.FAILED,
+            actions=[],
+            applied_count=0,
+            errors=[f"Unexpected {err=}"],
         )
 
-        if not dry_run and event_manager:
+    logger.info(
+        f"Task {request_id} completed",
+        status=result.status,
+        total_actions=len(result.actions),
+        applied_count=result.applied_count,
+        actions=[action.model_dump() for action in result.actions],
+        errors=result.errors,
+    )
+
+    if not dry_run and event_manager:
+        try:
             for action in result.applied_actions:
                 event_manager.publish_event(
                     Event(
@@ -131,14 +139,7 @@ def reconcile_glitchtip_project_alerts_task(
                         datacontenttype="application/json",
                     )
                 )
+        except Exception:
+            logger.exception(f"Task {request_id} failed to publish events")
 
-        return result
-
-    except Exception as err:
-        logger.exception(f"Task {request_id} failed with error")
-        return GlitchtipProjectAlertsTaskResult(
-            status=TaskStatus.FAILED,
-            actions=[],
-            applied_count=0,
-            errors=[f"Unexpected {err=}"],
-        )
+    return result

--- a/qontract_api/qontract_api/integrations/openshift_namespaces/tasks.py
+++ b/qontract_api/qontract_api/integrations/openshift_namespaces/tasks.py
@@ -99,38 +99,49 @@ def reconcile_openshift_namespaces_task(
     request_id = self.request.id
     secret_errors: list[str] = []
 
-    try:  # ruff: ignore[too-many-statements-in-try-clause]
+    try:
         cache = get_cache()
         secret_manager = get_secret_manager(cache=cache)
+    except Exception as err:
+        logger.exception(f"Task {request_id} failed with error")
+        result = OpenShiftNamespacesTaskResult(
+            status=TaskStatus.FAILED,
+            actions=[],
+            applied_count=0,
+            errors=[f"Unexpected {err=}"],
+        )
+        _publish_result_events(result, dry_run=dry_run)
+        return result
 
-        connection_params: list[ClusterConnectionParams] = []
-        for cluster in clusters:
-            try:
-                params = _resolve_cluster_connection(cluster, secret_manager)
-            except Exception:
-                error_msg = f"Failed to read token for cluster {cluster.cluster_name}"
-                logger.exception(error_msg)
-                secret_errors.append(error_msg)
-            else:
-                connection_params.append(params)
+    connection_params: list[ClusterConnectionParams] = []
+    for cluster in clusters:
+        try:
+            params = _resolve_cluster_connection(cluster, secret_manager)
+        except Exception:
+            error_msg = f"Failed to read token for cluster {cluster.cluster_name}"
+            logger.exception(error_msg)
+            secret_errors.append(error_msg)
+        else:
+            connection_params.append(params)
 
-        connected_clusters = {p.cluster_name for p in connection_params}
-        cluster_namespaces: dict[str, list[DesiredNamespace]] = {
-            cluster.cluster_name: list(cluster.namespaces)
-            for cluster in clusters
-            if cluster.cluster_name in connected_clusters
-        }
+    connected_clusters = {p.cluster_name for p in connection_params}
+    cluster_namespaces: dict[str, list[DesiredNamespace]] = {
+        cluster.cluster_name: list(cluster.namespaces)
+        for cluster in clusters
+        if cluster.cluster_name in connected_clusters
+    }
 
-        if not connection_params:
-            result = OpenShiftNamespacesTaskResult(
-                status=TaskStatus.FAILED,
-                actions=[],
-                applied_count=0,
-                errors=secret_errors,
-            )
-            _publish_result_events(result, dry_run=dry_run)
-            return result
+    if not connection_params:
+        result = OpenShiftNamespacesTaskResult(
+            status=TaskStatus.FAILED,
+            actions=[],
+            applied_count=0,
+            errors=secret_errors,
+        )
+        _publish_result_events(result, dry_run=dry_run)
+        return result
 
+    try:
         with ClusterClientMap(connection_params, cache, settings) as cluster_map:
             service = OpenShiftNamespacesService()
             result = service.reconcile(
@@ -138,28 +149,6 @@ def reconcile_openshift_namespaces_task(
                 cluster_namespaces=cluster_namespaces,
                 dry_run=dry_run,
             )
-
-        if secret_errors:
-            result = OpenShiftNamespacesTaskResult(
-                status=TaskStatus.FAILED,
-                actions=result.actions,
-                applied_actions=result.applied_actions,
-                applied_count=result.applied_count,
-                errors=[*secret_errors, *result.errors],
-            )
-
-        logger.info(
-            f"Task {request_id} completed",
-            status=result.status,
-            total_actions=len(result.actions),
-            applied_count=result.applied_count,
-            actions=[action.model_dump() for action in result.actions],
-            errors=result.errors,
-        )
-
-        _publish_result_events(result, dry_run=dry_run)
-        return result
-
     except Exception as err:
         logger.exception(f"Task {request_id} failed with error")
         result = OpenShiftNamespacesTaskResult(
@@ -170,3 +159,24 @@ def reconcile_openshift_namespaces_task(
         )
         _publish_result_events(result, dry_run=dry_run)
         return result
+
+    if secret_errors:
+        result = OpenShiftNamespacesTaskResult(
+            status=TaskStatus.FAILED,
+            actions=result.actions,
+            applied_actions=result.applied_actions,
+            applied_count=result.applied_count,
+            errors=[*secret_errors, *result.errors],
+        )
+
+    logger.info(
+        f"Task {request_id} completed",
+        status=result.status,
+        total_actions=len(result.actions),
+        applied_count=result.applied_count,
+        actions=[action.model_dump() for action in result.actions],
+        errors=result.errors,
+    )
+
+    _publish_result_events(result, dry_run=dry_run)
+    return result

--- a/qontract_api/qontract_api/integrations/openshift_namespaces/tasks.py
+++ b/qontract_api/qontract_api/integrations/openshift_namespaces/tasks.py
@@ -53,32 +53,41 @@ def _publish_result_events(
     result: OpenShiftNamespacesTaskResult,
     *,
     dry_run: bool,
+    request_id: str,
 ) -> None:
-    """Publish CloudEvents for applied actions and errors."""
+    """Publish CloudEvents for applied actions and errors.
+
+    Publication failures are logged and swallowed so a broken event manager
+    never prevents the caller from returning its already-computed result.
+    """
     if dry_run:
         return
-    event_manager = get_event_manager()
-    if not event_manager:
-        return
 
-    for action in result.applied_actions:
-        event_manager.publish_event(
-            Event(
-                source=__name__,
-                type=f"qontract-api.openshift-namespaces.{action.action_type}",
-                data=action.model_dump(mode="json"),
-                datacontenttype="application/json",
+    try:
+        event_manager = get_event_manager()
+        if not event_manager:
+            return
+
+        for action in result.applied_actions:
+            event_manager.publish_event(
+                Event(
+                    source=__name__,
+                    type=f"qontract-api.openshift-namespaces.{action.action_type}",
+                    data=action.model_dump(mode="json"),
+                    datacontenttype="application/json",
+                )
             )
-        )
-    for error in result.errors:
-        event_manager.publish_event(
-            Event(
-                source=__name__,
-                type="qontract-api.openshift-namespaces.error",
-                data={"error": error},
-                datacontenttype="application/json",
+        for error in result.errors:
+            event_manager.publish_event(
+                Event(
+                    source=__name__,
+                    type="qontract-api.openshift-namespaces.error",
+                    data={"error": error},
+                    datacontenttype="application/json",
+                )
             )
-        )
+    except Exception:
+        logger.exception(f"Task {request_id} failed to publish events")
 
 
 def generate_lock_key(_self: Task, clusters: list[ClusterNamespaces], **_: Any) -> str:
@@ -110,7 +119,7 @@ def reconcile_openshift_namespaces_task(
             applied_count=0,
             errors=[f"Unexpected {err=}"],
         )
-        _publish_result_events(result, dry_run=dry_run)
+        _publish_result_events(result, dry_run=dry_run, request_id=request_id)
         return result
 
     connection_params: list[ClusterConnectionParams] = []
@@ -138,7 +147,7 @@ def reconcile_openshift_namespaces_task(
             applied_count=0,
             errors=secret_errors,
         )
-        _publish_result_events(result, dry_run=dry_run)
+        _publish_result_events(result, dry_run=dry_run, request_id=request_id)
         return result
 
     try:
@@ -157,7 +166,7 @@ def reconcile_openshift_namespaces_task(
             applied_count=0,
             errors=[*secret_errors, f"Unexpected {err=}"],
         )
-        _publish_result_events(result, dry_run=dry_run)
+        _publish_result_events(result, dry_run=dry_run, request_id=request_id)
         return result
 
     if secret_errors:
@@ -178,5 +187,5 @@ def reconcile_openshift_namespaces_task(
         errors=result.errors,
     )
 
-    _publish_result_events(result, dry_run=dry_run)
+    _publish_result_events(result, dry_run=dry_run, request_id=request_id)
     return result

--- a/qontract_api/qontract_api/integrations/slack_usergroups/tasks.py
+++ b/qontract_api/qontract_api/integrations/slack_usergroups/tasks.py
@@ -110,7 +110,7 @@ def reconcile_slack_usergroups_task(
     """
     request_id = self.request.id
 
-    try:  # ruff: ignore[too-many-statements-in-try-clause]
+    try:
         # Get shared dependencies
         cache = get_cache()
         secret_manager = get_secret_manager(cache=cache)
@@ -128,17 +128,26 @@ def reconcile_slack_usergroups_task(
             workspaces=workspaces,
             dry_run=dry_run,
         )
-
-        logger.info(
-            f"Task {request_id} completed",
-            status=result.status,
-            total_actions=len(result.actions),
-            applied_count=result.applied_count,
-            actions=[action.model_dump() for action in result.actions],
-            errors=result.errors,
+    except Exception as err:
+        logger.exception(f"Task {request_id} failed with error")
+        return SlackUsergroupsTaskResult(
+            status=TaskStatus.FAILED,
+            actions=[],
+            applied_count=0,
+            errors=[f"Unexpected {err=}"],
         )
 
-        if not dry_run and event_manager:
+    logger.info(
+        f"Task {request_id} completed",
+        status=result.status,
+        total_actions=len(result.actions),
+        applied_count=result.applied_count,
+        actions=[action.model_dump() for action in result.actions],
+        errors=result.errors,
+    )
+
+    if not dry_run and event_manager:
+        try:
             for action in result.applied_actions:
                 event_manager.publish_event(
                     Event(
@@ -163,14 +172,7 @@ def reconcile_slack_usergroups_task(
                         datacontenttype="application/json",
                     )
                 )
+        except Exception:
+            logger.exception(f"Task {request_id} failed to publish events")
 
-        return result
-
-    except Exception as err:
-        logger.exception(f"Task {request_id} failed with error")
-        return SlackUsergroupsTaskResult(
-            status=TaskStatus.FAILED,
-            actions=[],
-            applied_count=0,
-            errors=[f"Unexpected {err=}"],
-        )
+    return result


### PR DESCRIPTION
## Summary
- Remove all 5 remaining `# ruff: ignore[too-many-statements-in-try-clause]` comments in `qontract_api` tasks.py files, matching the try/except shape already used in `qontract_api/integrations/ocm_oidc_idp/tasks.py`
- `glitchtip`, `glitchtip_project_alerts`, `github_owners`, `slack_usergroups`: the try clause now covers only dependency setup plus the `service.reconcile()` call; logging and event publishing moved outside the try (event publishing gets its own narrow try/except that only logs on failure, matching `ocm_oidc_idp`)
- `openshift_namespaces`: needed a different split since its per-cluster connection-resolution loop already handles its own exceptions internally and can't raise - it stays unguarded between two minimal try blocks, one for `get_cache()`/`get_secret_manager()`, one for the `ClusterClientMap`/`service.reconcile()` call. Same branches and error aggregation as before, just restructured.
- Follow-up (review feedback): `_publish_result_events` in `openshift_namespaces/tasks.py` now catches and logs its own publication failures (including from `get_event_manager()`), so a broken event manager can no longer crash the task and discard an already-computed result - matching the protection already added to the other 4 files.

## Test plan
- `make test` in `qontract_api/` passes (ruff check, ruff format, mypy strict, pytest - 611 passed)
- No `too-many-statements-in-try-clause` suppressions remain in any tasks.py file

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved integration task error handling so setup and reconciliation failures produce clear failed results.
  * Event-publishing failures are now logged separately without replacing the underlying reconciliation outcome.
  * Namespace reconciliation can continue for valid clusters while reporting token-resolution errors.
  * Tasks consistently return the reconciliation result after completion, improving the reliability of reported integration status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->