### PR TITLE
fix(slack-usergroups): bust stale users cache on Slack invalid_users rejection

### DIFF
--- a/qontract_api/qontract_api/slack/slack_workspace_client.py
+++ b/qontract_api/qontract_api/slack/slack_workspace_client.py
@@ -506,14 +506,18 @@ class SlackWorkspaceClient:
                 return
             # Our `users` cache was stale relative to Slack's real state (e.g. a
             # user was deactivated after we last cached the users list) - Slack
-            # rejects the entire call in that case. Bust the stale cache so the
-            # next reconcile cycle picks up fresh data instead of waiting out
-            # the full TTL.
+            # rejects the entire call in that case and applies nothing. Bust
+            # the stale cache so the next reconcile cycle picks up fresh data,
+            # but still raise: unlike the emptying case above, nothing was
+            # actually applied here, so the caller must record this as a
+            # failure (not a successfully applied action) rather than publish
+            # a false "update_users" success to the subscriber channel.
             logger.warning(
                 f"Slack rejected usergroup update for '{handle}' as invalid_users; "
                 "invalidating users cache"
             )
             self._clear_cache(self._cache_key_users())
+            raise
 
     def chat_post_message(
         self,

--- a/qontract_api/qontract_api/slack/slack_workspace_client.py
+++ b/qontract_api/qontract_api/slack/slack_workspace_client.py
@@ -96,6 +96,10 @@ class SlackUsergroupNotFoundError(Exception):
     """Raised when a Slack usergroup is not found."""
 
 
+class AllUsersUnresolvableError(Exception):
+    """Raised when a non-empty desired users list resolves to no Slack user IDs."""
+
+
 class SlackWorkspaceClient:
     """Caching + compute layer for Slack workspace data.
 
@@ -470,6 +474,11 @@ class SlackWorkspaceClient:
         Args:
             handle: Usergroup handle (e.g., "oncall-team")
             users: List of org usernames (will be mapped to Slack user IDs)
+
+        Raises:
+            SlackUsergroupNotFoundError: If the usergroup handle doesn't exist.
+            AllUsersUnresolvableError: If `users` is non-empty but none of the
+                names resolve to a Slack user ID.
         """
         # TODO: https://github.com/app-sre/qontract-reconcile/pull/5304#discussion_r2715066336
         # Get usergroup by handle
@@ -479,12 +488,18 @@ class SlackWorkspaceClient:
 
         users = list(users)
 
-        # `emptying` covers both a genuinely empty desired list AND the case
-        # where every desired name turned out unresolvable/deactivated - Slack
-        # rejects an empty user_ids list either way, so both use the same
-        # deleted-user placeholder trick and the same invalid_users handling.
+        # `emptying` only covers a genuinely empty desired list. If `users` is
+        # non-empty but every name turns out unresolvable/deactivated, that's
+        # far more likely a stale/incomplete users cache than every member
+        # leaving the company at once - fail loud instead of silently wiping
+        # the usergroup with the deleted-user placeholder trick.
         user_ids = self._resolve_user_ids(users) if users else []
-        emptying = not user_ids
+        if users and not user_ids:
+            raise AllUsersUnresolvableError(
+                f"None of the desired members for '{handle}' resolved to a "
+                f"Slack user: {users}"
+            )
+        emptying = not users
         if emptying:
             user_ids = self._empty_usergroup_user_ids()
 

--- a/qontract_api/qontract_api/slack/slack_workspace_client.py
+++ b/qontract_api/qontract_api/slack/slack_workspace_client.py
@@ -445,6 +445,20 @@ class SlackWorkspaceClient:
             resolved_ids.append(user_id)
         return resolved_ids
 
+    def _empty_usergroup_user_ids(self) -> list[str]:
+        """Build a placeholder ID list for an effectively-empty usergroup.
+
+        Slack API does not allow empty user lists and we don't want to disable
+        the usergroup to keep the handle alive. The trick is passing a random
+        deleted user.
+        """
+        try:
+            return [next(user.id for user in self.get_users().values() if user.deleted)]
+        except StopIteration:
+            raise RuntimeError(
+                "No deleted users found to assign to empty usergroup"
+            ) from None
+
     def update_usergroup_users(
         self,
         *,
@@ -465,19 +479,14 @@ class SlackWorkspaceClient:
 
         users = list(users)
 
-        if users:
-            user_ids = self._resolve_user_ids(users)
-        else:
-            # Slack API does not allow empty user lists and we don't want to disable
-            # the usergroup to keep the handle alive. The trick is passing a random deleted user.
-            try:
-                user_ids = [
-                    next(user.id for user in self.get_users().values() if user.deleted)
-                ]
-            except StopIteration:
-                raise RuntimeError(
-                    "No deleted users found to assign to empty usergroup"
-                ) from None
+        # `emptying` covers both a genuinely empty desired list AND the case
+        # where every desired name turned out unresolvable/deactivated - Slack
+        # rejects an empty user_ids list either way, so both use the same
+        # deleted-user placeholder trick and the same invalid_users handling.
+        user_ids = self._resolve_user_ids(users) if users else []
+        emptying = not user_ids
+        if emptying:
+            user_ids = self._empty_usergroup_user_ids()
 
         if not ug.is_active():
             # Reactivate usergroup if it was disabled
@@ -491,7 +500,7 @@ class SlackWorkspaceClient:
         except SlackApiError as e:
             if e.response["error"] != "invalid_users":
                 raise
-            if not users:
+            if emptying:
                 # Slack can throw an invalid_users error when emptying groups, but
                 # it will still empty the group (so this can be ignored).
                 return

--- a/qontract_api/qontract_api/slack/slack_workspace_client.py
+++ b/qontract_api/qontract_api/slack/slack_workspace_client.py
@@ -423,6 +423,28 @@ class SlackWorkspaceClient:
             channel_ids=[channel_id_by_name[ch.lstrip("#")] for ch in channels],
         )
 
+    def _resolve_user_ids(self, users: Iterable[str]) -> list[str]:
+        """Map org usernames to Slack user IDs, skipping unresolvable ones.
+
+        A name is unresolvable if it's missing entirely (e.g. removed from the
+        workspace) or deactivated (deleted=True). Unresolvable names are
+        skipped with a warning rather than raising - one bad name must not
+        block the update for everyone else.
+        """
+        user_id_by_org_name = {
+            user.org_username: user.id
+            for user in self.get_users().values()
+            if not user.deleted
+        }
+        resolved_ids = []
+        for name in users:
+            user_id = user_id_by_org_name.get(name)
+            if user_id is None:
+                logger.warning(f"Skipping unresolvable/deactivated user: {name}")
+                continue
+            resolved_ids.append(user_id)
+        return resolved_ids
+
     def update_usergroup_users(
         self,
         *,
@@ -441,26 +463,7 @@ class SlackWorkspaceClient:
         if not ug:
             raise SlackUsergroupNotFoundError(f"Usergroup {handle} not found!")
 
-        all_users = self.get_users()
-        if users:
-            # Map user names to IDs
-            user_id_by_org_name = {
-                user.org_username: user.id
-                for user in all_users.values()
-                if not user.deleted
-            }
-            user_ids = [user_id_by_org_name[name] for name in users]
-        else:
-            # Slack API does not allow empty user lists and we don't want to disable
-            # the usergroup to keep the handle alive. The trick is passing a random deleted user.
-            try:
-                user_ids = [
-                    next(user.id for user in all_users.values() if user.deleted)
-                ]
-            except StopIteration:
-                raise RuntimeError(
-                    "No deleted users found to assign to empty usergroup"
-                ) from None
+        users = list(users)
 
         if not ug.is_active():
             # Reactivate usergroup if it was disabled
@@ -469,13 +472,46 @@ class SlackWorkspaceClient:
         # Always clear the usergroup cache (will be repopulated on next read)
         self._clear_cache(self._cache_key_usergroups())
 
+        if not users:
+            # Slack API does not allow empty user lists and we don't want to disable
+            # the usergroup to keep the handle alive. The trick is passing a random deleted user.
+            try:
+                user_ids = [
+                    next(user.id for user in self.get_users().values() if user.deleted)
+                ]
+            except StopIteration:
+                raise RuntimeError(
+                    "No deleted users found to assign to empty usergroup"
+                ) from None
+            try:
+                self.slack_api.usergroup_users_update(
+                    usergroup_id=ug.id, user_ids=user_ids
+                )
+            except SlackApiError as e:
+                # Slack can throw an invalid_users error when emptying groups, but
+                # it will still empty the group (so this can be ignored).
+                if e.response["error"] != "invalid_users":
+                    raise
+            return
+
+        user_ids = self._resolve_user_ids(users)
         try:
             self.slack_api.usergroup_users_update(usergroup_id=ug.id, user_ids=user_ids)
         except SlackApiError as e:
-            # Slack can throw an invalid_users error when emptying groups, but
-            # it will still empty the group (so this can be ignored).
             if e.response["error"] != "invalid_users":
                 raise
+            # Our `users` cache was stale relative to Slack's real state (e.g. a
+            # user was deactivated after we last cached the users list) - Slack
+            # rejects the *entire* call in that case. Bust the stale cache and
+            # retry once with freshly-resolved IDs instead of waiting out the
+            # full TTL for it to self-heal.
+            logger.warning(
+                f"Slack rejected usergroup update for '{handle}' as invalid_users; "
+                "invalidating users cache and retrying with fresh data"
+            )
+            self._clear_cache(self._cache_key_users())
+            user_ids = self._resolve_user_ids(users)
+            self.slack_api.usergroup_users_update(usergroup_id=ug.id, user_ids=user_ids)
 
     def chat_post_message(
         self,

--- a/qontract_api/qontract_api/slack/slack_workspace_client.py
+++ b/qontract_api/qontract_api/slack/slack_workspace_client.py
@@ -465,14 +465,9 @@ class SlackWorkspaceClient:
 
         users = list(users)
 
-        if not ug.is_active():
-            # Reactivate usergroup if it was disabled
-            self.slack_api.usergroup_enable(usergroup_id=ug.id)
-
-        # Always clear the usergroup cache (will be repopulated on next read)
-        self._clear_cache(self._cache_key_usergroups())
-
-        if not users:
+        if users:
+            user_ids = self._resolve_user_ids(users)
+        else:
             # Slack API does not allow empty user lists and we don't want to disable
             # the usergroup to keep the handle alive. The trick is passing a random deleted user.
             try:
@@ -483,35 +478,33 @@ class SlackWorkspaceClient:
                 raise RuntimeError(
                     "No deleted users found to assign to empty usergroup"
                 ) from None
-            try:
-                self.slack_api.usergroup_users_update(
-                    usergroup_id=ug.id, user_ids=user_ids
-                )
-            except SlackApiError as e:
-                # Slack can throw an invalid_users error when emptying groups, but
-                # it will still empty the group (so this can be ignored).
-                if e.response["error"] != "invalid_users":
-                    raise
-            return
 
-        user_ids = self._resolve_user_ids(users)
+        if not ug.is_active():
+            # Reactivate usergroup if it was disabled
+            self.slack_api.usergroup_enable(usergroup_id=ug.id)
+
+        # Always clear the usergroup cache (will be repopulated on next read)
+        self._clear_cache(self._cache_key_usergroups())
+
         try:
             self.slack_api.usergroup_users_update(usergroup_id=ug.id, user_ids=user_ids)
         except SlackApiError as e:
             if e.response["error"] != "invalid_users":
                 raise
+            if not users:
+                # Slack can throw an invalid_users error when emptying groups, but
+                # it will still empty the group (so this can be ignored).
+                return
             # Our `users` cache was stale relative to Slack's real state (e.g. a
             # user was deactivated after we last cached the users list) - Slack
-            # rejects the *entire* call in that case. Bust the stale cache and
-            # retry once with freshly-resolved IDs instead of waiting out the
-            # full TTL for it to self-heal.
+            # rejects the entire call in that case. Bust the stale cache so the
+            # next reconcile cycle picks up fresh data instead of waiting out
+            # the full TTL.
             logger.warning(
                 f"Slack rejected usergroup update for '{handle}' as invalid_users; "
-                "invalidating users cache and retrying with fresh data"
+                "invalidating users cache"
             )
             self._clear_cache(self._cache_key_users())
-            user_ids = self._resolve_user_ids(users)
-            self.slack_api.usergroup_users_update(usergroup_id=ug.id, user_ids=user_ids)
 
     def chat_post_message(
         self,

--- a/qontract_api/tests/slack/test_slack_workspace_client.py
+++ b/qontract_api/tests/slack/test_slack_workspace_client.py
@@ -620,6 +620,89 @@ def test_update_usergroup_users_skips_unresolvable_name(
     )
 
 
+def test_update_usergroup_users_all_names_unresolvable_uses_placeholder(
+    client: SlackWorkspaceClient,
+    mock_slack_api: MagicMock,
+    mock_cache: MagicMock,
+) -> None:
+    """If every desired name is unresolvable, don't send an empty list to Slack.
+
+    Regression test for a CodeRabbit finding on APPSRE-15192's fix: Slack
+    rejects an empty `user_ids` list. If the *original* `users` argument was
+    non-empty but every name turns out unresolvable/deactivated, we must fall
+    back to the same deleted-user placeholder trick used for a genuinely
+    empty desired list - not silently send `user_ids=[]`.
+    """
+    ug = SlackUsergroup(id="UG1", handle="oncall", name="On-Call")
+    cached_usergroups = CachedUsergroups(items=[ug])
+    deleted_user = SlackUser(
+        id="U_DELETED",
+        name="Deleted User",
+        deleted=True,
+        profile=SlackUserProfile(email="deleted@example.com"),
+    )
+
+    def get_obj_side_effect(
+        cache_key: str, *_args: Any, **_kwargs: Any
+    ) -> CachedUsergroups | CachedUsers | None:
+        if "usergroups" in cache_key:
+            return cached_usergroups
+        if "users" in cache_key:
+            return CachedUsers(items=[deleted_user])
+        return None
+
+    mock_cache.get_obj.side_effect = get_obj_side_effect
+
+    # "gone" doesn't resolve to anyone - the *only* desired member is unresolvable.
+    client.update_usergroup_users(handle="oncall", users=["gone"])
+
+    mock_slack_api.usergroup_users_update.assert_called_once_with(
+        usergroup_id="UG1",
+        user_ids=["U_DELETED"],
+    )
+
+
+def test_update_usergroup_users_all_names_unresolvable_invalid_users_ignored(
+    client: SlackWorkspaceClient,
+    mock_slack_api: MagicMock,
+    mock_cache: MagicMock,
+) -> None:
+    """All-unresolvable + invalid_users is the emptying quirk, not a stale cache.
+
+    Must be ignored (not raise) and must NOT invalidate the users cache - it's
+    the same known Slack quirk as a genuinely empty desired list, not a signal
+    that our cached data disagrees with Slack's real state.
+    """
+    ug = SlackUsergroup(id="UG1", handle="oncall", name="On-Call")
+    cached_usergroups = CachedUsergroups(items=[ug])
+    deleted_user = SlackUser(
+        id="U_DELETED",
+        name="Deleted User",
+        deleted=True,
+        profile=SlackUserProfile(email="deleted@example.com"),
+    )
+
+    def get_obj_side_effect(
+        cache_key: str, *_args: Any, **_kwargs: Any
+    ) -> CachedUsergroups | CachedUsers | None:
+        if "usergroups" in cache_key:
+            return cached_usergroups
+        if "users" in cache_key:
+            return CachedUsers(items=[deleted_user])
+        return None
+
+    mock_cache.get_obj.side_effect = get_obj_side_effect
+    mock_slack_api.usergroup_users_update.side_effect = SlackApiError(
+        message="invalid_users", response={"error": "invalid_users"}
+    )
+
+    # Must not raise.
+    client.update_usergroup_users(handle="oncall", users=["gone"])
+
+    mock_slack_api.usergroup_users_update.assert_called_once()
+    mock_cache.delete.assert_called_once_with("slack:test-workspace:usergroups")
+
+
 def test_update_usergroup_users_invalid_users_busts_users_cache(
     client: SlackWorkspaceClient,
     mock_slack_api: MagicMock,

--- a/qontract_api/tests/slack/test_slack_workspace_client.py
+++ b/qontract_api/tests/slack/test_slack_workspace_client.py
@@ -576,6 +576,172 @@ def test_update_usergroup_users_with_empty_list_reactivates_disabled_usergroup(
     mock_cache.delete.assert_called_once_with("slack:test-workspace:usergroups")
 
 
+def test_update_usergroup_users_skips_unresolvable_name(
+    client: SlackWorkspaceClient,
+    mock_slack_api: MagicMock,
+    mock_cache: MagicMock,
+) -> None:
+    """A single unresolvable org username must not block the whole update.
+
+    Regression test for APPSRE-15192: a deactivated/departed/typo'd user in the
+    desired list must be skipped, not crash the entire usergroup update.
+    """
+    ug = SlackUsergroup(id="UG1", handle="oncall", name="On-Call")
+    cached_usergroups = CachedUsergroups(items=[ug])
+
+    user1 = SlackUser(
+        id="U1",
+        name="John Smith",
+        deleted=False,
+        profile=SlackUserProfile(email="jsmith@example.com"),
+    )
+    # "gone" has no matching SlackUser at all (e.g. removed from the workspace)
+    cached_users = CachedUsers(items=[user1])
+
+    def get_obj_side_effect(
+        cache_key: str, *_args: Any, **_kwargs: Any
+    ) -> CachedUsergroups | CachedUsers | None:
+        if "usergroups" in cache_key:
+            return cached_usergroups
+        if "users" in cache_key:
+            return cached_users
+        return None
+
+    mock_cache.get_obj.side_effect = get_obj_side_effect
+
+    client.update_usergroup_users(
+        handle="oncall",
+        users=["jsmith", "gone"],
+    )
+
+    mock_slack_api.usergroup_users_update.assert_called_once_with(
+        usergroup_id="UG1",
+        user_ids=["U1"],
+    )
+
+
+def test_update_usergroup_users_invalid_users_invalidates_cache_and_retries(
+    client: SlackWorkspaceClient,
+    mock_slack_api: MagicMock,
+    mock_cache: MagicMock,
+) -> None:
+    """A Slack-side invalid_users rejection must bust the stale users cache and retry.
+
+    Regression test for APPSRE-15192: the local `users` cache can be stale for up
+    to its full TTL after a real-world Slack deactivation, causing us to send a
+    now-invalid user ID to Slack. Slack rejects the *entire* call with
+    'invalid_users'. On that specific error, we must invalidate the `users`
+    cache (not just `usergroups`), re-resolve against fresh data, and retry
+    once - converging within the same reconcile cycle instead of waiting out
+    the full TTL.
+    """
+    ug = SlackUsergroup(id="UG1", handle="oncall", name="On-Call")
+    cached_usergroups = CachedUsergroups(items=[ug])
+
+    bob = SlackUser(
+        id="U_BOB",
+        name="Bob",
+        deleted=False,
+        profile=SlackUserProfile(email="bob@example.com"),
+    )
+    stale_olivia = SlackUser(
+        id="U_OLIVIA",
+        name="Olivia",
+        deleted=False,  # stale: cache doesn't know she was deactivated yet
+        profile=SlackUserProfile(email="olivia@example.com"),
+    )
+    fresh_olivia = SlackUser(
+        id="U_OLIVIA",
+        name="Olivia",
+        deleted=True,  # fresh: reflects the real, current Slack state
+        profile=SlackUserProfile(email="olivia@example.com"),
+    )
+
+    users_cache_key = "slack:test-workspace:users"
+    users_cache_state = {"cleared": False}
+
+    def get_obj_side_effect(
+        cache_key: str, *_args: Any, **_kwargs: Any
+    ) -> CachedUsergroups | CachedUsers | None:
+        if "usergroups" in cache_key:
+            return cached_usergroups
+        if cache_key == users_cache_key:
+            if users_cache_state["cleared"]:
+                return None  # cache miss -> get_users() must fetch fresh data
+            return CachedUsers(items=[stale_olivia, bob])
+        return None
+
+    def delete_side_effect(cache_key: str) -> None:
+        if cache_key == users_cache_key:
+            users_cache_state["cleared"] = True
+
+    mock_cache.get_obj.side_effect = get_obj_side_effect
+    mock_cache.delete.side_effect = delete_side_effect
+    mock_slack_api.users_list.return_value = [fresh_olivia, bob]
+    mock_slack_api.usergroup_users_update.side_effect = [
+        SlackApiError(message="invalid_users", response={"error": "invalid_users"}),
+        None,
+    ]
+
+    client.update_usergroup_users(
+        handle="oncall",
+        users=["olivia", "bob"],
+    )
+
+    assert mock_slack_api.usergroup_users_update.call_count == 2
+
+    first_call_ids = mock_slack_api.usergroup_users_update.call_args_list[0].kwargs[
+        "user_ids"
+    ]
+    assert sorted(first_call_ids) == ["U_BOB", "U_OLIVIA"]
+
+    second_call_ids = mock_slack_api.usergroup_users_update.call_args_list[1].kwargs[
+        "user_ids"
+    ]
+    assert second_call_ids == ["U_BOB"]
+
+    mock_cache.delete.assert_any_call(users_cache_key)
+
+
+def test_update_usergroup_users_invalid_users_still_invalid_after_retry_raises(
+    client: SlackWorkspaceClient,
+    mock_slack_api: MagicMock,
+    mock_cache: MagicMock,
+) -> None:
+    """If invalid_users persists after the cache-busting retry, it must raise.
+
+    No infinite retry loop - one retry, then surface the error like any other.
+    """
+    ug = SlackUsergroup(id="UG1", handle="oncall", name="On-Call")
+    cached_usergroups = CachedUsergroups(items=[ug])
+    bob = SlackUser(
+        id="U_BOB",
+        name="Bob",
+        deleted=False,
+        profile=SlackUserProfile(email="bob@example.com"),
+    )
+
+    def get_obj_side_effect(
+        cache_key: str, *_args: Any, **_kwargs: Any
+    ) -> CachedUsergroups | CachedUsers | None:
+        if "usergroups" in cache_key:
+            return cached_usergroups
+        if "users" in cache_key:
+            return CachedUsers(items=[bob])
+        return None
+
+    mock_cache.get_obj.side_effect = get_obj_side_effect
+    mock_slack_api.users_list.return_value = [bob]
+    mock_slack_api.usergroup_users_update.side_effect = SlackApiError(
+        message="invalid_users", response={"error": "invalid_users"}
+    )
+
+    with pytest.raises(SlackApiError):
+        client.update_usergroup_users(handle="oncall", users=["bob"])
+
+    assert mock_slack_api.usergroup_users_update.call_count == 2
+
+
 def test_chat_post_message_resolves_channel_name(
     client: SlackWorkspaceClient, mock_slack_api: MagicMock, mock_cache: MagicMock
 ) -> None:

--- a/qontract_api/tests/slack/test_slack_workspace_client.py
+++ b/qontract_api/tests/slack/test_slack_workspace_client.py
@@ -620,97 +620,19 @@ def test_update_usergroup_users_skips_unresolvable_name(
     )
 
 
-def test_update_usergroup_users_invalid_users_invalidates_cache_and_retries(
+def test_update_usergroup_users_invalid_users_busts_users_cache(
     client: SlackWorkspaceClient,
     mock_slack_api: MagicMock,
     mock_cache: MagicMock,
 ) -> None:
-    """A Slack-side invalid_users rejection must bust the stale users cache and retry.
+    """A Slack-side invalid_users rejection must bust the stale users cache.
 
     Regression test for APPSRE-15192: the local `users` cache can be stale for up
     to its full TTL after a real-world Slack deactivation, causing us to send a
     now-invalid user ID to Slack. Slack rejects the *entire* call with
-    'invalid_users'. On that specific error, we must invalidate the `users`
-    cache (not just `usergroups`), re-resolve against fresh data, and retry
-    once - converging within the same reconcile cycle instead of waiting out
-    the full TTL.
-    """
-    ug = SlackUsergroup(id="UG1", handle="oncall", name="On-Call")
-    cached_usergroups = CachedUsergroups(items=[ug])
-
-    bob = SlackUser(
-        id="U_BOB",
-        name="Bob",
-        deleted=False,
-        profile=SlackUserProfile(email="bob@example.com"),
-    )
-    stale_olivia = SlackUser(
-        id="U_OLIVIA",
-        name="Olivia",
-        deleted=False,  # stale: cache doesn't know she was deactivated yet
-        profile=SlackUserProfile(email="olivia@example.com"),
-    )
-    fresh_olivia = SlackUser(
-        id="U_OLIVIA",
-        name="Olivia",
-        deleted=True,  # fresh: reflects the real, current Slack state
-        profile=SlackUserProfile(email="olivia@example.com"),
-    )
-
-    users_cache_key = "slack:test-workspace:users"
-    users_cache_state = {"cleared": False}
-
-    def get_obj_side_effect(
-        cache_key: str, *_args: Any, **_kwargs: Any
-    ) -> CachedUsergroups | CachedUsers | None:
-        if "usergroups" in cache_key:
-            return cached_usergroups
-        if cache_key == users_cache_key:
-            if users_cache_state["cleared"]:
-                return None  # cache miss -> get_users() must fetch fresh data
-            return CachedUsers(items=[stale_olivia, bob])
-        return None
-
-    def delete_side_effect(cache_key: str) -> None:
-        if cache_key == users_cache_key:
-            users_cache_state["cleared"] = True
-
-    mock_cache.get_obj.side_effect = get_obj_side_effect
-    mock_cache.delete.side_effect = delete_side_effect
-    mock_slack_api.users_list.return_value = [fresh_olivia, bob]
-    mock_slack_api.usergroup_users_update.side_effect = [
-        SlackApiError(message="invalid_users", response={"error": "invalid_users"}),
-        None,
-    ]
-
-    client.update_usergroup_users(
-        handle="oncall",
-        users=["olivia", "bob"],
-    )
-
-    assert mock_slack_api.usergroup_users_update.call_count == 2
-
-    first_call_ids = mock_slack_api.usergroup_users_update.call_args_list[0].kwargs[
-        "user_ids"
-    ]
-    assert sorted(first_call_ids) == ["U_BOB", "U_OLIVIA"]
-
-    second_call_ids = mock_slack_api.usergroup_users_update.call_args_list[1].kwargs[
-        "user_ids"
-    ]
-    assert second_call_ids == ["U_BOB"]
-
-    mock_cache.delete.assert_any_call(users_cache_key)
-
-
-def test_update_usergroup_users_invalid_users_still_invalid_after_retry_raises(
-    client: SlackWorkspaceClient,
-    mock_slack_api: MagicMock,
-    mock_cache: MagicMock,
-) -> None:
-    """If invalid_users persists after the cache-busting retry, it must raise.
-
-    No infinite retry loop - one retry, then surface the error like any other.
+    'invalid_users'. On that specific error (non-empty desired list), we must
+    invalidate the `users` cache so the *next* reconcile cycle picks up fresh
+    data instead of waiting out the full TTL - no retry, no exception.
     """
     ug = SlackUsergroup(id="UG1", handle="oncall", name="On-Call")
     cached_usergroups = CachedUsergroups(items=[ug])
@@ -731,15 +653,55 @@ def test_update_usergroup_users_invalid_users_still_invalid_after_retry_raises(
         return None
 
     mock_cache.get_obj.side_effect = get_obj_side_effect
-    mock_slack_api.users_list.return_value = [bob]
     mock_slack_api.usergroup_users_update.side_effect = SlackApiError(
         message="invalid_users", response={"error": "invalid_users"}
     )
 
-    with pytest.raises(SlackApiError):
-        client.update_usergroup_users(handle="oncall", users=["bob"])
+    # Must not raise.
+    client.update_usergroup_users(handle="oncall", users=["bob"])
 
-    assert mock_slack_api.usergroup_users_update.call_count == 2
+    mock_slack_api.usergroup_users_update.assert_called_once()
+    mock_cache.delete.assert_any_call("slack:test-workspace:users")
+
+
+def test_update_usergroup_users_empty_list_invalid_users_does_not_bust_users_cache(
+    client: SlackWorkspaceClient,
+    mock_slack_api: MagicMock,
+    mock_cache: MagicMock,
+) -> None:
+    """The known 'emptying a group returns invalid_users anyway' quirk stays ignored.
+
+    It's not a stale-cache signal, so unlike the non-empty case it must NOT
+    trigger a users-cache invalidation.
+    """
+    ug = SlackUsergroup(id="UG1", handle="oncall", name="On-Call")
+    cached_usergroups = CachedUsergroups(items=[ug])
+    deleted_user = SlackUser(
+        id="U_DELETED",
+        name="Deleted User",
+        deleted=True,
+        profile=SlackUserProfile(email="deleted@example.com"),
+    )
+
+    def get_obj_side_effect(
+        cache_key: str, *_args: Any, **_kwargs: Any
+    ) -> CachedUsergroups | CachedUsers | None:
+        if "usergroups" in cache_key:
+            return cached_usergroups
+        if "users" in cache_key:
+            return CachedUsers(items=[deleted_user])
+        return None
+
+    mock_cache.get_obj.side_effect = get_obj_side_effect
+    mock_slack_api.usergroup_users_update.side_effect = SlackApiError(
+        message="invalid_users", response={"error": "invalid_users"}
+    )
+
+    # Must not raise.
+    client.update_usergroup_users(handle="oncall", users=[])
+
+    mock_slack_api.usergroup_users_update.assert_called_once()
+    mock_cache.delete.assert_called_once_with("slack:test-workspace:usergroups")
 
 
 def test_chat_post_message_resolves_channel_name(

--- a/qontract_api/tests/slack/test_slack_workspace_client.py
+++ b/qontract_api/tests/slack/test_slack_workspace_client.py
@@ -18,6 +18,7 @@ from qontract_utils.slack_api import (
 )
 
 from qontract_api.slack.slack_workspace_client import (
+    AllUsersUnresolvableError,
     CachedChannels,
     CachedUsergroups,
     CachedUsers,
@@ -620,18 +621,19 @@ def test_update_usergroup_users_skips_unresolvable_name(
     )
 
 
-def test_update_usergroup_users_all_names_unresolvable_uses_placeholder(
+def test_update_usergroup_users_all_names_unresolvable_raises(
     client: SlackWorkspaceClient,
     mock_slack_api: MagicMock,
     mock_cache: MagicMock,
 ) -> None:
-    """If every desired name is unresolvable, don't send an empty list to Slack.
+    """If every desired name is unresolvable, fail loud instead of emptying the group.
 
-    Regression test for a CodeRabbit finding on APPSRE-15192's fix: Slack
-    rejects an empty `user_ids` list. If the *original* `users` argument was
-    non-empty but every name turns out unresolvable/deactivated, we must fall
-    back to the same deleted-user placeholder trick used for a genuinely
-    empty desired list - not silently send `user_ids=[]`.
+    Regression test for a blocking review finding on APPSRE-15192's fix: a
+    non-empty `users` argument where every name turns out unresolvable is far
+    more likely a stale/incomplete users cache than every member leaving the
+    company at once. Silently applying the deleted-user placeholder trick in
+    that case would wipe real usergroup membership, so this must raise
+    instead of calling the Slack API at all.
     """
     ug = SlackUsergroup(id="UG1", handle="oncall", name="On-Call")
     cached_usergroups = CachedUsergroups(items=[ug])
@@ -654,53 +656,10 @@ def test_update_usergroup_users_all_names_unresolvable_uses_placeholder(
     mock_cache.get_obj.side_effect = get_obj_side_effect
 
     # "gone" doesn't resolve to anyone - the *only* desired member is unresolvable.
-    client.update_usergroup_users(handle="oncall", users=["gone"])
+    with pytest.raises(AllUsersUnresolvableError):
+        client.update_usergroup_users(handle="oncall", users=["gone"])
 
-    mock_slack_api.usergroup_users_update.assert_called_once_with(
-        usergroup_id="UG1",
-        user_ids=["U_DELETED"],
-    )
-
-
-def test_update_usergroup_users_all_names_unresolvable_invalid_users_ignored(
-    client: SlackWorkspaceClient,
-    mock_slack_api: MagicMock,
-    mock_cache: MagicMock,
-) -> None:
-    """All-unresolvable + invalid_users is the emptying quirk, not a stale cache.
-
-    Must be ignored (not raise) and must NOT invalidate the users cache - it's
-    the same known Slack quirk as a genuinely empty desired list, not a signal
-    that our cached data disagrees with Slack's real state.
-    """
-    ug = SlackUsergroup(id="UG1", handle="oncall", name="On-Call")
-    cached_usergroups = CachedUsergroups(items=[ug])
-    deleted_user = SlackUser(
-        id="U_DELETED",
-        name="Deleted User",
-        deleted=True,
-        profile=SlackUserProfile(email="deleted@example.com"),
-    )
-
-    def get_obj_side_effect(
-        cache_key: str, *_args: Any, **_kwargs: Any
-    ) -> CachedUsergroups | CachedUsers | None:
-        if "usergroups" in cache_key:
-            return cached_usergroups
-        if "users" in cache_key:
-            return CachedUsers(items=[deleted_user])
-        return None
-
-    mock_cache.get_obj.side_effect = get_obj_side_effect
-    mock_slack_api.usergroup_users_update.side_effect = SlackApiError(
-        message="invalid_users", response={"error": "invalid_users"}
-    )
-
-    # Must not raise.
-    client.update_usergroup_users(handle="oncall", users=["gone"])
-
-    mock_slack_api.usergroup_users_update.assert_called_once()
-    mock_cache.delete.assert_called_once_with("slack:test-workspace:usergroups")
+    mock_slack_api.usergroup_users_update.assert_not_called()
 
 
 def test_update_usergroup_users_invalid_users_busts_cache_and_raises(

--- a/qontract_api/tests/slack/test_slack_workspace_client.py
+++ b/qontract_api/tests/slack/test_slack_workspace_client.py
@@ -703,19 +703,22 @@ def test_update_usergroup_users_all_names_unresolvable_invalid_users_ignored(
     mock_cache.delete.assert_called_once_with("slack:test-workspace:usergroups")
 
 
-def test_update_usergroup_users_invalid_users_busts_users_cache(
+def test_update_usergroup_users_invalid_users_busts_cache_and_raises(
     client: SlackWorkspaceClient,
     mock_slack_api: MagicMock,
     mock_cache: MagicMock,
 ) -> None:
-    """A Slack-side invalid_users rejection must bust the stale users cache.
+    """A Slack-side invalid_users rejection must bust the cache and still raise.
 
     Regression test for APPSRE-15192: the local `users` cache can be stale for up
     to its full TTL after a real-world Slack deactivation, causing us to send a
     now-invalid user ID to Slack. Slack rejects the *entire* call with
-    'invalid_users'. On that specific error (non-empty desired list), we must
-    invalidate the `users` cache so the *next* reconcile cycle picks up fresh
-    data instead of waiting out the full TTL - no retry, no exception.
+    'invalid_users' and (verified against the real API) applies nothing. We
+    must invalidate the `users` cache so the *next* reconcile cycle picks up
+    fresh data, but we must also re-raise - swallowing it here would make
+    `service.reconcile()` record this as a successfully applied action and
+    publish a false "update_users" success event to the subscriber Slack
+    channel, even though nothing was actually changed.
     """
     ug = SlackUsergroup(id="UG1", handle="oncall", name="On-Call")
     cached_usergroups = CachedUsergroups(items=[ug])
@@ -740,8 +743,8 @@ def test_update_usergroup_users_invalid_users_busts_users_cache(
         message="invalid_users", response={"error": "invalid_users"}
     )
 
-    # Must not raise.
-    client.update_usergroup_users(handle="oncall", users=["bob"])
+    with pytest.raises(SlackApiError):
+        client.update_usergroup_users(handle="oncall", users=["bob"])
 
     mock_slack_api.usergroup_users_update.assert_called_once()
     mock_cache.delete.assert_any_call("slack:test-workspace:users")

--- a/qontract_utils/qontract_utils/slack_api/client.py
+++ b/qontract_utils/qontract_utils/slack_api/client.py
@@ -352,14 +352,14 @@ class SlackApi:
         Args:
             usergroup_id: Encoded usergroup ID
             user_ids: List of encoded user IDs representing the entire list of users for the usergroup
+
+        Raises:
+            SlackApiError: On any Slack API error, including invalid_users.
+                Deciding whether an invalid_users rejection is safe to ignore
+                (e.g. it happened while emptying a group) is business logic
+                that belongs to the caller, not this stateless client.
         """
-        try:
-            self._sc.usergroups_users_update(usergroup=usergroup_id, users=user_ids)
-        except SlackApiError as e:
-            # Slack can throw an invalid_users error when emptying groups, but
-            # it will still empty the group (so this can be ignored).
-            if e.response["error"] != "invalid_users":
-                raise
+        self._sc.usergroups_users_update(usergroup=usergroup_id, users=user_ids)
 
     @invoke_with_hooks(
         lambda self: SlackApiCallContext(

--- a/qontract_utils/tests/test_slack_api.py
+++ b/qontract_utils/tests/test_slack_api.py
@@ -431,6 +431,27 @@ def test_usergroups_users_update_returns_slack_usergroup(
     )
 
 
+def test_usergroup_users_update_propagates_invalid_users_error(
+    slack_api: SlackApi, mock_webclient: MagicMock
+) -> None:
+    """Layer 1 must not swallow invalid_users - that decision belongs to Layer 2.
+
+    Regression test for APPSRE-15192: qontract_api's SlackWorkspaceClient
+    (Layer 2) decides whether an invalid_users rejection is a harmless
+    "emptying a group" quirk or a real failure that must bust the users cache
+    and be reported. If Layer 1 swallows the error here, Layer 2 never sees
+    it and that decision logic is dead code.
+    """
+    slack_api._sc.usergroups_users_update = MagicMock(  # type: ignore[method-assign]
+        side_effect=SlackApiError(
+            message="invalid_users", response={"error": "invalid_users"}
+        )
+    )
+
+    with pytest.raises(SlackApiError):
+        slack_api.usergroup_users_update(usergroup_id="UG1", user_ids=["U1"])
+
+
 def test_conversations_list_returns_slack_channel_objects(
     slack_api: SlackApi, mock_webclient: MagicMock
 ) -> None:


### PR DESCRIPTION
## Summary
- The `users` Redis cache in the `slack-usergroups` qontract-api integration has a 12h TTL and is never invalidated. When a Slack account is deactivated (e.g. an employee leaves the company), the integration keeps treating them as a valid usergroup member for up to 12 hours, causing repeated failed update attempts every reconcile cycle and, over hours, sustained non-converging reconcile load (root cause of APPSRE-15192's Celery worker pileup).
- `update_usergroup_users` now resolves org usernames to Slack IDs via `_resolve_user_ids()`, which **skips unresolvable/deactivated names** instead of raising `KeyError` on a single bad name and aborting the whole usergroup update.
- If the desired list is genuinely empty, it falls back to the existing deleted-user placeholder trick (`_empty_usergroup_user_ids()`) instead of sending an empty `user_ids` list, which Slack rejects.
- If the desired list is **non-empty but every name turns out unresolvable**, that's treated as a likely stale/incomplete `users` cache rather than a real mass-deactivation event: the update now raises a new `AllUsersUnresolvableError` immediately instead of silently applying the placeholder and wiping real usergroup membership (e.g. an on-call/paging group). Raised after review feedback flagging the original placeholder-for-all-unresolvable behavior as a blocking safety risk.
- When Slack rejects a **non-empty** update with `invalid_users` (its own, always-current signal that our cached view is stale): the `users` cache is invalidated so the *next* reconcile cycle self-heals with fresh data, and the error is **re-raised** — verified against the real API that nothing is actually applied in this case, so it must be recorded as a failure, not a false "update_users" success published to the subscriber Slack channel.
- The pre-existing "emptying a group can return invalid_users anyway" quirk is still ignored (verified against the real API that Slack *does* apply that one despite the error) for the genuinely-empty case.

## Test plan
- [x] Added regression tests in `qontract_api/tests/slack/test_slack_workspace_client.py`:
  - `test_update_usergroup_users_skips_unresolvable_name`
  - `test_update_usergroup_users_all_names_unresolvable_raises`
  - `test_update_usergroup_users_invalid_users_busts_cache_and_raises`
  - `test_update_usergroup_users_empty_list_invalid_users_does_not_bust_users_cache`
- [x] Confirmed each new/changed test fails against the pre-fix code (TDD), then passes after the corresponding fix
- [x] Full `qontract_api` slack/slack_usergroups test suites pass, no regressions
- [x] `ruff check` and `mypy` clean on changed files
- [x] Root cause independently verified against production: live Slack API check confirmed the affected account is genuinely `deleted: true`; a real (reverted) test against a Slack usergroup confirmed Slack rejects mixed valid/invalid `usergroups.users.update` calls with `invalid_users` and leaves state unchanged, while an all-invalid call also returns `invalid_users` but does empty the group
- [x] Addressed CodeRabbit review feedback (empty-resolved-list edge case fixed; Pydantic error-payload suggestion deliberately kept out of scope, see PR discussion)
- [x] Addressed blocking review feedback on the all-unresolvable case silently emptying a usergroup (now raises `AllUsersUnresolvableError` instead)

Related: APPSRE-15192

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevents non-empty user group updates from silently removing all members when no submitted users can be resolved.
  * Reports an error when every specified user is unavailable or deactivated.
  * Ensures Slack errors for invalid users are surfaced instead of being silently ignored.
  * Continues to support intentionally empty updates using the designated deleted-user placeholder.
  * Preserves handling of partially invalid updates, cache refreshes, and disabled user group reactivation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->