### PR TITLE
fix(gitlab-fork-compliance): allow MR-level collaboration as alternative to fork maintainer access

### DIFF
--- a/reconcile/gitlab_fork_compliance.py
+++ b/reconcile/gitlab_fork_compliance.py
@@ -26,7 +26,9 @@ MSG_BRANCH = (
 MSG_ACCESS = (
     "@{user}, the user @{bot} is not a Maintainer in "
     "your fork of {project_name}. "
-    "Please add the @{bot} user to your fork as a Maintainer "
+    'Please enable the "Allow commits from members who can merge '
+    'to the target branch" option on this Merge Request (preferred), '
+    "or add the @{bot} user to your fork as a Maintainer, "
     'and retest by commenting "/retest" on the Merge Request.'
 )
 
@@ -65,10 +67,10 @@ class GitlabForkCompliance:
         if self.exit_code:
             sys.exit(self.exit_code)
 
-        # At this point, we know that the bot is a maintainer, so
-        # we check if all the maintainers are in the fork, adding those
-        # who are not
-        if self.maintainers_group:
+        # At this point, we know that the bot is either a maintainer of the
+        # fork or has collaboration access to it. Syncing maintainers into
+        # the fork requires actual maintainer access, so skip it otherwise.
+        if self.maintainers_group and self.bot_is_maintainer:
             group = self.gl_cli.gl.groups.get(self.maintainers_group)
             maintainers = group.members.list(iterator=True)
             project_maintainers = self.src.get_project_maintainers()
@@ -105,9 +107,14 @@ class GitlabForkCompliance:
             self.handle_error("access denied for user {bot}", MSG_ACCESS)
             return self.ERR_NOT_A_MEMBER
 
-        if self.gl_cli.user.username not in self.src.get_project_maintainers():
+        self.bot_is_maintainer = (
+            self.gl_cli.user.username in self.src.get_project_maintainers()
+        )
+        if not self.bot_is_maintainer and not self.mr.allow_collaboration:
             self.handle_error(
-                "{bot} is not a maintainer in the fork project", MSG_ACCESS
+                "{bot} is not a maintainer in the fork project and "
+                "allow_collaboration is not enabled on the Merge Request",
+                MSG_ACCESS,
             )
             return self.ERR_NOT_A_MAINTAINER
 


### PR DESCRIPTION
This is a theory to be tested — not yet confirmed against a real MR/fork setup.

## Summary
- Accept a merge request as compliant when either the bot is a Maintainer in the fork, or the MR has "Allow commits from members who can merge to the target branch" (`allow_collaboration`) enabled — both grant the bot push access to the fork.
- Skip syncing the maintainers group into the fork when the bot isn't actually a maintainer there, since that sync requires maintainer access.
- Update the MR comment and debug log to mention the `allow_collaboration` option as the preferred remediation.

## Test plan
- [ ] `make linter-test`
- [ ] `make types-test`
- [ ] Manually verify against a real MR with `allow_collaboration` enabled and bot not a fork maintainer

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Bots can now access eligible fork workflows through enabled Merge Request collaboration without requiring Maintainer access.

* **Bug Fixes**
  * Maintainer synchronization now occurs only when the bot has actual Maintainer permissions.
  * Access errors now clearly distinguish collaboration access from missing Maintainer access and provide guidance for resolving the issue.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->