### PR TITLE
fix(aws-account-manager): select active ROSA marketplace offer and rate card

### DIFF
--- a/qontract_utils/qontract_utils/aws_api_typed/marketplace.py
+++ b/qontract_utils/qontract_utils/aws_api_typed/marketplace.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 import logging
+import re
+from datetime import UTC, datetime
 from typing import Any
 
 from pydantic import BaseModel
@@ -69,13 +71,21 @@ class AWSApiMarketplace:
             msg = "No purchase options found for ROSA HCP product"
             raise RuntimeError(msg)
 
+        # list_purchase_options returns *all* purchase options for the product,
+        # including expired / not-yet-available offers, in no guaranteed order.
+        # Picking the first one blindly can select a rotated-out offer whose
+        # agreementProposalId is inactive, so create_agreement_request then
+        # fails with "Provided agreement proposal is inactive". Select the
+        # currently-active offer instead.
+        option = self._select_active_purchase_option(options)
+
         offer_id = next(
             (
                 entity["offer"]["offerId"]
-                for entity in options[0].get("associatedEntities", [])
+                for entity in option.get("associatedEntities", [])
                 if entity.get("offer", {}).get("offerId")
             ),
-            options[0].get("purchaseOptionId"),
+            option.get("purchaseOptionId"),
         )
         if not offer_id:
             msg = "Could not determine offer ID for ROSA HCP product"
@@ -97,6 +107,34 @@ class AWSApiMarketplace:
             offer_id=offer_id,
             agreement_proposal_id=agreement_proposal_id,
             requested_terms=requested_terms,
+        )
+
+    @staticmethod
+    def _select_active_purchase_option(
+        options: list[dict[str, Any]],
+    ) -> dict[str, Any]:
+        """Select the currently-active purchase option.
+
+        AWS returns every purchase option for the product — including offers
+        that have already expired or are not yet available — with no guaranteed
+        ordering. An option is active when its availability window
+        (availableFromTime .. expirationTime) contains 'now'; boto3 returns
+        these as timezone-aware datetimes. When several are active, prefer the
+        most recently available one.
+        """
+        now = datetime.now(UTC)
+        active = [
+            o
+            for o in options
+            if (o.get("availableFromTime") is None or o["availableFromTime"] <= now)
+            and (o.get("expirationTime") is None or o["expirationTime"] > now)
+        ]
+        if not active:
+            msg = "No active purchase options found for ROSA HCP product"
+            raise RuntimeError(msg)
+        return max(
+            active,
+            key=lambda o: o.get("availableFromTime") or datetime.min.replace(tzinfo=UTC),
         )
 
     @classmethod
@@ -134,22 +172,22 @@ class AWSApiMarketplace:
                 requested_terms.append(requested)
         return requested_terms
 
-    @staticmethod
-    def _build_upfront_config(term_data: dict[str, Any]) -> dict[str, Any]:
+    @classmethod
+    def _build_upfront_config(cls, term_data: dict[str, Any]) -> dict[str, Any]:
         """Zero-commitment configuration for a configurableUpfrontPricingTerm.
 
-        Uses the term's first rate card selector and lists every dimension with
-        a committed quantity of 0.
+        A term can offer several rate cards — one per contract-duration selector
+        (e.g. P12M / P24M / P36M) — in no guaranteed order. Pick deterministically
+        (shortest committed duration) rather than positionally, and list every
+        dimension with a committed quantity of 0 so there is no upfront spend
+        regardless of the duration chosen.
         """
         rate_cards = term_data.get("rateCards") or []
         if not rate_cards:
             msg = "configurableUpfrontPricingTerm has no rateCards"
             raise RuntimeError(msg)
