### PR TITLE
chore(acs): enable ACS Multi-Instance Strict Instance Filtering

### DIFF
--- a/reconcile/acs_policies.py
+++ b/reconcile/acs_policies.py
@@ -188,8 +188,8 @@ class AcsPoliciesIntegration(
             self._build_policy(gql_policy, notifier_name_to_id, cluster_name_to_id)
             for gql_policy in gql_acs_policies.query(query_func=query_func).acs_policies
             or []
-            # TODO: Update logic once ACS files in App-interface have been updated with the "instance" field
-            if gql_policy.instance is None or gql_policy.instance.name == instance_name
+            if gql_policy.instance is not None
+            and gql_policy.instance.name == instance_name
         ]
 
     def reconcile(

--- a/reconcile/acs_rbac.py
+++ b/reconcile/acs_rbac.py
@@ -167,9 +167,8 @@ class AcsRbacIntegration(QontractReconcileIntegration[AcsIntegrationParams]):
                 for permission in role.oidc_permissions or []:
                     if isinstance(permission, OidcPermissionAcsV1):
                         if (
-                            # TODO: Update logic once ACS files in App-interface have been updated with the "instance" field
-                            permission.instance is not None
-                            and permission.instance.name != instance_name
+                            permission.instance is None
+                            or permission.instance.name != instance_name
                         ):
                             continue
                         permission_usernames[

--- a/reconcile/test/test_acs_policies.py
+++ b/reconcile/test/test_acs_policies.py
@@ -486,13 +486,13 @@ def test_get_desired_state_filters_by_instance(
     assert result == []
 
 
-def test_get_desired_state_includes_policies_without_instance(
+def test_get_desired_state_excludes_policies_without_instance(
     mocker: MockerFixture,
     query_data_desired_state: AcsPolicyQueryData,
     api_response_list_notifiers: list[AcsPolicyApi.NotifierIdentifiers],
     api_response_list_clusters: list[AcsPolicyApi.ClusterIdentifiers],
 ) -> None:
-    # Permissive filter: policies with instance=None are included (treated as "belongs to all instances")
+    # Strict filter: policies with instance=None are excluded
     for policy in query_data_desired_state.acs_policies or []:
         policy.instance = None
 
@@ -508,4 +508,4 @@ def test_get_desired_state_includes_policies_without_instance(
         notifiers=api_response_list_notifiers,
         clusters=api_response_list_clusters,
     )
-    assert len(result) == len(query_data_desired_state.acs_policies or [])
+    assert result == []

--- a/reconcile/test/test_acs_rbac.py
+++ b/reconcile/test/test_acs_rbac.py
@@ -921,11 +921,11 @@ def test_get_desired_state_filters_by_instance(
     assert result == []
 
 
-def test_get_desired_state_includes_permissions_without_instance(
+def test_get_desired_state_excludes_permissions_without_instance(
     mocker: MockerFixture,
     query_data_desired_state: AcsRbacQueryData,
 ) -> None:
-    # Permissive filter: permissions with instance=None are included (treated as "belongs to all instances")
+    # Strict filter: permissions with instance=None are excluded
     for user in query_data_desired_state.acs_rbacs or []:
         for role in user.roles or []:
             for perm in role.oidc_permissions or []:
@@ -938,4 +938,4 @@ def test_get_desired_state_includes_permissions_without_instance(
     integration = AcsRbacIntegration()
     result = integration.get_desired_state(query_func, "app-sre-acs")
 
-    assert len(result) > 0
+    assert result == []


### PR DESCRIPTION
**Ticket:** [APPSRE-14643](https://redhat.atlassian.net/browse/APPSRE-14643)  
**Phase:** 5 of 5 (Multi-Instance ACS Support)
**Co-authored:** `Claude`

## Summary

This PR implements Phase 5 of the multi-instance ACS support plan. It changes the ACS integrations from permissive to strict instance filtering. The strict filter rejects policies and permissions that do not have an `instance` field. This prevents the integrations from reconciling these items against any ACS instance.

### Phase Coordination

This PR is `Phase 5` of a multi-phase rollout.

1. **Phase 1** (qontract-schemas): Add optional `instance` field to schemas. (✅ Complete)
2. **Phase 2** (qontract-reconcile): Update reconciliation code to support multiple instances. (✅ Complete)
3. **Phase 3** (app-interface): Tag all existing permissions and policies with `instance: app-sre-acs`. (✅ Complete)
4. **Phase 4** (qontract-schemas): Make `instance` required in schemas. (✅ Complete)
5. **Phase 5** (qontract-reconcile): Switch from permissive to strict filtering.

## Changes

### Integration Logic

**`reconcile/acs_policies.py`** — Changed policy filtering to strict mode:
- **Before:** `if gql_policy.instance is None or gql_policy.instance.name == instance_name`
- **After:** `if gql_policy.instance is not None and gql_policy.instance.name == instance_name`
- The filter includes only policies that have an instance set and match the target instance.

**`reconcile/acs_rbac.py`** — Changed permission filtering to strict mode:
- **Before:** Skip only if instance is set AND does not match
- **After:** `if permission.instance is None or permission.instance.name != instance_name: continue`
- The filter skips permissions that have no instance OR do not match the target instance.

### Tests

**`reconcile/test/test_acs_policies.py`** — Updated test expectations:
- Renamed test: `test_get_desired_state_excludes_policies_without_instance`
- Changed assertion: the test expects an empty result when `instance=None`

**`reconcile/test/test_acs_rbac.py`** — Updated test expectations:
- Renamed test: `test_get_desired_state_excludes_permissions_without_instance`
- Changed assertion: the test expects an empty result when `instance=None`

## Rationale

The permissive filter treated `instance=None` as "belongs to all instances". This was safe during the Phase 2 to Phase 3 transition when existing data had no `instance` field. The strict filter prevents inconsistent data from being pushed to every ACS instance.

## Testing

- ✅ All 22 ACS integration tests pass
- ✅ Linter checks pass (ruff)
- ✅ Type checks pass (mypy strict mode)

## Files Changed

```
reconcile/acs_policies.py           | 4 ++--
reconcile/acs_rbac.py               | 5 ++---
reconcile/test/test_acs_policies.py | 6 +++---
reconcile/test/test_acs_rbac.py     | 6 +++---
4 files changed, 10 insertions(+), 11 deletions(-)
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * ACS policies and permissions are now limited to the selected ACS instance.
  * Entries without an associated instance are no longer included in the desired state.

* **Tests**
  * Updated coverage to verify that unassigned policies and permissions are excluded.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->