### PR TITLE
fix(ocm-clusters): replace deprecated OCM version.channel_group with channel

### DIFF
--- a/reconcile/templates/rosa-classic-cluster-creation.sh.j2
+++ b/reconcile/templates/rosa-classic-cluster-creation.sh.j2
@@ -58,5 +58,5 @@ rosa create cluster -y --cluster-name={{ cluster_name }} \
     {% if cluster.spec.fips -%}
     --fips \
     {% endif -%}
-    --channel {{ cluster.spec.channel }}-{{ (cluster.spec.initial_version | split("."))[:2] | join(".") }}
+    --channel {{ channel }}
 

--- a/reconcile/templates/rosa-classic-cluster-creation.sh.j2
+++ b/reconcile/templates/rosa-classic-cluster-creation.sh.j2
@@ -58,5 +58,5 @@ rosa create cluster -y --cluster-name={{ cluster_name }} \
     {% if cluster.spec.fips -%}
     --fips \
     {% endif -%}
-    --channel-group {{ cluster.spec.channel }}
+    --channel {{ cluster.spec.channel }}-{{ (cluster.spec.initial_version | split("."))[:2] | join(".") }}
 

--- a/reconcile/templates/rosa-hcp-cluster-creation.sh.j2
+++ b/reconcile/templates/rosa-hcp-cluster-creation.sh.j2
@@ -62,4 +62,4 @@ rosa create cluster --cluster-name={{ cluster_name }} \
     {% if cluster.spec.fips -%}
     --fips \
     {% endif -%}
-    --channel {{ cluster.spec.channel }}-{{ (cluster.spec.initial_version | split("."))[:2] | join(".") }}
+    --channel {{ channel }}

--- a/reconcile/templates/rosa-hcp-cluster-creation.sh.j2
+++ b/reconcile/templates/rosa-hcp-cluster-creation.sh.j2
@@ -62,4 +62,4 @@ rosa create cluster --cluster-name={{ cluster_name }} \
     {% if cluster.spec.fips -%}
     --fips \
     {% endif -%}
-    --channel-group {{ cluster.spec.channel }}
+    --channel {{ cluster.spec.channel }}-{{ (cluster.spec.initial_version | split("."))[:2] | join(".") }}

--- a/reconcile/test/fixtures/clusters/osd_spec_post.json
+++ b/reconcile/test/fixtures/clusters/osd_spec_post.json
@@ -34,8 +34,8 @@
     "value": 4402341478400.0
   },
   "version": {
-    "channel_group": "candidate",
     "id": "openshift-v4.8.10"
   },
+  "channel": "candidate-4.8",
   "fips": false
 }

--- a/reconcile/test/fixtures/clusters/rosa_spec_post.json
+++ b/reconcile/test/fixtures/clusters/rosa_spec_post.json
@@ -54,7 +54,7 @@
     "id": "us-east-1"
   },
   "version": {
-    "channel_group": "stable",
     "id": "openshift-v4.8.10"
-  }
+  },
+  "channel": "stable-4.8"
 }

--- a/reconcile/test/fixtures/rosa/rosa_classic_script_result.sh
+++ b/reconcile/test/fixtures/rosa/rosa_classic_script_result.sh
@@ -40,4 +40,4 @@ rosa create cluster -y --cluster-name=cluster-2 \
     --replicas 3 \
     --compute-machine-type m5.xlarge \
     --disable-workload-monitoring \
-    --channel-group stable
+    --channel stable-4.8

--- a/reconcile/test/fixtures/rosa/rosa_hcp_script_result.sh
+++ b/reconcile/test/fixtures/rosa/rosa_hcp_script_result.sh
@@ -40,4 +40,4 @@ rosa create cluster --cluster-name=cluster-1 \
     --compute-machine-type m5.xlarge \
     --disable-workload-monitoring \
     --properties provision_shard_id:provision_shard_id \
-    --channel-group stable
+    --channel stable-4.8

--- a/reconcile/test/fixtures/rosa/rosa_hcp_script_result_billing_account.sh
+++ b/reconcile/test/fixtures/rosa/rosa_hcp_script_result_billing_account.sh
@@ -41,4 +41,4 @@ rosa create cluster --cluster-name=cluster-1 \
     --compute-machine-type m5.xlarge \
     --disable-workload-monitoring \
     --properties provision_shard_id:provision_shard_id \
