### PR TITLE
fix(glhk): eject OMM members on is_rebased 404

### DIFF
--- a/reconcile/gitlab_housekeeping.py
+++ b/reconcile/gitlab_housekeeping.py
@@ -1104,7 +1104,26 @@ def _process_omm_member(
     ]
 
     fresh_mr = gl.get_merge_request(mr.iid)
-    mr_is_rebased = is_rebased(fresh_mr, gl)
+    try:
+        mr_is_rebased = is_rebased(fresh_mr, gl)
+    except gitlab.exceptions.GitlabGetError as e:
+        if e.response_code != 404:
+            raise
+        logging.warning([
+            "omm-group",
+            "ref-not-found",
+            gl.project.name,
+            mr.iid,
+            fresh_mr.sha,
+            str(e),
+        ])
+        if not dry_run:
+            gl.remove_label(mr, OMM_PENDING)
+        optimistic_merge_rejected.labels(
+            project_id=mr.target_project_id,
+            reason="ref_not_found",
+        ).inc()
+        return _MemberResult()
 
     if not pipelines:
         if mr_is_rebased:

--- a/reconcile/test/test_gitlab_housekeeping.py
+++ b/reconcile/test/test_gitlab_housekeeping.py
@@ -3060,6 +3060,56 @@ def test_omm_group_skip_ci_rebase_failure_ejects_member(
     [("abc123", None), (None, "abc123")],
     ids=["merge-commit", "squash-commit"],
 )
+def test_omm_group_ref_not_found_ejects_member(
+    mocker: MockerFixture,
+    merge_sha: str | None,
+    squash_sha: str | None,
+) -> None:
+    """When is_rebased raises GitlabGetError 404 the member is ejected
+    without a rebase attempt and the group can adaptive-close."""
+    _setup_omm_group_mocks(mocker)
+    mocker.patch(
+        "reconcile.gitlab_housekeeping.is_rebased",
+        side_effect=GitlabGetError("404 Ref Not Found", 404),
+    )
+    clear_mock = mocker.patch(
+        "reconcile.gitlab_housekeeping.clear_omm_group",
+    )
+
+    lead = create_autospec(ProjectMergeRequest)
+    lead.merge_commit_sha = merge_sha
+    lead.squash_commit_sha = squash_sha
+    lead.target_branch = "master"
+
+    mr = _make_merge_mr(11, ["approved", "tenant-bar", "omm-pending"])
+
+    mocker.patch(
+        "reconcile.gitlab_housekeeping.get_omm_pending_mrs",
+        return_value=[mr],
+    )
+
+    mocked_gl = _make_omm_gl(head_sha="abc123")
+    mocked_gl.get_merge_request_pipelines.return_value = [_success_pipeline()]
+
+    merges = gl_h._process_omm_group(
+        dry_run=False,
+        gl=mocked_gl,
+        lead=lead,
+        app_sre_usernames=set(),
+    )
+
+    assert merges == 0
+    mr.merge.assert_not_called()
+    mr.rebase.assert_not_called()
+    mocked_gl.remove_label.assert_called_once_with(mr, "omm-pending")
+    clear_mock.assert_called_once()
+
+
+@pytest.mark.parametrize(
+    "merge_sha, squash_sha",
+    [("abc123", None), (None, "abc123")],
+    ids=["merge-commit", "squash-commit"],
+)
 def test_omm_group_merge_limit_enforced(
     mocker: MockerFixture,
     merge_sha: str | None,


### PR DESCRIPTION
## Summary

[APPSRE-15099](https://redhat.atlassian.net/browse/APPSRE-15099)

On 2026-08-18, gitlab-housekeeping semi-stalled on app-interface after OMM pending MR !202346 hit `repository_compare` with `404 Ref Not Found`. `is_rebased()` has no handler, so `@retry` on `merge_merge_requests` retried the same permanent 404 for ~8 minutes, then died.

OMM pending bypasses `preprocess_merge_requests()` (which skips 0-commit MRs on the serial path), so this only blows up within an OMM group. The SHA is gone — usually GitLab empty-diff / null merge base after skip-ci rebase. Housekeeping cannot heal that.

This PR catches **404 only** in `_process_omm_member`, removes `omm-pending`, and returns inactive. Siblings keep merging; last member → adaptive-close. No rebase (that does not restore the SHA). No `rebase-error` label (404 is not always a rebase failure). 500/403 still raise so `@retry` still works.

Does **not** fix the upstream GitLab empty-diff bug. Human close/reopen or local force-push still required for the eaten MR.

## Test plan

- [ ] `test_omm_group_ref_not_found_ejects_member` — 404 ejects, no merge/rebase, group adaptive-closes
- [ ] Confirm a leftover SUCCESS pipeline on a 404 member does **not** trigger skip-ci rebase
- [ ] After deploy, a `ref-not-found` warning should eject the member without Retrying/crash logs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of missing GitLab merge request references during housekeeping.
  * Affected pending entries are now removed safely, with appropriate warnings and rejection tracking.
  * Processing continues without attempting unnecessary merge or rebase actions when the reference is unavailable.

* **Tests**
  * Added coverage for missing-reference scenarios, including pending-label removal and group cleanup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->