### PR TITLE
fix(qontract-utils): set User-Agent header on all OCM/HTTP API clients

### DIFF
--- a/qontract_api/qontract_api/ocm/ocm_client_factory.py
+++ b/qontract_api/qontract_api/ocm/ocm_client_factory.py
@@ -52,7 +52,6 @@ def create_ocm_workspace_client(
             access_token_client_secret=access_token_client_secret,
             timeout=settings.ocm.api_timeout,
             max_retries=settings.ocm.api_max_retries,
-            user_agent=f"{settings.app_name}/{settings.version}",
         )
 
     # Stable, non-secret identity for this OCM environment + calling client, used

--- a/qontract_api/qontract_api/ocm/ocm_client_factory.py
+++ b/qontract_api/qontract_api/ocm/ocm_client_factory.py
@@ -52,6 +52,7 @@ def create_ocm_workspace_client(
             access_token_client_secret=access_token_client_secret,
             timeout=settings.ocm.api_timeout,
             max_retries=settings.ocm.api_max_retries,
+            user_agent=f"{settings.app_name}/{settings.version}",
         )
 
     # Stable, non-secret identity for this OCM environment + calling client, used

--- a/qontract_utils/qontract_utils/github_org/api.py
+++ b/qontract_utils/qontract_utils/github_org/api.py
@@ -116,18 +116,18 @@ class GithubOrgApi:
         self,
         token: str,
         base_url: str = "https://api.github.com",
-        user_agent: str = DEFAULT_USER_AGENT,
         hooks: Hooks | None = None,  # ruff: ignore[unused-method-argument] - handled by @with_hooks
+        user_agent: str = DEFAULT_USER_AGENT,
     ) -> None:
         """Initialize GithubOrgApi.
 
         Args:
             token: GitHub API token
             base_url: GitHub API base URL (override for GHE)
+            hooks: Optional custom hooks merged with built-in hooks
             user_agent: User-Agent header sent with every request. Defaults to
                 identifying qontract-utils itself; callers embedded in a larger
                 service should pass their own app name/version instead.
-            hooks: Optional custom hooks merged with built-in hooks
         """
         self._token = token
         self._base_url = base_url

--- a/qontract_utils/qontract_utils/github_org/api.py
+++ b/qontract_utils/qontract_utils/github_org/api.py
@@ -23,6 +23,7 @@ from prometheus_client import Counter, Histogram
 
 from qontract_utils.hooks import Hooks, invoke_with_hooks, with_hooks
 from qontract_utils.metrics import DEFAULT_BUCKETS_EXTERNAL_API
+from qontract_utils.user_agent import DEFAULT_USER_AGENT
 
 logger = structlog.get_logger(__name__)
 
@@ -115,6 +116,7 @@ class GithubOrgApi:
         self,
         token: str,
         base_url: str = "https://api.github.com",
+        user_agent: str = DEFAULT_USER_AGENT,
         hooks: Hooks | None = None,  # ruff: ignore[unused-method-argument] - handled by @with_hooks
     ) -> None:
         """Initialize GithubOrgApi.
@@ -122,11 +124,15 @@ class GithubOrgApi:
         Args:
             token: GitHub API token
             base_url: GitHub API base URL (override for GHE)
+            user_agent: User-Agent header sent with every request. Defaults to
+                identifying qontract-utils itself; callers embedded in a larger
+                service should pass their own app name/version instead.
             hooks: Optional custom hooks merged with built-in hooks
         """
         self._token = token
         self._base_url = base_url
-        self._gh = Github(token, base_url=base_url)
+        self._user_agent = user_agent
+        self._gh = Github(token, base_url=base_url, user_agent=user_agent)
 
     def _paginated_get(self, path: str) -> list[dict[str, Any]]:
         """Perform a paginated GET against the GitHub REST API.
@@ -141,6 +147,7 @@ class GithubOrgApi:
         headers = {
             "Authorization": f"token {self._token}",
             "Accept": "application/vnd.github.v3+json",
+            "User-Agent": self._user_agent,
         }
         items: list[dict[str, Any]] = []
 

--- a/qontract_utils/qontract_utils/glitchtip_api/client.py
+++ b/qontract_utils/qontract_utils/glitchtip_api/client.py
@@ -23,6 +23,7 @@ from qontract_utils.glitchtip_api.models import (
 )
 from qontract_utils.hooks import Hooks, invoke_with_hooks, with_hooks
 from qontract_utils.metrics import DEFAULT_BUCKETS_EXTERNAL_API
+from qontract_utils.user_agent import DEFAULT_USER_AGENT
 
 logger = structlog.get_logger(__name__)
 
@@ -177,6 +178,7 @@ class GlitchtipApi:
         token: str,
         timeout: int = TIMEOUT,
         max_retries: int = 3,
+        user_agent: str = DEFAULT_USER_AGENT,
         hooks: Hooks | None = None,  # ruff: ignore[unused-method-argument] - Handled by @with_hooks decorator
     ) -> None:
         """Initialize Glitchtip API client.
@@ -186,13 +188,19 @@ class GlitchtipApi:
             token: Glitchtip API token (Bearer token)
             timeout: API request timeout in seconds (default: 30)
             max_retries: Number of retries for failed requests (default: 3)
+            user_agent: User-Agent header sent with every request. Defaults to
+                identifying qontract-utils itself; callers embedded in a larger
+                service should pass their own app name/version instead.
             hooks: Optional custom hooks to merge with built-in hooks.
                 Built-in hooks (metrics, logging, latency) are automatically included.
         """
         self.host = host.rstrip("/")
         self._client = httpx2.Client(
             base_url=self.host,
-            headers={"Authorization": f"Bearer {token}"},
+            headers={
+                "Authorization": f"Bearer {token}",
+                "User-Agent": user_agent,
+            },
             timeout=timeout,
             transport=httpx2.HTTPTransport(retries=max_retries),
         )

--- a/qontract_utils/qontract_utils/glitchtip_api/client.py
+++ b/qontract_utils/qontract_utils/glitchtip_api/client.py
@@ -178,8 +178,8 @@ class GlitchtipApi:
         token: str,
         timeout: int = TIMEOUT,
         max_retries: int = 3,
-        user_agent: str = DEFAULT_USER_AGENT,
         hooks: Hooks | None = None,  # ruff: ignore[unused-method-argument] - Handled by @with_hooks decorator
+        user_agent: str = DEFAULT_USER_AGENT,
     ) -> None:
         """Initialize Glitchtip API client.
 