-    --channel-group stable
+    --channel stable-4.8

--- a/reconcile/test/fixtures/rosa/rosa_hcp_script_result_dry_run.sh
+++ b/reconcile/test/fixtures/rosa/rosa_hcp_script_result_dry_run.sh
@@ -41,4 +41,4 @@ rosa create cluster --cluster-name=cluster-1 \
     --compute-machine-type m5.xlarge \
     --disable-workload-monitoring \
     --properties provision_shard_id:provision_shard_id \
-    --channel-group stable
+    --channel stable-4.8

--- a/reconcile/test/fixtures/rosa/rosa_hcp_script_result_no_provision_shard.sh
+++ b/reconcile/test/fixtures/rosa/rosa_hcp_script_result_no_provision_shard.sh
@@ -39,4 +39,4 @@ rosa create cluster --cluster-name=cluster-1 \
     --replicas 3 \
     --compute-machine-type m5.xlarge \
     --disable-workload-monitoring \
-    --channel-group stable
+    --channel stable-4.8

--- a/reconcile/test/fixtures/rosa/rosa_hcp_script_result_private.sh
+++ b/reconcile/test/fixtures/rosa/rosa_hcp_script_result_private.sh
@@ -42,4 +42,4 @@ rosa create cluster --cluster-name=cluster-1 \
     --default-ingress-private \
     --disable-workload-monitoring \
     --properties provision_shard_id:provision_shard_id \
-    --channel-group stable
+    --channel stable-4.8

--- a/reconcile/test/fixtures/rosa/rosa_hcp_script_result_reuse_oidc_config.sh
+++ b/reconcile/test/fixtures/rosa/rosa_hcp_script_result_reuse_oidc_config.sh
@@ -34,4 +34,4 @@ rosa create cluster --cluster-name=cluster-1 \
     --compute-machine-type m5.xlarge \
     --disable-workload-monitoring \
     --properties provision_shard_id:provision_shard_id \
-    --channel-group stable
+    --channel stable-4.8

--- a/reconcile/test/fixtures/rosa/rosa_hcp_script_result_uwm_enabled.sh
+++ b/reconcile/test/fixtures/rosa/rosa_hcp_script_result_uwm_enabled.sh
@@ -39,4 +39,4 @@ rosa create cluster --cluster-name=cluster-1 \
     --replicas 3 \
     --compute-machine-type m5.xlarge \
     --properties provision_shard_id:provision_shard_id \
-    --channel-group stable
+    --channel stable-4.8

--- a/reconcile/test/ocm/test_utils_ocm_products.py
+++ b/reconcile/test/ocm/test_utils_ocm_products.py
@@ -1,0 +1,43 @@
+import pytest
+
+from reconcile.utils.ocm.products import (
+    OCMProductHypershift,
+    OCMProductOsd,
+    OCMProductRosa,
+    build_ystream_channel,
+)
+
+
+@pytest.mark.parametrize(
+    ("channel_group", "version", "expected"),
+    [
+        ("stable", "4.8.10", "stable-4.8"),
+        ("stable", "4.16.0", "stable-4.16"),
+        ("eus", "4.16.3", "eus-4.16"),
+        ("candidate", "4.10", "candidate-4.10"),
+    ],
+)
+def test_build_ystream_channel(channel_group: str, version: str, expected: str) -> None:
+    assert build_ystream_channel(channel_group, version) == expected
+
+
+def test_osd_update_spec_channel_is_ystream() -> None:
+    spec = OCMProductOsd()._get_update_cluster_spec({"channel": "stable"}, "4.16.0")
+    assert spec == {"channel": "stable-4.16"}
+
+
+def test_rosa_update_spec_channel_is_ystream() -> None:
+    spec = OCMProductRosa(None)._get_update_cluster_spec(
+        {"channel": "stable"}, "4.16.0"
+    )
+    assert spec == {"channel": "stable-4.16"}
+
+
+def test_hypershift_update_spec_channel_is_ystream() -> None:
+    # Regression: SPEC_ATTR_CHANNEL is in Hypershift's ALLOWED_SPEC_UPDATE_FIELDS,
+    # so a channel change must be translated into the OCM PATCH body instead of
+    # being silently dropped (which caused an endless no-op reconcile loop).
+    spec = OCMProductHypershift(None)._get_update_cluster_spec(
+        {"channel": "stable"}, "4.16.0"
+    )
+    assert spec == {"channel": "stable-4.16"}

