### PR TITLE
feat(qontract-cli): add RDS EOL and next-version columns

### DIFF
--- a/tools/cli_commands/rds_eol.py
+++ b/tools/cli_commands/rds_eol.py
@@ -3,10 +3,11 @@ from __future__ import annotations
 import logging
 from collections import defaultdict
 from operator import itemgetter
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING
 
 import requests
 import yaml
+from pydantic import BaseModel
 
 from reconcile.utils.datetime_util import utc_now
 from reconcile.utils.semver_helper import parse_semver
@@ -14,25 +15,47 @@ from reconcile.utils.semver_helper import parse_semver
 if TYPE_CHECKING:
     from semver import VersionInfo
 
-RDS_EOL_URL = (
+DEFAULT_RDS_EOL_URL = (
     "https://raw.githubusercontent.com/app-sre/aws-generated-data"
     "/main/output/rds_eol.yaml"
 )
 
 
-def load_rds_eol_data() -> list[dict[str, Any]]:
+class RdsEolEntry(BaseModel):
+    """A single entry from the AWS RDS end-of-life calendar dataset."""
+
+    engine: str
+    version: str
+    eol: str
+
+
+def load_rds_eol_data(url: str = DEFAULT_RDS_EOL_URL) -> list[RdsEolEntry]:
     """Fetch the AWS RDS calendar dataset. Returns an empty list on failure."""
     try:
-        resp = requests.get(RDS_EOL_URL, timeout=10)
+        resp = requests.get(url, timeout=10)
         resp.raise_for_status()
         data = yaml.safe_load(resp.text) or []
     except (requests.RequestException, yaml.YAMLError) as exc:
-        logging.warning("Could not fetch RDS EOL data from %s: %s", RDS_EOL_URL, exc)
+        logging.warning("Could not fetch RDS EOL data from %s: %s", url, exc)
         return []
     if not isinstance(data, list):
-        logging.warning("RDS EOL data from %s is not a list", RDS_EOL_URL)
+        logging.warning("RDS EOL data from %s is not a list", url)
         return []
-    return [entry for entry in data if isinstance(entry, dict)]
+    entries: list[RdsEolEntry] = []
+    for raw in data:
+        if not isinstance(raw, dict):
+            continue
+        try:
+            entries.append(
+                RdsEolEntry(
+                    engine=str(raw["engine"]),
+                    version=str(raw["version"]),
+                    eol=str(raw["eol"]),
+                )
+            )
+        except KeyError, TypeError:
+            continue
+    return entries
 
 
 def _parse_rds_version(version: str) -> VersionInfo | None:
@@ -43,22 +66,14 @@ def _parse_rds_version(version: str) -> VersionInfo | None:
 
 
 def build_eol_lookup(
-    eol_data: list[dict[str, Any]],
+    eol_data: list[RdsEolEntry],
 ) -> dict[tuple[str, str], str]:
     """Map exact (engine, version) strings from the AWS calendar to EOL dates."""
-    lookup: dict[tuple[str, str], str] = {}
-    for entry in eol_data:
-        engine = entry.get("engine")
-        version = entry.get("version")
-        eol = entry.get("eol")
-        if engine is None or version is None or eol is None:
-            continue
-        lookup[str(engine), str(version)] = str(eol)
-    return lookup
+    return {(entry.engine, entry.version): entry.eol for entry in eol_data}
 
 
 def build_next_version_lookup(
-    eol_data: list[dict[str, Any]],
+    eol_data: list[RdsEolEntry],
     today: str | None = None,
 ) -> dict[tuple[str, str], str]:
     """Map (engine, version) to the next non-EOL version in the same major line.
@@ -75,50 +90,39 @@ def build_next_version_lookup(
         list
     )
     for entry in eol_data:
-        engine = entry.get("engine")
-        version = entry.get("version")
-        if engine is None or version is None:
-            continue
-        version_str = str(version)
-        parsed = _parse_rds_version(version_str)
+        parsed = _parse_rds_version(entry.version)
         if parsed is None:
             continue
-        by_engine_major[str(engine), parsed.major].append((parsed, version_str))
+        by_engine_major[entry.engine, parsed.major].append((parsed, entry.version))
 
     for versions in by_engine_major.values():
         versions.sort(key=itemgetter(0))
 
     result: dict[tuple[str, str], str] = {}
     for entry in eol_data:
-        engine = entry.get("engine")
-        version = entry.get("version")
-        if engine is None or version is None:
-            continue
-        engine_str = str(engine)
-        version_str = str(version)
-        current = _parse_rds_version(version_str)
+        current = _parse_rds_version(entry.version)
         if current is None:
             continue
-        for candidate, candidate_str in by_engine_major[engine_str, current.major]:
+        for candidate, candidate_str in by_engine_major[entry.engine, current.major]:
             if candidate <= current:
                 continue
-            candidate_eol = eol_lookup.get((engine_str, candidate_str), "")
+            candidate_eol = eol_lookup.get((entry.engine, candidate_str), "")
             if candidate_eol >= today:
-                result[engine_str, version_str] = candidate_str
+                result[entry.engine, entry.version] = candidate_str
                 break
     return result
 
 
 def rds_version_fields(
-    engine: object | None,
-    engine_version: object | None,
+    engine: str | None,
+    engine_version: str | None,
     eol_lookup: dict[tuple[str, str], str],
     next_version_lookup: dict[tuple[str, str], str],
 ) -> tuple[str, str]:
     """Return (eol_date, next_version) only for an exact calendar match."""
     if engine is None or engine_version is None:
         return "", ""
-    key = (str(engine), str(engine_version))
+    key = (engine, engine_version)
     if key not in eol_lookup:
         return "", ""
     return eol_lookup[key], next_version_lookup.get(key, "")

--- a/tools/cli_commands/rds_eol.py
+++ b/tools/cli_commands/rds_eol.py
@@ -1,0 +1,124 @@
+from __future__ import annotations
+
+import logging
+from collections import defaultdict
+from operator import itemgetter
+from typing import TYPE_CHECKING, Any
+
+import requests
+import yaml
+
+from reconcile.utils.datetime_util import utc_now
+from reconcile.utils.semver_helper import parse_semver
+
+if TYPE_CHECKING:
+    from semver import VersionInfo
+
+RDS_EOL_URL = (
+    "https://raw.githubusercontent.com/app-sre/aws-generated-data"
+    "/main/output/rds_eol.yaml"
+)
+
+
+def load_rds_eol_data() -> list[dict[str, Any]]:
+    """Fetch the AWS RDS calendar dataset. Returns an empty list on failure."""
+    try:
+        resp = requests.get(RDS_EOL_URL, timeout=10)
+        resp.raise_for_status()
+        data = yaml.safe_load(resp.text) or []
+    except (requests.RequestException, yaml.YAMLError) as exc:
+        logging.warning("Could not fetch RDS EOL data from %s: %s", RDS_EOL_URL, exc)
+        return []
+    if not isinstance(data, list):
+        logging.warning("RDS EOL data from %s is not a list", RDS_EOL_URL)
+        return []
+    return [entry for entry in data if isinstance(entry, dict)]
+
+
+def _parse_rds_version(version: str) -> VersionInfo | None:
+    try:
+        return parse_semver(version, optional_minor_and_patch=True)
+    except ValueError:
+        return None
+
+
+def build_eol_lookup(
+    eol_data: list[dict[str, Any]],
+) -> dict[tuple[str, str], str]:
+    """Map exact (engine, version) strings from the AWS calendar to EOL dates."""
+    lookup: dict[tuple[str, str], str] = {}
+    for entry in eol_data:
+        engine = entry.get("engine")
+        version = entry.get("version")
+        eol = entry.get("eol")
+        if engine is None or version is None or eol is None:
+            continue
+        lookup[str(engine), str(version)] = str(eol)
+    return lookup
+
+
+def build_next_version_lookup(
+    eol_data: list[dict[str, Any]],
+    today: str | None = None,
+) -> dict[tuple[str, str], str]:
+    """Map (engine, version) to the next non-EOL version in the same major line.
+
+    Only exact versions present in the AWS calendar dataset are keys. There is
+    no fuzzy match for major-only versions (e.g. "17"). Missing keys mean blank
+    output. "Next" never crosses a major version.
+    """
+    if today is None:
+        today = utc_now().strftime("%Y-%m-%d")
+
+    eol_lookup = build_eol_lookup(eol_data)
+    by_engine_major: dict[tuple[str, int], list[tuple[VersionInfo, str]]] = defaultdict(
+        list
+    )
+    for entry in eol_data:
+        engine = entry.get("engine")
+        version = entry.get("version")
+        if engine is None or version is None:
+            continue
+        version_str = str(version)
+        parsed = _parse_rds_version(version_str)
+        if parsed is None:
+            continue
+        by_engine_major[str(engine), parsed.major].append((parsed, version_str))
+
+    for versions in by_engine_major.values():
+        versions.sort(key=itemgetter(0))
+
+    result: dict[tuple[str, str], str] = {}
+    for entry in eol_data:
+        engine = entry.get("engine")
+        version = entry.get("version")
+        if engine is None or version is None:
+            continue
+        engine_str = str(engine)
+        version_str = str(version)
+        current = _parse_rds_version(version_str)
+        if current is None:
+            continue
+        for candidate, candidate_str in by_engine_major[engine_str, current.major]:
+            if candidate <= current:
+                continue
+            candidate_eol = eol_lookup.get((engine_str, candidate_str), "")
+            if candidate_eol >= today:
+                result[engine_str, version_str] = candidate_str
+                break
+    return result
+
+
+def rds_version_fields(
+    engine: object | None,
+    engine_version: object | None,
+    eol_lookup: dict[tuple[str, str], str],
+    next_version_lookup: dict[tuple[str, str], str],
+) -> tuple[str, str]:
+    """Return (eol_date, next_version) only for an exact calendar match."""
+    if engine is None or engine_version is None:
+        return "", ""
+    key = (str(engine), str(engine_version))
+    if key not in eol_lookup:
+        return "", ""
+    return eol_lookup[key], next_version_lookup.get(key, "")

--- a/tools/cli_commands/test/test_rds_eol.py
+++ b/tools/cli_commands/test/test_rds_eol.py
@@ -1,0 +1,118 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+from unittest.mock import Mock
+
+import requests
+
+from tools.cli_commands import rds_eol
+
+if TYPE_CHECKING:
+    from pytest_mock import MockerFixture
+
+RDS_EOL_SAMPLE: list[dict[str, str]] = [
+    {"engine": "postgres", "version": "15.12", "eol": "2026-03-31"},
+    {"engine": "postgres", "version": "15.13", "eol": "2026-09-30"},
+    {"engine": "postgres", "version": "16.8", "eol": "2026-03-31"},
+    {"engine": "postgres", "version": "16.9", "eol": "2026-09-30"},
+    {"engine": "mysql", "version": "8.4.9", "eol": "2026-09-30"},
+    {"engine": "mysql", "version": "8.4.10", "eol": "2027-01-31"},
+]
+
+
+def test_build_eol_lookup_exact_match() -> None:
+    lookup = rds_eol.build_eol_lookup(RDS_EOL_SAMPLE)
+    assert lookup["postgres", "15.13"] == "2026-09-30"
+    assert lookup["mysql", "8.4.10"] == "2027-01-31"
+    assert ("postgres", "17") not in lookup
+    assert ("postgres", "15") not in lookup
+
+
+def test_build_eol_lookup_skips_incomplete_entries() -> None:
+    lookup = rds_eol.build_eol_lookup([
+        {"engine": "postgres", "version": "15.13"},
+        {"engine": "postgres", "eol": "2026-09-30"},
+        {"version": "15.13", "eol": "2026-09-30"},
+        {"engine": "postgres", "version": "15.13", "eol": "2026-09-30"},
+    ])
+    assert lookup == {("postgres", "15.13"): "2026-09-30"}
+
+
+def test_next_version_stays_in_same_major() -> None:
+    lookup = rds_eol.build_next_version_lookup(RDS_EOL_SAMPLE, today="2026-08-17")
+    assert lookup["postgres", "15.12"] == "15.13"
+    assert lookup["postgres", "16.8"] == "16.9"
+    assert lookup["mysql", "8.4.9"] == "8.4.10"
+    assert ("postgres", "15.13") not in lookup
+    assert lookup["postgres", "15.12"] != "16.8"
+
+
+def test_next_version_skips_candidates_past_eol() -> None:
+    data = [
+        {"engine": "postgres", "version": "15.10", "eol": "2025-01-01"},
+        {"engine": "postgres", "version": "15.11", "eol": "2025-06-01"},
+        {"engine": "postgres", "version": "15.12", "eol": "2026-09-30"},
+    ]
+    lookup = rds_eol.build_next_version_lookup(data, today="2026-08-17")
+    assert lookup["postgres", "15.10"] == "15.12"
+    assert lookup["postgres", "15.11"] == "15.12"
+    assert ("postgres", "15.12") not in lookup
+
+
+def test_next_version_blank_when_higher_versions_are_eol() -> None:
+    data = [
+        {"engine": "postgres", "version": "15.10", "eol": "2026-09-30"},
+        {"engine": "postgres", "version": "15.11", "eol": "2026-01-01"},
+    ]
+    lookup = rds_eol.build_next_version_lookup(data, today="2026-08-17")
+    assert lookup == {}
+
+
+def test_rds_version_fields_blank_without_exact_calendar_match() -> None:
+    eol_lookup = rds_eol.build_eol_lookup(RDS_EOL_SAMPLE)
+    next_lookup = rds_eol.build_next_version_lookup(RDS_EOL_SAMPLE, today="2026-08-17")
+    assert rds_eol.rds_version_fields("postgres", "15.13", eol_lookup, next_lookup) == (
+        "2026-09-30",
+        "",
+    )
+    assert rds_eol.rds_version_fields("postgres", "15.12", eol_lookup, next_lookup) == (
+        "2026-03-31",
+        "15.13",
+    )
+    assert rds_eol.rds_version_fields("postgres", "17", eol_lookup, next_lookup) == (
+        "",
+        "",
+    )
+    assert rds_eol.rds_version_fields("postgres", None, eol_lookup, next_lookup) == (
+        "",
+        "",
+    )
+    assert rds_eol.rds_version_fields(
+        "not-an-engine", "15.13", eol_lookup, next_lookup
+    ) == ("", "")
+
+
+def test_load_rds_eol_data_success(mocker: MockerFixture) -> None:
+    response = Mock()
+    response.text = "- engine: postgres\n  version: '15.13'\n  eol: '2026-09-30'\n"
+    response.raise_for_status.return_value = None
+    mocker.patch("tools.cli_commands.rds_eol.requests.get", return_value=response)
+
+    data = rds_eol.load_rds_eol_data()
+    assert data == [{"engine": "postgres", "version": "15.13", "eol": "2026-09-30"}]
+
+
+def test_load_rds_eol_data_http_failure(mocker: MockerFixture) -> None:
+    mocker.patch(
+        "tools.cli_commands.rds_eol.requests.get",
+        side_effect=requests.RequestException("boom"),
+    )
+    assert rds_eol.load_rds_eol_data() == []
+
+
+def test_load_rds_eol_data_rejects_non_list(mocker: MockerFixture) -> None:
+    response = Mock()
+    response.text = "engine: postgres\n"
+    response.raise_for_status.return_value = None
+    mocker.patch("tools.cli_commands.rds_eol.requests.get", return_value=response)
+    assert rds_eol.load_rds_eol_data() == []

--- a/tools/cli_commands/test/test_rds_eol.py
+++ b/tools/cli_commands/test/test_rds_eol.py
@@ -3,25 +3,30 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 from unittest.mock import Mock
 
+import pytest
 import requests
 
 from tools.cli_commands import rds_eol
+from tools.cli_commands.rds_eol import RdsEolEntry, load_rds_eol_data
 
 if TYPE_CHECKING:
     from pytest_mock import MockerFixture
 
-RDS_EOL_SAMPLE: list[dict[str, str]] = [
-    {"engine": "postgres", "version": "15.12", "eol": "2026-03-31"},
-    {"engine": "postgres", "version": "15.13", "eol": "2026-09-30"},
-    {"engine": "postgres", "version": "16.8", "eol": "2026-03-31"},
-    {"engine": "postgres", "version": "16.9", "eol": "2026-09-30"},
-    {"engine": "mysql", "version": "8.4.9", "eol": "2026-09-30"},
-    {"engine": "mysql", "version": "8.4.10", "eol": "2027-01-31"},
-]
+
+@pytest.fixture
+def rds_eol_sample() -> list[RdsEolEntry]:
+    return [
+        RdsEolEntry(engine="postgres", version="15.12", eol="2026-03-31"),
+        RdsEolEntry(engine="postgres", version="15.13", eol="2026-09-30"),
+        RdsEolEntry(engine="postgres", version="16.8", eol="2026-03-31"),
+        RdsEolEntry(engine="postgres", version="16.9", eol="2026-09-30"),
+        RdsEolEntry(engine="mysql", version="8.4.9", eol="2026-09-30"),
+        RdsEolEntry(engine="mysql", version="8.4.10", eol="2027-01-31"),
+    ]
 
 
-def test_build_eol_lookup_exact_match() -> None:
-    lookup = rds_eol.build_eol_lookup(RDS_EOL_SAMPLE)
+def test_build_eol_lookup_exact_match(rds_eol_sample: list[RdsEolEntry]) -> None:
+    lookup = rds_eol.build_eol_lookup(rds_eol_sample)
     assert lookup["postgres", "15.13"] == "2026-09-30"
     assert lookup["mysql", "8.4.10"] == "2027-01-31"
     assert ("postgres", "17") not in lookup
@@ -29,17 +34,23 @@ def test_build_eol_lookup_exact_match() -> None:
 
 
 def test_build_eol_lookup_skips_incomplete_entries() -> None:
-    lookup = rds_eol.build_eol_lookup([
+    raw_data = [
         {"engine": "postgres", "version": "15.13"},
         {"engine": "postgres", "eol": "2026-09-30"},
         {"version": "15.13", "eol": "2026-09-30"},
         {"engine": "postgres", "version": "15.13", "eol": "2026-09-30"},
-    ])
+    ]
+    entries = [
+        RdsEolEntry(**d)
+        for d in raw_data
+        if "engine" in d and "version" in d and "eol" in d
+    ]
+    lookup = rds_eol.build_eol_lookup(entries)
     assert lookup == {("postgres", "15.13"): "2026-09-30"}
 
 
-def test_next_version_stays_in_same_major() -> None:
-    lookup = rds_eol.build_next_version_lookup(RDS_EOL_SAMPLE, today="2026-08-17")
+def test_next_version_stays_in_same_major(rds_eol_sample: list[RdsEolEntry]) -> None:
+    lookup = rds_eol.build_next_version_lookup(rds_eol_sample, today="2026-08-17")
     assert lookup["postgres", "15.12"] == "15.13"
     assert lookup["postgres", "16.8"] == "16.9"
     assert lookup["mysql", "8.4.9"] == "8.4.10"
@@ -49,9 +60,9 @@ def test_next_version_stays_in_same_major() -> None:
 
 def test_next_version_skips_candidates_past_eol() -> None:
     data = [
-        {"engine": "postgres", "version": "15.10", "eol": "2025-01-01"},
-        {"engine": "postgres", "version": "15.11", "eol": "2025-06-01"},
-        {"engine": "postgres", "version": "15.12", "eol": "2026-09-30"},
+        RdsEolEntry(engine="postgres", version="15.10", eol="2025-01-01"),
+        RdsEolEntry(engine="postgres", version="15.11", eol="2025-06-01"),
+        RdsEolEntry(engine="postgres", version="15.12", eol="2026-09-30"),
     ]
     lookup = rds_eol.build_next_version_lookup(data, today="2026-08-17")
     assert lookup["postgres", "15.10"] == "15.12"
@@ -61,16 +72,18 @@ def test_next_version_skips_candidates_past_eol() -> None:
 
 def test_next_version_blank_when_higher_versions_are_eol() -> None:
     data = [
-        {"engine": "postgres", "version": "15.10", "eol": "2026-09-30"},
-        {"engine": "postgres", "version": "15.11", "eol": "2026-01-01"},
+        RdsEolEntry(engine="postgres", version="15.10", eol="2026-09-30"),
+        RdsEolEntry(engine="postgres", version="15.11", eol="2026-01-01"),
     ]
     lookup = rds_eol.build_next_version_lookup(data, today="2026-08-17")
     assert lookup == {}
 
 
-def test_rds_version_fields_blank_without_exact_calendar_match() -> None:
-    eol_lookup = rds_eol.build_eol_lookup(RDS_EOL_SAMPLE)
-    next_lookup = rds_eol.build_next_version_lookup(RDS_EOL_SAMPLE, today="2026-08-17")
+def test_rds_version_fields_blank_without_exact_calendar_match(
+    rds_eol_sample: list[RdsEolEntry],
+) -> None:
+    eol_lookup = rds_eol.build_eol_lookup(rds_eol_sample)
+    next_lookup = rds_eol.build_next_version_lookup(rds_eol_sample, today="2026-08-17")
     assert rds_eol.rds_version_fields("postgres", "15.13", eol_lookup, next_lookup) == (
         "2026-09-30",
         "",
@@ -98,8 +111,11 @@ def test_load_rds_eol_data_success(mocker: MockerFixture) -> None:
     response.raise_for_status.return_value = None
     mocker.patch("tools.cli_commands.rds_eol.requests.get", return_value=response)
 
-    data = rds_eol.load_rds_eol_data()
-    assert data == [{"engine": "postgres", "version": "15.13", "eol": "2026-09-30"}]
+    data = load_rds_eol_data()
+    assert len(data) == 1
+    assert data[0].engine == "postgres"
+    assert data[0].version == "15.13"
+    assert data[0].eol == "2026-09-30"
 
 
 def test_load_rds_eol_data_http_failure(mocker: MockerFixture) -> None:
@@ -107,7 +123,7 @@ def test_load_rds_eol_data_http_failure(mocker: MockerFixture) -> None:
         "tools.cli_commands.rds_eol.requests.get",
         side_effect=requests.RequestException("boom"),
     )
-    assert rds_eol.load_rds_eol_data() == []
+    assert load_rds_eol_data() == []
 
 
 def test_load_rds_eol_data_rejects_non_list(mocker: MockerFixture) -> None:
@@ -115,4 +131,33 @@ def test_load_rds_eol_data_rejects_non_list(mocker: MockerFixture) -> None:
     response.text = "engine: postgres\n"
     response.raise_for_status.return_value = None
     mocker.patch("tools.cli_commands.rds_eol.requests.get", return_value=response)
-    assert rds_eol.load_rds_eol_data() == []
+    assert load_rds_eol_data() == []
+
+
+def test_load_rds_eol_data_skips_incomplete_entries(mocker: MockerFixture) -> None:
+    response = Mock()
+    response.text = (
+        "- engine: postgres\n  version: '15.13'\n  eol: '2026-09-30'\n"
+        "- engine: postgres\n  version: '15.14'\n"
+        "- engine: postgres\n"
+    )
+    response.raise_for_status.return_value = None
+    mocker.patch("tools.cli_commands.rds_eol.requests.get", return_value=response)
+
+    data = load_rds_eol_data()
+    assert len(data) == 1
+    assert data[0].version == "15.13"
+
+
+def test_load_rds_eol_data_custom_url(mocker: MockerFixture) -> None:
+    response = Mock()
+    response.text = "- engine: mysql\n  version: '8.4.9'\n  eol: '2026-09-30'\n"
+    response.raise_for_status.return_value = None
+    mock_get = mocker.patch(
+        "tools.cli_commands.rds_eol.requests.get", return_value=response
+    )
+
+    custom_url = "https://example.com/custom-eol.yaml"
+    data = load_rds_eol_data(custom_url)
+    assert len(data) == 1
+    mock_get.assert_called_once_with(custom_url, timeout=10)

--- a/tools/qontract_cli.py
+++ b/tools/qontract_cli.py
@@ -195,6 +195,7 @@ from tools.cli_commands.gpg_encrypt import (
     GPGEncryptCommandData,
 )
 from tools.cli_commands.rds_eol import (
+    DEFAULT_RDS_EOL_URL,
     build_eol_lookup,
     build_next_version_lookup,
     load_rds_eol_data,
@@ -1832,15 +1833,13 @@ def aws_terraform_resources(ctx: click.Context) -> None:
 
 
 def rds_attr(
-    attr: str, overrides: dict[str, str], defaults: dict[str, str]
-) -> str | None:
-    return overrides.get(attr) or defaults.get(attr)
-
-
-def rds_value(
     attr: str, overrides: dict[str, Any], defaults: dict[str, Any]
 ) -> Any | None:
-    """Return an override when the key is present, including falsey YAML values."""
+    """Return the override value if the key is present, otherwise the default.
+
+    Uses key membership (not truthiness) so falsey values like False or 0 are
+    preserved when explicitly set in overrides.
+    """
     if attr in overrides:
         return overrides[attr]
     return defaults.get(attr)
@@ -1854,8 +1853,8 @@ def region_from_az(az: str | None) -> str | None:
 
 def rds_region(
     spec: ExternalResourceSpec,
-    overrides: dict[str, str],
-    defaults: dict[str, str],
+    overrides: dict[str, Any],
+    defaults: dict[str, Any],
     accounts: dict[str, Any],
 ) -> str | None:
     return (
@@ -1868,12 +1867,18 @@ def rds_region(
 
 
 @get.command
+@click.option(
+    "--eol-url",
+    default=DEFAULT_RDS_EOL_URL,
+    show_default=True,
+    help="URL to the RDS EOL calendar YAML dataset.",
+)
 @click.pass_context
-def rds(ctx: click.Context) -> None:
+def rds(ctx: click.Context, eol_url: str) -> None:
     namespaces = tfr.get_namespaces()
     accounts = {a["name"]: a for a in queries.get_aws_accounts()}
 
-    eol_data = load_rds_eol_data()
+    eol_data = load_rds_eol_data(eol_url)
     eol_lookup = build_eol_lookup(eol_data)
     next_version_lookup = build_next_version_lookup(eol_data)
 
@@ -1898,6 +1903,7 @@ def rds(ctx: click.Context) -> None:
             eol_date, next_version = rds_version_fields(
                 engine, engine_version, eol_lookup, next_version_lookup
             )
+            amvu = rds_attr("auto_minor_version_upgrade", overrides, defaults)
             item = {
                 "identifier": spec.identifier,
                 "account": spec.provisioner_name,
@@ -1906,9 +1912,7 @@ def rds(ctx: click.Context) -> None:
                 "engine": engine,
                 "engine_version": engine_version,
                 "instance_class": rds_attr("instance_class", overrides, defaults),
-                "auto_minor_version_upgrade": rds_value(
-                    "auto_minor_version_upgrade", overrides, defaults
-                ),
+                "auto_minor_version_upgrade": "" if amvu is None else str(amvu),
                 "eol_date": eol_date,
                 "next_version": next_version,
             }

--- a/tools/qontract_cli.py
+++ b/tools/qontract_cli.py
@@ -1914,19 +1914,19 @@ def rds(ctx: click.Context) -> None:
             }
             results.append(item)
 
-    rds_fields = [
-        {"key": "identifier", "sortable": True},
-        {"key": "account", "sortable": True},
-        {"key": "account_uid", "sortable": True},
-        {"key": "region", "sortable": True},
-        {"key": "engine", "sortable": True},
-        {"key": "engine_version", "sortable": True},
-        {"key": "instance_class", "sortable": True},
-        {"key": "auto_minor_version_upgrade", "sortable": True},
-        {"key": "eol_date", "sortable": True},
-        {"key": "next_version", "sortable": True},
+    columns = [
+        "identifier",
+        "account",
+        "account_uid",
+        "region",
+        "engine",
+        "engine_version",
+        "instance_class",
+        "auto_minor_version_upgrade",
+        "eol_date",
+        "next_version",
     ]
-    columns = [field["key"] for field in rds_fields]
+    rds_fields = [{"key": c, "sortable": True} for c in columns]
 
     if ctx.obj["options"]["output"] == "md":
         json_table = {

--- a/tools/qontract_cli.py
+++ b/tools/qontract_cli.py
@@ -194,6 +194,12 @@ from tools.cli_commands.gpg_encrypt import (
     GPGEncryptCommand,
     GPGEncryptCommandData,
 )
+from tools.cli_commands.rds_eol import (
+    build_eol_lookup,
+    build_next_version_lookup,
+    load_rds_eol_data,
+    rds_version_fields,
+)
 from tools.cli_commands.systems_and_tools import get_systems_and_tools_inventory
 from tools.sre_checkpoints import (
     full_name,
@@ -1831,6 +1837,15 @@ def rds_attr(
     return overrides.get(attr) or defaults.get(attr)
 
 
+def rds_value(
+    attr: str, overrides: dict[str, Any], defaults: dict[str, Any]
+) -> Any | None:
+    """Return an override when the key is present, including falsey YAML values."""
+    if attr in overrides:
+        return overrides[attr]
+    return defaults.get(attr)
+
+
 def region_from_az(az: str | None) -> str | None:
     if not az:
         return None
@@ -1857,6 +1872,11 @@ def rds_region(
 def rds(ctx: click.Context) -> None:
     namespaces = tfr.get_namespaces()
     accounts = {a["name"]: a for a in queries.get_aws_accounts()}
+
+    eol_data = load_rds_eol_data()
+    eol_lookup = build_eol_lookup(eol_data)
+    next_version_lookup = build_next_version_lookup(eol_data)
+
     results = []
     for namespace in namespaces:
         if namespace.delete:
@@ -1873,31 +1893,45 @@ def rds(ctx: click.Context) -> None:
                 gql.get_resource(spec.resource["defaults"])["content"]
             )
             overrides = json.loads(spec.resource.get("overrides") or "{}")
+            engine = rds_attr("engine", overrides, defaults)
+            engine_version = rds_attr("engine_version", overrides, defaults)
+            eol_date, next_version = rds_version_fields(
+                engine, engine_version, eol_lookup, next_version_lookup
+            )
             item = {
                 "identifier": spec.identifier,
                 "account": spec.provisioner_name,
                 "account_uid": accounts[spec.provisioner_name]["uid"],
                 "region": rds_region(spec, overrides, defaults, accounts),
-                "engine": rds_attr("engine", overrides, defaults),
-                "engine_version": rds_attr("engine_version", overrides, defaults),
+                "engine": engine,
+                "engine_version": engine_version,
                 "instance_class": rds_attr("instance_class", overrides, defaults),
-                "storage_type": rds_attr("storage_type", overrides, defaults),
+                "auto_minor_version_upgrade": rds_value(
+                    "auto_minor_version_upgrade", overrides, defaults
+                ),
+                "eol_date": eol_date,
+                "next_version": next_version,
             }
             results.append(item)
+
+    rds_fields = [
+        {"key": "identifier", "sortable": True},
+        {"key": "account", "sortable": True},
+        {"key": "account_uid", "sortable": True},
+        {"key": "region", "sortable": True},
+        {"key": "engine", "sortable": True},
+        {"key": "engine_version", "sortable": True},
+        {"key": "instance_class", "sortable": True},
+        {"key": "auto_minor_version_upgrade", "sortable": True},
+        {"key": "eol_date", "sortable": True},
+        {"key": "next_version", "sortable": True},
+    ]
+    columns = [field["key"] for field in rds_fields]
 
     if ctx.obj["options"]["output"] == "md":
         json_table = {
             "filter": True,
-            "fields": [
-                {"key": "identifier", "sortable": True},
-                {"key": "account", "sortable": True},
-                {"key": "account_uid", "sortable": True},
-                {"key": "region", "sortable": True},
-                {"key": "engine", "sortable": True},
-                {"key": "engine_version", "sortable": True},
-                {"key": "instance_class", "sortable": True},
-                {"key": "storage_type", "sortable": True},
-            ],
+            "fields": rds_fields,
             "items": results,
         }
 
@@ -1913,16 +1947,6 @@ You can view the source of this Markdown to extract the JSON data.
             """
         )
     else:
