### PR TITLE
Revert "fix(quay-robot-accounts): opt-in orgs and fail closed on auth"

### DIFF
--- a/reconcile/gql_definitions/introspection.json
+++ b/reconcile/gql_definitions/introspection.json
@@ -4563,11 +4563,6 @@
                         },
                         {
                             "kind": "OBJECT",
-                            "name": "AcsInstance_v1",
-                            "ofType": null
-                        },
-                        {
-                            "kind": "OBJECT",
                             "name": "StatusPageComponent_v1",
                             "ofType": null
                         },
@@ -4714,6 +4709,11 @@
                         {
                             "kind": "OBJECT",
                             "name": "GitlabInstance_v1",
+                            "ofType": null
+                        },
+                        {
+                            "kind": "OBJECT",
+                            "name": "AcsInstance_v1",
                             "ofType": null
                         },
                         {
@@ -19641,18 +19641,6 @@
                             "deprecationReason": null
                         },
                         {
-                            "name": "instance",
-                            "description": null,
-                            "args": [],
-                            "type": {
-                                "kind": "OBJECT",
-                                "name": "AcsInstance_v1",
-                                "ofType": null
-                            },
-                            "isDeprecated": false,
-                            "deprecationReason": null
-                        },
-                        {
                             "name": "description",
                             "description": null,
                             "args": [],
@@ -19765,222 +19753,6 @@
                             "ofType": null
                         }
                     ],
