### PR TITLE
fix(gitlab-housekeeping): don't silently abandon unmergeable MRs

### DIFF
--- a/reconcile/gitlab_housekeeping.py
+++ b/reconcile/gitlab_housekeeping.py
@@ -506,6 +506,7 @@ def get_merge_requests(
     gl: GitLabApi,
     state: State,
     users_allowed_to_label: Iterable[str] | None = None,
+    skip_unmergeable: bool = True,
 ) -> list[dict[str, Any]]:
     mrs = gl.get_merge_requests(state=MRState.OPENED)
     return preprocess_merge_requests(
@@ -514,6 +515,7 @@ def get_merge_requests(
         project_merge_requests=mrs,
         state=state,
         users_allowed_to_label=users_allowed_to_label,
+        skip_unmergeable=skip_unmergeable,
     )
 
 
@@ -524,6 +526,7 @@ def preprocess_merge_requests(
     state: State,
     users_allowed_to_label: Iterable[str] | None = None,
     must_pass: Iterable[str] | None = None,
+    skip_unmergeable: bool = True,
 ) -> list[dict[str, Any]]:
     results = []
     for mr in project_merge_requests:
@@ -531,7 +534,14 @@ def preprocess_merge_requests(
             MRStatus.CANNOT_BE_MERGED,
             MRStatus.CANNOT_BE_MERGED_RECHECK,
         }:
-            continue
+            logging.warning([
+                "preprocess",
+                gl.project.name,
+                mr.iid,
+                f"merge_status={mr.merge_status}, MR likely conflicts with target branch",
+            ])
+            if skip_unmergeable:
+                continue
         if mr.draft:
             continue
         if len(mr.commits()) == 0:
@@ -913,6 +923,7 @@ def _rebase_merge_requests_active_cap(
             gl=gl,
             state=state,
             users_allowed_to_label=users_allowed_to_label,
+            skip_unmergeable=False,
         )
         if not item["error"]
     ]
@@ -986,6 +997,7 @@ def _rebase_merge_requests_old_burst(
             gl=gl,
             state=state,
             users_allowed_to_label=users_allowed_to_label,
+            skip_unmergeable=False,
         )
         if not item["error"]
     ]
@@ -1472,7 +1484,17 @@ def run_error_healthcheck(
             MRStatus.CANNOT_BE_MERGED,
             MRStatus.CANNOT_BE_MERGED_RECHECK,
         }:
-            continue
+            # Don't skip: this is exactly the state a real merge conflict
+            # produces, and it's the case the merge_error/rebase-error check
+            # below exists to catch. Skipping here means a conflicting MR
+            # can never be flagged, however it got into this state.
+            logging.warning([
+                "error-healthcheck",
+                "unmergeable",
+                gl.project.name,
+                mr.iid,
+                f"merge_status={mr.merge_status}",
+            ])
 
         if not is_good_to_merge(mr.labels):
             continue

--- a/reconcile/gitlab_housekeeping.py
+++ b/reconcile/gitlab_housekeeping.py
@@ -534,14 +534,17 @@ def preprocess_merge_requests(
             MRStatus.CANNOT_BE_MERGED,
             MRStatus.CANNOT_BE_MERGED_RECHECK,
         }:
-            logging.warning([
+            if skip_unmergeable:
+                continue
+            # cannot_be_merged_recheck is a transient state GitLab sets for
+            # nearly every open MR on every reconcile cycle -- debug only,
+            # see run_error_healthcheck() for why this isn't a warning.
+            logging.debug([
                 "preprocess",
                 gl.project.name,
                 mr.iid,
-                f"merge_status={mr.merge_status}, MR likely conflicts with target branch",
+                f"merge_status={mr.merge_status}, including for rebase",
             ])
-            if skip_unmergeable:
-                continue
         if mr.draft:
             continue
         if len(mr.commits()) == 0:
@@ -1480,24 +1483,29 @@ def run_error_healthcheck(
         if mr.draft:
             continue
 
+        # Don't skip on cannot_be_merged/cannot_be_merged_recheck: that's
+        # exactly the state a real merge conflict produces, and it's the case
+        # the merge_error/rebase-error check below exists to catch. Skipping
+        # here means a conflicting MR can never be flagged. No log at this
+        # point though -- cannot_be_merged_recheck is a transient state that
+        # GitLab sets for nearly every open MR on every reconcile cycle
+        # before approval is even checked; logging here was tried in #5733
+        # and reverted in #5742 for producing ~1,700 log lines/hour.
+
+        if not is_good_to_merge(mr.labels):
+            continue
+
         if mr.merge_status in {
             MRStatus.CANNOT_BE_MERGED,
             MRStatus.CANNOT_BE_MERGED_RECHECK,
         }:
-            # Don't skip: this is exactly the state a real merge conflict
-            # produces, and it's the case the merge_error/rebase-error check
-            # below exists to catch. Skipping here means a conflicting MR
-            # can never be flagged, however it got into this state.
-            logging.warning([
+            logging.debug([
                 "error-healthcheck",
                 "unmergeable",
                 gl.project.name,
                 mr.iid,
                 f"merge_status={mr.merge_status}",
             ])
-
-        if not is_good_to_merge(mr.labels):
-            continue
 
         labels = set(mr.labels)
 

--- a/reconcile/test/test_gitlab_housekeeping.py
+++ b/reconcile/test/test_gitlab_housekeeping.py
@@ -982,6 +982,35 @@ def test_error_mr_skipped_in_rebase(
     assert normal_mr.rebase.call_count == 1
 
 
+@pytest.mark.parametrize(
+    "strategy", [RebaseStrategy.ACTIVE_CAP, RebaseStrategy.OLD_BURST]
+)
+def test_rebase_strategies_pass_skip_unmergeable_false(
+    mocker: MockerFixture,
+    gitlab_api: Mock,
+    state: Mock,
+    strategy: RebaseStrategy,
+) -> None:
+    """Both rebase strategies must ask preprocessing to include MRs that are
+    currently unmergeable -- otherwise a conflicting MR can never be picked
+    up for a rebase attempt in the first place, regardless of which strategy
+    is active."""
+    mocked_get_merge_requests = mocker.patch(
+        "reconcile.gitlab_housekeeping.get_merge_requests",
+        return_value=[],
+    )
+
+    gl_h.rebase_merge_requests(
+        dry_run=False,
+        gl=gitlab_api,
+        rebase_limit=2,
+        state=state,
+        strategy=strategy,
+    )
+
+    assert mocked_get_merge_requests.call_args.kwargs.get("skip_unmergeable") is False
+
+
 # --- get_rebase_strategy tests ---
 
 
@@ -1450,6 +1479,37 @@ def test_healthcheck_applies_rebase_error_on_merge_error_field(
     mocked_gl.get_merge_request_pipelines.assert_not_called()
 
 
+def test_healthcheck_applies_rebase_error_when_currently_unmergeable(
+    project: Project,
+) -> None:
+    """The rebase-error label is the mechanism that's supposed to make a
+    broken MR visible in the review queue. It must still fire while GitLab
+    currently reports the MR as unmergeable -- that's exactly the state a
+    real merge conflict produces, and it's the case this healthcheck exists
+    to catch."""
+    mr = _make_healthcheck_mr(
+        labels=["lgtm"],
+        merge_status="cannot_be_merged",
+    )
+    fresh_mr = create_autospec(ProjectMergeRequest)
+    fresh_mr.merge_error = (
+        "Rebase failed: Rebase locally, resolve all conflicts, then push the branch."
+    )
+
+    mocked_gl = create_autospec(GitLabApi)
+    mocked_gl.project = project
+    mocked_gl.get_merge_request.return_value = fresh_mr
+
+    gl_h.run_error_healthcheck(
+        dry_run=False,
+        gl=mocked_gl,
+        project_merge_requests=[mr],
+    )
+
+    mocked_gl.get_merge_request.assert_called_once_with(mr.iid)
+    mocked_gl.add_label_to_merge_request.assert_called_once_with(mr, "rebase-error")
+
+
 @pytest.mark.parametrize(
     "resolved_status",
     ["mergeable", "ci_must_pass"],
@@ -1691,6 +1751,74 @@ def test_error_labels_visible_in_queue(
     assert len(results) == 1
     assert results[0]["mr"] is mr
     assert results[0]["error"] is True
+
+
+def test_preprocess_merge_requests_skips_unmergeable_by_default(
+    state: Mock,
+    project: Project,
+    add_lgtm_merge_request_resource_label_event: ProjectMergeRequestResourceLabelEvent,
+) -> None:
+    """An MR that GitLab reports as unmergeable (real conflict with the
+    target branch) is excluded from the results by default -- this is what
+    keeps the merge-queue report from listing something that can't actually
+    be merged."""
+    mr = create_autospec(ProjectMergeRequest)
+    mr.merge_status = "cannot_be_merged"
+    mr.draft = False
+    mr.commits.return_value = [create_autospec(ProjectCommit)]
+    mr.labels = ["lgtm"]
+    mr.iid = 1
+
+    mocked_gl = create_autospec(GitLabApi)
+    mocked_gl.project = project
+    mocked_gl.get_merge_request_label_events.return_value = [
+        add_lgtm_merge_request_resource_label_event
+    ]
+
+    results = gl_h.preprocess_merge_requests(
+        dry_run=False,
+        gl=mocked_gl,
+        project_merge_requests=[mr],
+        state=state,
+        users_allowed_to_label=None,
+    )
+
+    assert results == []
+
+
+def test_preprocess_merge_requests_includes_unmergeable_when_flag_set(
+    state: Mock,
+    project: Project,
+    add_lgtm_merge_request_resource_label_event: ProjectMergeRequestResourceLabelEvent,
+) -> None:
+    """With skip_unmergeable=False, an otherwise-approved MR that is
+    currently unmergeable still comes back as a candidate -- this is what
+    lets the rebase strategies pick it up and attempt to fix it, instead of
+    it being silently abandoned forever."""
+    mr = create_autospec(ProjectMergeRequest)
+    mr.merge_status = "cannot_be_merged"
+    mr.draft = False
+    mr.commits.return_value = [create_autospec(ProjectCommit)]
+    mr.labels = ["lgtm"]
+    mr.iid = 1
+
+    mocked_gl = create_autospec(GitLabApi)
+    mocked_gl.project = project
+    mocked_gl.get_merge_request_label_events.return_value = [
+        add_lgtm_merge_request_resource_label_event
+    ]
+
+    results = gl_h.preprocess_merge_requests(
+        dry_run=False,
+        gl=mocked_gl,
+        project_merge_requests=[mr],
+        state=state,
+        users_allowed_to_label=None,
+        skip_unmergeable=False,
+    )
+
+    assert len(results) == 1
+    assert results[0]["mr"] is mr
 
 
 class TestMergeErrorCycleEndToEnd:


### PR DESCRIPTION
## Summary

`gitlab-housekeeping` silently abandons MRs that GitLab reports as unmergeable
(`merge_status: cannot_be_merged` — a real conflict with the target branch, not just "behind").
Such an MR:

- is never picked up for an automatic rebase attempt (by either rebase strategy),
- never gets flagged by the error healthcheck that exists specifically to catch broken MRs
  (`rebase-error` label), and
- produces **zero log output** anywhere in the process.

It just disappears from `app-interface-merge-queue.md` and from view, indistinguishable from "does
not exist," until a human happens to check the GitLab API directly. This PR closes that hole for two
of the three places it exists, and documents the third (intentionally left alone).

## How this was found

MR [service/app-interface!201755](https://gitlab.cee.redhat.com/service/app-interface/-/merge_requests/201755)
(`glitchtip: prod bump to 6.2.6`) should have been on the merge queue and picked up by the bot, but
wasn't. It is used as the concrete, verifiable example throughout this description. All API
responses below were captured live via `glab api` against that MR while investigating.

```json
// GET /projects/service%2Fapp-interface/merge_requests/201755
{
  "merge_status": "cannot_be_merged",
  "detailed_merge_status": "commits_status",
  "has_conflicts": true,
  "merge_error": null,
  "draft": false,
  "approved": true
}
```

```
// resource_label_events (chronological)
2026-08-13T12:30:10Z devtools-bot add self-serviceable
2026-08-13T12:30:10Z devtools-bot add change-owner/show-self-serviceable-in-review-queue
2026-08-13T12:30:10Z devtools-bot add "bot/approved: progressive-delivery"
```

The MR is a self-serviceable change; it never needed `/lgtm` — it was auto-approved by the
change-owner bot with `bot/approved: progressive-delivery`, which **is** one of the
`MERGE_LABELS_PRIORITY` labels (`prioritized_approval_label(ChangeTypePriority.PROGRESSIVE_DELIVERY.value)`,
see `reconcile/utils/mr/labels.py` / `reconcile/gitlab_housekeeping.py:71-77`). So this MR was, in
every other respect, a perfectly normal rebase/merge candidate.

Root cause: the target file `data/services/glitchtip/cicd/saas.yaml` received a concurrent SAPM
auto-promotion commit on `master` (`!201480`, 2026-08-12T10:04) on the same ref line the day before
this MR was opened, one day after this MR's base commit — a genuine, unavoidable conflict, not a
bot malfunction on its own. What *is* a bot malfunction is what happens next: nothing.

## Root cause: three copies of the same premature filter

All three locations treat `mr.merge_status in {CANNOT_BE_MERGED, CANNOT_BE_MERGED_RECHECK}` as
"skip this MR, no logging":

### 1. `preprocess_merge_requests()` — `reconcile/gitlab_housekeeping.py:530-534` (before this PR)

This is the single function behind `get_merge_requests()`, which feeds **both**:

- the `app_interface_merge_queue` CLI report (`tools/qontract_cli.py:2314-2353`, the source of
  `app-interface-merge-queue.md`), and
- **both** rebase strategies: `_rebase_merge_requests_active_cap` (line 909-918) and
  `_rebase_merge_requests_old_burst` (line 982-991).

The `continue` at the very top of the loop fires before any label/approval logic runs, and before
either rebase strategy ever sees the MR. **Effect: `mr.rebase()` is never called on a conflicting MR,
regardless of which rebase strategy is active.** This is correct behavior for the merge-queue
report (a conflicting MR genuinely isn't ready to merge) but wrong for the rebase candidate list —
rebasing is exactly the mechanism meant to *resolve* this state, not something that should be
gated behind already being past it.

### 2. `run_error_healthcheck()` — `reconcile/gitlab_housekeeping.py:1471-1475` (before this PR)

This function's entire purpose (per its own docstring) is to detect problems and label them
(`rebase-error`, `pipeline-error`, `merge-error`) so a human sees them via the review queue. It has
the exact same early `continue`, before it ever looks at `mr.merge_error` for the substring
`"Rebase failed"`. In other words: it skips the one case it exists to catch.

### 3. `tools/qontract_cli.py:2390-2394` (`app_interface_review_queue`) — **left untouched**

An independent, inline duplicate of the same check. This is a reporting-only code path, not part of
the automation loop — flagging it here so reviewers don't think it was missed. Changing it isn't
needed to fix the automation gap and is out of scope for this PR.

## The full causal chain (why MR 201755 produced *zero* signal anywhere)

```
1. preprocess_merge_requests() skips the MR before rebase is ever attempted
        │
        ▼
2. GitLab never gets a rebase request → mr.merge_error stays null
   (confirmed live: "merge_error": null on the real MR, months after it started conflicting)
        │
        ▼
3. run_error_healthcheck() also skips the MR outright, so even if merge_error
   *were* populated, it would never be inspected
        │
        ▼
4. No rebase attempt, no error label, no log line, no queue entry.
   Indistinguishable from "MR does not exist."
```

This matches an earlier, previously unsolved "similar case" — same shape, same silence.

## Fix

Minimal, two-function change. No new labels, no new concepts — this makes the *existing*
`rebase-error` label mechanism reachable for the case it was already designed for.

### `preprocess_merge_requests()` / `get_merge_requests()`

Added `skip_unmergeable: bool = True`.

- **Default `True`** preserves current behavior for the CLI report
  (`tools/qontract_cli.py:2321`, call site unchanged) — a conflicting MR must still not be reported
  as "ready to merge."
- **`False`** (used by both rebase strategies): don't skip — log a warning and let the MR flow into
  the normal approval/label checks, so it can become a rebase candidate.

```python
if mr.merge_status in {MRStatus.CANNOT_BE_MERGED, MRStatus.CANNOT_BE_MERGED_RECHECK}:
    logging.warning([...])
    if skip_unmergeable:
        continue
```

### `run_error_healthcheck()`

Removed the hard `continue` on `cannot_be_merged`/`cannot_be_merged_recheck`; replaced with a
warning log and fall-through into the existing (already implemented, already tested for the
`can_be_merged` case) `merge_error`/`rebase_failed` detection.

### End-to-end effect

Bot now attempts a rebase on a conflicting-but-approved MR → if GitLab's rebase genuinely fails
(real conflicting hunks — already handled via `GitlabMRRebaseError` in `_try_rebase`,
`gitlab_housekeeping.py:683-697`) → next healthcheck run sees `merge_error` containing
`"Rebase failed"` → applies the `rebase-error` label → the MR becomes visible in the review queue
instead of vanishing.

**Note:** this fix restores *visibility and automation*. It does not retroactively fix MR 201755's
conflict — that MR still needs a manual rebase to actually merge, same as before. What changes is
that the *next* MR in this situation will get a rebase attempt and, on failure, a `rebase-error`
label — not silence.

## Tests (TDD: written first, confirmed red, then the fix, confirmed green)

All four in `reconcile/test/test_gitlab_housekeeping.py`, following existing fixture/mocking
patterns exactly (synthetic MR data — the real MR number is only used in this description, not
baked into any test):

| Test                                                                   | Purpose                                | Result before fix                                                        | Result after fix |
| ---------------------------------------------------------------------- | -------------------------------------- | ------------------------------------------------------------------------ | ---------------- |
| `test_preprocess_merge_requests_skips_unmergeable_by_default`          | Locks in unchanged CLI-report behavior | passed (pre-existing behavior)                                           | passed           |
| `test_preprocess_merge_requests_includes_unmergeable_when_flag_set`    | Reproduces the rebase-candidate bug    | **failed** — `TypeError: unexpected keyword argument 'skip_unmergeable'` | passed           |
| `test_rebase_strategies_pass_skip_unmergeable_false` (both strategies) | Confirms both rebase strategies opt in | **failed** — kwarg not passed                                            | passed           |
| `test_healthcheck_applies_rebase_error_when_currently_unmergeable`     | Reproduces the healthcheck bug         | **failed** — `get_merge_request` never called (0 times)                  | passed           |

```
$ uv run pytest reconcile/test/test_gitlab_housekeeping.py -k unmergeable -v   # before the fix
FAILED test_rebase_strategies_pass_skip_unmergeable_false[active-cap]
FAILED test_rebase_strategies_pass_skip_unmergeable_false[old-burst]
FAILED test_healthcheck_applies_rebase_error_when_currently_unmergeable
FAILED test_preprocess_merge_requests_includes_unmergeable_when_flag_set
==== 4 failed, 1 passed ====

$ uv run pytest reconcile/test/test_gitlab_housekeeping.py -k unmergeable -v   # after the fix
==== 5 passed ====

$ uv run pytest reconcile/test/test_gitlab_housekeeping.py   # full file, no regressions
==== 163 passed ====
```

`uv run mypy` and `uv run ruff check`/`ruff format --check` pass clean on both changed files.

## Test plan

- [x] New unit tests confirmed red before the fix, green after (see table above)
- [x] Full `test_gitlab_housekeeping.py` suite passes (163/163, no regressions)
- [x] `mypy` strict passes on changed files
- [x] `ruff check` / `ruff format --check` pass on changed files
- [ ] Manual follow-up: rebase MR !201755 by hand (this PR doesn't retroactively fix it)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Unmergeable merge requests are now excluded from standard processing by default.
  * Rebase checks continue to include unmergeable merge requests, allowing conflicts and rebase errors to be identified and labeled correctly.
  * Processing logs now clearly report the status of unmergeable merge requests.
  * Error health checks now evaluate merge and rebase error labels for unmergeable merge requests.

* **Tests**
  * Added coverage for default filtering and rebase-specific handling of unmergeable merge requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->