-        rate_card = rate_cards[0]
-        selector_value = (rate_card.get("selector") or {}).get("value")
-        if not selector_value:
-            msg = "configurableUpfrontPricingTerm rateCard has no selector value"
-            raise RuntimeError(msg)
+        rate_card = cls._select_rate_card(rate_cards)
+        selector_value = rate_card["selector"]["value"]
         dimensions = [
             {"dimensionKey": d["dimensionKey"], "dimensionValue": 0}
             for d in rate_card.get("rateCard") or []
@@ -159,6 +197,40 @@ class AWSApiMarketplace:
             msg = "configurableUpfrontPricingTerm rateCard has no dimensions"
             raise RuntimeError(msg)
         return {"selectorValue": selector_value, "dimensions": dimensions}
+
+    @classmethod
+    def _select_rate_card(cls, rate_cards: list[dict[str, Any]]) -> dict[str, Any]:
+        """Deterministically pick the shortest-duration usable rate card.
+
+        Only rate cards carrying a selector value are considered; among those,
+        the one with the shortest contract duration wins (ties broken by the
+        selector string for stability).
+        """
+        with_selector = [
+            rc for rc in rate_cards if (rc.get("selector") or {}).get("value")
+        ]
+        if not with_selector:
+            msg = "configurableUpfrontPricingTerm rateCard has no selector value"
+            raise RuntimeError(msg)
+        return min(
+            with_selector,
+            key=lambda rc: (
+                cls._duration_months(rc["selector"]["value"]),
+                rc["selector"]["value"],
+            ),
+        )
+
+    @staticmethod
+    def _duration_months(value: str) -> int:
+        """Months in an ISO-8601 duration selector (e.g. P12M, P1Y, P1Y6M).
+
+        Unparseable selectors sort last so a recognizable duration is always
+        preferred when one exists.
+        """
+        m = re.fullmatch(r"P(?:(\d+)Y)?(?:(\d+)M)?", value)
+        if not m or not (m.group(1) or m.group(2)):
+            return 10**9
+        return int(m.group(1) or 0) * 12 + int(m.group(2) or 0)
 
     @invoke_with_hooks(
         lambda: AWSApiCallContext(

--- a/qontract_utils/qontract_utils/aws_api_typed/marketplace.py
+++ b/qontract_utils/qontract_utils/aws_api_typed/marketplace.py
@@ -5,7 +5,7 @@ import re
 from datetime import UTC, datetime
 from typing import Any
 
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 from qontract_utils.aws_api_typed._hooks import AWS_DEFAULT_HOOKS, AWSApiCallContext
 from qontract_utils.hooks import Hooks, invoke_with_hooks, with_hooks
@@ -21,6 +21,40 @@ class RosaOffer(BaseModel):
     # fully-formed requestedTerms payload for create_agreement_request, i.e. a
     # list of {"id": ..., "configuration": {...}?} entries.
     requested_terms: list[dict[str, Any]]
+
+
+# Typed boundary models for the raw marketplace-discovery responses. Fields use
+# the AWS wire-format aliases so raw responses parse via Model(**raw), matching
+# the pattern in the sibling aws_api_typed modules.
+class MarketplaceOffer(BaseModel):
+    offer_id: str | None = Field(None, alias="offerId")
+
+
+class AssociatedEntity(BaseModel):
+    offer: MarketplaceOffer | None = None
+
+
+class PurchaseOption(BaseModel):
+    purchase_option_id: str | None = Field(None, alias="purchaseOptionId")
+    available_from_time: datetime | None = Field(None, alias="availableFromTime")
+    expiration_time: datetime | None = Field(None, alias="expirationTime")
+    associated_entities: list[AssociatedEntity] = Field(
+        default_factory=list, alias="associatedEntities"
+    )
+
+
+class RateCardSelector(BaseModel):
+    value: str | None = None
+
+
+class RateCardDimension(BaseModel):
+    dimension_key: str | None = Field(None, alias="dimensionKey")
+
+
+class RateCard(BaseModel):
+    selector: RateCardSelector | None = None
+    # AWS names the dimension list "rateCard" inside each rate card entry.
+    dimensions: list[RateCardDimension] = Field(default_factory=list, alias="rateCard")
 
 
 @with_hooks(hooks=AWS_DEFAULT_HOOKS)
@@ -66,10 +100,11 @@ class AWSApiMarketplace:
                 }
             ],
         )
