### PR TITLE
fix(aws_api): stop fetching resolved support cases in get_support_cases

### DIFF
--- a/reconcile/test/utils/test_aws_api.py
+++ b/reconcile/test/utils/test_aws_api.py
@@ -102,6 +102,57 @@ def test_default_region(aws_api: AWSApi, accounts: list[dict]) -> None:
         assert aws_api.sessions[a["name"]].region_name == a["resourcesDefaultRegion"]
 
 
+def test_get_support_cases_excludes_resolved_and_paginates(
+    aws_api: AWSApi, mocker: MockerFixture
+) -> None:
+    aws_api.accounts = {
+        "some-account": {
+            "name": "some-account",
+            "premiumSupport": True,
+            "partition": "aws",
+        }
+    }
+    aws_api.sessions = {"some-account": mocker.MagicMock()}
+
+    mock_support_client = mocker.MagicMock()
+    mock_paginator = mocker.MagicMock()
+    mock_paginator.paginate.return_value = [
+        {"cases": [{"caseId": "case-1"}]},
+        {"cases": [{"caseId": "case-2"}]},
+    ]
+    mock_support_client.get_paginator.return_value = mock_paginator
+    mocker.patch.object(aws_api, "get_session_client", return_value=mock_support_client)
+
+    result = aws_api.get_support_cases()
+
+    # both pages are flattened into a single list - confirms pagination
+    # is actually followed, not just the first page
+    assert result == {"some-account": [{"caseId": "case-1"}, {"caseId": "case-2"}]}
+    mock_support_client.get_paginator.assert_called_once_with("describe_cases")
+    mock_paginator.paginate.assert_called_once_with(
+        includeResolvedCases=False, includeCommunications=True
+    )
+
+
+def test_get_support_cases_skips_non_premium_support_accounts(
+    aws_api: AWSApi, mocker: MockerFixture
+) -> None:
+    aws_api.accounts = {
+        "some-account": {
+            "name": "some-account",
+            "premiumSupport": False,
+            "partition": "aws",
+        }
+    }
+    aws_api.sessions = {"some-account": mocker.MagicMock()}
+    mock_get_session_client = mocker.patch.object(aws_api, "get_session_client")
+
+    result = aws_api.get_support_cases()
+
+    assert result == {}
+    mock_get_session_client.assert_not_called()
+
+
 def test_filter_amis_regex(aws_api: AWSApi) -> None:
     regex = re.compile(r"^match.*$")
     images = [

--- a/reconcile/utils/aws_api.py
+++ b/reconcile/utils/aws_api.py
@@ -649,9 +649,17 @@ class AWSApi:
             )
             try:
                 support = self.get_session_client(s, "support", support_region)
-                support_cases = support.describe_cases(
-                    includeResolvedCases=True, includeCommunications=True
-                )["cases"]
+                support_cases = list(
+                    self.paginate(
+                        support,
+                        "describe_cases",
+                        "cases",
+                        params={
+                            "includeResolvedCases": False,
+                            "includeCommunications": True,
+                        },
+                    )
+                )
                 all_support_cases[account] = support_cases
             except Exception as e:
                 msg = "[{}] error getting support cases. details: {}"

--- a/reconcile/utils/aws_api.py
+++ b/reconcile/utils/aws_api.py
@@ -473,7 +473,7 @@ class AWSApi:
     @staticmethod
     def paginate(
         client: BaseClient, method: str, key: str, params: Mapping | None = None
-    ) -> Iterable:
+    ) -> list:
         """paginate returns an aggregated list of the specified key
         from all pages returned by executing the client's specified method."""
         if params is None:
@@ -649,16 +649,14 @@ class AWSApi:
             )
             try:
                 support = self.get_session_client(s, "support", support_region)
-                support_cases = list(
-                    self.paginate(
-                        support,
-                        "describe_cases",
-                        "cases",
-                        params={
-                            "includeResolvedCases": False,
-                            "includeCommunications": True,
-                        },
-                    )
+                support_cases = self.paginate(
+                    support,
+                    "describe_cases",
+                    "cases",
+                    params={
+                        "includeResolvedCases": False,
+                        "includeCommunications": True,
+                    },
                 )
                 all_support_cases[account] = support_cases
             except Exception as e:


### PR DESCRIPTION
## Summary

`AWSApi.get_support_cases()` was calling `describe_cases(includeResolvedCases=True, includeCommunications=True)` once per premium-support AWS account, with no pagination — grabbing only the first page via `["cases"]` directly instead of following `nextToken`.

This integration ([`aws-support-cases-sos`](reconcile/aws_support_cases_sos.py)) only exists to detect AWS's automated "we found your leaked access key" notification, which only ever appears on **newly opened** cases. Pulling every historical resolved case (with full communication thread bodies) across every premium-support account was unnecessary, and that dataset only grows over time as more accounts and case history accumulate.

In production this was causing `qontract-reconcile-aws-support-cases-sos` to OOM every ~6 minutes even at a 2Gi memory limit (73 restarts over 9h when we caught it).

## Changes
- Use the existing `paginate()` helper (follows `nextToken` via the `DescribeCases` boto3 paginator) instead of a single unpaginated call
- Set `includeResolvedCases=False` — only open cases are relevant to this integration's purpose
- Added test coverage for `get_support_cases` (previously had none): confirms pagination is followed across multiple pages, confirms non-premium-support accounts are skipped, confirms `includeResolvedCases=False` is passed through

## Test plan
- [x] `uv run pytest reconcile/test/utils/test_aws_api.py reconcile/test/test_aws_support_cases_sos.py` — 31 passed
- [x] `uv run mypy reconcile/utils/aws_api.py` — no issues
- [x] `ruff check` / `ruff format --check` — clean
- [ ] Confirm OOM restarts stop in app-interface-production/stage after this deploys

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Support case retrieval now excludes resolved cases.
  - Paginated support case results are consistently combined.
  - Accounts without premium support are skipped without creating unnecessary service clients.

- **Tests**
  - Added coverage for pagination, filtering resolved cases, required request parameters, and unsupported accounts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->