### PR TITLE
fix(aws-version-sync): do not downgrade ElastiCache engine on stale AWS metrics

### DIFF
--- a/reconcile/aws_version_sync/integration.py
+++ b/reconcile/aws_version_sync/integration.py
@@ -171,7 +171,7 @@ EXTENDED_SUPPORT_VERSION_INDICATOR = "-rds."
 # supports upgrading a Redis instance to Valkey, but never the other way round.
 # used to detect stale AWS metrics that still report the pre-upgrade engine
 # while app-interface already reflects the (already applied) upgrade.
-ENGINE_UPGRADE_PATHS = {"redis": "valkey"}
+ENGINE_UPGRADE_PATHS: dict[str, str] = {"redis": "valkey"}
 
 
 class AVSIntegration(QontractReconcileIntegration[AVSIntegrationParams]):

--- a/reconcile/aws_version_sync/integration.py
+++ b/reconcile/aws_version_sync/integration.py
@@ -167,6 +167,11 @@ AppInterfaceExternalResources = list[ExternalResource]
 UidAndReplicationGroupId = tuple[str, str]
 ReplicationGroupIdToIdentifier = dict[UidAndReplicationGroupId, str]
 EXTENDED_SUPPORT_VERSION_INDICATOR = "-rds."
+# maps an engine to the engine it can be upgraded to, e.g. AWS ElastiCache
+# supports upgrading a Redis instance to Valkey, but never the other way round.
+# used to detect stale AWS metrics that still report the pre-upgrade engine
+# while app-interface already reflects the (already applied) upgrade.
+ENGINE_UPGRADE_PATHS = {"redis": "valkey"}
 
 
 class AVSIntegration(QontractReconcileIntegration[AVSIntegrationParams]):
@@ -449,12 +454,19 @@ class AVSIntegration(QontractReconcileIntegration[AVSIntegrationParams]):
             aws_resource = diff_pair.desired
             app_interface_resource = diff_pair.current
             if (
-                aws_resource.resource_engine_version
+                aws_resource.resource_engine == app_interface_resource.resource_engine
+                and aws_resource.resource_engine_version
                 <= app_interface_resource.resource_engine_version
-                and aws_resource.resource_engine
-                == app_interface_resource.resource_engine
             ):
                 # do not downgrade the version
+                continue
+            if (
+                ENGINE_UPGRADE_PATHS.get(aws_resource.resource_engine)
+                == app_interface_resource.resource_engine
+            ):
+                # the AWS metrics still report the pre-upgrade engine (e.g. "redis")
+                # while app-interface already reflects the applied engine upgrade
+                # (e.g. "valkey"); the AWS metrics are stale, do not downgrade the engine
                 continue
             # make mypy happy
             assert app_interface_resource.namespace_file

--- a/reconcile/test/aws_version_sync/test_avs_integration.py
+++ b/reconcile/test/aws_version_sync/test_avs_integration.py
@@ -497,6 +497,29 @@ def test_avs_reconcile(mocker: MockerFixture, intg: AVSIntegration) -> None:
         resource_engine="redis",
         resource_engine_version="13.1",
     )
+    # AWS metrics are stale and still report "redis" while app-interface
+    # already reflects an already-applied redis -> valkey engine upgrade.
+    # The integration must not revert this to "redis" (no engine downgrade).
+    ec_stale_aws_metrics_no_engine_downgrade_aws = ExternalResource(
+        namespace_file=None,
+        provider="aws",
+        provisioner=ExternalResourceProvisioner(uid="version_update", path=None),
+        resource_provider="elasticache",
+        resource_identifier="ec-stale-aws-metrics-no-engine-downgrade",
+        resource_engine="redis",
+        resource_engine_version="7.1",
+    )
+    ec_stale_aws_metrics_no_engine_downgrade_ai = ExternalResource(
+        namespace_file="/version_update_ai-namespace-file.yml",
+        provider="aws",
+        provisioner=ExternalResourceProvisioner(
+            uid="version_update", path="version_update.yml"
+        ),
+        resource_provider="elasticache",
+        resource_identifier="ec-stale-aws-metrics-no-engine-downgrade",
+        resource_engine="valkey",
+        resource_engine_version="7.2",
+    )
     external_resources_aws = [
         no_change_aws,
         version_update_aws,
@@ -505,6 +528,7 @@ def test_avs_reconcile(mocker: MockerFixture, intg: AVSIntegration) -> None:
         ec_version_update_aws,
         ec_engine_update_aws,
         ec_engine_and_version_update_aws,
+        ec_stale_aws_metrics_no_engine_downgrade_aws,
     ]
 
     external_resources_app_interface = [
@@ -516,6 +540,7 @@ def test_avs_reconcile(mocker: MockerFixture, intg: AVSIntegration) -> None:
         ec_version_update_ai,
         ec_engine_update_ai,
         ec_engine_and_version_update_ai,
+        ec_stale_aws_metrics_no_engine_downgrade_ai,
     ]
     # randomize the order of the external resources
     random.shuffle(external_resources_aws)


### PR DESCRIPTION
## Summary
- Fixes a bug in `aws-version-sync` where a stale AWS ElastiCache metric (still reporting `redis`) could cause the integration to open an MR reverting app-interface's already-applied `redis` -> `valkey` engine upgrade.
- The existing anti-downgrade check only compared version numbers when the AWS and app-interface engines already matched, so a mismatched engine always went through as a "change", regardless of direction.
- Adds an `ENGINE_UPGRADE_PATHS` map (`redis` -> `valkey`) and skips reconciliation when AWS still reports the pre-upgrade engine while app-interface already reflects the upgrade — treating it as stale AWS data rather than a desired change.
- The reverse case (AWS enforces the upgrade: metrics show `valkey`, app-interface still shows `redis`) is unaffected and continues to open an MR as before.
- Replaces/Supersedes #5530


## Test plan
- [x] Added a TDD regression test (`ec_stale_aws_metrics_no_engine_downgrade_*`) to `test_avs_reconcile` reproducing the stale-metrics scenario; confirmed it failed before the fix (5 MRs instead of 4) and passes after.
- [x] `uv run pytest reconcile/test/aws_version_sync/` — 40 passed, 5 xfailed.
- [x] `uv run ruff check` / `uv run ruff format --check` — clean.
- [x] `uv run mypy reconcile/aws_version_sync/integration.py` — no issues.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Prevented reconciliation from proposing engine downgrades when AWS reports a predecessor engine after an upgrade.
  - Preserved existing protection against version downgrades.
  - Added coverage for scenarios where Redis resources have been upgraded to Valkey.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->