@@ -188,11 +188,11 @@ class GlitchtipApi:
             token: Glitchtip API token (Bearer token)
             timeout: API request timeout in seconds (default: 30)
             max_retries: Number of retries for failed requests (default: 3)
+            hooks: Optional custom hooks to merge with built-in hooks.
+                Built-in hooks (metrics, logging, latency) are automatically included.
             user_agent: User-Agent header sent with every request. Defaults to
                 identifying qontract-utils itself; callers embedded in a larger
                 service should pass their own app name/version instead.
-            hooks: Optional custom hooks to merge with built-in hooks.
-                Built-in hooks (metrics, logging, latency) are automatically included.
         """
         self.host = host.rstrip("/")
         self._client = httpx2.Client(

--- a/qontract_utils/qontract_utils/keycloak_api/client.py
+++ b/qontract_utils/qontract_utils/keycloak_api/client.py
@@ -23,6 +23,7 @@ from qontract_utils.keycloak_api._raw_client import (
 )
 from qontract_utils.keycloak_api.models import KeycloakSsoClient
 from qontract_utils.metrics import DEFAULT_BUCKETS_EXTERNAL_API
+from qontract_utils.user_agent import DEFAULT_USER_AGENT
 
 logger = structlog.get_logger(__name__)
 
@@ -130,6 +131,7 @@ class KeycloakApi:
         hooks: Hooks | None = None,
         timeout: float = TIMEOUT,
         max_retries: int = MAX_RETRIES,
+        user_agent: str = DEFAULT_USER_AGENT,
     ) -> None:
         """Initialize the Keycloak API client.
 
@@ -138,6 +140,9 @@ class KeycloakApi:
             initial_access_token: static per-realm bearer token used to register clients
             timeout: API request timeout in seconds (default: 30)
             max_retries: number of transport-level retries for failed requests (default: 3)
+            user_agent: User-Agent header sent with every request. Defaults to
+                identifying qontract-utils itself; callers embedded in a larger
+                service should pass their own app name/version instead.
             hooks: Optional custom hooks to merge with built-in hooks. Not read here -
                 @with_hooks intercepts and merges it into self._hooks before this body runs.
         """
@@ -145,7 +150,10 @@ class KeycloakApi:
         self.url = url
         self._client = httpx2.Client(
             base_url=url,
-            headers={"Authorization": f"Bearer {initial_access_token}"},
+            headers={
+                "Authorization": f"Bearer {initial_access_token}",
+                "User-Agent": user_agent,
+            },
             timeout=timeout,
             transport=httpx2.HTTPTransport(retries=max_retries),
         )

--- a/qontract_utils/qontract_utils/ocm_api/client.py
+++ b/qontract_utils/qontract_utils/ocm_api/client.py
@@ -10,7 +10,6 @@ from __future__ import annotations
 import contextvars
 import time
 from dataclasses import dataclass
-from importlib.metadata import PackageNotFoundError, version
 from typing import TYPE_CHECKING, Self
 
 import httpx2
@@ -36,6 +35,7 @@ from qontract_utils.ocm_api.models import (
     OcmSubscription,
     OcmSubscriptionLabel,
 )
+from qontract_utils.user_agent import DEFAULT_USER_AGENT
 
 if TYPE_CHECKING:
     from qontract_utils.ocm_api._raw_client import RawCluster, RawSubscription
@@ -46,13 +46,6 @@ logger = structlog.get_logger(__name__)
 TIMEOUT = 60.0
 MAX_RETRIES = 3
 CHUNK_SIZE = 100
-
-try:
-    _QONTRACT_UTILS_VERSION = version("qontract-utils")
-except PackageNotFoundError:
-    _QONTRACT_UTILS_VERSION = "unknown"
-
-DEFAULT_USER_AGENT = f"qontract-utils/{_QONTRACT_UTILS_VERSION}"
 
 # Prometheus metrics
 ocm_request = Counter(

--- a/qontract_utils/qontract_utils/ocm_api/client.py
+++ b/qontract_utils/qontract_utils/ocm_api/client.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import contextvars
 import time
 from dataclasses import dataclass
+from importlib.metadata import PackageNotFoundError, version
 from typing import TYPE_CHECKING, Self
 
 import httpx2
@@ -45,6 +46,13 @@ logger = structlog.get_logger(__name__)
 TIMEOUT = 60.0
 MAX_RETRIES = 3
 CHUNK_SIZE = 100
+
+try:
+    _QONTRACT_UTILS_VERSION = version("qontract-utils")
+except PackageNotFoundError:
+    _QONTRACT_UTILS_VERSION = "unknown"
+
+DEFAULT_USER_AGENT = f"qontract-utils/{_QONTRACT_UTILS_VERSION}"
 
 # Prometheus metrics
 ocm_request = Counter(
@@ -171,6 +179,7 @@ class OcmApi:
         hooks: Hooks | None = None,
         timeout: float = TIMEOUT,
         max_retries: int = MAX_RETRIES,
+        user_agent: str = DEFAULT_USER_AGENT,
     ) -> None:
         """Initialize the OCM API client.
 
@@ -181,6 +190,10 @@ class OcmApi:
             access_token_client_secret: OAuth2 client secret (already resolved plaintext)
             timeout: API request timeout in seconds (default: 60)
             max_retries: number of transport-level retries for failed requests (default: 3)
