### PR TITLE
fix(openshift-cluster-bots): gate clusterAdminAutomationTokens on clu…

### DIFF
--- a/reconcile/openshift_cluster_bots.py
+++ b/reconcile/openshift_cluster_bots.py
@@ -563,12 +563,21 @@ def process_entry(
     )
 
 
+def _cluster_admin_entries(cluster: ClusterV1) -> list[AnyTokenEntry]:
+    # clusterAdminAutomationTokens are only processed when the cluster is
+    # authorized for cluster-admin automation, matching the clusterAdmin gate
+    # that create_all_bots enforces for the legacy singular field.
+    if not cluster.cluster_admin:
+        return []
+    return list(cluster.cluster_admin_automation_tokens or [])
+
+
 def process_cluster_entries(
     cluster: ClusterV1, ocm: OCM, config: Config
 ) -> list[EntryResult]:
     entries: list[tuple[AnyTokenEntry, bool]] = [
         (entry, False) for entry in (cluster.automation_tokens or [])
-    ] + [(entry, True) for entry in (cluster.cluster_admin_automation_tokens or [])]
+    ] + [(entry, True) for entry in _cluster_admin_entries(cluster)]
     if not entries:
         return []
 
@@ -702,9 +711,7 @@ def _entry_needs_processing(entry: AnyTokenEntry) -> bool:
 
 
 def cluster_needs_list_processing(cluster: ClusterV1) -> bool:
-    entries = list(cluster.automation_tokens or []) + list(
-        cluster.cluster_admin_automation_tokens or []
-    )
+    entries = list(cluster.automation_tokens or []) + _cluster_admin_entries(cluster)
     return any(_entry_needs_processing(entry) for entry in entries)
 
 

--- a/reconcile/openshift_cluster_bots.py
+++ b/reconcile/openshift_cluster_bots.py
@@ -735,17 +735,16 @@ def filter_clusters(
         if not cluster_is_reachable(cluster):
             continue
 
+        cluster_admin_entries = _cluster_admin_entries(cluster)
         has_list_entries = bool(cluster.automation_tokens) or bool(
-            cluster.cluster_admin_automation_tokens
+            cluster_admin_entries
         )
         if has_list_entries:
             if cluster_needs_list_processing(cluster):
                 list_based.append(cluster)
             elif (
                 not _has_active_token_with_secret(cluster.automation_tokens)
-                and not _has_active_token_with_secret(
-                    cluster.cluster_admin_automation_tokens
-                )
+                and not _has_active_token_with_secret(cluster_admin_entries)
                 and cluster.automation_token is None
                 and cluster.cluster_admin_automation_token is None
             ):

--- a/reconcile/test/test_openshift_cluster_bots.py
+++ b/reconcile/test/test_openshift_cluster_bots.py
@@ -268,8 +268,15 @@ def test_cluster_needs_list_processing(cluster: Callable, secret: dict) -> None:
     assert ocb.cluster_needs_list_processing(
         cluster(automation_tokens=[automation_token_entry(secret=secret, delete=True)])
     )
-    assert ocb.cluster_needs_list_processing(
+    # cluster_admin_automation_tokens are ignored unless clusterAdmin is true
+    assert not ocb.cluster_needs_list_processing(
         cluster(cluster_admin_automation_tokens=[automation_token_entry(secret=None)])
+    )
+    assert ocb.cluster_needs_list_processing(
+        cluster(
+            admin=True,
+            cluster_admin_automation_tokens=[automation_token_entry(secret=None)],
+        )
     )
 
 

--- a/reconcile/test/test_openshift_cluster_bots.py
+++ b/reconcile/test/test_openshift_cluster_bots.py
@@ -292,14 +292,22 @@ def test_filter_clusters_legacy_vs_list(
     list_needs_work = cluster(automation_tokens=[automation_token_entry(secret=None)])
     list_synced = cluster(automation_tokens=[automation_token_entry(secret=secret)])
 
+    # a cluster missing its da token plus a disabled (clusterAdmin=false)
+    # cluster-admin list entry must still be classified as legacy, not
+    # dropped from both buckets because of the unauthorized ca entry
+    legacy_with_disabled_ca_entry = cluster(
+        cluster_admin_automation_tokens=[automation_token_entry(secret=None)],
+    )
+
     legacy_result, list_result = ocb.filter_clusters([
         legacy_needs_work,
         legacy_synced,
         list_needs_work,
         list_synced,
+        legacy_with_disabled_ca_entry,
     ])
 
-    assert legacy_result == [legacy_needs_work]
+    assert legacy_result == [legacy_needs_work, legacy_with_disabled_ca_entry]
     assert list_result == [list_needs_work]
 
 


### PR DESCRIPTION
## Problem

#5754 introduced list-based `automationTokens`/`clusterAdminAutomationTokens` rotation support in `openshift-cluster-bots`, but the new code path never checks `Cluster.clusterAdmin` before processing `clusterAdminAutomationTokens` entries.

The legacy singular-field flow (`create_cluster_bots`/`cluster_misses_bot_tokens`) only creates the cluster-admin bot `if cluster.cluster_admin:`. The new list-based flow (`filter_clusters` → `cluster_needs_list_processing` → `process_cluster_entries`) skips that check entirely — declaring a `clusterAdminAutomationTokens` entry in a cluster's data is, on its own, enough to make the integration create a ServiceAccount **and attach a cluster-admin ClusterRoleBinding**, regardless of whether the cluster was ever authorized (`clusterAdmin: true`) for cluster-admin automation.

Found while migrating the first cluster (`appsret01ue1`) to the new list-based fields — it doesn't have `clusterAdmin: true` set, and would have had a cluster-admin bot silently provisioned anyway.

## Fix

Added `_cluster_admin_entries()`, which returns `cluster.cluster_admin_automation_tokens` only when `cluster.cluster_admin` is `True` (empty list otherwise). Both `process_cluster_entries()` and `cluster_needs_list_processing()` now go through this helper, so:

- `filter_clusters()` no longer flags a cluster for list-based processing solely because of an unauthorized `clusterAdminAutomationTokens` entry.
- `process_cluster_entries()` no longer creates the cluster-admin SA/ClusterRoleBinding for such a cluster.

This restores parity with the legacy flow's authorization gate.

## Testing

- Updated `test_cluster_needs_list_processing` to assert `clusterAdminAutomationTokens` entries are ignored without `clusterAdmin: true`, and processed once it's set.
- `ruff format` / `ruff check` clean.
- Full `test_openshift_cluster_bots.py` suite passes (22 tests).