-        options = resp.get("purchaseOptions", [])
-        if not options:
+        options_raw = resp.get("purchaseOptions", [])
+        if not options_raw:
             msg = "No purchase options found for ROSA HCP product"
             raise RuntimeError(msg)
+        options = [PurchaseOption(**o) for o in options_raw]
 
         # list_purchase_options returns *all* purchase options for the product,
         # including expired / not-yet-available offers, in no guaranteed order.
@@ -81,11 +116,11 @@ class AWSApiMarketplace:
 
         offer_id = next(
             (
-                entity["offer"]["offerId"]
-                for entity in option.get("associatedEntities", [])
-                if entity.get("offer", {}).get("offerId")
+                entity.offer.offer_id
+                for entity in option.associated_entities
+                if entity.offer and entity.offer.offer_id
             ),
-            option.get("purchaseOptionId"),
+            option.purchase_option_id,
         )
         if not offer_id:
             msg = "Could not determine offer ID for ROSA HCP product"
@@ -111,8 +146,8 @@ class AWSApiMarketplace:
 
     @staticmethod
     def _select_active_purchase_option(
-        options: list[dict[str, Any]],
-    ) -> dict[str, Any]:
+        options: list[PurchaseOption],
+    ) -> PurchaseOption:
         """Select the currently-active purchase option.
 
         AWS returns every purchase option for the product — including offers
@@ -126,17 +161,15 @@ class AWSApiMarketplace:
         active = [
             o
             for o in options
-            if (o.get("availableFromTime") is None or o["availableFromTime"] <= now)
-            and (o.get("expirationTime") is None or o["expirationTime"] > now)
+            if (o.available_from_time is None or o.available_from_time <= now)
+            and (o.expiration_time is None or o.expiration_time > now)
         ]
         if not active:
             msg = "No active purchase options found for ROSA HCP product"
             raise RuntimeError(msg)
         return max(
             active,
-            key=lambda o: (
-                o.get("availableFromTime") or datetime.min.replace(tzinfo=UTC)
-            ),
+            key=lambda o: o.available_from_time or datetime.min.replace(tzinfo=UTC),
         )
 
     @classmethod
@@ -184,21 +217,26 @@ class AWSApiMarketplace:
         dimension with a committed quantity of 0 so there is no upfront spend
         regardless of the duration chosen.
         """
-        rate_cards = term_data.get("rateCards") or []
-        if not rate_cards:
+        rate_cards_raw = term_data.get("rateCards") or []
+        if not rate_cards_raw:
             msg = "configurableUpfrontPricingTerm has no rateCards"
             raise RuntimeError(msg)
+        rate_cards = [RateCard(**rc) for rc in rate_cards_raw]
         rate_card = cls._select_rate_card(rate_cards)
-        selector_value = rate_card["selector"]["value"]
+        # _select_rate_card guarantees a selector value and >=1 dimension.
+        selector_value = rate_card.selector.value if rate_card.selector else None
+        if not selector_value:
+            msg = "configurableUpfrontPricingTerm rateCard has no selector value"
+            raise RuntimeError(msg)
         dimensions = [
-            {"dimensionKey": d["dimensionKey"], "dimensionValue": 0}
-            for d in rate_card.get("rateCard") or []
-            if "dimensionKey" in d
+            {"dimensionKey": d.dimension_key, "dimensionValue": 0}
+            for d in rate_card.dimensions
+            if d.dimension_key
         ]
         return {"selectorValue": selector_value, "dimensions": dimensions}
 
     @classmethod
-    def _select_rate_card(cls, rate_cards: list[dict[str, Any]]) -> dict[str, Any]:
+    def _select_rate_card(cls, rate_cards: list[RateCard]) -> RateCard:
         """Deterministically pick the shortest-duration usable rate card.
 
         A rate card is usable only if it carries both a selector value and at
@@ -206,25 +244,24 @@ class AWSApiMarketplace:
         duration wins (ties broken by the selector string for stability). When
         none are usable, raise the most specific error for diagnostics.
         """
