### PR TITLE
[APPSRE-15181] add optional prefixStartSlaveCmd to Jenkins SSHConnector

### DIFF
--- a/reconcile/gql_definitions/introspection.json
+++ b/reconcile/gql_definitions/introspection.json
@@ -6221,6 +6221,18 @@
                             "deprecationReason": null
                         },
                         {
+                            "name": "prefixStartSlaveCmd",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "SCALAR",
+                                "name": "String",
+                                "ofType": null
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
                             "name": "retryWaitTime",
                             "description": null,
                             "args": [],

--- a/reconcile/jenkins_worker_fleets.py
+++ b/reconcile/jenkins_worker_fleets.py
@@ -30,6 +30,7 @@ class SSHConnector(BaseModel, use_enum_values=True):
     credentials_id: str = Field(..., alias="credentialsId")
     launch_timeout_seconds: int | None = Field(None, alias="launchTimeoutSeconds")
     max_num_retries: int | None = Field(None, alias="maxNumRetries")
+    prefix_start_slave_cmd: str | None = Field(None, alias="prefixStartSlaveCmd")
     retry_wait_time: int | None = Field(None, alias="retryWaitTime")
     port: int | None = 22
     jvm_options: str | None = Field(None, alias="jvmOptions")

--- a/reconcile/queries.py
+++ b/reconcile/queries.py
@@ -295,6 +295,7 @@ JENKINS_INSTANCES_QUERY = """
         launchTimeoutSeconds
         maxNumRetries
         port
+        prefixStartSlaveCmd
         retryWaitTime
         sshHostKeyVerificationStrategy
       }

--- a/reconcile/test/fixtures/jenkins_worker_fleets/gql-queries.yml
+++ b/reconcile/test/fixtures/jenkins_worker_fleets/gql-queries.yml
@@ -139,6 +139,27 @@ gql_response:
           - provider: asg
             identifier: test-same-sshConnector-JVMOpts
             defaults: "/terraform/resources/asg-1.yml"
+    - account: app-sre
+      identifier: test-add-sshConnector-prefixStartSlaveCmd
+      sshConnector:
+        credentialsId: jenkins
+        prefixStartSlaveCmd: "cloud-init status --wait && "
+      fsRoot: "/var/lib/jenkins"
+      labelString: rhel7
+      numExecutors: 3
+      namespace:
+        name: app-sre
+        managedExternalResources: true
+        externalResources:
+        - provider: aws
+          provisioner:
+            name: app-sre
+            resourcesDefaultRegion: us-east-1
+          resources:
+          - provider: aws-iam-service-account
+          - provider: asg
+            identifier: test-add-sshConnector-prefixStartSlaveCmd
+            defaults: "/terraform/resources/asg-1.yml"
 
   - name: ci-ext
     workerFleets:

--- a/reconcile/test/fixtures/jenkins_worker_fleets/jcasc-apply.yml
+++ b/reconcile/test/fixtures/jenkins_worker_fleets/jcasc-apply.yml
@@ -143,3 +143,26 @@ jenkins:
       alwaysReconnect: true
       privateIpUsed: true
       restrictUsage: true
+  - eC2Fleet:
+      name: test-add-sshConnector-prefixStartSlaveCmd
+      fleet: test-add-sshConnector-prefixStartSlaveCmd
+      region: us-east-1
+      minSize: 1
+      maxSize: 1
+      computerConnector:
+        sSHConnector:
+          credentialsId: jenkins
+          port: 22
+          sshHostKeyVerificationStrategy: nonVerifyingKeyVerificationStrategy
+          prefixStartSlaveCmd: "cloud-init status --wait && "
+      fsRoot: "/var/lib/jenkins"
+      labelString: rhel7
+      numExecutors: 3
+      idleMinutes: 30
+      minSpareSize: 0
+      maxTotalUses: -1
+      noDelayProvision: false
+      addNodeOnlyIfRunning: true
+      alwaysReconnect: true
+      privateIpUsed: true
+      restrictUsage: true

--- a/reconcile/test/fixtures/jenkins_worker_fleets/jcasc-export.yml
+++ b/reconcile/test/fixtures/jenkins_worker_fleets/jcasc-export.yml
@@ -105,6 +105,7 @@ jenkins:
           port: 22
           retryWaitTime: 15
           sshHostKeyVerificationStrategy: "nonVerifyingKeyVerificationStrategy"
+          prefixStartSlaveCmd: "cloud-init status --wait && "
       disableTaskResubmit: false
       fleet: "test-remove-sshConnector-attrs"
       fsRoot: "/var/lib/jenkins"
@@ -174,6 +175,34 @@ jenkins:
       minSize: 1
       minSpareSize: 0
       name: "test-same-sshConnector-JVMOpts"
+      noDelayProvision: false
+      numExecutors: 3
+      oldId: "a7833fe6-f643-4d5f-8178-a7109fecc9b7"
+      privateIpUsed: true
+      region: "us-east-1"
+      restrictUsage: true
+      scaleExecutorsByWeight: false
+  - eC2Fleet:
+      addNodeOnlyIfRunning: true
+      alwaysReconnect: true
+      cloudStatusIntervalSec: 10
+      computerConnector:
+        sSHConnector:
+          credentialsId: "jenkins"
+          port: 22
+          sshHostKeyVerificationStrategy: "nonVerifyingKeyVerificationStrategy"
+      disableTaskResubmit: false
+      fleet: "test-add-sshConnector-prefixStartSlaveCmd"
+      fsRoot: "/var/lib/jenkins"
+      idleMinutes: 30
+      initOnlineCheckIntervalSec: 15
+      initOnlineTimeoutSec: 180
+      labelString: "rhel7"
+      maxSize: 1
+      maxTotalUses: -1
+      minSize: 1
+      minSpareSize: 0
+      name: "test-add-sshConnector-prefixStartSlaveCmd"
       noDelayProvision: false
       numExecutors: 3
       oldId: "a7833fe6-f643-4d5f-8178-a7109fecc9b7"

--- a/reconcile/test/test_jenkins_worker_fleets.py
+++ b/reconcile/test/test_jenkins_worker_fleets.py
@@ -51,6 +51,7 @@ def test_jenkins_worker_fleets(
         "['update_jenkins_worker_fleet', 'ci-int', 'ci-int-jenkins-worker-app-sre']",
         "['update_jenkins_worker_fleet', 'ci-int', 'test-remove-sshConnector-attrs']",
         "['update_jenkins_worker_fleet', 'ci-int', 'test-add-sshConnector-JVMOpts']",
+        "['update_jenkins_worker_fleet', 'ci-int', 'test-add-sshConnector-prefixStartSlaveCmd']",
     ])
 
 


### PR DESCRIPTION
What

Adds support for the prefixStartSlaveCmd SSH-connector option to the jenkins-worker-fleets integration.

Why

We want to use this field to make the agent wait until the environment is ready.

Changes

- reconcile/jenkins_worker_fleets.py — add optional prefix_start_slave_cmd: str | None field to the SSHConnector model (alias prefixStartSlaveCmd), defaulting to None.
- reconcile/queries.py — add prefixStartSlaveCmd to the sshConnector selection in JENKINS_INSTANCES_QUERY.
- reconcile/test/test_jenkins_worker_fleets.py + fixtures — add coverage for the new field.

Testing

reconcile/test/test_jenkins_worker_fleets.py exercises the new field end-to-end via fixtures:
- test-add-sshConnector-prefixStartSlaveCmd

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for configuring a command prefix to run before starting Jenkins worker agents.
  * Worker fleet configurations now recognize and apply this SSH connector setting.

* **Bug Fixes**
  * Improved synchronization of worker fleet SSH connector settings, including updates to command prefixes.
  * Added coverage for configuring, exporting, importing, and updating worker fleets with this setting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->