-                    "enumValues": null,
-                    "possibleTypes": null
-                },
-                {
-                    "kind": "OBJECT",
-                    "name": "AcsInstance_v1",
-                    "description": null,
-                    "fields": [
-                        {
-                            "name": "schema",
-                            "description": null,
-                            "args": [],
-                            "type": {
-                                "kind": "NON_NULL",
-                                "name": null,
-                                "ofType": {
-                                    "name": "String",
-                                    "kind": "SCALAR",
-                                    "ofType": null
-                                }
-                            },
-                            "isDeprecated": false,
-                            "deprecationReason": null
-                        },
-                        {
-                            "name": "path",
-                            "description": null,
-                            "args": [],
-                            "type": {
-                                "kind": "NON_NULL",
-                                "name": null,
-                                "ofType": {
-                                    "name": "String",
-                                    "kind": "SCALAR",
-                                    "ofType": null
-                                }
-                            },
-                            "isDeprecated": false,
-                            "deprecationReason": null
-                        },
-                        {
-                            "name": "labels",
-                            "description": null,
-                            "args": [],
-                            "type": {
-                                "kind": "SCALAR",
-                                "name": "JSON",
-                                "ofType": null
-                            },
-                            "isDeprecated": false,
-                            "deprecationReason": null
-                        },
-                        {
-                            "name": "name",
-                            "description": null,
-                            "args": [],
-                            "type": {
-                                "kind": "NON_NULL",
-                                "name": null,
-                                "ofType": {
-                                    "name": "String",
-                                    "kind": "SCALAR",
-                                    "ofType": null
-                                }
-                            },
-                            "isDeprecated": false,
-                            "deprecationReason": null
-                        },
-                        {
-                            "name": "description",
-                            "description": null,
-                            "args": [],
-                            "type": {
-                                "kind": "NON_NULL",
-                                "name": null,
-                                "ofType": {
-                                    "name": "String",
-                                    "kind": "SCALAR",
-                                    "ofType": null
-                                }
-                            },
-                            "isDeprecated": false,
-                            "deprecationReason": null
-                        },
-                        {
-                            "name": "url",
-                            "description": null,
-                            "args": [],
-                            "type": {
-                                "kind": "NON_NULL",
-                                "name": null,
-                                "ofType": {
-                                    "name": "String",
-                                    "kind": "SCALAR",
-                                    "ofType": null
-                                }
-                            },
-                            "isDeprecated": false,
-                            "deprecationReason": null
-                        },
-                        {
-                            "name": "credentials",
-                            "description": null,
-                            "args": [],
-                            "type": {
-                                "kind": "NON_NULL",
-                                "name": null,
-                                "ofType": {
-                                    "name": "VaultSecret_v1",
-                                    "kind": "OBJECT",
-                                    "ofType": null
-                                }
-                            },
-                            "isDeprecated": false,
-                            "deprecationReason": null
-                        },
-                        {
-                            "name": "authProvider",
-                            "description": null,
-                            "args": [],
-                            "type": {
-                                "kind": "NON_NULL",
-                                "name": null,
-                                "ofType": {
-                                    "name": "AcsInstanceAuthProvider_v1",
-                                    "kind": "OBJECT",
-                                    "ofType": null
-                                }
-                            },
-                            "isDeprecated": false,
-                            "deprecationReason": null
-                        }
-                    ],
-                    "inputFields": null,
-                    "interfaces": [
-                        {
-                            "kind": "INTERFACE",
-                            "name": "DatafileObject_v1",
-                            "ofType": null
-                        }
-                    ],
-                    "enumValues": null,
-                    "possibleTypes": null
-                },
-                {
-                    "kind": "OBJECT",
-                    "name": "AcsInstanceAuthProvider_v1",
-                    "description": null,
-                    "fields": [
-                        {
-                            "name": "schema",
-                            "description": null,
-                            "args": [],
-                            "type": {
-                                "kind": "NON_NULL",
-                                "name": null,
-                                "ofType": {
-                                    "name": "String",
-                                    "kind": "SCALAR",
-                                    "ofType": null
-                                }
-                            },
-                            "isDeprecated": false,
-                            "deprecationReason": null
-                        },
-                        {
-                            "name": "name",
-                            "description": null,
-                            "args": [],
-                            "type": {
-                                "kind": "NON_NULL",
-                                "name": null,
-                                "ofType": {
-                                    "name": "String",
-                                    "kind": "SCALAR",
-                                    "ofType": null
-                                }
-                            },
-                            "isDeprecated": false,
-                            "deprecationReason": null
-                        },
-                        {
-                            "name": "id",
-                            "description": null,
-                            "args": [],
-                            "type": {
-                                "kind": "NON_NULL",
-                                "name": null,
-                                "ofType": {
-                                    "name": "String",
-                                    "kind": "SCALAR",
-                                    "ofType": null
-                                }
-                            },
-                            "isDeprecated": false,
-                            "deprecationReason": null
-                        },
-                        {
-                            "name": "kind",
-                            "description": null,
-                            "args": [],
-                            "type": {
-                                "kind": "NON_NULL",
-                                "name": null,
-                                "ofType": {
-                                    "name": "String",
-                                    "kind": "SCALAR",
-                                    "ofType": null
-                                }
-                            },
-                            "isDeprecated": false,
-                            "deprecationReason": null
-                        }
-                    ],
-                    "inputFields": null,
-                    "interfaces": [],
                     "enumValues": null,
                     "possibleTypes": null
                 },
@@ -30736,6 +30508,222 @@
                                             "ofType": null
                                         }
                                     }
