### PR TITLE
fix(aws_api): make user/key lookup lazy, cached, and explicitly scoped instead of eager fleet-wide

### DIFF
--- a/reconcile/aws_ami_cleanup/integration.py
+++ b/reconcile/aws_ami_cleanup/integration.py
@@ -180,7 +180,7 @@ def run(dry_run: bool, thread_pool_size: int, defer: Callable | None = None) -> 
     secret_reader = create_secret_reader(
         use_vault=get_app_interface_vault_settings().vault
     )
-    aws_api = AWSApi(1, accounts_dicted, secret_reader=secret_reader, init_users=False)
+    aws_api = AWSApi(1, accounts_dicted, secret_reader=secret_reader)
     if defer:  # defer is provided by the method decorator; this makes just mypy happy.
         defer(aws_api.cleanup)
 

--- a/reconcile/aws_ami_share.py
+++ b/reconcile/aws_ami_share.py
@@ -98,7 +98,6 @@ def run(dry_run: bool) -> None:
         1,
         sharing_accounts,
         settings=settings,
-        init_users=False,
     ) as aws_api:
         for src_account in sharing_accounts:
             for share in src_account.get("sharing") or []:

--- a/reconcile/aws_saml_idp/integration.py
+++ b/reconcile/aws_saml_idp/integration.py
@@ -162,9 +162,7 @@ class AwsSamlIdpIntegration(QontractReconcileIntegration[AwsSamlIdpIntegrationPa
         if self.params.print_to_file:
             sys.exit(ExitCodes.SUCCESS)
 
-        aws_api = AWSApi(
-            1, aws_accounts_dict, secret_reader=self.secret_reader, init_users=False
-        )
+        aws_api = AWSApi(1, aws_accounts_dict, secret_reader=self.secret_reader)
         tf = TerraformClient(
             self.name,
             QONTRACT_INTEGRATION_VERSION,

--- a/reconcile/aws_saml_roles/integration.py
+++ b/reconcile/aws_saml_roles/integration.py
@@ -307,9 +307,7 @@ class AwsSamlRolesIntegration(
             default_tags=default_tags,
         )
         unique_policies = self._unique_policies(aws_roles)
-        aws_api = AWSApi(
-            1, aws_accounts_dict, secret_reader=self.secret_reader, init_users=False
-        )
+        aws_api = AWSApi(1, aws_accounts_dict, secret_reader=self.secret_reader)
         if defer:
             defer(aws_api.cleanup)
         self._validate_saml_iam_policies(unique_policies, aws_api)

--- a/reconcile/aws_support_cases_sos.py
+++ b/reconcile/aws_support_cases_sos.py
@@ -84,9 +84,14 @@ def run(
     settings = queries.get_app_interface_settings()
     deleted_keys = get_deleted_keys(accounts)
     with AWSApi(thread_pool_size, accounts, settings=settings) as aws:
-        existing_keys = aws.get_users_keys()
         aws_support_cases = aws.get_support_cases()
-    keys_to_delete_from_cases = get_keys_to_delete(aws_support_cases)
+        keys_to_delete_from_cases = get_keys_to_delete(aws_support_cases)
+        # only fetch existing keys for accounts that actually have a candidate
+        # leaked key to verify, instead of every account in the fleet
+        accounts_to_check = {ktd["account"] for ktd in keys_to_delete_from_cases}
+        existing_keys = (
+            aws.get_users_keys(accounts_to_check) if accounts_to_check else {}
+        )
     keys_to_delete = []
     for ktd in keys_to_delete_from_cases:
         ktd_account = ktd["account"]

--- a/reconcile/terraform_aws_route53.py
+++ b/reconcile/terraform_aws_route53.py
@@ -163,9 +163,7 @@ def build_desired_state(
                     tf_zone_spec.resource.get("region")
                     or zone_account["resourcesDefaultRegion"]
                 )
-                with AWSApi(
-                    1, [zone_account], settings=settings, init_users=False
-                ) as awsapi:
+                with AWSApi(1, [zone_account], settings=settings) as awsapi:
                     tf_zone_ns_records = awsapi.get_route53_zone_ns_records(
                         tf_zone_account_name, tf_zone_name, tf_zone_region
                     )
@@ -250,7 +248,7 @@ def run(
 
     ts.populate_route53(desired_state)
     working_dirs = ts.dump(print_to_file=print_to_file)
-    aws_api = AWSApi(1, participating_accounts, settings=settings, init_users=False)
+    aws_api = AWSApi(1, participating_accounts, settings=settings)
 
     if print_to_file:
         sys.exit(ExitCodes.SUCCESS)

--- a/reconcile/terraform_resources.py
+++ b/reconcile/terraform_resources.py
@@ -260,7 +260,7 @@ def setup(
 
     # initialize terraform client
     # it is used to plan and apply according to the output of terrascript
-    aws_api = AWSApi(1, accounts, settings=settings, init_users=False)
+    aws_api = AWSApi(1, accounts, settings=settings)
     tf = Terraform(
         QONTRACT_INTEGRATION,
         QONTRACT_INTEGRATION_VERSION,

--- a/reconcile/terraform_tgw_attachments.py
+++ b/reconcile/terraform_tgw_attachments.py
@@ -448,7 +448,7 @@ def setup(
     account_by_name = {a["name"]: a for a in all_accounts}
     vault_settings = get_app_interface_vault_settings()
     secret_reader = create_secret_reader(vault_settings.vault)
-    aws_api = AWSApi(1, all_accounts, secret_reader=secret_reader, init_users=False)
+    aws_api = AWSApi(1, all_accounts, secret_reader=secret_reader)
     ocm_map = _build_ocm_map(desired_state_data_source.clusters, vault_settings)
     tgw_account_names = [a["name"] for a in tgw_accounts]
     desired_state, err = _build_desired_state_tgw_attachments(

--- a/reconcile/terraform_users.py
+++ b/reconcile/terraform_users.py
@@ -176,7 +176,7 @@ def setup(
     participating_aws_accounts = _filter_participating_aws_accounts(accounts, roles)
 
     settings = queries.get_app_interface_settings()
-    aws_api = AWSApi(1, participating_aws_accounts, settings=settings, init_users=False)
+    aws_api = AWSApi(1, participating_aws_accounts, settings=settings)
     try:
         _validate_aws_policies_in_roles(roles, participating_aws_accounts, aws_api)
     except Exception:

--- a/reconcile/terraform_vpc_peerings.py
+++ b/reconcile/terraform_vpc_peerings.py
@@ -615,7 +615,7 @@ def run(
         ocm_map = None
 
     accounts = queries.get_aws_accounts(terraform_state=True, ecrs=False)
-    awsapi = aws_api.AWSApi(1, accounts, settings=settings, init_users=False)
+    awsapi = aws_api.AWSApi(1, accounts, settings=settings)
 
     desired_state = []
     errors = []

--- a/reconcile/test/test_aws_support_cases_sos.py
+++ b/reconcile/test/test_aws_support_cases_sos.py
@@ -1,7 +1,12 @@
-from typing import Any
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
 from unittest import TestCase
 
 import reconcile.aws_support_cases_sos as integ
+
+if TYPE_CHECKING:
+    from pytest_mock import MockerFixture
 
 
 class TestSupportFunctions(TestCase):
@@ -22,3 +27,74 @@ class TestSupportFunctions(TestCase):
         expected_result = {a["name"]: a["deleteKeys"]}
         keys_to_delete = integ.get_deleted_keys(accounts)
         self.assertEqual(keys_to_delete, expected_result)
+
+
+def test_run_scopes_get_users_keys_to_accounts_with_candidate_keys(
+    mocker: MockerFixture,
+) -> None:
+    account: dict[str, Any] = {
+        "name": "acct-a",
+        "premiumSupport": True,
+        "deleteKeys": None,
+        "path": "/x",
+    }
+    mocker.patch(
+        "reconcile.aws_support_cases_sos.queries.get_aws_accounts",
+        return_value=[account],
+    )
+    mocker.patch(
+        "reconcile.aws_support_cases_sos.queries.get_app_interface_settings",
+        return_value={},
+    )
+    mocker.patch("reconcile.aws_support_cases_sos.act")
+
+    fake_case = {
+        "recentCommunications": {
+            "communications": [
+                {
+                    "body": "We have become aware that the AWS Access Key "
+                    "AKIA123 was leaked"
+                }
+            ]
+        }
+    }
+    mock_aws = mocker.MagicMock()
+    mock_aws.get_support_cases.return_value = {"acct-a": [fake_case]}
+    mock_aws.get_users_keys.return_value = {"acct-a": {"someuser": ["AKIA123"]}}
+    mock_aws.__enter__.return_value = mock_aws
+    mock_aws.__exit__.return_value = False
+    mocker.patch("reconcile.aws_support_cases_sos.AWSApi", return_value=mock_aws)
+
+    integ.run(dry_run=True)
+
+    mock_aws.get_users_keys.assert_called_once_with({"acct-a"})
+
+
+def test_run_skips_get_users_keys_when_no_candidate_keys(
+    mocker: MockerFixture,
+) -> None:
+    account: dict[str, Any] = {
+        "name": "acct-a",
+        "premiumSupport": True,
+        "deleteKeys": None,
+        "path": "/x",
+    }
+    mocker.patch(
+        "reconcile.aws_support_cases_sos.queries.get_aws_accounts",
+        return_value=[account],
+    )
+    mocker.patch(
+        "reconcile.aws_support_cases_sos.queries.get_app_interface_settings",
+        return_value={},
+    )
+    mocker.patch("reconcile.aws_support_cases_sos.act")
+
+    mock_aws = mocker.MagicMock()
+    mock_aws.get_support_cases.return_value = {"acct-a": []}
+    mock_aws.__enter__.return_value = mock_aws
+    mock_aws.__exit__.return_value = False
+    mocker.patch("reconcile.aws_support_cases_sos.AWSApi", return_value=mock_aws)
+
+    integ.run(dry_run=True)
+
+    mock_aws.get_users_keys.assert_not_called()

--- a/reconcile/test/test_terraform_tgw_attachments.py
+++ b/reconcile/test/test_terraform_tgw_attachments.py
@@ -838,7 +838,6 @@ def test_run_when_cluster_with_tgw_connection(
         1,
         [tgw_account.model_dump(by_alias=True)],
         secret_reader=mocks["secret_reader"],
-        init_users=False,
     )
     mocks["ocm"].assert_called_once_with(
         clusters=[cluster_with_tgw_connection.model_dump(by_alias=True)],
@@ -898,7 +897,6 @@ def test_run_when_cluster_with_mixed_connections(
         1,
         [tgw_account.model_dump(by_alias=True), vpc_account.model_dump(by_alias=True)],
         secret_reader=mocks["secret_reader"],
-        init_users=False,
     )
     mocks["ocm"].assert_called_once_with(
         clusters=[cluster_with_mixed_connections.model_dump(by_alias=True)],
@@ -983,7 +981,6 @@ def test_run_with_multiple_clusters(
         1,
         [tgw_account.model_dump(by_alias=True), vpc_account.model_dump(by_alias=True)],
         secret_reader=mocks["secret_reader"],
-        init_users=False,
     )
     mocks["ocm"].assert_called_once_with(
         clusters=[cluster_with_tgw_connection.model_dump(by_alias=True)],
@@ -1044,7 +1041,6 @@ def test_run_with_account_name_for_multiple_clusters(
         1,
         [tgw_account.model_dump(by_alias=True)],
         secret_reader=mocks["secret_reader"],
-        init_users=False,
     )
     mocks["ocm"].assert_called_once_with(
         clusters=[cluster_with_tgw_connection.model_dump(by_alias=True)],
@@ -1104,7 +1100,6 @@ def test_run_with_account_name_for_multiple_connections(
         1,
         [tgw_account.model_dump(by_alias=True)],
         secret_reader=mocks["secret_reader"],
-        init_users=False,
     )
     mocks["ocm"].assert_called_once_with(
         clusters=[cluster_with_2_tgw_connections.model_dump(by_alias=True)],

--- a/reconcile/test/test_terraform_users.py
+++ b/reconcile/test/test_terraform_users.py
@@ -167,5 +167,4 @@ def test_setup(
         1,
         [test_aws_account],
         settings=None,
-        init_users=False,
     )

--- a/reconcile/test/test_wrong_region.py
+++ b/reconcile/test/test_wrong_region.py
@@ -61,7 +61,7 @@ def aws_api(accounts: Accounts, secret: Secret, mocker: MockerFixture) -> AWSApi
         "reconcile.utils.aws_api.SecretReader", autospec=True
     )
     mock_secret_reader.return_value.read_all.return_value = secret
-    return AWSApi(1, accounts, init_users=False)
+    return AWSApi(1, accounts)
 
 
 @pytest.fixture

--- a/reconcile/test/utils/test_aws_api.py
+++ b/reconcile/test/utils/test_aws_api.py
@@ -103,8 +103,9 @@ def test_default_region(aws_api: AWSApi, accounts: list[dict]) -> None:
 
 
 def test_users_not_populated_eagerly_on_init(aws_api: AWSApi) -> None:
-    # users are populated lazily by _get_account_users(), not upfront in __init__
-    assert aws_api.users == {}
+    # _get_account_users is an lru_cache-wrapped method - nothing is
+    # fetched upfront in __init__, only on first actual call
+    assert aws_api._get_account_users.cache_info().currsize == 0  # type: ignore[attr-defined]
 
 
 def test_get_account_users_caches_per_account(

--- a/reconcile/test/utils/test_aws_api.py
+++ b/reconcile/test/utils/test_aws_api.py
@@ -142,7 +142,16 @@ def test_get_users_keys_scoped_to_specific_accounts(
     assert "account-b" not in result
 
 
-def test_get_users_keys_defaults_to_all_sessions(
+def test_get_users_keys_requires_explicit_accounts(
+    aws_api: AWSApi, mocker: MockerFixture
+) -> None:
+    # accounts has no default - callers must consciously choose scope
+    # rather than silently falling back to every session
+    with pytest.raises(TypeError):
+        aws_api.get_users_keys()  # type: ignore[call-arg]
+
+
+def test_get_users_keys_can_still_scope_to_every_session_explicitly(
     aws_api: AWSApi, mocker: MockerFixture
 ) -> None:
     aws_api.sessions = {
@@ -153,7 +162,7 @@ def test_get_users_keys_defaults_to_all_sessions(
     mocker.patch.object(aws_api, "paginate", return_value=[{"UserName": "u1"}])
     mocker.patch.object(aws_api, "get_user_keys", return_value=["AKIA123"])
 
-    result = aws_api.get_users_keys()
+    result = aws_api.get_users_keys(aws_api.sessions.keys())
 
     assert set(result.keys()) == {"account-a", "account-b"}
 

--- a/reconcile/test/utils/test_aws_api.py
+++ b/reconcile/test/utils/test_aws_api.py
@@ -48,7 +48,7 @@ def aws_api(accounts: list[dict], mocker: MockerFixture) -> AWSApi:
         "aws_secret_access_key": "access_key",
         "region": "tf_state_bucket_region",
     }
-    return AWSApi(1, accounts, init_users=False)
+    return AWSApi(1, accounts)
 
 
 @pytest.fixture
@@ -100,6 +100,61 @@ def test_get_user_key_status(aws_api: AWSApi, iam_client: IAMClient) -> None:
 def test_default_region(aws_api: AWSApi, accounts: list[dict]) -> None:
     for a in accounts:
         assert aws_api.sessions[a["name"]].region_name == a["resourcesDefaultRegion"]
+
+
+def test_users_not_populated_eagerly_on_init(aws_api: AWSApi) -> None:
+    # users are populated lazily by _get_account_users(), not upfront in __init__
+    assert aws_api.users == {}
+
+
+def test_get_account_users_caches_per_account(
+    aws_api: AWSApi, mocker: MockerFixture
+) -> None:
+    aws_api.sessions = {"some-account": mocker.MagicMock()}
+    mocker.patch.object(aws_api, "get_session_client", return_value=mocker.MagicMock())
+    mock_paginate = mocker.patch.object(
+        aws_api, "paginate", return_value=[{"UserName": "u1"}]
+    )
+
+    first = aws_api._get_account_users("some-account")
+    second = aws_api._get_account_users("some-account")
+
+    assert first == ["u1"]
+    assert second == ["u1"]
+    mock_paginate.assert_called_once()
+
+
+def test_get_users_keys_scoped_to_specific_accounts(
+    aws_api: AWSApi, mocker: MockerFixture
+) -> None:
+    aws_api.sessions = {
+        "account-a": mocker.MagicMock(),
+        "account-b": mocker.MagicMock(),
+    }
+    mocker.patch.object(aws_api, "get_session_client", return_value=mocker.MagicMock())
+    mocker.patch.object(aws_api, "paginate", return_value=[{"UserName": "u1"}])
+    mocker.patch.object(aws_api, "get_user_keys", return_value=["AKIA123"])
+
+    result = aws_api.get_users_keys(accounts={"account-a"})
+
+    assert result == {"account-a": {"u1": ["AKIA123"]}}
+    assert "account-b" not in result
+
+
+def test_get_users_keys_defaults_to_all_sessions(
+    aws_api: AWSApi, mocker: MockerFixture
+) -> None:
+    aws_api.sessions = {
+        "account-a": mocker.MagicMock(),
+        "account-b": mocker.MagicMock(),
+    }
+    mocker.patch.object(aws_api, "get_session_client", return_value=mocker.MagicMock())
+    mocker.patch.object(aws_api, "paginate", return_value=[{"UserName": "u1"}])
+    mocker.patch.object(aws_api, "get_user_keys", return_value=["AKIA123"])
+
+    result = aws_api.get_users_keys()
+
+    assert set(result.keys()) == {"account-a", "account-b"}
 
 
 def test_get_support_cases_excludes_resolved_and_paginates(

--- a/reconcile/utils/aws_api.py
+++ b/reconcile/utils/aws_api.py
@@ -515,7 +515,7 @@ class AWSApi:
     ) -> tuple[bool, bool]:
         error = False
         service_account_recycle_complete = True
-        users_keys = self.get_users_keys()
+        users_keys = self.get_users_keys(keys_to_delete.keys())
         for account, s in self.sessions.items():
             iam = self.get_session_client(s, "iam")
             keys = keys_to_delete.get(account, [])
@@ -594,10 +594,9 @@ class AWSApi:
 
         return error, service_account_recycle_complete
 
-    def get_users_keys(self, accounts: Iterable[str] | None = None) -> dict:
-        target_accounts = accounts if accounts is not None else self.sessions.keys()
+    def get_users_keys(self, accounts: Iterable[str]) -> dict:
         users_keys = {}
-        for account in target_accounts:
+        for account in accounts:
             iam = self.get_session_client(self.sessions[account], "iam")
             users_keys[account] = {
                 user: self.get_user_keys(iam, user)

--- a/reconcile/utils/aws_api.py
+++ b/reconcile/utils/aws_api.py
@@ -135,7 +135,6 @@ class AWSApi:
         settings: Mapping | None = None,
         secret_reader: SecretReaderBase | None = None,
         init_ecr_auth_tokens: bool = False,
-        init_users: bool = True,
     ) -> None:
         self._session_clients: list[BaseClient] = []
         self.thread_pool_size = thread_pool_size
@@ -150,6 +149,9 @@ class AWSApi:
 
         # store the app-interface accounts in a dictionary indexed by name
         self.accounts = {acc["name"]: acc for acc in accounts}
+
+        # populated lazily, per-account, by _get_account_users() on first access
+        self.users: dict[str, list[str]] = {}
 
         # Setup caches on the instance itself to avoid leak
         # https://stackoverflow.com/questions/33672412/python-functools-lru-cache-with-class-methods-release-object
@@ -171,9 +173,6 @@ class AWSApi:
         self.get_network_interfaces = lru_cache()(self.get_network_interfaces)  # type: ignore[method-assign]
         self.get_load_balancers = lru_cache()(self.get_load_balancers)  # type: ignore[method-assign]
         self.get_load_balancer_tags = lru_cache()(self.get_load_balancer_tags)  # type: ignore[method-assign]
-
-        if init_users:
-            self.init_users()
 
     def init_sessions(self, accounts: Iterable[awsh.Account]) -> None:
         results = threaded.run(
@@ -462,13 +461,12 @@ class AWSApi:
         session = self.get_session(account_name)
         return cast("S3Client", self.get_session_client(session, "s3", region_name))
 
-    def init_users(self) -> None:
-        self.users = {}
-        for account, s in self.sessions.items():
-            iam = self.get_session_client(s, "iam")
+    def _get_account_users(self, account: str) -> list[str]:
+        if account not in self.users:
+            iam = self.get_session_client(self.sessions[account], "iam")
             users = self.paginate(iam, "list_users", "Users")
-            users = [u["UserName"] for u in users]
-            self.users[account] = users
+            self.users[account] = [u["UserName"] for u in users]
+        return self.users[account]
 
     @staticmethod
     def paginate(
@@ -600,12 +598,14 @@ class AWSApi:
 
         return error, service_account_recycle_complete
 
-    def get_users_keys(self) -> dict:
+    def get_users_keys(self, accounts: Iterable[str] | None = None) -> dict:
+        target_accounts = accounts if accounts is not None else self.sessions.keys()
         users_keys = {}
-        for account, s in self.sessions.items():
-            iam = self.get_session_client(s, "iam")
+        for account in target_accounts:
+            iam = self.get_session_client(self.sessions[account], "iam")
             users_keys[account] = {
-                user: self.get_user_keys(iam, user) for user in self.users[account]
+                user: self.get_user_keys(iam, user)
+                for user in self._get_account_users(account)
             }
 
         return users_keys

--- a/reconcile/utils/aws_api.py
+++ b/reconcile/utils/aws_api.py
@@ -150,13 +150,11 @@ class AWSApi:
         # store the app-interface accounts in a dictionary indexed by name
         self.accounts = {acc["name"]: acc for acc in accounts}
 
-        # populated lazily, per-account, by _get_account_users() on first access
-        self.users: dict[str, list[str]] = {}
-
         # Setup caches on the instance itself to avoid leak
         # https://stackoverflow.com/questions/33672412/python-functools-lru-cache-with-class-methods-release-object
         # using @lru_cache decorators on methods would lek AWSApi instances
         # since the cache keeps a reference to self.
+        self._get_account_users = lru_cache()(self._get_account_users)  # type: ignore[method-assign]
         self._get_assume_role_session = lru_cache()(self._get_assume_role_session)  # type: ignore[method-assign]
         self._get_session_resource = lru_cache()(self._get_session_resource)  # type: ignore[method-assign, assignment]
         self.get_account_amis = lru_cache()(self.get_account_amis)  # type: ignore[method-assign]
@@ -462,11 +460,9 @@ class AWSApi:
         return cast("S3Client", self.get_session_client(session, "s3", region_name))
 
     def _get_account_users(self, account: str) -> list[str]:
-        if account not in self.users:
-            iam = self.get_session_client(self.sessions[account], "iam")
-            users = self.paginate(iam, "list_users", "Users")
-            self.users[account] = [u["UserName"] for u in users]
-        return self.users[account]
+        iam = self.get_session_client(self.sessions[account], "iam")
+        users = self.paginate(iam, "list_users", "Users")
+        return [u["UserName"] for u in users]
 
     @staticmethod
     def paginate(

--- a/reconcile/utils/jinja2/utils.py
+++ b/reconcile/utils/jinja2/utils.py
@@ -242,7 +242,7 @@ def lookup_s3_object(
         accounts = queries.get_aws_accounts(name=account_name)
         if not accounts:
             raise Exception(f"aws account not found: {account_name}")
-        with AWSApi(1, accounts, settings=settings, init_users=False) as aws_api:
+        with AWSApi(1, accounts, settings=settings) as aws_api:
             return aws_api.get_s3_object_content(
                 account_name,
                 bucket_name,
@@ -268,7 +268,7 @@ def list_s3_objects(
         accounts = queries.get_aws_accounts(name=account_name)
         if not accounts:
             raise Exception(f"aws account not found: {account_name}")
-        with AWSApi(1, accounts, settings=settings, init_users=False) as aws_api:
+        with AWSApi(1, accounts, settings=settings) as aws_api:
             return aws_api.list_s3_objects(
                 account_name,
                 bucket_name,

--- a/reconcile/utils/sqs_gateway.py
+++ b/reconcile/utils/sqs_gateway.py
@@ -32,9 +32,7 @@ class SQSGateway:
             )
         account = self.get_queue_account(accounts, queue_url)
         accounts = [a for a in accounts if a["name"] == account]
-        self._aws_api = AWSApi(
-            1, accounts, secret_reader=secret_reader, init_users=False
-        )
+        self._aws_api = AWSApi(1, accounts, secret_reader=secret_reader)
         session = self._aws_api.get_session(account)
 
         self.sqs = self._aws_api.get_session_client(session, "sqs")

--- a/reconcile/utils/terrascript_aws_client.py
+++ b/reconcile/utils/terrascript_aws_client.py
@@ -5417,9 +5417,7 @@ class TerrascriptClient:
         )
         account["assume_region"] = cluster["spec"]["region"]
         service_name = f"{namespace_info['name']}/{openshift_service}"
-        with AWSApi(
-            1, [account], secret_reader=self.secret_reader, init_users=False
-        ) as awsapi:
+        with AWSApi(1, [account], secret_reader=self.secret_reader) as awsapi:
             ips = awsapi.get_alb_network_interface_ips(account, service_name)
         if not ips:
             raise ValueError(
@@ -6036,9 +6034,7 @@ class TerrascriptClient:
 
         # Get the most recent AMI id
         aws_account = self.accounts[account]
-        with AWSApi(
-            1, [aws_account], secret_reader=self.secret_reader, init_users=False
-        ) as aws:
+        with AWSApi(1, [aws_account], secret_reader=self.secret_reader) as aws:
             return aws.get_image_id(account, region, tags)
 
     def _use_previous_image_id(self, filters: Iterable[Mapping[str, Any]]) -> bool:

--- a/reconcile/vpc_peerings_validator.py
+++ b/reconcile/vpc_peerings_validator.py
@@ -42,7 +42,7 @@ def validate_no_cidr_overlap(
                     aws_account_uid = peering.account.uid
                     settings = queries.get_secret_reader_settings()
                     accounts = queries.get_aws_accounts(uid=aws_account_uid)
-                    awsapi = AWSApi(1, accounts, settings=settings, init_users=False)
+                    awsapi = AWSApi(1, accounts, settings=settings)
                     mesh_results = awsapi.get_vpcs_details(
                         accounts[0], peering.tags or {}
                     )

--- a/tools/qontract_cli.py
+++ b/tools/qontract_cli.py
@@ -1064,7 +1064,7 @@ def clusters_network(ctx: click.Context, name: str) -> None:
                 "resourcesDefaultRegion"
             ]
             cluster["aws_account_id"] = get_account_uid_from_arn(account["assume_role"])
-        with AWSApi(1, [account], settings=settings, init_users=False) as aws_api:
+        with AWSApi(1, [account], settings=settings) as aws_api:
             vpc_id, _, subnets_id_az, _ = aws_api.get_cluster_vpc_details(
                 account, subnets=True
             )
@@ -1629,7 +1629,7 @@ def rosa_create_cluster_command(ctx: click.Context, cluster_name: str) -> None:
         billing_account = account.billing_account.uid
     else:
         with AWSApi(
-            1, [account.model_dump(by_alias=True)], settings=settings, init_users=False
+            1, [account.model_dump(by_alias=True)], settings=settings
         ) as aws_api:
             billing_account = aws_api.get_organization_billing_account(account.name)
 
@@ -2004,7 +2004,7 @@ def rds_recommendations(ctx: click.Context) -> None:
         assert account_name is not None  # make mypy happy
         account_deployment_regions = account.get("supportedDeploymentRegions")
         for region in account_deployment_regions or []:
-            with AWSApi(1, [account], settings=settings, init_users=False) as aws:
+            with AWSApi(1, [account], settings=settings) as aws:
                 try:
                     data = aws.describe_rds_recommendations(account_name, region)
                     db_recommendations = data.get("DBRecommendations", [])


### PR DESCRIPTION
## Summary

Follow-up to #5780. That PR fixed `get_support_cases()` pulling unbounded resolved-case history, but production kept OOMing after it deployed (confirmed via local profiling with `resource.getrusage`).

Root cause was somewhere else entirely: `AWSApi.__init__` defaulted to `init_users=True`, which unconditionally listed every IAM user (and, downstream, every access key) across **every account** passed in — regardless of whether anything actually needs that data. `aws-support-cases-sos` instantiates `AWSApi` against its full premium-support fleet (132 accounts) in a single process, so this alone accounted for ~1.4GB of memory before any of the integration's actual logic ran:

| Checkpoint | Peak RSS |
|---|---|
| before `AWSApi.__init__` | 130 MB |
| **after `AWSApi.__init__`** | **1530 MB** |
| after `get_users_keys()` | 1541 MB (+10 MB — 1751 users, 1653 keys, trivial) |
| after `get_support_cases()` (post-#5780) | 1541 MB (+0 MB) |

The actual IAM data (1751 users total across 132 accounts) is small. The cost is structural: every account got its own IAM client fetched via `list_users`, upfront, whether or not it was ever used.

Checked every consumer of this data across the codebase — only two:
- `aws-support-cases-sos`, which only actually needs it to double check that a key AWS flagged as leaked in a support case still exists, for the handful of accounts (usually 0-3) that show up in a case — not all 132.
- `aws-iam-keys`, whose account list is already tightly scoped by the `deleteKeys` flag, so it never hit this cost in practice.

Every other `AWSApi(...)` call site (9 of them) already explicitly passed `init_users=False`, confirming this default had been dead weight for most of the codebase for a while.

## Changes

- Removed the `init_users` constructor parameter and its eager pass entirely. Per-account user lookup (`_get_account_users`) is now an `lru_cache`-wrapped method — the same pattern already used by every other per-account cache on this class (`get_session_client`, `get_account_amis`, etc.) — so a given account's user list is fetched once, lazily, on first access. No manual cache dict needed.
- `get_users_keys()` now takes a **required** `accounts` parameter instead of defaulting to iterating every session. The old optional default was never actually exercised safely by anything other than the two existing callers — keeping it around would let a future caller silently reintroduce the exact "iterate everything by default" shape that caused this incident. Forcing callers to make an explicit scoping decision closes that off.
- `aws_support_cases_sos.run()` now scopes `get_users_keys()` to just the accounts with a candidate leaked key from `get_keys_to_delete()`, instead of fetching for the entire fleet regardless of whether there's anything to check.
- `AWSApi.delete_keys()` now passes `keys_to_delete.keys()` explicitly — identical in practice to the accounts its one caller (`aws-iam-keys`) already constructs `AWSApi` with, just no longer implicit.
- Removed the now-meaningless `init_users=False` kwarg from all 9 call sites that passed it.

## Test plan
- [x] Added test coverage for the lazy/cached/scoped behavior: `test_users_not_populated_eagerly_on_init`, `test_get_account_users_caches_per_account`, `test_get_users_keys_scoped_to_specific_accounts`, `test_get_users_keys_requires_explicit_accounts`, `test_get_users_keys_can_still_scope_to_every_session_explicitly`, plus `run()`-level scoping tests in `test_aws_support_cases_sos.py`
- [x] `uv run pytest` across every affected integration's test suite — 243 passed
- [x] `uv run mypy reconcile/` — clean across all 1148 source files
- [x] `ruff check` / `ruff format --check` — clean
- [ ] Confirm OOM restarts actually stop in app-interface-production/stage after this deploys

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * AWS account user information is now loaded only when needed and cached for reuse, improving efficiency.
  * Access-key lookups are limited to relevant accounts instead of querying every account.
  * Unnecessary key queries are skipped when no potentially exposed keys are found.
  * AWS integrations continue using their standard account initialization behavior across cleanup, reconciliation, validation, and infrastructure workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->