--- a/reconcile/utils/ocm/ocm.py
+++ b/reconcile/utils/ocm/ocm.py
@@ -158,7 +158,9 @@ class OCM:
         cluster = self.clusters[cluster_name]
         cluster_id = self.cluster_ids[cluster_name]
         impl = self.get_product_impl(cluster.spec.product, cluster.spec.hypershift)
-        impl.update_cluster(self.ocm_api, cluster_id, update_spec, dry_run)
+        impl.update_cluster(
+            self.ocm_api, cluster_id, update_spec, cluster.spec.version, dry_run
+        )
 
     def get_group_if_exists(self, cluster: str, group_id: str) -> dict[str, Any] | None:
         """Returns a list of users in a group in a cluster.

--- a/reconcile/utils/ocm/products.py
+++ b/reconcile/utils/ocm/products.py
@@ -756,6 +756,10 @@ class OCMProductHypershift(OCMProduct):
     ) -> dict[str, Any]:
         ocm_spec: dict[str, Any] = {}
 
+        channel = update_spec.get(SPEC_ATTR_CHANNEL)
+        if channel is not None:
+            ocm_spec["channel"] = build_ystream_channel(channel, version)
+
         disable_uwm = update_spec.get(SPEC_ATTR_DISABLE_UWM)
         if disable_uwm is not None:
             ocm_spec["disable_user_workload_monitoring"] = disable_uwm

--- a/reconcile/utils/ocm/products.py
+++ b/reconcile/utils/ocm/products.py
@@ -72,6 +72,7 @@ def build_ystream_channel(channel_group: str, version: str) -> str:
     major_minor = ".".join(version.split(".")[:2])
     return f"{channel_group}-{major_minor}"
 
+
 OCM_PRODUCT_OSD = "osd"
 OCM_PRODUCT_ROSA = "rosa"
 OCM_PRODUCT_HYPERSHIFT = "hypershift"
@@ -259,7 +260,8 @@ class OCMProductOsd(OCMProduct):
                 "id": f"openshift-v{cluster.spec.initial_version}",
             },
             "channel": build_ystream_channel(
-                cluster.spec.channel, cluster.spec.initial_version or cluster.spec.version
+                cluster.spec.channel,
+                cluster.spec.initial_version or cluster.spec.version,
             ),
             "multi_az": cluster.spec.multi_az,
             "nodes": self._get_nodes_spec(cluster),
@@ -520,7 +522,8 @@ class OCMProductRosa(OCMProduct):
                 "id": f"openshift-v{cluster.spec.initial_version}",
             },
             "channel": build_ystream_channel(
-                cluster.spec.channel, cluster.spec.initial_version or cluster.spec.version
+                cluster.spec.channel,
+                cluster.spec.initial_version or cluster.spec.version,
             ),
             "hypershift": {"enabled": cluster.spec.hypershift},
             "multi_az": cluster.spec.multi_az,

--- a/reconcile/utils/ocm/products.py
+++ b/reconcile/utils/ocm/products.py
@@ -59,6 +59,19 @@ SPEC_ATTR_PATH = "path"
 BYTES_IN_GIGABYTE = 1024**3
 DEFAULT_OCM_MACHINE_POOL_ID = "worker"
 
+
+def build_ystream_channel(channel_group: str, version: str) -> str:
+    """Build the OCM Y-stream ``channel`` field value.
+
+    OCM deprecated the ``version.channel_group`` request field in favour of the
+    top-level ``channel`` field, which must be in Y-stream format
+    (e.g. ``stable-4.16``, ``eus-4.16``). App-interface only stores the plain
+    channel group (e.g. ``stable``), so combine it with the cluster version's
+    major.minor to produce the value OCM expects.
+    """
+    major_minor = ".".join(version.split(".")[:2])
+    return f"{channel_group}-{major_minor}"
+
 OCM_PRODUCT_OSD = "osd"
 OCM_PRODUCT_ROSA = "rosa"
 OCM_PRODUCT_HYPERSHIFT = "hypershift"
@@ -89,6 +102,7 @@ class OCMProduct:
         ocm: OCMBaseClient,
         cluster_id: str,
         update_spec: Mapping[str, Any],
+        version: str,
         dry_run: bool,
     ) -> None:
         pass
@@ -142,9 +156,10 @@ class OCMProductOsd(OCMProduct):
         ocm: OCMBaseClient,
         cluster_id: str,
         update_spec: Mapping[str, Any],
+        version: str,
         dry_run: bool,
     ) -> None:
-        ocm_spec = self._get_update_cluster_spec(update_spec)
+        ocm_spec = self._get_update_cluster_spec(update_spec, version)
         api = f"{CS_API_BASE}/v1/clusters/{cluster_id}"
         params: dict[str, Any] = {}
         if dry_run:
@@ -242,8 +257,10 @@ class OCMProductOsd(OCMProduct):
             "region": {"id": cluster.spec.region},
             "version": {
                 "id": f"openshift-v{cluster.spec.initial_version}",
-                "channel_group": cluster.spec.channel,
             },
+            "channel": build_ystream_channel(
+                cluster.spec.channel, cluster.spec.initial_version or cluster.spec.version
+            ),
             "multi_az": cluster.spec.multi_az,
             "nodes": self._get_nodes_spec(cluster),
             "network": {
@@ -279,7 +296,7 @@ class OCMProductOsd(OCMProduct):
         return ocm_spec
 
     def _get_update_cluster_spec(
-        self, update_spec: Mapping[str, Any]
+        self, update_spec: Mapping[str, Any], version: str
     ) -> dict[str, Any]:
         ocm_spec: dict[str, Any] = {}
 
@@ -297,7 +314,7 @@ class OCMProductOsd(OCMProduct):
 
         channel = update_spec.get("channel")
         if channel is not None:
-            ocm_spec["version"] = {"channel_group": channel}
+            ocm_spec["channel"] = build_ystream_channel(channel, version)
 
         disable_uwm = update_spec.get("disable_user_workload_monitoring")
         if disable_uwm is not None:
@@ -367,9 +384,10 @@ class OCMProductRosa(OCMProduct):
         ocm: OCMBaseClient,
         cluster_id: str,
         update_spec: Mapping[str, Any],
+        version: str,
         dry_run: bool,
     ) -> None:
-        ocm_spec = self._get_update_cluster_spec(update_spec)
+        ocm_spec = self._get_update_cluster_spec(update_spec, version)
         api = f"{CS_API_BASE}/v1/clusters/{cluster_id}"
         params: dict[str, Any] = {}
         if dry_run:
@@ -500,8 +518,10 @@ class OCMProductRosa(OCMProduct):
             "region": {"id": cluster.spec.region},
             "version": {
                 "id": f"openshift-v{cluster.spec.initial_version}",
-                "channel_group": cluster.spec.channel,
             },
+            "channel": build_ystream_channel(
+                cluster.spec.channel, cluster.spec.initial_version or cluster.spec.version
+            ),
             "hypershift": {"enabled": cluster.spec.hypershift},
             "multi_az": cluster.spec.multi_az,
             "nodes": self._get_nodes_spec(cluster),
@@ -566,13 +586,13 @@ class OCMProductRosa(OCMProduct):
         return ocm_spec
 
     def _get_update_cluster_spec(
-        self, update_spec: Mapping[str, Any]
+        self, update_spec: Mapping[str, Any], version: str
     ) -> dict[str, Any]:
         ocm_spec: dict[str, Any] = {}
 
         channel = update_spec.get(SPEC_ATTR_CHANNEL)
         if channel is not None:
-            ocm_spec["version"] = {"channel_group": channel}
+            ocm_spec["channel"] = build_ystream_channel(channel, version)
 
         disable_uwm = update_spec.get(SPEC_ATTR_DISABLE_UWM)
         if disable_uwm is not None:
@@ -644,9 +664,10 @@ class OCMProductHypershift(OCMProduct):
         ocm: OCMBaseClient,
         cluster_id: str,
         update_spec: Mapping[str, Any],
+        version: str,
         dry_run: bool,
     ) -> None:
-        ocm_spec = self._get_update_cluster_spec(update_spec)
+        ocm_spec = self._get_update_cluster_spec(update_spec, version)
         api = f"{CS_API_BASE}/v1/clusters/{cluster_id}"
         params: dict[str, Any] = {}
         if dry_run:
@@ -728,7 +749,7 @@ class OCMProductHypershift(OCMProduct):
         return ocm_spec
 
     def _get_update_cluster_spec(
-        self, update_spec: Mapping[str, Any]
+        self, update_spec: Mapping[str, Any], version: str
     ) -> dict[str, Any]:
         ocm_spec: dict[str, Any] = {}
 

--- a/reconcile/utils/rosa/session.py
+++ b/reconcile/utils/rosa/session.py
@@ -10,6 +10,7 @@ from pydantic import BaseModel
 from reconcile.utils.constants import PROJ_ROOT
 from reconcile.utils.jobcontroller.controller import K8sJobController
 from reconcile.utils.jobcontroller.models import JobConcurrencyPolicy, JobStatus
+from reconcile.utils.ocm.products import build_ystream_channel
 from reconcile.utils.rosa.rosa_cli import (
     LogHandle,
     RosaCliError,
@@ -219,4 +220,8 @@ def generate_rosa_creation_script(
         cluster_name=cluster_name,
         cluster=cluster,
         dry_run=dry_run,
+        channel=build_ystream_channel(
+            cluster.spec.channel,
+            cluster.spec.initial_version or cluster.spec.version,
+        ),
     )


### PR DESCRIPTION
## Problem

[APPSRE-15073](https://redhat.atlassian.net/browse/APPSRE-15073)

The `ocm-clusters` integration sends the deprecated OCM API field `version.channel_group`. OCM warns and instructs callers to use the top-level `channel` field instead for Y-stream version selection. Observed during `scilwp01ue1` cluster creation (APPSRE-14985):

```
[ocm-clusters] WARNING: You are using OCM API fields that have been deprecated -
version.channel_group: The 'version.channel_group' field will be deprecated in the
future. Please use 'channel' instead for Y-stream version selection.
```

## Investigation

Verified against `uhc-clusters-service`:
- The warning fires **only on writes** that send `version.channel_group`. Read responses still return it.
- The replacement `channel` field must be **Y-stream format** (regex-validated, e.g. `stable-4.16`), and is mutually exclusive with `version.channel_group`.
- app-interface only stores the plain channel group (e.g. `stable`), so the Y-stream value is built from the group + the cluster version's major.minor.

The actual ROSA create path is the **rosa CLI** invocation (Jinja templates), not the JSON builder — the `rosa create cluster` command passed `--channel-group`. The rosa CLI exposes a `--channel` flag (Y-stream) as the replacement.

## Changes

**Write paths** (source of the warning):
- `rosa-classic` + `rosa-hcp` creation templates: `--channel-group <group>` → `--channel <group>-<major.minor>` (real ROSA create path).
- OSD create (JSON POST) and OSD/ROSA update (JSON PATCH): send top-level `channel`; current cluster version threaded through `update_cluster` to build the Y-stream value on updates.
- New `build_ystream_channel()` helper (single source of truth for the format).

**Read paths**: intentionally left on `version.channel_group` — OCM still returns it, it holds the plain group that `OCMClusterSpec.channel` expects, and the deprecation only affects writes.

## Testing

- `reconcile/test/test_ocm_clusters.py` + `reconcile/test/utils/rosa/` — 51 pass.
- POST/PATCH JSON fixtures and all rosa creation-script fixtures updated to the Y-stream `channel` output.
- `mypy` (strict) + `ruff` clean.

## Out of scope

`rosa upgrade account-roles --channel-group` (`reconcile/utils/rosa/session.py`) is a **different** command flag (account-role upgrade), unrelated to the cluster `version.channel_group` field. Newer rosa CLI no longer exposes `--channel-group` there — flagging as a potential latent issue, not addressed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Cluster creation and updates now use version-specific Y-stream channels, such as `stable-4.8` or `candidate-4.8`.
  * Channel values are automatically derived from the configured channel and cluster version.

* **Bug Fixes**
  * Improved channel handling for ROSA classic, ROSA HCP, and OSD cluster operations.
  * Updated dry-run and cluster configuration outputs to reflect the correct channel format.

* **Tests**
  * Added coverage to verify channel formatting across supported cluster types and update scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->