-        usable = [
-            rc
-            for rc in rate_cards
-            if (rc.get("selector") or {}).get("value")
-            and any("dimensionKey" in d for d in rc.get("rateCard") or [])
-        ]
+        usable: list[tuple[RateCard, str]] = []
+        for rc in rate_cards:
+            value = rc.selector.value if rc.selector else None
+            if value and any(d.dimension_key for d in rc.dimensions):
+                usable.append((rc, value))
         if not usable:
-            if any((rc.get("selector") or {}).get("value") for rc in rate_cards):
-                msg = "configurableUpfrontPricingTerm rateCard has no dimensions"
-            else:
-                msg = "configurableUpfrontPricingTerm rateCard has no selector value"
+            has_selector = any(rc.selector and rc.selector.value for rc in rate_cards)
+            msg = (
+                "configurableUpfrontPricingTerm rateCard has no dimensions"
+                if has_selector
+                else "configurableUpfrontPricingTerm rateCard has no selector value"
+            )
             raise RuntimeError(msg)
-        return min(
+        rate_card, _ = min(
             usable,
-            key=lambda rc: (
-                cls._duration_months(rc["selector"]["value"]),
-                rc["selector"]["value"],
-            ),
+            key=lambda t: (cls._duration_months(t[1]), t[1]),
         )
+        return rate_card
 
     @staticmethod
     def _duration_months(value: str) -> int:

--- a/qontract_utils/qontract_utils/aws_api_typed/marketplace.py
+++ b/qontract_utils/qontract_utils/aws_api_typed/marketplace.py
@@ -134,7 +134,9 @@ class AWSApiMarketplace:
             raise RuntimeError(msg)
         return max(
             active,
-            key=lambda o: o.get("availableFromTime") or datetime.min.replace(tzinfo=UTC),
+            key=lambda o: (
+                o.get("availableFromTime") or datetime.min.replace(tzinfo=UTC)
+            ),
         )
 
     @classmethod
@@ -193,27 +195,31 @@ class AWSApiMarketplace:
             for d in rate_card.get("rateCard") or []
             if "dimensionKey" in d
         ]
-        if not dimensions:
-            msg = "configurableUpfrontPricingTerm rateCard has no dimensions"
-            raise RuntimeError(msg)
         return {"selectorValue": selector_value, "dimensions": dimensions}
 
     @classmethod
     def _select_rate_card(cls, rate_cards: list[dict[str, Any]]) -> dict[str, Any]:
         """Deterministically pick the shortest-duration usable rate card.
 
-        Only rate cards carrying a selector value are considered; among those,
-        the one with the shortest contract duration wins (ties broken by the
-        selector string for stability).
+        A rate card is usable only if it carries both a selector value and at
+        least one dimension; among the usable ones the shortest contract
+        duration wins (ties broken by the selector string for stability). When
+        none are usable, raise the most specific error for diagnostics.
         """
