### PR TITLE
fix(aws-account-manager): correct create_agreement_request params for ROSA marketplace

### DIFF
--- a/qontract_utils/qontract_utils/aws_api_typed/marketplace.py
+++ b/qontract_utils/qontract_utils/aws_api_typed/marketplace.py
@@ -112,10 +112,9 @@ class AWSApiMarketplace:
         self, agreement_proposal_id: str, term_ids: Iterable[str]
     ) -> str:
         create_resp = self.agreement_client.create_agreement_request(
-            catalog="AWSMarketplace",
-            agreementProposalId=agreement_proposal_id,
+            agreementProposalIdentifier=agreement_proposal_id,
             intent="NEW",
-            requestedTerms=[{"termId": tid} for tid in term_ids],
+            requestedTerms=[{"id": tid} for tid in term_ids],
         )
         agreement_request_id = create_resp["agreementRequestId"]
 

--- a/qontract_utils/tests/aws_api_typed/test_aws_api_typed_marketplace.py
+++ b/qontract_utils/tests/aws_api_typed/test_aws_api_typed_marketplace.py
@@ -2,7 +2,9 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+import boto3
 import pytest
+from botocore.stub import Stubber
 from qontract_utils.aws_api_typed.marketplace import (
     ROSA_HCP_PRODUCT_ID,
     AWSApiMarketplace,
@@ -13,6 +15,7 @@ from qontract_utils.hooks import Hooks
 if TYPE_CHECKING:
     from unittest.mock import MagicMock
 
+    from botocore.client import BaseClient
     from pytest_mock import MockerFixture
     from qontract_utils.aws_api_typed._hooks import AWSApiCallContext
 
@@ -171,10 +174,9 @@ def test_subscribe_rosa(
 
     assert result == "agr-456"
     agreement_client.create_agreement_request.assert_called_once_with(
-        catalog="AWSMarketplace",
-        agreementProposalId="prop-xyz",
+        agreementProposalIdentifier="prop-xyz",
         intent="NEW",
-        requestedTerms=[{"termId": "term-1"}, {"termId": "term-2"}],
+        requestedTerms=[{"id": "term-1"}, {"id": "term-2"}],
     )
     agreement_client.accept_agreement_request.assert_called_once_with(
         agreementRequestId="req-123",
@@ -212,3 +214,75 @@ def test_hooks_fire_on_method_call(
     assert len(contexts) == 1
     assert contexts[0].method == "has_rosa_subscription"
     assert contexts[0].service == "marketplace-agreement"
+
+
+# The tests below drive the API against real botocore clients wrapped in a
+# Stubber. Unlike the Mock-based tests above, the Stubber runs botocore's
+# parameter validation against the actual service model, so any drift between
+# the params we send and the AWS API (wrong key names, unknown params, missing
+# required fields) fails the test instead of silently passing. This guards
+# against regressions like passing `catalog`/`agreementProposalId`/`termId` to
+# create_agreement_request, which Mocks accept but AWS rejects at runtime.
+
+
+@pytest.fixture
+def real_agreement_client() -> BaseClient:
+    return boto3.client(
+        "marketplace-agreement",
+        region_name="us-east-1",
+        aws_access_key_id="testing",
+        aws_secret_access_key="testing",
+    )
+
+
+def test_has_rosa_subscription_params_valid_against_botocore_model(
+    real_agreement_client: BaseClient, mocker: MockerFixture
+) -> None:
+    api = AWSApiMarketplace(
+        agreement_client=real_agreement_client, discovery_client=mocker.Mock()
+    )
+    stubber = Stubber(real_agreement_client)
+    stubber.add_response(
+        "search_agreements",
+        {"agreementViewSummaries": [{"agreementId": "agr-123"}]},
+        expected_params={
+            "catalog": "AWSMarketplace",
+            "filters": [
+                {"name": "PartyType", "values": ["Acceptor"]},
+                {"name": "AgreementType", "values": ["PurchaseAgreement"]},
+                {"name": "ResourceIdentifier", "values": [ROSA_HCP_PRODUCT_ID]},
+            ],
+        },
+    )
+    with stubber:
+        assert api.has_rosa_subscription() is True
+    stubber.assert_no_pending_responses()
+
+
+def test_subscribe_rosa_params_valid_against_botocore_model(
+    real_agreement_client: BaseClient, mocker: MockerFixture
+) -> None:
+    api = AWSApiMarketplace(
+        agreement_client=real_agreement_client, discovery_client=mocker.Mock()
+    )
+    stubber = Stubber(real_agreement_client)
+    stubber.add_response(
+        "create_agreement_request",
+        {"agreementRequestId": "req-123"},
+        expected_params={
+            "agreementProposalIdentifier": "prop-xyz",
+            "intent": "NEW",
+            "requestedTerms": [{"id": "term-1"}, {"id": "term-2"}],
+        },
+    )
+    stubber.add_response(
+        "accept_agreement_request",
+        {"agreementId": "agr-456"},
+        expected_params={"agreementRequestId": "req-123"},
+    )
+    with stubber:
+        result = api.subscribe_rosa(
+            agreement_proposal_id="prop-xyz", term_ids=["term-1", "term-2"]
+        )
+    assert result == "agr-456"
+    stubber.assert_no_pending_responses()


### PR DESCRIPTION
## Summary

`subscribe_rosa()` (added in #5724) passes invalid parameter names to the AWS Marketplace Agreement API's `create_agreement_request`, so **every ROSA HCP account onboarding fails** at the marketplace-enablement step. Observed in production (`aws-account-manager`) retrying every cycle on a freshly onboarded account:

```
botocore.exceptions.ParamValidationError: Parameter validation failed:
Unknown parameter in input: "catalog", must be one of: clientToken, intent, requestedTerms, sourceAgreementIdentifier, agreementProposalIdentifier, taxConfiguration
Unknown parameter in input: "agreementProposalId", must be one of: ... agreementProposalIdentifier ...
Missing required parameter in requestedTerms[*]: "id"
Unknown parameter in requestedTerms[*]: "termId", must be one of: id, configuration
```

Because it raises before `create_account_file`, the account's template-collection MR never opens and onboarding is fully blocked.

## Fix

In `qontract_utils/aws_api_typed/marketplace.py::subscribe_rosa`, align with the `marketplace-agreement` service model:

- drop the invalid `catalog` argument
- `agreementProposalId` → `agreementProposalIdentifier`
- `requestedTerms=[{"termId": tid}]` → `[{"id": tid}]`

Verified param names/shapes against the botocore service model for `CreateAgreementRequest` / `AcceptAgreementRequest`.

## Why it shipped & how this prevents recurrence

The existing unit tests mocked the boto3 client — **Mocks don't run botocore parameter validation**, so the wrong keys passed CI. This PR adds `Stubber`-based tests that drive the API through real botocore clients, so any parameter drift (unknown/renamed/missing keys) fails in CI instead of only at runtime against AWS. Confirmed the guard raises `ParamValidationError` on the old params.

## Test plan

- [x] `pytest qontract_utils/tests/aws_api_typed/test_aws_api_typed_marketplace.py` — 12 passed
- [x] `mypy` clean on changed files
- [x] `ruff` clean
- [x] Verified Stubber guard fails on the pre-fix params

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated ROSA Marketplace subscription requests to use the current AWS agreement and term parameters.
  * Removed obsolete catalog and legacy parameter fields from subscription requests.

* **Tests**
  * Added validation to ensure subscription and agreement requests match AWS API requirements.
  * Expanded coverage for successful subscription checks, agreement acceptance, and response handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->