### PR TITLE
fix(qontract-cli) MR skipped pipelines are invisible review queue

### DIFF
--- a/tools/qontract_cli.py
+++ b/tools/qontract_cli.py
@@ -2413,6 +2413,7 @@ def app_interface_review_queue(ctx: click.Context) -> None:
                 continue
 
             pipelines = gl.get_merge_request_pipelines(mr)
+            pipelines = [p for p in pipelines if p.status != PipelineStatus.SKIPPED]
             if not pipelines:
                 continue
             running_pipelines = [

--- a/tools/test/test_qontract_cli.py
+++ b/tools/test/test_qontract_cli.py
@@ -588,9 +588,7 @@ def test_review_queue_includes_mr_when_skipped_pipeline_precedes_success(
     """An MR whose most recent pipeline is 'skipped' (merge_request_event)
     but has a successful CI pipeline behind it must still appear in the
     review queue — the skipped pipeline is not a real CI result."""
-    mock_review_queue_gl.get_merge_requests.return_value = [
-        _mock_mr(8, [])
-    ]
+    mock_review_queue_gl.get_merge_requests.return_value = [_mock_mr(8, [])]
     mock_review_queue_gl.get_merge_request_pipelines.return_value = [
         Mock(status=PipelineStatus.SKIPPED),
         Mock(status=PipelineStatus.SUCCESS),

--- a/tools/test/test_qontract_cli.py
+++ b/tools/test/test_qontract_cli.py
@@ -582,6 +582,30 @@ def test_review_queue_excludes_self_serviceable_mr_without_error(
     assert "MR 6" not in result.output
 
 
+def test_review_queue_includes_mr_when_skipped_pipeline_precedes_success(
+    mock_review_queue_gl: Mock,
+) -> None:
+    """An MR whose most recent pipeline is 'skipped' (merge_request_event)
+    but has a successful CI pipeline behind it must still appear in the
+    review queue — the skipped pipeline is not a real CI result."""
+    mock_review_queue_gl.get_merge_requests.return_value = [
+        _mock_mr(8, [])
+    ]
+    mock_review_queue_gl.get_merge_request_pipelines.return_value = [
+        Mock(status=PipelineStatus.SKIPPED),
+        Mock(status=PipelineStatus.SUCCESS),
+    ]
+
+    runner = CliRunner()
+    result = runner.invoke(
+        qontract_cli.get,
+        ["app-interface-review-queue"],
+        obj={"options": {"output": "table", "sort": True}},
+    )
+    assert result.exit_code == 0
+    assert "MR 8" in result.output
+
+
 def test_review_queue_includes_bot_authored_self_serviceable_mr_with_pipeline_error(
     mock_review_queue_gl: Mock,
 ) -> None:

--- a/tools/test/test_qontract_cli.py
+++ b/tools/test/test_qontract_cli.py
@@ -588,11 +588,14 @@ def test_review_queue_includes_mr_when_skipped_pipeline_precedes_success(
     """An MR whose most recent pipeline is 'skipped' (merge_request_event)
     but has a successful CI pipeline behind it must still appear in the
     review queue — the skipped pipeline is not a real CI result."""
-    mock_review_queue_gl.get_merge_requests.return_value = [_mock_mr(8, [])]
+    mock_review_queue_gl.get_merge_requests.return_value = [
+        _mock_mr(8, ["not-self-serviceable"])
+    ]
     mock_review_queue_gl.get_merge_request_pipelines.return_value = [
         Mock(status=PipelineStatus.SKIPPED),
         Mock(status=PipelineStatus.SUCCESS),
     ]
+    mock_review_queue_gl.is_last_action_by_team.return_value = False
 
     runner = CliRunner()
     result = runner.invoke(


### PR DESCRIPTION
## Summary

MRs with a `skipped` merge-request-event pipeline sorted before a successful CI pipeline were invisible in the review queue. `pipelines[0].status` was checked without filtering out `SKIPPED` first, so the review queue saw `skipped` != `success` and dropped the MR.

This matches the existing pattern used in 4 places in `gitlab_housekeeping.py` (lines 854, 929, 1088, 1392) where skipped pipelines are already filtered before status checks.

## Root Cause

GitLab returns `merge_request_event` pipelines (typically `status=skipped`) sorted before real CI pipelines (`source=push`/`external`, `status=success`). The review queue took `pipelines[0]` raw without filtering.

Concrete example: [!201360](https://gitlab.cee.redhat.com/service/app-interface/-/merge_requests/201360) — 7 pipelines, two most recent are `skipped` (merge_request_event), real CI pipelines are `success`. Never appeared in the review queue despite needing review.

## Fix

One-line addition in `tools/qontract_cli.py`:

```python
pipelines = [p for p in pipelines if p.status != PipelineStatus.SKIPPED]
```

## Test plan

- [x] New unit test: `test_review_queue_includes_mr_when_skipped_pipeline_precedes_success`
- [ ] Verify MR 201360 appears in review queue after deploy

Closes [APPSRE-15067](https://redhat.atlassian.net/browse/APPSRE-15067)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Merge requests with a skipped pipeline followed by a successful pipeline are now correctly included in the review queue.
  * Skipped pipelines no longer interfere with pipeline status and result evaluation.

* **Tests**
  * Added coverage to verify correct review-queue behavior in this scenario.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->