### PR TITLE
fix(aws-account-manager): send valid requestedTerms for ROSA marketplace subscribe

### DIFF
--- a/qontract_utils/qontract_utils/aws_api_typed/marketplace.py
+++ b/qontract_utils/qontract_utils/aws_api_typed/marketplace.py
@@ -155,6 +155,9 @@ class AWSApiMarketplace:
             for d in rate_card.get("rateCard") or []
             if "dimensionKey" in d
         ]
+        if not dimensions:
+            msg = "configurableUpfrontPricingTerm rateCard has no dimensions"
+            raise RuntimeError(msg)
         return {"selectorValue": selector_value, "dimensions": dimensions}
 
     @invoke_with_hooks(

--- a/qontract_utils/qontract_utils/aws_api_typed/marketplace.py
+++ b/qontract_utils/qontract_utils/aws_api_typed/marketplace.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import logging
-from collections.abc import Iterable
 from typing import Any
 
 from pydantic import BaseModel
@@ -17,7 +16,9 @@ log = logging.getLogger(__name__)
 class RosaOffer(BaseModel):
     offer_id: str
     agreement_proposal_id: str
-    term_ids: list[str]
+    # fully-formed requestedTerms payload for create_agreement_request, i.e. a
+    # list of {"id": ..., "configuration": {...}?} entries.
+    requested_terms: list[dict[str, Any]]
 
 
 @with_hooks(hooks=AWS_DEFAULT_HOOKS)
@@ -87,21 +88,74 @@ class AWSApiMarketplace:
             raise RuntimeError(msg)
 
         terms_resp = self.discovery_client.get_offer_terms(offerId=offer_id)
-        term_ids = [
-            term_data["id"]
-            for term_wrapper in terms_resp.get("offerTerms", [])
-            for term_data in term_wrapper.values()
-            if isinstance(term_data, dict) and "id" in term_data
-        ]
-        if not term_ids:
+        requested_terms = self._build_requested_terms(terms_resp.get("offerTerms", []))
+        if not requested_terms:
             msg = f"No terms found for ROSA HCP offer {offer_id}"
             raise RuntimeError(msg)
 
         return RosaOffer(
             offer_id=offer_id,
             agreement_proposal_id=agreement_proposal_id,
-            term_ids=term_ids,
+            requested_terms=requested_terms,
         )
+
+    @classmethod
+    def _build_requested_terms(
+        cls,
+        offer_terms: list[dict[str, Any]],
+    ) -> list[dict[str, Any]]:
+        """Build the create_agreement_request requestedTerms payload.
+
+        AWS requires *all* mandatory offer terms to be accepted, and the
+        configurable pricing / renewal terms must carry a configuration:
+
+        - configurableUpfrontPricingTerm: accepted with zero committed
+          quantities (dimensionValue 0) so there is no upfront/contract spend;
+          all consumption is billed via the usageBasedPricingTerm.
+        - renewalTerm: accepted with auto-renew enabled.
+        - every other term (usage/legal/support/validity/...) is accepted by id.
+        """
+        requested_terms: list[dict[str, Any]] = []
+        for term_wrapper in offer_terms:
+            for term_type, term_data in term_wrapper.items():
+                if not isinstance(term_data, dict) or "id" not in term_data:
+                    continue
+                requested: dict[str, Any] = {"id": term_data["id"]}
+                if term_type == "renewalTerm":
+                    requested["configuration"] = {
+                        "renewalTermConfiguration": {"enableAutoRenew": True}
+                    }
+                elif term_type == "configurableUpfrontPricingTerm":
+                    requested["configuration"] = {
+                        "configurableUpfrontPricingTermConfiguration": (
+                            cls._build_upfront_config(term_data)
+                        )
+                    }
+                requested_terms.append(requested)
+        return requested_terms
+
+    @staticmethod
+    def _build_upfront_config(term_data: dict[str, Any]) -> dict[str, Any]:
+        """Zero-commitment configuration for a configurableUpfrontPricingTerm.
+
+        Uses the term's first rate card selector and lists every dimension with
+        a committed quantity of 0.
+        """
+        rate_cards = term_data.get("rateCards") or []
+        if not rate_cards:
+            msg = "configurableUpfrontPricingTerm has no rateCards"
+            raise RuntimeError(msg)
+        rate_card = rate_cards[0]
+        selector_value = (rate_card.get("selector") or {}).get("value")
+        if not selector_value:
+            msg = "configurableUpfrontPricingTerm rateCard has no selector value"
+            raise RuntimeError(msg)
+        dimensions = [
+            {"dimensionKey": d["dimensionKey"], "dimensionValue": 0}
+            for d in rate_card.get("rateCard") or []
+            if "dimensionKey" in d
+        ]
+        return {"selectorValue": selector_value, "dimensions": dimensions}
 
     @invoke_with_hooks(
         lambda: AWSApiCallContext(
@@ -109,12 +163,12 @@ class AWSApiMarketplace:
         )
     )
     def subscribe_rosa(
-        self, agreement_proposal_id: str, term_ids: Iterable[str]
+        self, agreement_proposal_id: str, requested_terms: list[dict[str, Any]]
     ) -> str:
         create_resp = self.agreement_client.create_agreement_request(
             agreementProposalIdentifier=agreement_proposal_id,
             intent="NEW",
-            requestedTerms=[{"id": tid} for tid in term_ids],
+            requestedTerms=requested_terms,
         )
         agreement_request_id = create_resp["agreementRequestId"]
 

--- a/qontract_utils/tests/aws_api_typed/test_aws_api_typed_marketplace.py
+++ b/qontract_utils/tests/aws_api_typed/test_aws_api_typed_marketplace.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 import boto3
 import pytest
@@ -77,24 +77,68 @@ def test_discover_rosa_offer(
     discovery_client.get_offer.return_value = {
         "agreementProposalId": "prop-xyz",
     }
+    # mirrors the real ROSA HCP offer: pay-as-you-go usage term, a mandatory
+    # configurable upfront term (accepted at zero committed quantity),
+    # legal/support terms, and a renewal term (auto-renew).
     discovery_client.get_offer_terms.return_value = {
         "offerTerms": [
             {
                 "usageBasedPricingTerm": {
-                    "id": "term-1",
+                    "id": "term-usage",
                     "type": "UsageBasedPricingTerm",
                 }
             },
-            {"legalTerm": {"id": "term-2", "type": "LegalTerm"}},
+            {
+                "configurableUpfrontPricingTerm": {
+                    "id": "term-upfront",
+                    "type": "ConfigurableUpfrontPricingTerm",
+                    "rateCards": [
+                        {
+                            "selector": {"type": "Duration", "value": "P12M"},
+                            "rateCard": [
+                                {"dimensionKey": "control_plane", "price": "2190"},
+                                {"dimensionKey": "four_vcpu_hour", "price": "1000"},
+                            ],
+                        }
+                    ],
+                }
+            },
+            {"legalTerm": {"id": "term-legal", "type": "LegalTerm"}},
+            {"supportTerm": {"id": "term-support", "type": "SupportTerm"}},
+            {"renewalTerm": {"id": "term-renewal", "type": "RenewalTerm"}},
         ]
     }
 
     offer = marketplace_api.discover_rosa_offer()
 
+    # all terms accepted: upfront carries a zero-quantity configuration, renewal
+    # carries auto-renew, the rest are id-only.
     assert offer == RosaOffer(
         offer_id="offer-abc",
         agreement_proposal_id="prop-xyz",
-        term_ids=["term-1", "term-2"],
+        requested_terms=[
+            {"id": "term-usage"},
+            {
+                "id": "term-upfront",
+                "configuration": {
+                    "configurableUpfrontPricingTermConfiguration": {
+                        "selectorValue": "P12M",
+                        "dimensions": [
+                            {"dimensionKey": "control_plane", "dimensionValue": 0},
+                            {"dimensionKey": "four_vcpu_hour", "dimensionValue": 0},
+                        ],
+                    }
+                },
+            },
+            {"id": "term-legal"},
+            {"id": "term-support"},
+            {
+                "id": "term-renewal",
+                "configuration": {
+                    "renewalTermConfiguration": {"enableAutoRenew": True}
+                },
+            },
+        ],
     )
     discovery_client.list_purchase_options.assert_called_once()
     discovery_client.get_offer.assert_called_once_with(offerId="offer-abc")
@@ -169,14 +213,30 @@ def test_subscribe_rosa(
 
     result = marketplace_api.subscribe_rosa(
         agreement_proposal_id="prop-xyz",
-        term_ids=["term-1", "term-2"],
+        requested_terms=[
+            {"id": "term-1"},
+            {
+                "id": "term-2",
+                "configuration": {
+                    "renewalTermConfiguration": {"enableAutoRenew": True}
+                },
+            },
+        ],
     )
 
     assert result == "agr-456"
     agreement_client.create_agreement_request.assert_called_once_with(
         agreementProposalIdentifier="prop-xyz",
         intent="NEW",
-        requestedTerms=[{"id": "term-1"}, {"id": "term-2"}],
+        requestedTerms=[
+            {"id": "term-1"},
+            {
+                "id": "term-2",
+                "configuration": {
+                    "renewalTermConfiguration": {"enableAutoRenew": True}
+                },
+            },
+        ],
     )
     agreement_client.accept_agreement_request.assert_called_once_with(
         agreementRequestId="req-123",
@@ -193,7 +253,7 @@ def test_subscribe_rosa_fallback_to_request_id(
 
     result = marketplace_api.subscribe_rosa(
         agreement_proposal_id="prop-xyz",
-        term_ids=["term-1"],
+        requested_terms=[{"id": "term-1"}],
     )
     assert result == "req-123"
 
@@ -266,13 +326,33 @@ def test_subscribe_rosa_params_valid_against_botocore_model(
         agreement_client=real_agreement_client, discovery_client=mocker.Mock()
     )
     stubber = Stubber(real_agreement_client)
+    # include a term with a renewalTermConfiguration so botocore validates the
+    # nested configuration union shape too, not just id-only terms.
+    requested_terms: list[dict[str, Any]] = [
+        {"id": "term-1"},
+        {
+            "id": "term-2",
+            "configuration": {"renewalTermConfiguration": {"enableAutoRenew": True}},
+        },
+        {
+            "id": "term-3",
+            "configuration": {
+                "configurableUpfrontPricingTermConfiguration": {
+                    "selectorValue": "P12M",
+                    "dimensions": [
+                        {"dimensionKey": "control_plane", "dimensionValue": 0}
+                    ],
+                }
+            },
+        },
+    ]
     stubber.add_response(
         "create_agreement_request",
         {"agreementRequestId": "req-123"},
         expected_params={
             "agreementProposalIdentifier": "prop-xyz",
             "intent": "NEW",
-            "requestedTerms": [{"id": "term-1"}, {"id": "term-2"}],
+            "requestedTerms": requested_terms,
         },
     )
     stubber.add_response(
@@ -282,7 +362,7 @@ def test_subscribe_rosa_params_valid_against_botocore_model(
     )
     with stubber:
         result = api.subscribe_rosa(
-            agreement_proposal_id="prop-xyz", term_ids=["term-1", "term-2"]
+            agreement_proposal_id="prop-xyz", requested_terms=requested_terms
         )
     assert result == "agr-456"
     stubber.assert_no_pending_responses()

--- a/qontract_utils/tests/aws_api_typed/test_aws_api_typed_marketplace.py
+++ b/qontract_utils/tests/aws_api_typed/test_aws_api_typed_marketplace.py
@@ -203,6 +203,33 @@ def test_discover_rosa_offer_no_terms(
         marketplace_api.discover_rosa_offer()
 
 
+def test_discover_rosa_offer_upfront_no_dimensions(
+    marketplace_api: AWSApiMarketplace, discovery_client: MagicMock
+) -> None:
+    discovery_client.list_purchase_options.return_value = {
+        "purchaseOptions": [{"purchaseOptionId": "po-1", "associatedEntities": []}]
+    }
+    discovery_client.get_offer.return_value = {"agreementProposalId": "prop-1"}
+    discovery_client.get_offer_terms.return_value = {
+        "offerTerms": [
+            {
+                "configurableUpfrontPricingTerm": {
+                    "id": "term-upfront",
+                    "type": "ConfigurableUpfrontPricingTerm",
+                    "rateCards": [
+                        {
+                            "selector": {"type": "Duration", "value": "P12M"},
+                            "rateCard": [],
+                        }
+                    ],
+                }
+            },
+        ]
+    }
+    with pytest.raises(RuntimeError, match="no dimensions"):
+        marketplace_api.discover_rosa_offer()
+
+
 def test_subscribe_rosa(
     marketplace_api: AWSApiMarketplace, agreement_client: MagicMock
 ) -> None:

--- a/reconcile/aws_account_manager/reconciler.py
+++ b/reconcile/aws_account_manager/reconciler.py
@@ -406,7 +406,7 @@ class AWSReconciler:
             offer = aws_api.marketplace.discover_rosa_offer()
             agreement_id = aws_api.marketplace.subscribe_rosa(
                 agreement_proposal_id=offer.agreement_proposal_id,
-                term_ids=offer.term_ids,
+                requested_terms=offer.requested_terms,
             )
             state.value = agreement_id
 

--- a/reconcile/test/aws_account_manager/test_aws_account_manager_reconciler.py
+++ b/reconcile/test/aws_account_manager/test_aws_account_manager_reconciler.py
@@ -891,7 +891,7 @@ def test_aws_account_manager_reconcile_enable_rosa_marketplace(
     aws_api.marketplace.discover_rosa_offer.return_value = RosaOffer(
         offer_id="offer-1",
         agreement_proposal_id="prop-1",
-        term_ids=["term-1", "term-2"],
+        requested_terms=[{"id": "term-1"}, {"id": "term-2"}],
     )
     aws_api.marketplace.subscribe_rosa.return_value = "agr-123"
 
@@ -900,7 +900,7 @@ def test_aws_account_manager_reconcile_enable_rosa_marketplace(
     aws_api.marketplace.discover_rosa_offer.assert_called_once()
     aws_api.marketplace.subscribe_rosa.assert_called_once_with(
         agreement_proposal_id="prop-1",
-        term_ids=["term-1", "term-2"],
+        requested_terms=[{"id": "term-1"}, {"id": "term-2"}],
     )
 
 


### PR DESCRIPTION
## Summary

Follow-up to #5762. After the parameter-name fix, ROSA HCP account onboarding still failed at the marketplace subscribe step against real AWS:

```
ValidationException: Provided requested term configuration is invalid.
```
and, when the upfront term was dropped:
```
ValidationException: All mandatory terms must be accepted to create an Agreement.
```

The ROSA HCP offer is a **CONTRACT-model** offer. Its terms include a **mandatory** `configurableUpfrontPricingTerm` and a `renewalTerm`, both of which require a per-term `configuration` in `create_agreement_request`. The code sent all terms id-only.

## Fix

`discover_rosa_offer` now returns a fully-formed `requestedTerms` payload (`RosaOffer.requested_terms`) built from the offer terms:

- **`configurableUpfrontPricingTerm`** accepted at **zero committed quantity** — `selectorValue` from its rate card, `dimensionValue: 0` for each dimension. No upfront/contract spend; all consumption bills via the `usageBasedPricingTerm`.
- **`renewalTerm`** accepted with `enableAutoRenew: true`.
- all other terms (usage/legal/support/…) accepted by id.

## Verification

Ran non-dry-run `aws-account-manager` against a real onboarding account (prod integration temporarily disabled via Unleash): the subscribe **succeeds**, the agreement is created, and a dry-run re-run short-circuits (state committed) — confirming idempotency.

## Tests

`Stubber`-based tests run botocore's real parameter validation over the exact `requestedTerms`, including the nested `configurableUpfrontPricingTermConfiguration` and `renewalTermConfiguration`, so future shape drift fails CI.

- [x] pytest (marketplace + reconciler) green
- [x] mypy / ruff clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - ROSA Marketplace offer discovery now supports renewal and configurable upfront pricing terms.
  - Subscription requests now include complete pricing and configuration details.

- **Bug Fixes**
  - Improved validation identifies missing terms, rate cards, or selectors before subscription.
  - Ensured discovered offer details are correctly carried through to the subscription process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->