-        columns = [
-            "identifier",
-            "account",
-            "account_uid",
-            "region",
-            "engine",
-            "engine_version",
-            "instance_class",
-            "storage_type",
-        ]
         ctx.obj["options"]["sort"] = False
         print_output(ctx.obj["options"], results, columns)
 

--- a/tools/test/test_qontract_cli.py
+++ b/tools/test/test_qontract_cli.py
@@ -649,12 +649,19 @@ def test_rds_command_columns_replace_storage_type(mocker: MockerFixture) -> None
     assert "NEXT_VERSION" in output
 
 
-def test_rds_value_preserves_false_override() -> None:
-    overrides = {"auto_minor_version_upgrade": False}
-    defaults = {"auto_minor_version_upgrade": True}
+def test_rds_attr_preserves_false_override() -> None:
+    overrides: dict = {"auto_minor_version_upgrade": False}
+    defaults: dict = {"auto_minor_version_upgrade": True}
     assert (
-        qontract_cli.rds_value("auto_minor_version_upgrade", overrides, defaults)
+        qontract_cli.rds_attr("auto_minor_version_upgrade", overrides, defaults)
         is False
     )
-    assert qontract_cli.rds_value("auto_minor_version_upgrade", {}, defaults) is True
-    assert qontract_cli.rds_value("auto_minor_version_upgrade", {}, {}) is None
+    assert qontract_cli.rds_attr("auto_minor_version_upgrade", {}, defaults) is True
+    assert qontract_cli.rds_attr("auto_minor_version_upgrade", {}, {}) is None
+
+
+def test_rds_attr_falls_through_when_key_absent() -> None:
+    overrides: dict = {}
+    defaults: dict = {"engine": "postgres"}
+    assert qontract_cli.rds_attr("engine", overrides, defaults) == "postgres"
+    assert qontract_cli.rds_attr("engine", {"engine": "mysql"}, defaults) == "mysql"

