### PR TITLE
fix(mr): case-insensitive github_username match when inferring MR author

### DIFF
--- a/reconcile/test/utils/test_mr.py
+++ b/reconcile/test/utils/test_mr.py
@@ -440,3 +440,20 @@ def test_author_github_username(
     assert (
         mr.infer_author(github_user_id=mr.github_user_id, all_users=users) == "org_user"
     )
+
+
+@patch.object(reconcile.typed_queries.smtp, "settings", autospec=True)
+def test_author_github_username_case_insensitive(
+    settings: MagicMock, users: list[User], smtp_settings: SmtpSettingsV1
+) -> None:
+    """app-interface github_username casing may differ from the casing GitHub reports."""
+    mr = PromoteQontractReconcileCommercial(
+        version="1q2w3e4",
+        commit_sha="1q2w3e4r5t6y7u8i9o0p1q2w3e4r5t6y7u8i9o0p",
+        github_user_id="Github_User",
+    )
+    settings.return_value = smtp_settings
+
+    assert (
+        mr.infer_author(github_user_id=mr.github_user_id, all_users=users) == "org_user"
+    )

--- a/reconcile/test/utils/test_mr.py
+++ b/reconcile/test/utils/test_mr.py
@@ -442,17 +442,13 @@ def test_author_github_username(
     )
 
 
-@patch.object(reconcile.typed_queries.smtp, "settings", autospec=True)
-def test_author_github_username_case_insensitive(
-    settings: MagicMock, users: list[User], smtp_settings: SmtpSettingsV1
-) -> None:
+def test_author_github_username_case_insensitive(users: list[User]) -> None:
     """app-interface github_username casing may differ from the casing GitHub reports."""
     mr = PromoteQontractReconcileCommercial(
         version="1q2w3e4",
         commit_sha="1q2w3e4r5t6y7u8i9o0p1q2w3e4r5t6y7u8i9o0p",
         github_user_id="Github_User",
     )
-    settings.return_value = smtp_settings
 
     assert (
         mr.infer_author(github_user_id=mr.github_user_id, all_users=users) == "org_user"

--- a/reconcile/utils/mr/base.py
+++ b/reconcile/utils/mr/base.py
@@ -121,15 +121,11 @@ class MergeRequestBase(ABC):
         if not all_users:
             return None
 
-        user = next(
-            (
-                u
-                for u in all_users
-                if u.github_username.casefold() == github_user_id.casefold()
-            ),
+        target = github_user_id.lower()
+        return next(
+            (u.org_username for u in all_users if u.github_username.lower() == target),
             None,
         )
-        return user.org_username if user else None
 
     def submit_to_sqs(self, sqs_cli: SQSGateway) -> None:
         """

--- a/reconcile/utils/mr/base.py
+++ b/reconcile/utils/mr/base.py
@@ -121,12 +121,15 @@ class MergeRequestBase(ABC):
         if not all_users:
             return None
 
-        users = [u for u in all_users if u.github_username == github_user_id]
-
-        if users:
-            return users[0].org_username
-
-        return None
+        user = next(
+            (
+                u
+                for u in all_users
+                if u.github_username.casefold() == github_user_id.casefold()
+            ),
+            None,
+        )
+        return user.org_username if user else None
 
     def submit_to_sqs(self, sqs_cli: SQSGateway) -> None:
         """


### PR DESCRIPTION
## Summary
- `MergeRequestBase.infer_author` compared `github_username` (as entered in app-interface, e.g. `BumbleFeng`) against the pipeline-supplied `github_user_id` (as GitHub reports it, e.g. `bumblefeng`) with a case-sensitive `==`. On a case mismatch, the lookup silently returned no match, so `promote_qontract_*` MR titles fell back to printing the bare username without an `@` prefix — no GitLab mention, no notification for the author.
- Fixed by comparing with `.lower()` on both sides (consistent with the existing convention in `github_owners_api.py`/`slack_usergroups_api.py`), and simplified the lookup to a single `next(...)` generator that extracts `org_username` directly.

## Test plan
- [x] Added `test_author_github_username_case_insensitive` in `reconcile/test/utils/test_mr.py`, confirmed it failed before the fix and passes after
- [x] `uv run pytest reconcile/test/utils/test_mr.py -v` — 15 passed
- [x] `uv run ruff check` / `ruff format --check` on changed files
- [x] `uv run mypy` on changed files
- [x] Addressed review feedback from hemslo: simplified `infer_author` further, switched `.casefold()` to `.lower()`, removed an unnecessary smtp mock from the new test

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Author inference now matches GitHub usernames regardless of capitalization.
  - Preserves existing behavior when author information or matching users are unavailable.

- **Tests**
  - Added regression coverage for case-insensitive GitHub username matching.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->