+                                }
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        }
+                    ],
+                    "inputFields": null,
+                    "interfaces": [],
+                    "enumValues": null,
+                    "possibleTypes": null
+                },
+                {
+                    "kind": "OBJECT",
+                    "name": "AcsInstance_v1",
+                    "description": null,
+                    "fields": [
+                        {
+                            "name": "schema",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "NON_NULL",
+                                "name": null,
+                                "ofType": {
+                                    "name": "String",
+                                    "kind": "SCALAR",
+                                    "ofType": null
+                                }
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "path",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "NON_NULL",
+                                "name": null,
+                                "ofType": {
+                                    "name": "String",
+                                    "kind": "SCALAR",
+                                    "ofType": null
+                                }
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "labels",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "SCALAR",
+                                "name": "JSON",
+                                "ofType": null
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "name",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "NON_NULL",
+                                "name": null,
+                                "ofType": {
+                                    "name": "String",
+                                    "kind": "SCALAR",
+                                    "ofType": null
+                                }
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "description",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "NON_NULL",
+                                "name": null,
+                                "ofType": {
+                                    "name": "String",
+                                    "kind": "SCALAR",
+                                    "ofType": null
+                                }
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "url",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "NON_NULL",
+                                "name": null,
+                                "ofType": {
+                                    "name": "String",
+                                    "kind": "SCALAR",
+                                    "ofType": null
+                                }
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "credentials",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "NON_NULL",
+                                "name": null,
+                                "ofType": {
+                                    "name": "VaultSecret_v1",
+                                    "kind": "OBJECT",
+                                    "ofType": null
+                                }
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "authProvider",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "NON_NULL",
+                                "name": null,
+                                "ofType": {
+                                    "name": "AcsInstanceAuthProvider_v1",
+                                    "kind": "OBJECT",
+                                    "ofType": null
+                                }
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        }
+                    ],
+                    "inputFields": null,
+                    "interfaces": [
+                        {
+                            "kind": "INTERFACE",
+                            "name": "DatafileObject_v1",
+                            "ofType": null
+                        }
+                    ],
+                    "enumValues": null,
+                    "possibleTypes": null
+                },
+                {
+                    "kind": "OBJECT",
+                    "name": "AcsInstanceAuthProvider_v1",
+                    "description": null,
+                    "fields": [
+                        {
+                            "name": "schema",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "NON_NULL",
+                                "name": null,
+                                "ofType": {
+                                    "name": "String",
+                                    "kind": "SCALAR",
+                                    "ofType": null
+                                }
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "name",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "NON_NULL",
+                                "name": null,
+                                "ofType": {
+                                    "name": "String",
+                                    "kind": "SCALAR",
+                                    "ofType": null
+                                }
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "id",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "NON_NULL",
+                                "name": null,
+                                "ofType": {
+                                    "name": "String",
+                                    "kind": "SCALAR",
+                                    "ofType": null
+                                }
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "kind",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "NON_NULL",
+                                "name": null,
+                                "ofType": {
+                                    "name": "String",
+                                    "kind": "SCALAR",
+                                    "ofType": null
                                 }
                             },
                             "isDeprecated": false,
@@ -51069,18 +51057,6 @@
                                     "kind": "SCALAR",
                                     "ofType": null
                                 }
-                            },
-                            "isDeprecated": false,
-                            "deprecationReason": null
-                        },
-                        {
-                            "name": "instance",
-                            "description": null,
-                            "args": [],
-                            "type": {
-                                "kind": "OBJECT",
-                                "name": "AcsInstance_v1",
-                                "ofType": null
                             },
                             "isDeprecated": false,
                             "deprecationReason": null

--- a/reconcile/quay_base.py
+++ b/reconcile/quay_base.py
@@ -13,7 +13,6 @@ class OrgInfo(TypedDict):
     push_token: dict[str, str] | None
     teams: list[str]
     managedRepos: bool
-    managedRobotAccounts: bool
     mirror: OrgKey | None
     mirror_filters: dict[str, Any]
     api: QuayApi
@@ -86,7 +85,6 @@ def get_quay_api_store() -> QuayApiStore:
             "push_token": push_token,
             "teams": org_data.get("managedTeams") or [],
             "managedRepos": bool(org_data.get("managedRepos")),
-            "managedRobotAccounts": bool(org_data.get("managedRobotAccounts")),
             "mirror": mirror,
             "mirror_filters": mirror_filters,
             "api": api,

--- a/reconcile/quay_robot_accounts.py
+++ b/reconcile/quay_robot_accounts.py
@@ -1,11 +1,10 @@
-from __future__ import annotations
-
 import logging
 import sys
 from dataclasses import dataclass
 from enum import Enum
 from typing import TYPE_CHECKING
 
+import requests
 from qontract_utils.differ import diff_mappings
 
 from reconcile.gql_definitions.quay_robot_accounts.quay_robot_accounts import (
@@ -17,11 +16,18 @@ from reconcile.status import ExitCodes
 from reconcile.utils import gql
 
 if TYPE_CHECKING:
-    from collections.abc import Iterable
-
     from reconcile.utils.quay_api import RobotAccountDetails
 
 QONTRACT_INTEGRATION = "quay-robot-accounts"
+
+# Quay org tokens in app-interface sometimes lack robot-account scope. Soft-skip
+# these auth failures so one under-privileged org does not block the rest.
+_AUTH_SKIP_HTTP_STATUSES = frozenset({401, 403})
+
+
+def _is_robot_auth_http_error(exc: requests.exceptions.HTTPError) -> bool:
+    status = exc.response.status_code if exc.response is not None else None
+    return status in _AUTH_SKIP_HTTP_STATUSES
 
 
 class RobotAccountActionType(Enum):
@@ -66,29 +72,30 @@ def get_robot_accounts_from_gql() -> list[QuayRobotV1]:
     return list(query_data.robot_accounts or [])
 
 
-def desired_org_keys(
-    desired_state: dict[tuple[str, str, str], RobotAccountState],
-) -> set[OrgKey]:
-    """Org keys referenced by desired robot definitions."""
-    return {
-        OrgKey(state.instance_name, state.org_name) for state in desired_state.values()
-    }
-
-
 def get_current_robot_accounts(
     quay_api_store: QuayApiStore,
-    org_keys: Iterable[OrgKey],
 ) -> dict[tuple[str, str], list[RobotAccountDetails]]:
-    """Fetch current robot accounts from Quay for the given organizations.
+    """Fetch current robot accounts from Quay API for all organizations.
 
-    Only opted-in orgs that appear in desired state should be passed here.
-    Auth failures (and other API errors) propagate — callers must fail closed.
+    Organizations that return HTTP 401/403 when listing robots are skipped with
+    a warning. Some Quay org tokens in app-interface lack robot-account scope;
+    failing closed on those would block reconciliation for every other org.
     """
     current_state: dict[tuple[str, str], list[RobotAccountDetails]] = {}
 
-    for org_key in org_keys:
-        org_info = quay_api_store[org_key]
-        robots = org_info["api"].list_robot_accounts()
+    for org_key, org_info in quay_api_store.items():
+        try:
+            robots = org_info["api"].list_robot_accounts()
+        except requests.exceptions.HTTPError as e:
+            if _is_robot_auth_http_error(e):
+                logging.warning(
+                    "Skipping org %s/%s: unauthorized to list robot accounts (%s)",
+                    org_key.instance,
+                    org_key.org_name,
+                    e.response.status_code if e.response is not None else "unknown",
+                )
+                continue
+            raise
         current_state[org_key.instance, org_key.org_name] = robots or []
 
     return current_state
@@ -133,29 +140,25 @@ def build_desired_state(
 def build_current_state(
     current_robots: dict[tuple[str, str], list[RobotAccountDetails]],
     quay_api_store: QuayApiStore,
-    desired_keys: set[tuple[str, str, str]],
 ) -> dict[tuple[str, str, str], RobotAccountState]:
-    """Build current state from Quay API data for desired robots only.
+    """Build current state from Quay API data.
 
-    Unmanaged robots (present in Quay but not in desired state) are ignored —
-    calculate_diff never deletes them without delete: true. Only managedTeams
-    memberships are tracked, and repository permissions only when managedRepos
-    is true. Auth failures on permission lookups propagate.
+    Only managedTeams memberships are tracked (same scope as quay-membership),
+    and repository permissions are only tracked when managedRepos is true.
     """
     current_state = {}
 
     for (instance_name, org_name), robots in current_robots.items():
         org_key = OrgKey(instance_name, org_name)
+        if org_key not in quay_api_store:
+            continue
+
         org_info = quay_api_store[org_key]
         quay_api = org_info["api"]
         managed_teams = set(org_info["teams"] or [])
 
         for robot_data in robots:
             robot_name = robot_data["name"]  # already normalized to short name
-            key = (instance_name, org_name, robot_name)
-            if key not in desired_keys:
-                continue
-
             description = robot_data.get("description")
 
             # Only reconcile membership for teams declared as managedTeams
@@ -166,7 +169,23 @@ def build_current_state(
             # does not manage repos (same gate as quay-permissions / quay-repos).
             repositories: dict[str, str] = {}
             if org_info["managedRepos"]:
-                permissions = quay_api.get_robot_account_permissions(robot_name)
+                try:
+                    permissions = quay_api.get_robot_account_permissions(robot_name)
+                except requests.exceptions.HTTPError as e:
+                    if _is_robot_auth_http_error(e):
+                        logging.warning(
+                            "Skipping repo permissions for robot %s in %s/%s: "
+                            "unauthorized (%s)",
+                            robot_name,
+                            instance_name,
+                            org_name,
+                            e.response.status_code
+                            if e.response is not None
+                            else "unknown",
+                        )
+                        permissions = []
+                    else:
+                        raise
                 for perm in permissions:
                     repositories[perm["repository"]["name"]] = perm["role"]
 
@@ -179,7 +198,7 @@ def build_current_state(
                 repositories=repositories,
             )
 
-            current_state[key] = state
+            current_state[instance_name, org_name, robot_name] = state
 
     return current_state
 
@@ -192,7 +211,6 @@ def validate_desired_state(
 
     Mirrors quay-membership (managedTeams) and quay-permissions (managedRepos):
     - org must have an automation token / API client in the store
-    - org must opt in via managedRobotAccounts=true
     - every desired team must be listed in the org's managedTeams
     - repository permissions require managedRepos=true on the org
 
@@ -210,19 +228,10 @@ def validate_desired_state(
             valid = False
             continue
 
-        org_info = quay_api_store[org_key]
-        if not org_info["managedRobotAccounts"]:
-            logging.error(
-                f"Can not manage robot {desired.name} in "
-                f"{desired.instance_name}/{desired.org_name} since "
-                f"managedRobotAccounts is not set to true."
-            )
-            valid = False
-            continue
-
         if desired.delete:
             continue
 
+        org_info = quay_api_store[org_key]
         managed_teams = set(org_info["teams"] or [])
 
         for team in desired.teams:
@@ -468,21 +477,40 @@ def run(dry_run: bool = False) -> None:
     error = False
 
     with get_quay_api_store() as quay_api_store:
+        current_robots = get_current_robot_accounts(quay_api_store)
+
+        # Orgs present in the store but missing from current_robots were soft-skipped
+        # on 401/403. Drop matching desired robots so we do not invent CREATE plans.
+        unauthorized_orgs = {
+            (org_key.instance, org_key.org_name)
+            for org_key in quay_api_store
+            if (org_key.instance, org_key.org_name) not in current_robots
+        }
+
         desired_state = build_desired_state(robot_accounts)
+        if unauthorized_orgs:
+            filtered_desired: dict[tuple[str, str, str], RobotAccountState] = {}
+            for key, state in desired_state.items():
+                org = (state.instance_name, state.org_name)
+                if org in unauthorized_orgs:
+                    logging.warning(
+                        "Skipping desired robot %s for %s/%s: unauthorized to list "
+                        "robot accounts",
+                        state.name,
+                        state.instance_name,
+                        state.org_name,
+                    )
+                    continue
+                filtered_desired[key] = state
+            desired_state = filtered_desired
 
-        if not validate_desired_state(desired_state, quay_api_store):
-            sys.exit(ExitCodes.ERROR)
-
-        # Inventory only orgs that have desired robots and opted in. Validation
-        # already ensured managedRobotAccounts=true for every desired org.
-        org_keys = desired_org_keys(desired_state)
-        current_robots = get_current_robot_accounts(quay_api_store, org_keys)
-        current_state = build_current_state(
-            current_robots, quay_api_store, set(desired_state)
-        )
+        current_state = build_current_state(current_robots, quay_api_store)
 
         logging.debug(f"Desired robots: {len(desired_state)}")
         logging.debug(f"Current robots: {len(current_state)}")
+
+        if not validate_desired_state(desired_state, quay_api_store):
+            sys.exit(ExitCodes.ERROR)
 
         actions = calculate_diff(desired_state, current_state)
 

--- a/reconcile/queries.py
+++ b/reconcile/queries.py
@@ -1871,7 +1871,6 @@ QUAY_ORGS_QUERY = """
   quay_orgs: quay_orgs_v1 {
     name
     managedRepos
-    managedRobotAccounts
     instance {
       name
       url

--- a/reconcile/test/test_quay_membership.py
+++ b/reconcile/test/test_quay_membership.py
@@ -91,7 +91,6 @@ def build_quay_api_store(fixture: dict[str, Any]) -> QuayApiStore:
             teams=org_data["managedTeams"],
             push_token=None,
             managedRepos=False,
-            managedRobotAccounts=False,
             mirror=None,
             mirror_filters={},
             api=mock_api,

--- a/reconcile/test/test_quay_repos.py
+++ b/reconcile/test/test_quay_repos.py
@@ -52,7 +52,6 @@ def quay_api_store() -> Iterator[QuayApiStore]:
             "push_token": None,
             "teams": [],
             "managedRepos": True,
-            "managedRobotAccounts": False,
             "mirror": None,
             "mirror_filters": {},
             "api": mock_api,

--- a/reconcile/test/test_quay_robot_accounts.py
+++ b/reconcile/test/test_quay_robot_accounts.py
@@ -71,7 +71,6 @@ def mock_quay_api_store(mock_quay_api: QuayApi) -> QuayApiStore:
             push_token=None,
             teams=["team1", "team2"],
             managedRepos=True,
-            managedRobotAccounts=True,
             mirror=None,
             mirror_filters={},
             api=mock_quay_api,
@@ -145,11 +144,8 @@ def test_build_current_state_single_robot(
         {"repository": {"name": "repo1"}, "role": "read"}
     ]
     current_robots = {("quay-instance", "test-org"): [mock_current_robot]}
-    desired_keys = {("quay-instance", "test-org", "existing-robot")}
 
-    current_state = build_current_state(
-        current_robots, mock_quay_api_store, desired_keys
-    )
+    current_state = build_current_state(current_robots, mock_quay_api_store)
 
     assert len(current_state) == 1
     key = ("quay-instance", "test-org", "existing-robot")
@@ -162,15 +158,14 @@ def test_build_current_state_single_robot(
     assert state.repositories == {"repo1": "read"}
 
 
-def test_build_current_state_missing_org_key_errors(
+def test_build_current_state_no_org_key(
     mock_current_robot: RobotAccountDetails, mock_quay_api_store: QuayApiStore
 ) -> None:
-    """Missing org in the store fails closed (caller must validate first)"""
+    """Test building current state with no matching org key"""
     current_robots = {("unknown-instance", "unknown-org"): [mock_current_robot]}
-    desired_keys = {("unknown-instance", "unknown-org", "existing-robot")}
 
-    with pytest.raises(KeyError):
-        build_current_state(current_robots, mock_quay_api_store, desired_keys)
+    current_state = build_current_state(current_robots, mock_quay_api_store)
+    assert len(current_state) == 0
 
 
 def test_build_current_state_empty_robots(mock_quay_api_store: QuayApiStore) -> None:
@@ -179,41 +174,8 @@ def test_build_current_state_empty_robots(mock_quay_api_store: QuayApiStore) -> 
         ("quay-instance", "test-org"): []
     }
 
-    current_state = build_current_state(current_robots, mock_quay_api_store, set())
+    current_state = build_current_state(current_robots, mock_quay_api_store)
     assert len(current_state) == 0
-
-
-def test_build_current_state_ignores_undesired_robots(
-    mock_quay_api: QuayApi,
-    mock_quay_api_store: QuayApiStore,
-) -> None:
-    """Robots not in desired state are not inventoried (no permission API calls)"""
-    unmanaged = RobotAccountDetails(
-        name="unmanaged-robot",
-        description="Outside app-interface",
-        teams=["team1"],
-        repositories=["repo1"],
-    )
-    managed = RobotAccountDetails(
-        name="managed-robot",
-        description="Managed",
-        teams=["team1"],
-        repositories=["repo1"],
-    )
-    mock_quay_api.get_robot_account_permissions.return_value = [  # type: ignore
-        {"repository": {"name": "repo1"}, "role": "read"}
-    ]
-    current_robots = {("quay-instance", "test-org"): [unmanaged, managed]}
-    desired_keys = {("quay-instance", "test-org", "managed-robot")}
-
-    current_state = build_current_state(
-        current_robots, mock_quay_api_store, desired_keys
-    )
-
-    assert set(current_state) == {("quay-instance", "test-org", "managed-robot")}
-    mock_quay_api.get_robot_account_permissions.assert_called_once_with(  # type: ignore
-        "managed-robot"
-    )
 
 
 def test_calculate_diff_create_robot() -> None:
@@ -453,9 +415,7 @@ def test_get_current_robot_accounts_success(
 
     mock_quay_api.list_robot_accounts.return_value = mock_robots  # type: ignore
 
-    result = get_current_robot_accounts(
-        mock_quay_api_store, [OrgKey("quay-instance", "test-org")]
-    )
+    result = get_current_robot_accounts(mock_quay_api_store)
 
     assert len(result) == 1
     assert ("quay-instance", "test-org") in result
@@ -466,22 +426,20 @@ def test_get_current_robot_accounts_propagates_exception(
     mock_quay_api: QuayApi,
     mock_quay_api_store: QuayApiStore,
 ) -> None:
-    """Test that API errors propagate instead of being swallowed"""
+    """Test that non-auth API errors propagate instead of being swallowed"""
     mock_quay_api.list_robot_accounts.side_effect = Exception("API Error")  # type: ignore
 
     with pytest.raises(Exception, match="API Error"):
-        get_current_robot_accounts(
-            mock_quay_api_store, [OrgKey("quay-instance", "test-org")]
-        )
+        get_current_robot_accounts(mock_quay_api_store)
 
 
-@pytest.mark.parametrize("status_code", [401, 403, 500])
-def test_get_current_robot_accounts_propagates_http_error(
+@pytest.mark.parametrize("status_code", [401, 403])
+def test_get_current_robot_accounts_skips_auth_errors(
     mock_quay_api: QuayApi,
     mock_quay_api_store: QuayApiStore,
     status_code: int,
 ) -> None:
-    """Auth and other HTTP errors fail the integration (no soft-skip)"""
+    """Orgs that return 401/403 when listing robots are skipped with a warning"""
     response = create_autospec(requests.Response, instance=True)
     response.status_code = status_code
     mock_quay_api.list_robot_accounts.side_effect = requests.exceptions.HTTPError(  # type: ignore
@@ -489,26 +447,32 @@ def test_get_current_robot_accounts_propagates_http_error(
         response=response,
     )
 
-    with pytest.raises(requests.exceptions.HTTPError):
-        get_current_robot_accounts(
-            mock_quay_api_store, [OrgKey("quay-instance", "test-org")]
-        )
+    result = get_current_robot_accounts(mock_quay_api_store)
 
-
-def test_get_current_robot_accounts_empty_org_keys(
-    mock_quay_api: QuayApi, mock_quay_api_store: QuayApiStore
-) -> None:
-    """No desired orgs means no Quay inventory calls"""
-    result = get_current_robot_accounts(mock_quay_api_store, [])
     assert result == {}
-    mock_quay_api.list_robot_accounts.assert_not_called()  # type: ignore
 
 
-def test_build_current_state_propagates_unauthorized_robot_permissions(
+def test_get_current_robot_accounts_propagates_non_auth_http_error(
     mock_quay_api: QuayApi,
     mock_quay_api_store: QuayApiStore,
 ) -> None:
-    """401/403 on get_robot_account_permissions fail closed"""
+    """Non-auth HTTP errors still fail the integration"""
+    response = create_autospec(requests.Response, instance=True)
+    response.status_code = 500
+    mock_quay_api.list_robot_accounts.side_effect = requests.exceptions.HTTPError(  # type: ignore
+        "500 Server Error",
+        response=response,
+    )
+
+    with pytest.raises(requests.exceptions.HTTPError, match="500 Server Error"):
+        get_current_robot_accounts(mock_quay_api_store)
+
+
+def test_build_current_state_skips_unauthorized_robot_permissions(
+    mock_quay_api: QuayApi,
+    mock_quay_api_store: QuayApiStore,
+) -> None:
+    """401/403 on get_robot_account_permissions soft-skips repo state for that robot"""
     robot = RobotAccountDetails(
         name="robot",
         description="Robot",
@@ -521,10 +485,12 @@ def test_build_current_state_propagates_unauthorized_robot_permissions(
         requests.exceptions.HTTPError("403 Client Error", response=response)
     )
     current_robots = {("quay-instance", "test-org"): [robot]}
-    desired_keys = {("quay-instance", "test-org", "robot")}
 
-    with pytest.raises(requests.exceptions.HTTPError, match="403 Client Error"):
-        build_current_state(current_robots, mock_quay_api_store, desired_keys)
+    current_state = build_current_state(current_robots, mock_quay_api_store)
+
+    state = current_state["quay-instance", "test-org", "robot"]
+    assert state.teams == {"team1"}
+    assert state.repositories == {}
 
 
 def test_build_current_state_filters_unmanaged_teams(
@@ -542,11 +508,8 @@ def test_build_current_state_filters_unmanaged_teams(
         {"repository": {"name": "repo1"}, "role": "read"}
     ]
     current_robots = {("quay-instance", "test-org"): [robot]}
-    desired_keys = {("quay-instance", "test-org", "robot")}
 
-    current_state = build_current_state(
-        current_robots, mock_quay_api_store, desired_keys
-    )
+    current_state = build_current_state(current_robots, mock_quay_api_store)
 
     state = current_state["quay-instance", "test-org", "robot"]
     assert state.teams == {"team1"}
@@ -563,7 +526,6 @@ def test_build_current_state_skips_repos_when_not_managed(
             push_token=None,
             teams=["team1"],
             managedRepos=False,
-            managedRobotAccounts=True,
             mirror=None,
             mirror_filters={},
             api=mock_quay_api,
@@ -576,9 +538,8 @@ def test_build_current_state_skips_repos_when_not_managed(
         repositories=["repo1"],
     )
     current_robots = {("quay-instance", "test-org"): [robot]}
-    desired_keys = {("quay-instance", "test-org", "robot")}
 
-    current_state = build_current_state(current_robots, store, desired_keys)
+    current_state = build_current_state(current_robots, store)
 
     state = current_state["quay-instance", "test-org", "robot"]
     assert state.teams == {"team1"}
@@ -600,26 +561,6 @@ def test_validate_desired_state_missing_org(mock_robot_gql: QuayRobotV1) -> None
     assert validate_desired_state(desired_state, QuayApiStore()) is False
 
 
-def test_validate_desired_state_requires_managed_robot_accounts(
-    mock_robot_gql: QuayRobotV1, mock_quay_api: QuayApi
-) -> None:
-    """Orgs must opt in via managedRobotAccounts=true"""
-    store = QuayApiStore({
-        OrgKey("quay-instance", "test-org"): OrgInfo(
-            url="quay.io",
-            push_token=None,
-            teams=["team1", "team2"],
-            managedRepos=True,
-            managedRobotAccounts=False,
-            mirror=None,
-            mirror_filters={},
-            api=mock_quay_api,
-        )
-    })
-    desired_state = build_desired_state([mock_robot_gql])
-    assert validate_desired_state(desired_state, store) is False
-
-
 def test_validate_desired_state_unmanaged_team(
     mock_robot_gql: QuayRobotV1, mock_quay_api_store: QuayApiStore
 ) -> None:
@@ -639,7 +580,6 @@ def test_validate_desired_state_repos_require_managed_repos(
             push_token=None,
             teams=["team1", "team2"],
             managedRepos=False,
-            managedRobotAccounts=True,
             mirror=None,
             mirror_filters={},
             api=mock_quay_api,


### PR DESCRIPTION
Reverts app-sre/qontract-reconcile#5760

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved Quay robot-account synchronization across organizations.
  * Unauthorized organizations and permission lookups are skipped gracefully.
  * Deleted robot accounts can be processed without unnecessary guardrail checks.

* **Bug Fixes**
  * Prevented false creation actions when access to an organization is unauthorized.
  * Non-authorization errors continue to be reported for visibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->