--- a/tools/test/test_qontract_cli.py
+++ b/tools/test/test_qontract_cli.py
@@ -628,3 +628,33 @@ def test_review_queue_includes_bot_authored_self_serviceable_mr_with_pipeline_er
     )
     assert result.exit_code == 0
     assert "MR 7" in result.output
+
+
+def test_rds_command_columns_replace_storage_type(mocker: MockerFixture) -> None:
+    mocker.patch("tools.qontract_cli.tfr.get_namespaces", return_value=[])
+    mocker.patch("tools.qontract_cli.queries.get_aws_accounts", return_value=[])
+    mocker.patch("tools.qontract_cli.load_rds_eol_data", return_value=[])
+
+    runner = CliRunner()
+    result = runner.invoke(
+        qontract_cli.get,
+        ["rds"],
+        obj={"options": {"output": "table", "sort": False}},
+    )
+    assert result.exit_code == 0
+    output = result.output
+    assert "STORAGE_TYPE" not in output
+    assert "AUTO_MINOR_VERSION_UPGRADE" in output
+    assert "EOL_DATE" in output
+    assert "NEXT_VERSION" in output
+
+
+def test_rds_value_preserves_false_override() -> None:
+    overrides = {"auto_minor_version_upgrade": False}
+    defaults = {"auto_minor_version_upgrade": True}
+    assert (
+        qontract_cli.rds_value("auto_minor_version_upgrade", overrides, defaults)
+        is False
+    )
+    assert qontract_cli.rds_value("auto_minor_version_upgrade", {}, defaults) is True
+    assert qontract_cli.rds_value("auto_minor_version_upgrade", {}, {}) is None


