### PR TITLE
fix(gitlab-api): compare parsed datetimes in is_last_action_by_team, not raw strings

### DIFF
--- a/reconcile/test/utils/test_gitlab_api.py
+++ b/reconcile/test/utils/test_gitlab_api.py
@@ -659,6 +659,56 @@ def test_get_repository_tree_as_git_cli_interface(
     )
 
 
+def test_is_last_action_by_team_handles_non_utc_commit_timezone(
+    mocked_gitlab_api: GitLabApi,
+) -> None:
+    """Commit timestamps carry the committer's local UTC offset (e.g. +10:00),
+    while comment timestamps from the GitLab API are always UTC ("Z"). Comparing
+    the raw ISO-8601 strings instead of parsed datetimes can flip the ordering."""
+    mocked_gitlab_api.user.username = "devtools-bot"
+
+    mr = create_autospec(ProjectMergeRequest)
+    mr.notes = create_autospec(ProjectMergeRequestNoteManager)
+
+    bot_note_1 = create_autospec(ProjectMergeRequestNote)
+    bot_note_1.system = False
+    bot_note_1.author = {"username": "devtools-bot"}
+    bot_note_1.body = "Change coverage report"
+    bot_note_1.created_at = "2026-08-13T06:28:43.746Z"
+    bot_note_1.id = 1
+
+    bot_note_2 = create_autospec(ProjectMergeRequestNote)
+    bot_note_2.system = False
+    bot_note_2.author = {"username": "devtools-bot"}
+    bot_note_2.body = "Build success"
+    bot_note_2.created_at = "2026-08-13T06:33:01.036Z"
+    bot_note_2.id = 2
+
+    team_note = create_autospec(ProjectMergeRequestNote)
+    team_note.system = False
+    team_note.author = {"username": "cassing"}
+    team_note.body = "Please get an /lgtm from someone from rhobs-dev"
+    team_note.created_at = "2026-08-13T07:28:01.558Z"
+    team_note.id = 3
+
+    mr.notes.list.return_value = [bot_note_1, bot_note_2, team_note]
+
+    # committer's local timezone (+10:00) is 06:23:51 UTC -- before team_note,
+    # but the raw string sorts *after* it because "16" > "07" lexicographically.
+    mr.commits.return_value = [Mock(created_at="2026-08-13T16:23:51.000+10:00")]
+
+    mr.resourcelabelevents = create_autospec(
+        ProjectMergeRequestResourceLabelEventManager
+    )
+    mr.resourcelabelevents.list.return_value = []
+
+    result = mocked_gitlab_api.is_last_action_by_team(
+        mr, team_usernames={"cassing", "devtools-bot"}, hold_labels=[]
+    )
+
+    assert result is True
+
+
 def test_last_assignment() -> None:
     mr = create_autospec(ProjectMergeRequest)
     mr.notes = create_autospec(ProjectMergeRequestNoteManager)

--- a/reconcile/utils/gitlab_api.py
+++ b/reconcile/utils/gitlab_api.py
@@ -6,6 +6,7 @@ import os
 import re
 import tarfile
 from dataclasses import dataclass
+from datetime import datetime
 from functools import cached_property
 from operator import attrgetter
 from typing import (
@@ -706,13 +707,13 @@ class GitLabApi:
         last_action_by_team = None
         # comments
         comments = self.get_merge_request_comments(mr)
-        comments.sort(key=attrgetter("created_at"), reverse=True)
+        comments.sort(key=lambda c: datetime.fromisoformat(c.created_at), reverse=True)
         for comment in comments:
             username = comment.username
             if username == self.user.username:
                 continue
             if username in team_usernames:
-                last_action_by_team = comment.created_at
+                last_action_by_team = datetime.fromisoformat(comment.created_at)
                 break
         # labels
         label_events = mr.resourcelabelevents.list(get_all=True)
@@ -722,10 +723,11 @@ class GitLabApi:
                 if username == self.user.username:
                     continue
                 if username in team_usernames:
+                    label_created_at = datetime.fromisoformat(label.created_at)
                     if not last_action_by_team:
-                        last_action_by_team = label.created_at
+                        last_action_by_team = label_created_at
                     else:
-                        last_action_by_team = max(label.created_at, last_action_by_team)
+                        last_action_by_team = max(label_created_at, last_action_by_team)
                     break
         if not last_action_by_team:
             return False
@@ -733,9 +735,9 @@ class GitLabApi:
         last_action_not_by_team = None
         # commits
         commits = list(mr.commits())
-        commits.sort(key=attrgetter("created_at"), reverse=True)
+        commits.sort(key=lambda c: datetime.fromisoformat(c.created_at), reverse=True)
         for commit in commits:
-            last_action_not_by_team = commit.created_at
+            last_action_not_by_team = datetime.fromisoformat(commit.created_at)
             break
         # comments
         for comment in comments:
@@ -743,7 +745,7 @@ class GitLabApi:
             if username == self.user.username:
                 continue
             if username not in team_usernames:
-                last_action_not_by_team = comment.created_at
+                last_action_not_by_team = datetime.fromisoformat(comment.created_at)
                 break
 
         if not last_action_not_by_team:


### PR DESCRIPTION
## Summary
- `is_last_action_by_team` compared raw ISO-8601 timestamp strings instead of parsed datetimes. Git commit timestamps preserve the committer's local UTC offset (e.g. `+10:00`), while GitLab comment/note timestamps are always UTC (`Z`). Whenever a commit's local hour digit was numerically larger than the comment's UTC hour, the string comparison flipped the real chronological order.
- This caused `is_last_action_by_team` to wrongly return `False` even when an AppSRE team member had genuinely commented last, which kept the affected MR stuck in the [app-interface review queue](https://gitlab.cee.redhat.com/service/app-interface-output/-/blob/master/app-interface-review-queue.md) indefinitely.
- Fix parses all `created_at` values with `datetime.fromisoformat` before sorting/comparing them.

Confirmed against production data for two real MRs (`service/app-interface` #201687 and #201691) where a non-UTC-offset commit (Australia `+10:00`, Europe `+02:00`) caused this exact misordering.

## Test plan
- [x] Added `test_is_last_action_by_team_handles_non_utc_commit_timezone`, reproducing the exact timestamp pattern from the real-world case; confirmed it fails before the fix and passes after.
- [x] `uv run pytest reconcile/test/utils/test_gitlab_api.py` — 37 passed
- [x] `uv run pytest tools/test/test_qontract_cli.py -k review_queue` — 8 passed
- [x] `uv run mypy reconcile/utils/gitlab_api.py` — no issues
- [x] `uv run ruff check` / `ruff format` — clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved activity ordering when commit timestamps include non-UTC timezone offsets.
  * Ensured the latest team action is identified correctly across comments, label changes, and commits.
  * Prevented inaccurate results when comparing commit activity with GitLab comment timestamps.

* **Tests**
  * Added regression coverage for timezone-offset timestamp handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->