+            user_agent: User-Agent header sent with every request. Defaults to
+                identifying qontract-utils itself; callers embedded in a larger
+                service (e.g. qontract-api) should pass their own app name/version
+                so OCM can attribute traffic to the actual caller.
             hooks: Optional custom hooks to merge with built-in hooks. Not read here -
                 @with_hooks intercepts and merges it into self._hooks before this body runs.
         """
@@ -195,7 +208,10 @@ class OcmApi:
         )
         self._client = httpx2.Client(
             base_url=url,
-            headers={"Authorization": f"Bearer {access_token}"},
+            headers={
+                "Authorization": f"Bearer {access_token}",
+                "User-Agent": user_agent,
+            },
             timeout=timeout,
             transport=httpx2.HTTPTransport(retries=max_retries),
         )

--- a/qontract_utils/qontract_utils/ocm_api/client.py
+++ b/qontract_utils/qontract_utils/ocm_api/client.py
@@ -118,6 +118,7 @@ def _fetch_access_token(
     access_token_client_id: str,
     access_token_client_secret: str,
     timeout: float,
+    user_agent: str,
 ) -> str:
     response = httpx2.post(
         access_token_url,
@@ -126,6 +127,7 @@ def _fetch_access_token(
             "client_id": access_token_client_id,
             "client_secret": access_token_client_secret,
         },
+        headers={"User-Agent": user_agent},
         timeout=timeout,
     )
     response.raise_for_status()
@@ -183,10 +185,11 @@ class OcmApi:
             access_token_client_secret: OAuth2 client secret (already resolved plaintext)
             timeout: API request timeout in seconds (default: 60)
             max_retries: number of transport-level retries for failed requests (default: 3)
-            user_agent: User-Agent header sent with every request. Defaults to
-                identifying qontract-utils itself; callers embedded in a larger
-                service (e.g. qontract-api) should pass their own app name/version
-                so OCM can attribute traffic to the actual caller.
+            user_agent: User-Agent header sent with every request, including the
+                OAuth token exchange. Defaults to identifying qontract-utils itself;
+                callers embedded in a larger service (e.g. qontract-api) should pass
+                their own app name/version so OCM can attribute traffic to the actual
+                caller.
             hooks: Optional custom hooks to merge with built-in hooks. Not read here -
                 @with_hooks intercepts and merges it into self._hooks before this body runs.
         """
@@ -198,6 +201,7 @@ class OcmApi:
             access_token_client_id,
             access_token_client_secret,
             timeout,
+            user_agent,
         )
         self._client = httpx2.Client(
             base_url=url,

--- a/qontract_utils/qontract_utils/user_agent.py
+++ b/qontract_utils/qontract_utils/user_agent.py
@@ -10,9 +10,17 @@ from __future__ import annotations
 
 from importlib.metadata import PackageNotFoundError, version
 
-try:
-    _QONTRACT_UTILS_VERSION = version("qontract-utils")
-except PackageNotFoundError:
-    _QONTRACT_UTILS_VERSION = "unknown"
 
-DEFAULT_USER_AGENT = f"qontract-utils/{_QONTRACT_UTILS_VERSION}"
+def resolve_version(package: str, fallback: str = "unknown") -> str:
+    """Resolve the installed version of a package, falling back if not found.
+
+    Shared by every module that builds a `<package>/<version>` User-Agent
+    string, so the fallback behavior only needs to change in one place.
+    """
+    try:
+        return version(package)
+    except PackageNotFoundError:
+        return fallback
+
+
+DEFAULT_USER_AGENT = f"qontract-utils/{resolve_version('qontract-utils')}"

--- a/qontract_utils/qontract_utils/user_agent.py
+++ b/qontract_utils/qontract_utils/user_agent.py
@@ -1,0 +1,18 @@
+"""Default User-Agent for qontract_utils HTTP clients.
+
+Every Layer 1 API client sends this by default so external services can
+attribute traffic to qontract-utils. Callers embedded in a larger service
+(e.g. qontract-api) should pass their own app name/version instead so the
+embedding service is what shows up in the traffic, not the shared library.
+"""
+
+from __future__ import annotations
+
+from importlib.metadata import PackageNotFoundError, version
+
+try:
+    _QONTRACT_UTILS_VERSION = version("qontract-utils")
+except PackageNotFoundError:
+    _QONTRACT_UTILS_VERSION = "unknown"
+
+DEFAULT_USER_AGENT = f"qontract-utils/{_QONTRACT_UTILS_VERSION}"

--- a/qontract_utils/qontract_utils/user_agent.py
+++ b/qontract_utils/qontract_utils/user_agent.py
@@ -1,7 +1,7 @@
 """Default User-Agent for qontract_utils HTTP clients.
 
-Every Layer 1 API client sends this by default so external services can
-attribute traffic to qontract-utils. Callers embedded in a larger service
+Every HTTP-based Layer 1 API client sends this by default so external services
+can attribute traffic to qontract-utils. Callers embedded in a larger service
 (e.g. qontract-api) should pass their own app name/version instead so the
 embedding service is what shows up in the traffic, not the shared library.
 """

--- a/qontract_utils/qontract_utils/vcs/providers/github_client.py
+++ b/qontract_utils/qontract_utils/vcs/providers/github_client.py
@@ -13,6 +13,7 @@ from prometheus_client import Counter, Histogram
 
 from qontract_utils.hooks import Hooks, invoke_with_hooks, with_hooks
 from qontract_utils.metrics import DEFAULT_BUCKETS_EXTERNAL_API
+from qontract_utils.user_agent import DEFAULT_USER_AGENT
 
 if TYPE_CHECKING:
     from github.Repository import Repository
@@ -108,6 +109,9 @@ class GitHubRepoApi:
         timeout: Request timeout in seconds
         hooks: Optional custom hooks to merge with built-in hooks.
             Built-in hooks (metrics, logging, latency) are automatically included.
+        user_agent: User-Agent header sent with every request. Defaults to
+            identifying qontract-utils itself; callers embedded in a larger
+            service should pass their own app name/version instead.
     """
 
     # Set by @with_hooks decorator
@@ -121,6 +125,7 @@ class GitHubRepoApi:
         github_api_url: str = "https://api.github.com",
         timeout: int = 30,
         hooks: Hooks | None = None,  # ruff: ignore[unused-method-argument] - Handled by @with_hooks decorator
+        user_agent: str = DEFAULT_USER_AGENT,
     ) -> None:
         self.owner = owner
         self.repo = repo
@@ -129,7 +134,10 @@ class GitHubRepoApi:
 
         # PyGithub expects base_url without /api/v3
         self._github = Github(
-            login_or_token=token, base_url=github_api_url.rstrip("/"), timeout=timeout
+            login_or_token=token,
+            base_url=github_api_url.rstrip("/"),
+            timeout=timeout,
+            user_agent=user_agent,
         )
         self._repository: Repository = self._github.get_repo(f"{owner}/{repo}")
 

--- a/qontract_utils/qontract_utils/vcs/providers/gitlab_client.py
+++ b/qontract_utils/qontract_utils/vcs/providers/gitlab_client.py
@@ -13,6 +13,7 @@ from prometheus_client import Counter, Histogram
 
 from qontract_utils.hooks import NO_RETRY_CONFIG, Hooks, invoke_with_hooks, with_hooks
 from qontract_utils.metrics import DEFAULT_BUCKETS_EXTERNAL_API
+from qontract_utils.user_agent import DEFAULT_USER_AGENT
 from qontract_utils.vcs.provider_protocol import (
     AUTO_MERGE_LABEL,
     CreateMergeRequestInput,
@@ -110,6 +111,9 @@ class GitLabRepoApi:
         timeout: Request timeout in seconds
         hooks: Optional custom hooks to merge with built-in hooks.
             Built-in hooks (metrics, logging, latency) are automatically included.
+        user_agent: User-Agent header sent with every request. Defaults to
+            identifying qontract-utils itself; callers embedded in a larger
+            service should pass their own app name/version instead.
     """
 
     # Set by @with_hooks decorator
@@ -122,6 +126,7 @@ class GitLabRepoApi:
         gitlab_url: str,
         timeout: int = 30,
         hooks: Hooks | None = None,  # ruff: ignore[unused-method-argument] - Handled by @with_hooks decorator
+        user_agent: str = DEFAULT_USER_AGENT,
     ) -> None:
         self.project_id = project_id
         self.repo_url = f"{gitlab_url}/{project_id}"
