### PR TITLE
update setuptools

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,10 +49,10 @@ dependencies = [
     "semver~=3.0",
     "sendgrid==6.12.5",
     "sentry-sdk==2.68.0",
-    # jenkins-job-builder uses pkg_resources from setuptools. pkg_resources is being deprecated and will be removed
-    # in setuptools 81.
-    # setuptools 80.9.0 set a deadline for the removal and started showing warnings when pkg_resources is used.
-    "setuptools==80.8.0",
+    # jenkins-job-builder uses pkg_resources from setuptools. pkg_resources was removed from setuptools in version 82.0.0
+    # See https://setuptools.pypa.io/en/latest/history.html#v82-0-0 for more information about the removal of pkg_resources
+    # jjb bug report: https://storyboard.openstack.org/#!/story/2011757
+    "setuptools<82.0.0",
     "slack_sdk>=3.10,<4.0",
     "sretoolbox==4.0.1",
     "tabulate==0.10.0",

--- a/uv.lock
+++ b/uv.lock
@@ -2640,7 +2640,7 @@ requires-dist = [
     { name = "semver", specifier = "~=3.0" },
     { name = "sendgrid", specifier = "==6.12.5" },
     { name = "sentry-sdk", specifier = "==2.68.0" },
-    { name = "setuptools", specifier = "==80.8.0" },
+    { name = "setuptools", specifier = "<82.0.0" },
     { name = "slack-sdk", specifier = ">=3.10,<4.0" },
     { name = "sretoolbox", specifier = "==4.0.1" },
     { name = "tabulate", specifier = "==0.10.0" },
@@ -2977,11 +2977,11 @@ wheels = [
 
 [[package]]
 name = "setuptools"
-version = "80.8.0"
+version = "81.0.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/8d/d2/ec1acaaff45caed5c2dedb33b67055ba9d4e96b091094df90762e60135fe/setuptools-80.8.0.tar.gz", hash = "sha256:49f7af965996f26d43c8ae34539c8d99c5042fbff34302ea151eaa9c207cd257", size = 1319720, upload-time = "2025-05-20T14:02:53.503Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/0d/1c/73e719955c59b8e424d015ab450f51c0af856ae46ea2da83eba51cc88de1/setuptools-81.0.0.tar.gz", hash = "sha256:487b53915f52501f0a79ccfd0c02c165ffe06631443a886740b91af4b7a5845a", size = 1198299, upload-time = "2026-02-06T21:10:39.601Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/58/29/93c53c098d301132196c3238c312825324740851d77a8500a2462c0fd888/setuptools-80.8.0-py3-none-any.whl", hash = "sha256:95a60484590d24103af13b686121328cc2736bee85de8936383111e421b9edc0", size = 1201470, upload-time = "2025-05-20T14:02:51.348Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/e3/c164c88b2e5ce7b24d667b9bd83589cf4f3520d97cad01534cd3c4f55fdb/setuptools-81.0.0-py3-none-any.whl", hash = "sha256:fdd925d5c5d9f62e4b74b30d6dd7828ce236fd6ed998a08d81de62ce5a6310d6", size = 1062021, upload-time = "2026-02-06T21:10:37.175Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Pin `setuptools < 82` because of jenkins-job-builder

replaces #5713 #5753

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the setuptools version constraint to support compatible releases below 82.0.0.
  * Added documentation explaining compatibility considerations related to the removal of `pkg_resources`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->