### PR DESCRIPTION
## Summary

- [APPSRE-12579](https://redhat.atlassian.net/browse/APPSRE-12579): improve `qontract-cli get rds` output
- Remove the `storage_type` column
- Add `auto_minor_version_upgrade`, `eol_date`, and `next_version`
- `eol_date` comes from the AWS RDS calendar dataset in [app-sre/aws-generated-data](https://github.com/app-sre/aws-generated-data/blob/main/output/rds_eol.yaml)
- `next_version` is the next non-EOL version in the **same major** line
- Lookup is an exact `(engine, version)` match; unmatched versions stay blank
- Fetch failures leave EOL columns blank instead of failing the command

## Test plan

- [x] Unit tests for EOL lookup, same-major next-version, exact-match blanks, and HTTP fetch fallback
- [x] CLI column test (`storage_type` gone; new columns present)
- [x] `rds_value` preserves `auto_minor_version_upgrade: false`
- [x] `make unittest` on Python 3.14 (3983 passed)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * RDS reports now include engine version, end-of-life date, and recommended next version information.
  * Recommendations remain within the same major version and exclude releases that are already end-of-life.
  * EOL details appear only for exact date matches.
  * RDS end-of-life data can be loaded from a configurable source.

* **Bug Fixes**
  * Explicit configuration values, including `False`, are now preserved in reports.

* **Changes**
  * Removed the previous storage type field from RDS output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->