### PR TITLE
Base qontract-api test stage on builder image

### DIFF
--- a/qontract_api/Dockerfile
+++ b/qontract_api/Dockerfile
@@ -61,15 +61,20 @@ RUN cd qontract_api && uv sync --frozen --no-group dev
 #
 # Test image
 #
-FROM base AS test
-COPY --from=ghcr.io/astral-sh/uv:0.12.5@sha256:e85be844203885286c60ffad8a858d48afb6c5a5c237ca0e67f12e74b8f174b1 /uv /bin/uv
+# Must use the builder image (python-314-minimal) rather than `base`
+# (ubi10-minimal + /usr/bin/python3.14). UV_PROJECT_ENVIRONMENT is /opt/app-root;
+# a different interpreter makes uv recreate that directory, which fails as
+# UID 1001 with: failed to remove directory `/opt/app-root`: Permission denied.
+FROM builder AS test
+
+ENV \
+    RUFF_CACHE_DIR=/tmp/.ruff_cache \
+    TESTFLAG=/tmp/.tests_passed
 
 USER root
-# install dependencies
-RUN microdnf install -y diffutils && microdnf clean all
+RUN microdnf install -y make diffutils && microdnf clean all
 USER 1001
 
-COPY --from=builder /opt/app-root /opt/app-root
 RUN cd qontract_api && uv sync --frozen
 RUN make -C qontract_api test
 RUN echo "true" > $TESTFLAG


### PR DESCRIPTION
Why

The qontract-api image build fails in its `test` stage with `failed to remove directory /opt/app-root: Permission denied`. The stage was based on `base` (`ubi10-minimal` plus a system-installed python3.14) while the virtualenv was built on `python-314-minimal`. uv sees a different interpreter, tries to recreate `UV_PROJECT_ENVIRONMENT` (`/opt/app-root`), and cannot remove it as UID 1001.

What

Base the `test` stage on `builder` so uv reuses the existing venv instead of recreating it, and re-add the make/diffutils install and the RUFF_CACHE_DIR/TESTFLAG env that `base` previously provided.

The change mirrors the qontract-api fix in
[#5790](https://github.com/app-sre/qontract-reconcile/pull/5790) so the two branches do not conflict on
[qontract_api/Dockerfile](qontract_api/Dockerfile), whichever merges first. The same qontract-api build failure is also observed on [#5789](https://github.com/app-sre/qontract-reconcile/pull/5789); landing this change independently unblocks the qontract-api check on both pull requests.

Scope

This addresses only the qontract-api image build. The separate qontract-reconcile-master-on-pull-request failure seen on [#5789](https://github.com/app-sre/qontract-reconcile/pull/5789) is not addressed here; its root cause is unconfirmed.

Attribution

The Dockerfile change originates from
[#5790](https://github.com/app-sre/qontract-reconcile/pull/5790). The branch and this commit message were prepared by the model named below at the user's direction.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the test environment to use the complete build environment.
  * Improved test-stage setup and tooling availability.
  * Simplified environment configuration for more consistent test execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->