@@ -132,6 +137,7 @@ class GitLabRepoApi:
             url=gitlab_url,
             private_token=token,
             timeout=timeout,
+            user_agent=user_agent,
         )
         self._project: Project = self._gitlab.projects.get(project_id)
 

--- a/qontract_utils/tests/keycloak_api/test_client.py
+++ b/qontract_utils/tests/keycloak_api/test_client.py
@@ -70,6 +70,45 @@ def test_register_client_sends_correct_body_and_auth(httpserver: HTTPServer) -> 
     assert "attributes" not in body or body["attributes"] is None
 
 
+def test_default_user_agent_identifies_qontract_utils(httpserver: HTTPServer) -> None:
+    api = _make_api(httpserver, initial_access_token="initial-token")
+    httpserver.expect_request(REGISTER_PATH, method="POST").respond_with_json(
+        _registration_response(
+            client_id="my-client",
+            secret="s3cr3t",
+            redirect_uris=[],
+            registration_access_token="reg-token",
+        )
+    )
+
+    api.register_client(client_name="my-client", redirect_uris=[])
+
+    request = next(req for req, _ in httpserver.log if req.path == REGISTER_PATH)
+    assert request.headers["User-Agent"].startswith("qontract-utils/")
+
+
+def test_custom_user_agent_overrides_default(httpserver: HTTPServer) -> None:
+    api = KeycloakApi(
+        url=httpserver.url_for(""),
+        initial_access_token="initial-token",
+        timeout=5,
+        user_agent="qontract-api/1.2.3",
+    )
+    httpserver.expect_request(REGISTER_PATH, method="POST").respond_with_json(
+        _registration_response(
+            client_id="my-client",
+            secret="s3cr3t",
+            redirect_uris=[],
+            registration_access_token="reg-token",
+        )
+    )
+
+    api.register_client(client_name="my-client", redirect_uris=[])
+
+    request = next(req for req, _ in httpserver.log if req.path == REGISTER_PATH)
+    assert request.headers["User-Agent"] == "qontract-api/1.2.3"
+
+
 def test_register_client_maps_response_to_domain_model(httpserver: HTTPServer) -> None:
     api = _make_api(httpserver, initial_access_token="initial-token")
     httpserver.expect_request(REGISTER_PATH, method="POST").respond_with_json(

--- a/qontract_utils/tests/ocm_api/test_client.py
+++ b/qontract_utils/tests/ocm_api/test_client.py
@@ -1,6 +1,7 @@
 """Tests for qontract_utils.ocm_api.client."""
 
 import json
+from collections.abc import Generator
 from unittest.mock import MagicMock
 
 import pydantic
@@ -13,6 +14,7 @@ from qontract_utils.ocm_api.models import (
     OcmIdentityProviderOidcOpenId,
 )
 from qontract_utils.ocm_api.search_filters import Filter
+from qontract_utils.user_agent import DEFAULT_USER_AGENT
 from werkzeug import Request, Response
 
 TOKEN_PATH = "/auth/token"
@@ -21,25 +23,42 @@ SUBSCRIPTIONS_PATH = "/api/accounts_mgmt/v1/subscriptions"
 CLUSTERS_PATH = "/api/clusters_mgmt/v1/clusters"
 IDPS_PATH = "/api/clusters_mgmt/v1/clusters/cluster-1/identity_providers"
 
+_created_apis: list[OcmApi] = []
+
+
+@pytest.fixture(autouse=True)
+def _close_ocm_apis() -> Generator[None]:
+    """Close every OcmApi created via `_make_ocm_api` after each test."""
+    yield
+    for api in _created_apis:
+        api.close()
+    _created_apis.clear()
+
 
 def _token_response(token: str) -> dict[str, object]:
     return {"access_token": token, "token_type": "bearer", "expires_in": 300}
 
 
 def _make_ocm_api(
-    httpserver: HTTPServer, token: str, hooks: Hooks | None = None
+    httpserver: HTTPServer,
+    token: str,
+    hooks: Hooks | None = None,
+    user_agent: str = DEFAULT_USER_AGENT,
 ) -> OcmApi:
     httpserver.expect_request(TOKEN_PATH, method="POST").respond_with_json(
         _token_response(token)
     )
-    return OcmApi(
+    api = OcmApi(
         url=httpserver.url_for(""),
         access_token_url=httpserver.url_for(TOKEN_PATH),
         access_token_client_id="client-id",
         access_token_client_secret="client-secret",
         hooks=hooks,
         timeout=5,
+        user_agent=user_agent,
     )
+    _created_apis.append(api)
+    return api
 
 
 def _empty_page() -> dict[str, object]:
@@ -86,18 +105,16 @@ def test_default_user_agent_identifies_qontract_utils(httpserver: HTTPServer) ->
     assert label_requests[0].headers["User-Agent"].startswith("qontract-utils/")
 
 
+def test_user_agent_sent_on_token_request(httpserver: HTTPServer) -> None:
+    _make_ocm_api(httpserver, token="test-token", user_agent="qontract-api/1.2.3")
+
+    token_requests = [req for req, _ in httpserver.log if req.path == TOKEN_PATH]
+    assert len(token_requests) == 1
+    assert token_requests[0].headers["User-Agent"] == "qontract-api/1.2.3"
+
+
 def test_custom_user_agent_overrides_default(httpserver: HTTPServer) -> None:
-    httpserver.expect_request(TOKEN_PATH, method="POST").respond_with_json(
-        _token_response("test-token")
-    )
-    api = OcmApi(
-        url=httpserver.url_for(""),
-        access_token_url=httpserver.url_for(TOKEN_PATH),
-        access_token_client_id="client-id",
-        access_token_client_secret="client-secret",
-        timeout=5,
-        user_agent="qontract-api/1.2.3",
-    )
+    api = _make_ocm_api(httpserver, token="test-token", user_agent="qontract-api/1.2.3")
     httpserver.expect_request(LABELS_PATH, method="GET").respond_with_json(
         _empty_page()
     )

--- a/qontract_utils/tests/ocm_api/test_client.py
+++ b/qontract_utils/tests/ocm_api/test_client.py
@@ -74,6 +74,40 @@ def test_bearer_token_sent_on_subsequent_requests(httpserver: HTTPServer) -> Non
     assert label_requests[0].headers["Authorization"] == "Bearer my-secret-token"
 
 
+def test_default_user_agent_identifies_qontract_utils(httpserver: HTTPServer) -> None:
+    api = _make_ocm_api(httpserver, token="test-token")
+    httpserver.expect_request(LABELS_PATH, method="GET").respond_with_json(
+        _empty_page()
+    )
+
+    api.get_labels(Filter().eq("key", "x"))
+
+    label_requests = [req for req, _ in httpserver.log if req.path == LABELS_PATH]
+    assert label_requests[0].headers["User-Agent"].startswith("qontract-utils/")
+
+
+def test_custom_user_agent_overrides_default(httpserver: HTTPServer) -> None:
+    httpserver.expect_request(TOKEN_PATH, method="POST").respond_with_json(
+        _token_response("test-token")
+    )
+    api = OcmApi(
+        url=httpserver.url_for(""),
+        access_token_url=httpserver.url_for(TOKEN_PATH),
+        access_token_client_id="client-id",
+        access_token_client_secret="client-secret",
+        timeout=5,
+        user_agent="qontract-api/1.2.3",
+    )
+    httpserver.expect_request(LABELS_PATH, method="GET").respond_with_json(
+        _empty_page()
+    )
+
+    api.get_labels(Filter().eq("key", "x"))
+
+    label_requests = [req for req, _ in httpserver.log if req.path == LABELS_PATH]
+    assert label_requests[0].headers["User-Agent"] == "qontract-api/1.2.3"
+
+
 #
 # per-instance isolation
 #

--- a/qontract_utils/tests/test_github_org_api.py
+++ b/qontract_utils/tests/test_github_org_api.py
@@ -1,0 +1,30 @@
+"""Tests for qontract_utils.github_org.api."""
+
+from pytest_httpserver import HTTPServer
+from qontract_utils.github_org.api import GithubOrgApi
+
+INVITATIONS_PATH = "/orgs/my-org/invitations"
+
+
+def test_default_user_agent_identifies_qontract_utils(httpserver: HTTPServer) -> None:
+    api = GithubOrgApi(token="token", base_url=httpserver.url_for(""))
+    httpserver.expect_request(INVITATIONS_PATH, method="GET").respond_with_json([])
+
+    api.get_pending_invitations("my-org")
+
+    request = next(req for req, _ in httpserver.log if req.path == INVITATIONS_PATH)
+    assert request.headers["User-Agent"].startswith("qontract-utils/")
+
+
+def test_custom_user_agent_overrides_default(httpserver: HTTPServer) -> None:
+    api = GithubOrgApi(
+        token="token",
+        base_url=httpserver.url_for(""),
+        user_agent="qontract-api/1.2.3",
+    )
+    httpserver.expect_request(INVITATIONS_PATH, method="GET").respond_with_json([])
+
+    api.get_pending_invitations("my-org")
+
+    request = next(req for req, _ in httpserver.log if req.path == INVITATIONS_PATH)
+    assert request.headers["User-Agent"] == "qontract-api/1.2.3"

--- a/qontract_utils/tests/test_glitchtip_api.py
+++ b/qontract_utils/tests/test_glitchtip_api.py
@@ -327,6 +327,26 @@ def test_glitchtip_api_host_stripped() -> None:
     assert api.host == "https://glitchtip.example.com"
 
 
+def test_glitchtip_api_default_user_agent() -> None:
+    """Test that a default qontract-utils User-Agent is sent."""
+    with patch("qontract_utils.glitchtip_api.client.httpx2.Client") as mock_cls:
+        GlitchtipApi(host="https://glitchtip.example.com", token="token")
+    headers = mock_cls.call_args.kwargs["headers"]
+    assert headers["User-Agent"].startswith("qontract-utils/")
+
+
+def test_glitchtip_api_custom_user_agent() -> None:
+    """Test that a custom User-Agent overrides the default."""
+    with patch("qontract_utils.glitchtip_api.client.httpx2.Client") as mock_cls:
+        GlitchtipApi(
+            host="https://glitchtip.example.com",
+            token="token",
+            user_agent="qontract-api/1.2.3",
+        )
+    headers = mock_cls.call_args.kwargs["headers"]
+    assert headers["User-Agent"] == "qontract-api/1.2.3"
+
+
 def test_organizations_single_page(
     glitchtip_api: GlitchtipApi, mock_httpx_client: MagicMock
 ) -> None:

--- a/qontract_utils/tests/test_user_agent.py
+++ b/qontract_utils/tests/test_user_agent.py
@@ -1,0 +1,29 @@
+"""Tests for qontract_utils.user_agent."""
+
+from importlib.metadata import PackageNotFoundError
+
+import pytest
+from pytest_mock import MockerFixture
+from qontract_utils.user_agent import DEFAULT_USER_AGENT, resolve_version
+
+
+def test_resolve_version_returns_installed_version(mocker: MockerFixture) -> None:
+    mocker.patch("qontract_utils.user_agent.version", return_value="1.2.3")
+    assert resolve_version("some-package") == "1.2.3"
+
+
+def test_resolve_version_falls_back_when_package_not_found(
+    mocker: MockerFixture,
+) -> None:
+    mocker.patch("qontract_utils.user_agent.version", side_effect=PackageNotFoundError)
+    assert resolve_version("some-package") == "unknown"
+
+
+def test_resolve_version_uses_custom_fallback(mocker: MockerFixture) -> None:
+    mocker.patch("qontract_utils.user_agent.version", side_effect=PackageNotFoundError)
+    assert resolve_version("some-package", fallback="dev") == "dev"
+
+
+@pytest.mark.parametrize("prefix", ["qontract-utils/"])
+def test_default_user_agent_has_qontract_utils_prefix(prefix: str) -> None:
+    assert DEFAULT_USER_AGENT.startswith(prefix)

--- a/qontract_utils/tests/vcs/test_github_client.py
+++ b/qontract_utils/tests/vcs/test_github_client.py
@@ -210,6 +210,31 @@ def test_github_api_find_merge_request_not_implemented(
         github_api.find_merge_request("some title")
 
 
+def test_github_api_default_user_agent(mock_github_client: MagicMock) -> None:
+    """Test GitHubRepoApi passes the default qontract-utils User-Agent to PyGithub."""
+    GitHubRepoApi(
+        owner="owner",
+        repo="repo",
+        token="token",
+    )
+
+    assert mock_github_client.call_args.kwargs["user_agent"].startswith(
+        "qontract-utils/"
+    )
+
+
+def test_github_api_custom_user_agent(mock_github_client: MagicMock) -> None:
+    """Test GitHubRepoApi passes a custom User-Agent to PyGithub."""
+    GitHubRepoApi(
+        owner="owner",
+        repo="repo",
+        token="token",
+        user_agent="qontract-api/1.2.3",
+    )
+
+    assert mock_github_client.call_args.kwargs["user_agent"] == "qontract-api/1.2.3"
+
+
 def test_github_api_call_context_immutable() -> None:
     """Test GitHubApiCallContext is immutable (frozen dataclass)."""
     context = GitHubApiCallContext(

--- a/qontract_utils/tests/vcs/test_gitlab_client.py
+++ b/qontract_utils/tests/vcs/test_gitlab_client.py
@@ -499,6 +499,31 @@ def test_gitlab_api_create_merge_request_calls_hooks(
     assert context.method == "create_merge_request"
 
 
+def test_gitlab_api_default_user_agent(mock_gitlab_client: MagicMock) -> None:
+    """Test GitLabRepoApi passes the default qontract-utils User-Agent to python-gitlab."""
+    GitLabRepoApi(
+        project_id="group/project",
+        token="token",
+        gitlab_url="https://gitlab.com",
+    )
+
+    assert mock_gitlab_client.call_args.kwargs["user_agent"].startswith(
+        "qontract-utils/"
+    )
+
+
+def test_gitlab_api_custom_user_agent(mock_gitlab_client: MagicMock) -> None:
+    """Test GitLabRepoApi passes a custom User-Agent to python-gitlab."""
+    GitLabRepoApi(
+        project_id="group/project",
+        token="token",
+        gitlab_url="https://gitlab.com",
+        user_agent="qontract-api/1.2.3",
+    )
+
+    assert mock_gitlab_client.call_args.kwargs["user_agent"] == "qontract-api/1.2.3"
+
+
 def test_gitlab_api_call_context_immutable() -> None:
     """Test GitLabApiCallContext is immutable (frozen dataclass)."""
     context = GitLabApiCallContext(

--- a/reconcile/test/ocm/test_utils_ocm_base.py
+++ b/reconcile/test/ocm/test_utils_ocm_base.py
@@ -11,6 +11,7 @@ from reconcile.utils.ocm_base_client import USER_AGENT, OCMBaseClient
 if TYPE_CHECKING:
     from collections.abc import Callable
 
+    from pytest_httpserver import HTTPServer
     from werkzeug import Request
 
 
@@ -39,6 +40,17 @@ def test_user_agent_header_is_set(
     assert req is not None
     assert req.headers["User-Agent"] == USER_AGENT
     assert USER_AGENT.startswith("qontract-reconcile/")
+
+
+def test_user_agent_header_is_sent_on_token_request(
+    ocm_base: OCMBaseClient,
+    httpserver: HTTPServer,
+    access_token_url: str,
+) -> None:
+    _ = ocm_base
+    token_requests = [req for req, _ in httpserver.log if req.url == access_token_url]
+    assert len(token_requests) == 1
+    assert token_requests[0].headers["User-Agent"] == USER_AGENT
 
 
 @pytest.mark.parametrize(

--- a/reconcile/test/ocm/test_utils_ocm_base.py
+++ b/reconcile/test/ocm/test_utils_ocm_base.py
@@ -6,7 +6,7 @@ import pytest
 
 from reconcile.test.ocm.fixtures import OcmUrl
 from reconcile.test.ocm.test_utils_ocm_get_json import build_paged_ocm_response
-from reconcile.utils.ocm_base_client import OCMBaseClient
+from reconcile.utils.ocm_base_client import USER_AGENT, OCMBaseClient
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -22,6 +22,23 @@ def ocm_base(access_token_url: str, ocm_url: str) -> OCMBaseClient:
         access_token_url=access_token_url,
         url=ocm_url,
     )
+
+
+def test_user_agent_header_is_set(
+    ocm_api: OCMBaseClient,
+    register_ocm_url_responses: Callable[[list[OcmUrl]], int],
+    find_ocm_http_request: Callable[[str, str], Request | None],
+) -> None:
+    register_ocm_url_responses([
+        OcmUrl(method="GET", uri="/api/some_path").add_list_response([])
+    ])
+
+    ocm_api.get("/api/some_path")
+
+    req = find_ocm_http_request("GET", "/api/some_path")
+    assert req is not None
+    assert req.headers["User-Agent"] == USER_AGENT
+    assert USER_AGENT.startswith("qontract-reconcile/")
 
 
 @pytest.mark.parametrize(

--- a/reconcile/test/ocm/test_utils_ocm_base.py
+++ b/reconcile/test/ocm/test_utils_ocm_base.py
@@ -53,6 +53,36 @@ def test_user_agent_header_is_sent_on_token_request(
     assert token_requests[0].headers["User-Agent"] == USER_AGENT
 
 
+def test_user_agent_header_can_be_overridden(
+    access_token_url: str,
+    ocm_url: str,
+    register_ocm_url_responses: Callable[[list[OcmUrl]], int],
+    find_ocm_http_request: Callable[[str, str], Request | None],
+    httpserver: HTTPServer,
+) -> None:
+    register_ocm_url_responses([
+        OcmUrl(method="GET", uri="/api/some_path").add_list_response([])
+    ])
+    custom_user_agent = "qontract-api/1.2.3"
+    client = OCMBaseClient(
+        access_token_client_id="some_client_id",
+        access_token_client_secret="some_client_secret",
+        access_token_url=access_token_url,
+        url=ocm_url,
+        user_agent=custom_user_agent,
+    )
+
+    client.get("/api/some_path")
+
+    req = find_ocm_http_request("GET", "/api/some_path")
+    assert req is not None
+    assert req.headers["User-Agent"] == custom_user_agent
+
+    token_requests = [req for req, _ in httpserver.log if req.url == access_token_url]
+    assert len(token_requests) == 1
+    assert token_requests[0].headers["User-Agent"] == custom_user_agent
+
+
 @pytest.mark.parametrize(
     "nr_of_items, page_size",
     [(10, 3), (10, 2), (1, 10), (10, 10)],

--- a/reconcile/utils/ocm_base_client.py
+++ b/reconcile/utils/ocm_base_client.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import logging
-from importlib.metadata import PackageNotFoundError, version
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -10,6 +9,7 @@ from typing import (
 )
 
 from pydantic import BaseModel
+from qontract_utils.user_agent import resolve_version
 from requests import (
     Session,
     codes,
@@ -33,12 +33,7 @@ if TYPE_CHECKING:
 
 REQUEST_TIMEOUT_SEC = 60
 
-try:
-    _RECONCILE_VERSION = version("qontract-reconcile")
-except PackageNotFoundError:
-    _RECONCILE_VERSION = "unknown"
-
-USER_AGENT = f"qontract-reconcile/{_RECONCILE_VERSION}"
+USER_AGENT = f"qontract-reconcile/{resolve_version('qontract-reconcile')}"
 
 
 class OCMBaseClient:
@@ -54,13 +49,14 @@ class OCMBaseClient:
         access_token_url: str,
         access_token_client_id: str,
         session: Session | None = None,
+        user_agent: str = USER_AGENT,
     ):
         self._access_token_client_secret = access_token_client_secret
         self._access_token_client_id = access_token_client_id
         self._access_token_url = access_token_url
         self._url = url
         self._session = session or Session()
-        self._session.headers["User-Agent"] = USER_AGENT
+        self._session.headers["User-Agent"] = user_agent
         self._init_access_token()
         self._init_request_headers()
 

--- a/reconcile/utils/ocm_base_client.py
+++ b/reconcile/utils/ocm_base_client.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import logging
+from importlib.metadata import PackageNotFoundError, version
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -31,6 +32,13 @@ if TYPE_CHECKING:
     from reconcile.gql_definitions.fragments.aus_organization import AUSOCMOrganization
 
 REQUEST_TIMEOUT_SEC = 60
+
+try:
+    _RECONCILE_VERSION = version("qontract-reconcile")
+except PackageNotFoundError:
+    _RECONCILE_VERSION = "unknown"
+
+USER_AGENT = f"qontract-reconcile/{_RECONCILE_VERSION}"
 
 
 class OCMBaseClient:
@@ -72,6 +80,7 @@ class OCMBaseClient:
         self._session.headers.update({
             "Authorization": f"Bearer {self._access_token}",
             "accept": "application/json",
+            "User-Agent": USER_AGENT,
         })
 
     def get(self, api_path: str, params: Mapping[str, str] | None = None) -> Any:

--- a/reconcile/utils/ocm_base_client.py
+++ b/reconcile/utils/ocm_base_client.py
@@ -60,6 +60,7 @@ class OCMBaseClient:
         self._access_token_url = access_token_url
         self._url = url
         self._session = session or Session()
+        self._session.headers["User-Agent"] = USER_AGENT
         self._init_access_token()
         self._init_request_headers()
 
@@ -80,7 +81,6 @@ class OCMBaseClient:
         self._session.headers.update({
             "Authorization": f"Bearer {self._access_token}",
             "accept": "application/json",
-            "User-Agent": USER_AGENT,
         })
 
     def get(self, api_path: str, params: Mapping[str, str] | None = None) -> Any:


### PR DESCRIPTION
## Summary

On 2026-07-21, CS pods crashed under request queue buildup. Alongside the primary
CS-side causes (N+1 queries, rate limiter bug), CS traced significant `list-clusters`
API traffic to the shared `sd-app-sre-ocm-sa` service account, but couldn't attribute
it to a specific caller/version because no custom `User-Agent` was set — all traffic
showed up as generic `python-requests`/`httpx` traffic.

- Set a custom `User-Agent` (`qontract-reconcile/<version>`) on `OCMBaseClient`
  (`reconcile/utils/ocm_base_client.py`), resolved via `importlib.metadata`, sent on
  every request including the OAuth token exchange. It also accepts an optional
  `user_agent` override now, so a CLI tool or `qontract-api` task wrapping it can
  identify itself distinctly from the default reconcile loop.
- Added `qontract_utils/qontract_utils/user_agent.py`, a single shared default
  (`qontract-utils/<version>`) for every HTTP-based Layer 1 client in
  `qontract_utils`: `OcmApi`, `GlitchtipApi`, `KeycloakApi`, `GithubOrgApi`,
  `GitHubRepoApi`, `GitLabRepoApi`. Each client also accepts an optional
  `user_agent` override, but nothing in `qontract_api` needs to configure or pass
  one — the default is enough for OCM/CS (or any other backend) to distinguish this
  traffic from `qontract-reconcile`'s.
- The `importlib.metadata.version` → `PackageNotFoundError` → `"unknown"` fallback
  pattern is now a single shared `resolve_version()` helper in
  `qontract_utils/user_agent.py`, used by both `qontract_utils` and
  `reconcile/utils/ocm_base_client.py`, instead of being duplicated in each module.
- The Kubernetes client (`qontract_utils/kubernetes/client.py`, lightkube-based) is
  intentionally excluded — lightkube has no headers/user_agent hook, and that
  traffic goes to per-tenant clusters rather than a shared rate-limited backend
  like OCM/CS.
- Per review feedback: the User-Agent is now applied before the OAuth2
  client-credentials token request fires in both `OCMBaseClient` and `OcmApi`, so
  the token exchange itself is attributable too, not just the subsequent API calls.
- Per review feedback: `user_agent` sits after `hooks` in every constructor
  (`OcmApi`, `KeycloakApi`, `GlitchtipApi`, `GithubOrgApi`), consistently, closing a
  latent positional-argument risk in `GlitchtipApi`/`GithubOrgApi`.
- Per review feedback: `GitHubRepoApi` and `GitLabRepoApi` (the vcs provider clients
  used for MR/PR operations) now also send a configurable User-Agent — they were the
  last HTTP-based Layer 1 clients still sending the third-party library default
  (PyGithub/python-gitlab). Verified both libraries actually apply the `user_agent`
  kwarg to the real request header rather than ignoring it.

Related: [APPSRE-14889](https://redhat.atlassian.net/browse/APPSRE-14889)

## Test plan

- [x] Added `test_user_agent_header_is_set`,
      `test_user_agent_header_is_sent_on_token_request`, and
      `test_user_agent_header_can_be_overridden` in
      `reconcile/test/ocm/test_utils_ocm_base.py` (verified to fail without the fix)
- [x] Added User-Agent default/override/token-request tests for `OcmApi`,
      `GlitchtipApi`, `KeycloakApi`, `GithubOrgApi`, `GitHubRepoApi`, and
      `GitLabRepoApi` in `qontract_utils/tests/`
- [x] Added `qontract_utils/tests/test_user_agent.py` covering `resolve_version()`'s
      installed-version and fallback paths
- [x] Added an autouse fixture in `qontract_utils/tests/ocm_api/test_client.py` to
      close every `OcmApi` created in the file after each test (review feedback)
- [x] `uv run pytest reconcile/test/ocm/` — 391 passed
- [x] `uv run pytest` (qontract_utils, full suite) — 732 passed
- [x] `uv run pytest -k "ocm or glitchtip or github or keycloak or sso_client"` (qontract_api) — 235+ passed
- [x] `uv run mypy` clean on all changed files
- [x] `uv run ruff check` / `ruff format --check` clean on all changed files

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - API requests now include a descriptive `User-Agent` identifying the client and its version.
  - Added consistent default identification across supported OCM, GitHub, GlitchTip, Keycloak, GitLab, and reconciliation requests.
  - Applications can provide a custom `User-Agent` for supported API clients.

- **Documentation**
  - API client options now describe default and customizable request-identification behavior.

- **Tests**
  - Added coverage confirming default and custom `User-Agent` values are sent correctly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->