-        with_selector = [
-            rc for rc in rate_cards if (rc.get("selector") or {}).get("value")
+        usable = [
+            rc
+            for rc in rate_cards
+            if (rc.get("selector") or {}).get("value")
+            and any("dimensionKey" in d for d in rc.get("rateCard") or [])
         ]
-        if not with_selector:
-            msg = "configurableUpfrontPricingTerm rateCard has no selector value"
+        if not usable:
+            if any((rc.get("selector") or {}).get("value") for rc in rate_cards):
+                msg = "configurableUpfrontPricingTerm rateCard has no dimensions"
+            else:
+                msg = "configurableUpfrontPricingTerm rateCard has no selector value"
             raise RuntimeError(msg)
         return min(
-            with_selector,
+            usable,
             key=lambda rc: (
                 cls._duration_months(rc["selector"]["value"]),
                 rc["selector"]["value"],

--- a/qontract_utils/tests/aws_api_typed/test_aws_api_typed_marketplace.py
+++ b/qontract_utils/tests/aws_api_typed/test_aws_api_typed_marketplace.py
@@ -310,9 +310,7 @@ def test_discover_rosa_offer_picks_shortest_duration_rate_card(
     marketplace_api: AWSApiMarketplace, discovery_client: MagicMock
 ) -> None:
     discovery_client.list_purchase_options.return_value = {
-        "purchaseOptions": [
-            {"purchaseOptionId": "po-1", "associatedEntities": []}
-        ]
+        "purchaseOptions": [{"purchaseOptionId": "po-1", "associatedEntities": []}]
     }
     discovery_client.get_offer.return_value = {"agreementProposalId": "prop-xyz"}
     discovery_client.get_offer_terms.return_value = {
@@ -359,9 +357,7 @@ def test_discover_rosa_offer_skips_rate_card_without_selector(
     marketplace_api: AWSApiMarketplace, discovery_client: MagicMock
 ) -> None:
     discovery_client.list_purchase_options.return_value = {
-        "purchaseOptions": [
-            {"purchaseOptionId": "po-1", "associatedEntities": []}
-        ]
+        "purchaseOptions": [{"purchaseOptionId": "po-1", "associatedEntities": []}]
     }
     discovery_client.get_offer.return_value = {"agreementProposalId": "prop-xyz"}
     discovery_client.get_offer_terms.return_value = {
@@ -392,6 +388,45 @@ def test_discover_rosa_offer_skips_rate_card_without_selector(
     ]
     assert config["selectorValue"] == "P12M"
     assert config["dimensions"] == [{"dimensionKey": "d12", "dimensionValue": 0}]
+
+
+def test_discover_rosa_offer_skips_rate_card_without_dimensions(
+    marketplace_api: AWSApiMarketplace, discovery_client: MagicMock
+) -> None:
+    # shortest-duration card has a selector but no dimensions; the longer one is
+    # fully usable and must be chosen instead of raising "no dimensions".
+    discovery_client.list_purchase_options.return_value = {
+        "purchaseOptions": [{"purchaseOptionId": "po-1", "associatedEntities": []}]
+    }
+    discovery_client.get_offer.return_value = {"agreementProposalId": "prop-xyz"}
+    discovery_client.get_offer_terms.return_value = {
+        "offerTerms": [
+            {
+                "configurableUpfrontPricingTerm": {
+                    "id": "term-upfront",
+                    "type": "ConfigurableUpfrontPricingTerm",
+                    "rateCards": [
+                        {
+                            "selector": {"type": "Duration", "value": "P12M"},
+                            "rateCard": [],
+                        },
+                        {
+                            "selector": {"type": "Duration", "value": "P24M"},
+                            "rateCard": [{"dimensionKey": "d24", "price": "1"}],
+                        },
+                    ],
+                }
+            },
+        ]
+    }
+
+    offer = marketplace_api.discover_rosa_offer()
+
+    config = offer.requested_terms[0]["configuration"][
+        "configurableUpfrontPricingTermConfiguration"
+    ]
+    assert config["selectorValue"] == "P24M"
+    assert config["dimensions"] == [{"dimensionKey": "d24", "dimensionValue": 0}]
 
 
 def test_subscribe_rosa(

--- a/qontract_utils/tests/aws_api_typed/test_aws_api_typed_marketplace.py
+++ b/qontract_utils/tests/aws_api_typed/test_aws_api_typed_marketplace.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from datetime import UTC, datetime, timedelta
 from typing import TYPE_CHECKING, Any
 
 import boto3
@@ -170,6 +171,81 @@ def test_discover_rosa_offer_fallback_to_purchase_option_id(
     discovery_client.get_offer.assert_called_once_with(offerId="po-fallback")
 
 
+def test_discover_rosa_offer_skips_expired_option(
+    marketplace_api: AWSApiMarketplace, discovery_client: MagicMock
+) -> None:
+    now = datetime.now(UTC)
+    discovery_client.list_purchase_options.return_value = {
+        "purchaseOptions": [
+            {
+                "purchaseOptionId": "po-expired",
+                "expirationTime": now - timedelta(days=1),
+                "associatedEntities": [{"offer": {"offerId": "offer-expired"}}],
+            },
+            {
+                "purchaseOptionId": "po-active",
+                "availableFromTime": now - timedelta(days=1),
+                "expirationTime": now + timedelta(days=30),
+                "associatedEntities": [{"offer": {"offerId": "offer-active"}}],
+            },
+        ]
+    }
+    discovery_client.get_offer.return_value = {"agreementProposalId": "prop-xyz"}
+    discovery_client.get_offer_terms.return_value = {
+        "offerTerms": [{"supportTerm": {"id": "term-1", "type": "SupportTerm"}}]
+    }
+
+    offer = marketplace_api.discover_rosa_offer()
+
+    assert offer.offer_id == "offer-active"
+    discovery_client.get_offer.assert_called_once_with(offerId="offer-active")
+
+
+def test_discover_rosa_offer_picks_most_recently_available(
+    marketplace_api: AWSApiMarketplace, discovery_client: MagicMock
+) -> None:
+    now = datetime.now(UTC)
+    discovery_client.list_purchase_options.return_value = {
+        "purchaseOptions": [
+            {
+                "purchaseOptionId": "po-old",
+                "availableFromTime": now - timedelta(days=100),
+                "associatedEntities": [{"offer": {"offerId": "offer-old"}}],
+            },
+            {
+                "purchaseOptionId": "po-new",
+                "availableFromTime": now - timedelta(days=1),
+                "associatedEntities": [{"offer": {"offerId": "offer-new"}}],
+            },
+        ]
+    }
+    discovery_client.get_offer.return_value = {"agreementProposalId": "prop-xyz"}
+    discovery_client.get_offer_terms.return_value = {
+        "offerTerms": [{"supportTerm": {"id": "term-1", "type": "SupportTerm"}}]
+    }
+
+    offer = marketplace_api.discover_rosa_offer()
+
+    assert offer.offer_id == "offer-new"
+
+
+def test_discover_rosa_offer_all_expired(
+    marketplace_api: AWSApiMarketplace, discovery_client: MagicMock
+) -> None:
+    now = datetime.now(UTC)
+    discovery_client.list_purchase_options.return_value = {
+        "purchaseOptions": [
+            {
+                "purchaseOptionId": "po-expired",
+                "expirationTime": now - timedelta(days=1),
+                "associatedEntities": [],
+            }
+        ]
+    }
+    with pytest.raises(RuntimeError, match="No active purchase options"):
+        marketplace_api.discover_rosa_offer()
+
+
 def test_discover_rosa_offer_no_purchase_options(
     marketplace_api: AWSApiMarketplace, discovery_client: MagicMock
 ) -> None:
@@ -228,6 +304,94 @@ def test_discover_rosa_offer_upfront_no_dimensions(
     }
     with pytest.raises(RuntimeError, match="no dimensions"):
         marketplace_api.discover_rosa_offer()
+
+
+def test_discover_rosa_offer_picks_shortest_duration_rate_card(
+    marketplace_api: AWSApiMarketplace, discovery_client: MagicMock
+) -> None:
+    discovery_client.list_purchase_options.return_value = {
+        "purchaseOptions": [
+            {"purchaseOptionId": "po-1", "associatedEntities": []}
+        ]
+    }
+    discovery_client.get_offer.return_value = {"agreementProposalId": "prop-xyz"}
+    discovery_client.get_offer_terms.return_value = {
+        "offerTerms": [
+            {
+                "configurableUpfrontPricingTerm": {
+                    "id": "term-upfront",
+                    "type": "ConfigurableUpfrontPricingTerm",
+                    "rateCards": [
+                        {
+                            "selector": {"type": "Duration", "value": "P36M"},
+                            "rateCard": [{"dimensionKey": "d36", "price": "1"}],
+                        },
+                        {
+                            "selector": {"type": "Duration", "value": "P12M"},
+                            "rateCard": [{"dimensionKey": "d12", "price": "1"}],
+                        },
+                        {
+                            "selector": {"type": "Duration", "value": "P24M"},
+                            "rateCard": [{"dimensionKey": "d24", "price": "1"}],
+                        },
+                    ],
+                }
+            },
+        ]
+    }
+
+    offer = marketplace_api.discover_rosa_offer()
+
+    assert offer.requested_terms == [
+        {
+            "id": "term-upfront",
+            "configuration": {
+                "configurableUpfrontPricingTermConfiguration": {
+                    "selectorValue": "P12M",
+                    "dimensions": [{"dimensionKey": "d12", "dimensionValue": 0}],
+                }
+            },
+        }
+    ]
+
+
+def test_discover_rosa_offer_skips_rate_card_without_selector(
+    marketplace_api: AWSApiMarketplace, discovery_client: MagicMock
+) -> None:
+    discovery_client.list_purchase_options.return_value = {
+        "purchaseOptions": [
+            {"purchaseOptionId": "po-1", "associatedEntities": []}
+        ]
+    }
+    discovery_client.get_offer.return_value = {"agreementProposalId": "prop-xyz"}
+    discovery_client.get_offer_terms.return_value = {
+        "offerTerms": [
+            {
+                "configurableUpfrontPricingTerm": {
+                    "id": "term-upfront",
+                    "type": "ConfigurableUpfrontPricingTerm",
+                    "rateCards": [
+                        {
+                            "selector": {},
+                            "rateCard": [{"dimensionKey": "d-noselector"}],
+                        },
+                        {
+                            "selector": {"type": "Duration", "value": "P12M"},
+                            "rateCard": [{"dimensionKey": "d12", "price": "1"}],
+                        },
+                    ],
+                }
+            },
+        ]
+    }
+
+    offer = marketplace_api.discover_rosa_offer()
+
+    config = offer.requested_terms[0]["configuration"][
+        "configurableUpfrontPricingTermConfiguration"
+    ]
+    assert config["selectorValue"] == "P12M"
+    assert config["dimensions"] == [{"dimensionKey": "d12", "dimensionValue": 0}]
 
 
 def test_subscribe_rosa(


### PR DESCRIPTION
## Summary

Fixes the runtime failure `ValidationException: Provided agreement proposal is inactive` seen when `aws_account_manager` enables ROSA HCP marketplace subscription (introduced in #5724).

### Root cause

`discover_rosa_offer` picked `purchaseOptions[0]` blindly. `list_purchase_options` returns **all** purchase options for the product — including expired / rotated-out offers, in no guaranteed order. The first one could be a stale offer whose `agreementProposalId` is already inactive, so `create_agreement_request` rejected it.

### Changes

- **Active offer selection** — new `_select_active_purchase_option` picks the currently-active purchase option by its availability window (`availableFromTime` .. `expirationTime`, boto3 timezone-aware datetimes), preferring the most recently available. Raises a clear `RuntimeError` when none are active instead of forwarding a stale proposal to AWS.
- **Deterministic rate-card selection** — a `configurableUpfrontPricingTerm` can offer several rate cards (one per contract-duration selector, e.g. `P12M`/`P24M`/`P36M`) in arbitrary order. `_select_rate_card` now picks the shortest valid duration (via `_duration_months`) rather than the positional first. Zero-commit (`dimensionValue: 0`) keeps this cost-neutral regardless of duration.

### Why enum-based filtering was not used

`list_purchase_options` supports `AVAILABILITY_STATUS` / `PURCHASE_OPTION_TYPE` filter types, but the exact `filterValues` enum strings could not be verified against the live service model (docs are JS-rendered, botocore carries no enum). Sending a wrong value would produce another `ValidationException`. Client-side filtering on `expirationTime`/`availableFromTime` — fields confirmed present in the botocore output model — is safe and needs no unverified strings.

## Test plan

- [x] 5 new unit tests: skip-expired option, pick most-recently-available, all-expired raises, shortest-duration rate card, skip rate card without selector
- [x] Existing marketplace tests unchanged and passing (18 total)
- [x] `ruff check` clean
- [x] `mypy` clean

## Follow-up (not in this PR)

Residual race: if AWS invalidates the proposal between `discover_rosa_offer` and `subscribe_rosa` (back-to-back calls, ms window), the same error could reappear. Not the observed cause; would need a re-discover+retry in the reconciler. Can add if desired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved ROSA HCP marketplace offer selection by excluding unavailable or expired options.
  * The newest active offer is now selected automatically.
  * Upfront pricing uses the shortest valid contract duration.
  * Clear errors are raised when no active offers or valid rate cards are available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->