### PR TITLE
fix(qontract-utils): use safe YAML loader for untrusted OWNERS file content

### DIFF
--- a/qontract_utils/qontract_utils/ruamel.py
+++ b/qontract_utils/qontract_utils/ruamel.py
@@ -1,5 +1,5 @@
 from io import StringIO
-from typing import Any
+from typing import Any, Literal
 
 from ruamel.yaml.scalarstring import PreservedScalarString
 
@@ -19,7 +19,7 @@ def create_ruamel_instance(
     explicit_start: bool = False,
     width: int = 4096,
     pure: bool = False,
-    typ: str = "rt",
+    typ: Literal["rt", "safe"] = "rt",
 ) -> yaml.YAML:
     """Create a configured ruamel.yaml YAML instance.
 

--- a/qontract_utils/qontract_utils/ruamel.py
+++ b/qontract_utils/qontract_utils/ruamel.py
@@ -19,8 +19,17 @@ def create_ruamel_instance(
     explicit_start: bool = False,
     width: int = 4096,
     pure: bool = False,
+    typ: str = "rt",
 ) -> yaml.YAML:
-    ruamel_instance = yaml.YAML(pure=pure)
+    """Create a configured ruamel.yaml YAML instance.
+
+    typ defaults to "rt" (round-trip), needed by callers that read-modify-write
+    YAML and must preserve comments/formatting. Pass typ="safe" when parsing
+    untrusted content - "rt" does not construct arbitrary Python objects from
+    tags like PyYAML's default loader does, but it also doesn't reject them,
+    silently loading tagged content as plain data instead of raising.
+    """
+    ruamel_instance = yaml.YAML(typ=typ, pure=pure)
 
     ruamel_instance.preserve_quotes = preserve_quotes
     ruamel_instance.explicit_start = explicit_start

--- a/qontract_utils/qontract_utils/vcs/owners_parser.py
+++ b/qontract_utils/qontract_utils/vcs/owners_parser.py
@@ -43,7 +43,9 @@ class OwnersParser:
         self._ref = ref
         self._repo_url = vcs_client.repo_url
         self._aliases: dict[str, list[str]] | None = None
-        self._yaml = yaml_client() if yaml_client else create_ruamel_instance()
+        self._yaml = (
+            yaml_client() if yaml_client else create_ruamel_instance(typ="safe")
+        )
 
     def get_owners(self, owners_file: str = "/OWNERS") -> RepoOwners:
         """Get owners defined in OWNERS file at specified path.

--- a/qontract_utils/tests/test_ruamel.py
+++ b/qontract_utils/tests/test_ruamel.py
@@ -1,5 +1,6 @@
 """Tests for ruamel YAML utilities."""
 
+import pytest
 from qontract_utils.ruamel import create_ruamel_instance, dump_yaml
 
 
@@ -31,6 +32,27 @@ def test_create_ruamel_instance_no_preserve_quotes() -> None:
     yaml = create_ruamel_instance(preserve_quotes=False)
 
     assert yaml.preserve_quotes is False
+
+
+def test_create_ruamel_instance_defaults_to_round_trip_typ() -> None:
+    """Test create_ruamel_instance defaults to the round-trip loader/dumper."""
+    from ruamel.yaml.comments import CommentedMap
+
+    yaml = create_ruamel_instance()
+
+    # Round-trip mode preserves comments/formatting; "rt" is the default typ
+    # unless explicitly overridden (e.g. typ="safe" for untrusted content).
+    assert isinstance(yaml.load("key: value"), CommentedMap)
+
+
+def test_create_ruamel_instance_safe_typ_rejects_python_object_tags() -> None:
+    """Test typ="safe" rejects YAML tags that construct arbitrary Python objects."""
+    from ruamel.yaml.constructor import ConstructorError
+
+    yaml = create_ruamel_instance(typ="safe")
+
+    with pytest.raises(ConstructorError):
+        yaml.load("key: !!python/object/apply:os.system ['echo pwned']")
 
 
 def test_dump_yaml() -> None:

--- a/qontract_utils/tests/vcs/test_owners_parser.py
+++ b/qontract_utils/tests/vcs/test_owners_parser.py
@@ -304,6 +304,29 @@ def test_get_owners_aliases_file_error(mock_vcs_client: Mock) -> None:
     assert owners == RepoOwners(approvers=[], reviewers=[])
 
 
+def test_get_owners_rejects_unsafe_yaml_tags(mock_vcs_client: Mock) -> None:
+    """Test that OWNERS files with YAML Python-object tags are rejected, not silently parsed.
+
+    APPSRE-14304: OWNERS file content comes from an arbitrary attacker-controlled
+    repository, so it must be parsed with a safe YAML loader that rejects
+    non-standard tags instead of treating them as loadable content.
+    """
+
+    def get_file_side_effect(path: str, ref: str) -> str | None:
+        if path == "OWNERS":
+            return "approvers: !!python/object/apply:os.system ['echo pwned']"
+        if path == "OWNERS_ALIASES":
+            return None
+        return None
+
+    mock_vcs_client.get_file.side_effect = get_file_side_effect
+
+    parser = OwnersParser(vcs_client=mock_vcs_client, ref="master")
+    owners = parser.get_owners()
+
+    assert owners == RepoOwners(approvers=[], reviewers=[])
+
+
 def test_get_owners_deduplicates_after_alias_expansion(mock_vcs_client: Mock) -> None:
     """Test that duplicate usernames are handled after alias expansion."""
 


### PR DESCRIPTION
## Summary
- `OwnersParser` parsed OWNERS/OWNERS_ALIASES file content fetched from an arbitrary attacker-controlled repository using `create_ruamel_instance()`'s default round-trip loader ([APPSRE-14304](https://redhat.atlassian.net/browse/APPSRE-14304))
- Round-trip mode doesn't construct arbitrary Python objects from tags like PyYAML's default loader does, but it also doesn't reject them - non-standard YAML tags (e.g. `!!python/object/apply:...`) are silently loaded as plain data instead of raising, letting attacker-controlled tag content flow into the parsed approvers/reviewers lists undetected
- Add a `typ` parameter to `create_ruamel_instance()` (defaulting to the existing `"rt"` behavior, so no other caller is affected - verified against every call site in the codebase) and pass `typ="safe"` in `OwnersParser`, which only ever reads OWNERS content one-way and never needs round-trip formatting preservation
- The safe loader rejects unknown tags outright, which `get_owners()` already catches and treats as an unparsable file

## Test plan
- Added `test_get_owners_rejects_unsafe_yaml_tags`; confirmed it failed against the previous code (approver list silently populated from the tagged content) before the fix
- Added `test_create_ruamel_instance_defaults_to_round_trip_typ` and `test_create_ruamel_instance_safe_typ_rejects_python_object_tags`
- `make test` in `qontract_utils/` passes (ruff, mypy strict, pytest - 705 passed)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added configurable YAML parsing modes, including round-trip and safe parsing.

- **Bug Fixes**
  - Improved handling of ownership files by rejecting unsafe YAML object tags.
  - Prevented potentially executable YAML content from being interpreted during parsing.

- **Tests**
  - Added coverage for default round-trip behavior and safe parsing protections.
  - Added regression coverage for unsafe ownership-file content.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->