### PR TITLE
fix(rhidp): create SSO clients via qontract-api instead of a stale Vault path

### DIFF
--- a/qontract_api/openapi.json
+++ b/qontract_api/openapi.json
@@ -4126,6 +4126,97 @@
         "title": "SsoClientCluster",
         "type": "object"
       },
+      "SsoClientCreateManualRequest": {
+        "description": "Request model for ad-hoc SSO client creation (not tied to an OCM cluster).\n\nUsed by qontract-cli to create one-off SSO clients without needing direct\naccess to vault.corp.redhat.com - qontract-api already holds AppRole\ncredentials for it and reads the IAT server-side via keycloak_instance.secret.",
+        "properties": {
+          "client_name": {
+            "description": "Keycloak client id / Vault secret name",
+            "title": "Client Name",
+            "type": "string"
+          },
+          "group_filter_regex": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Optional group filter regex for the SSO client",
+            "title": "Group Filter Regex"
+          },
+          "keycloak_instance": {
+            "$ref": "#/components/schemas/KeycloakInstanceSecret",
+            "description": "Keycloak issuer URL + Vault reference to its IAT secret"
+          },
+          "redirect_uris": {
+            "description": "Allowed redirect URIs",
+            "items": {
+              "type": "string"
+            },
+            "title": "Redirect Uris",
+            "type": "array"
+          }
+        },
+        "required": [
+          "client_name",
+          "redirect_uris",
+          "keycloak_instance"
+        ],
+        "title": "SsoClientCreateManualRequest",
+        "type": "object"
+      },
+      "SsoClientCreateManualResult": {
+        "description": "Result model for a completed ad-hoc SSO client creation task.",
+        "properties": {
+          "actions": {
+            "default": [],
+            "description": "Always empty - ad-hoc creation is a single action, not a diff. Present only so this result satisfies the shared task-polling Protocol (qontract_api.tasks._utils.TaskResult).",
+            "items": {
+              "type": "string"
+            },
+            "title": "Actions",
+            "type": "array"
+          },
+          "applied_count": {
+            "default": 0,
+            "description": "Number of actions actually applied (0 if dry_run=True)",
+            "title": "Applied Count",
+            "type": "integer"
+          },
+          "errors": {
+            "default": [],
+            "description": "List of errors encountered during reconciliation",
+            "items": {
+              "type": "string"
+            },
+            "title": "Errors",
+            "type": "array"
+          },
+          "status": {
+            "$ref": "#/components/schemas/TaskStatus",
+            "description": "Task execution status (pending/success/failed/skipped)"
+          },
+          "vault_secret_path": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Vault path where the created client secret was stored (set on success only)",
+            "title": "Vault Secret Path"
+          }
+        },
+        "required": [
+          "status"
+        ],
+        "title": "SsoClientCreateManualResult",
+        "type": "object"
+      },
       "SsoClientReconcileRequest": {
         "description": "Request model for RHIDP SSO client reconciliation.\n\nPOST requests always queue a background task (async execution).",
         "properties": {
@@ -5801,6 +5892,101 @@
           }
         ],
         "summary": "Slack Usergroups Task Status",
+        "tags": [
+          "integrations"
+        ]
+      }
+    },
+    "/api/v1/integrations/sso-client/manual": {
+      "post": {
+        "description": "Queue ad-hoc SSO client creation (not tied to an OCM cluster).\n\nUsed by qontract-cli for one-off client creation. Always queues a\nbackground task and returns immediately with a task_id. Use\nGET /manual/{task_id} to retrieve the result.",
+        "operationId": "sso-client-create-manual",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SsoClientCreateManualRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "202": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SsoClientTaskResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "summary": "Sso Client Create Manual",
+        "tags": [
+          "integrations"
+        ]
+      }
+    },
+    "/api/v1/integrations/sso-client/manual/{task_id}": {
+      "get": {
+        "description": "Retrieve ad-hoc SSO client creation result (blocking or non-blocking).",
+        "operationId": "sso-client-create-manual-task-status",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "task_id",
+            "required": true,
+            "schema": {
+              "title": "Task Id",
+              "type": "string"
+            }
+          },
+          {
+            "description": "Optional: Block up to N seconds for completion. Omit for immediate status check.",
+            "in": "query",
+            "name": "timeout",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "maximum": 300,
+                  "minimum": 1,
+                  "type": "integer"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Optional: Block up to N seconds for completion. Omit for immediate status check.",
+              "title": "Timeout"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SsoClientCreateManualResult"
+                }
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "summary": "Sso Client Create Manual Task Status",
         "tags": [
           "integrations"
         ]

--- a/qontract_api/qontract_api/config.py
+++ b/qontract_api/qontract_api/config.py
@@ -377,6 +377,20 @@ class SecretSettings(BaseModel):
     )
 
 
+class SsoClientSettings(BaseModel):
+    """RHIDP SSO client integration configuration."""
+
+    manual_vault_path_prefix: str = Field(
+        default="app-sre/integrations-throughput/rhidp/manual",
+        description=(
+            "Vault path prefix for ad-hoc (qontract-cli) SSO client secrets. "
+            "The client name is appended to form the full path. Must stay "
+            "within a prefix the qontract-api Vault AppRole is granted write "
+            "access to."
+        ),
+    )
+
+
 class QuaySettings(BaseModel):
     """Quay API and integration configuration."""
 
@@ -591,6 +605,12 @@ class Settings(BaseSettings):
     quay: QuaySettings = Field(
         default_factory=QuaySettings,
         description="Quay API and integration configuration",
+    )
+
+    # SSO Client (RHIDP) Configuration (nested)
+    sso_client: SsoClientSettings = Field(
+        default_factory=SsoClientSettings,
+        description="RHIDP SSO client integration configuration",
     )
 
     # Event Subscriber Configuration (nested)

--- a/qontract_api/qontract_api/config.py
+++ b/qontract_api/qontract_api/config.py
@@ -382,6 +382,7 @@ class SsoClientSettings(BaseModel):
 
     manual_vault_path_prefix: str = Field(
         default="app-sre/integrations-throughput/rhidp/manual",
+        min_length=1,
         description=(
             "Vault path prefix for ad-hoc (qontract-cli) SSO client secrets. "
             "The client name is appended to form the full path. Must stay "

--- a/qontract_api/qontract_api/integrations/sso_client/router.py
+++ b/qontract_api/qontract_api/integrations/sso_client/router.py
@@ -12,11 +12,16 @@ from fastapi import APIRouter, Query, Request, status
 from qontract_api.config import settings
 from qontract_api.dependencies import UserDep
 from qontract_api.integrations.sso_client.schemas import (
+    SsoClientCreateManualRequest,
+    SsoClientCreateManualResult,
     SsoClientReconcileRequest,
     SsoClientTaskResponse,
     SsoClientTaskResult,
 )
-from qontract_api.integrations.sso_client.tasks import reconcile_sso_client_task
+from qontract_api.integrations.sso_client.tasks import (
+    create_manual_sso_client_task,
+    reconcile_sso_client_task,
+)
 from qontract_api.logger import get_logger
 from qontract_api.models import TaskStatus
 from qontract_api.tasks import (
@@ -87,5 +92,64 @@ async def sso_client_task_status(
     """Retrieve reconciliation result (blocking or non-blocking)."""
     return await wait_for_task_completion(
         get_task_status=lambda: get_celery_task_result(task_id, SsoClientTaskResult),
+        timeout_seconds=timeout,
+    )
+
+
+@router.post(
+    "/manual",
+    status_code=status.HTTP_202_ACCEPTED,
+    operation_id="sso-client-create-manual",
+)
+def sso_client_create_manual(
+    create_request: SsoClientCreateManualRequest,
+    current_user: UserDep,  # ruff: ignore[unused-function-argument]
+    request: Request,
+) -> SsoClientTaskResponse:
+    """Queue ad-hoc SSO client creation (not tied to an OCM cluster).
+
+    Used by qontract-cli for one-off client creation. Always queues a
+    background task and returns immediately with a task_id. Use
+    GET /manual/{task_id} to retrieve the result.
+    """
+    create_manual_sso_client_task.apply_async(
+        task_id=request.state.request_id,
+        queue=queue_for(dry_run=False),
+        kwargs={"request": create_request},
+    )
+
+    return SsoClientTaskResponse(
+        id=request.state.request_id,
+        status=TaskStatus.PENDING,
+        status_url=str(
+            request.url_for(
+                "sso_client_create_manual_task_status",
+                task_id=request.state.request_id,
+            )
+        ),
+    )
+
+
+@router.get(
+    "/manual/{task_id}",
+    operation_id="sso-client-create-manual-task-status",
+)
+async def sso_client_create_manual_task_status(
+    task_id: str,
+    current_user: UserDep,  # ruff: ignore[unused-function-argument]
+    timeout: Annotated[
+        int | None,
+        Query(
+            ge=1,
+            le=settings.api_task_max_timeout,
+            description="Optional: Block up to N seconds for completion. Omit for immediate status check.",
+        ),
+    ] = settings.api_task_default_timeout,
+) -> SsoClientCreateManualResult:
+    """Retrieve ad-hoc SSO client creation result (blocking or non-blocking)."""
+    return await wait_for_task_completion(
+        get_task_status=lambda: get_celery_task_result(
+            task_id, SsoClientCreateManualResult
+        ),
         timeout_seconds=timeout,
     )

--- a/qontract_api/qontract_api/integrations/sso_client/schemas.py
+++ b/qontract_api/qontract_api/integrations/sso_client/schemas.py
@@ -85,3 +85,38 @@ class SsoClientTaskResponse(BaseModel, frozen=True):
     status_url: str = Field(
         ..., description="URL to retrieve task result (GET request)"
     )
+
+
+class SsoClientCreateManualRequest(BaseModel, frozen=True):
+    """Request model for ad-hoc SSO client creation (not tied to an OCM cluster).
+
+    Used by qontract-cli to create one-off SSO clients without needing direct
+    access to vault.corp.redhat.com - qontract-api already holds AppRole
+    credentials for it and reads the IAT server-side via keycloak_instance.secret.
+    """
+
+    client_name: str = Field(..., description="Keycloak client id / Vault secret name")
+    redirect_uris: list[str] = Field(..., description="Allowed redirect URIs")
+    group_filter_regex: str | None = Field(
+        default=None, description="Optional group filter regex for the SSO client"
+    )
+    keycloak_instance: KeycloakInstanceSecret = Field(
+        ..., description="Keycloak issuer URL + Vault reference to its IAT secret"
+    )
+
+
+class SsoClientCreateManualResult(TaskResult, frozen=True):
+    """Result model for a completed ad-hoc SSO client creation task."""
+
+    actions: list[str] = Field(
+        default=[],
+        description=(
+            "Always empty - ad-hoc creation is a single action, not a diff. "
+            "Present only so this result satisfies the shared task-polling "
+            "Protocol (qontract_api.tasks._utils.TaskResult)."
+        ),
+    )
+    vault_secret_path: str | None = Field(
+        default=None,
+        description="Vault path where the created client secret was stored (set on success only)",
+    )

--- a/qontract_api/qontract_api/integrations/sso_client/service.py
+++ b/qontract_api/qontract_api/integrations/sso_client/service.py
@@ -214,7 +214,7 @@ class SsoClientService:
         keycloak = keycloak_instances[request.keycloak_instance.url]
         target_secret = Secret(
             secret_manager_url=self.settings.secrets.default_provider_url,
-            path=f"app-sre/creds/rhidp/manual/{request.client_name}",
+            path=f"{self.settings.sso_client.manual_vault_path_prefix}/{request.client_name}",
         )
         try:
             self._register_and_persist_client(

--- a/qontract_api/qontract_api/integrations/sso_client/service.py
+++ b/qontract_api/qontract_api/integrations/sso_client/service.py
@@ -24,6 +24,8 @@ from qontract_api.integrations.sso_client.schemas import (
     SsoClientAction,
     SsoClientActionCreate,
     SsoClientActionDelete,
+    SsoClientCreateManualRequest,
+    SsoClientCreateManualResult,
     SsoClientTaskResult,
 )
 from qontract_api.logger import get_logger
@@ -117,6 +119,57 @@ class SsoClientService:
                 INTEGRATION_NAME, ocm_environment, entry.secret.path
             ).set(claims["exp"])
 
+    def _register_and_persist_client(
+        self,
+        *,
+        client_name: str,
+        redirect_uris: Iterable[str],
+        group_filter_regex: str | None,
+        issuer: str,
+        keycloak: KeycloakWorkspaceClient,
+        target_secret: Secret,
+    ) -> None:
+        """Register a client with Keycloak and persist its secret to Vault.
+
+        Rolls back the Keycloak registration if the Vault write fails, so a
+        failed persist never leaves an orphaned-but-unrecorded Keycloak client.
+        """
+        sso_client = keycloak.register_client(
+            client_name=client_name,
+            redirect_uris=list(redirect_uris),
+            group_filter_regex=group_filter_regex,
+        )
+        secret_data = SsoClientSecret(
+            client_id=sso_client.client_id,
+            client_name=client_name,
+            client_secret=sso_client.client_secret,
+            redirect_uris=sso_client.redirect_uris,
+            registration_access_token=sso_client.registration_access_token,
+            registration_client_uri=(
+                f"{issuer}/clients-registrations/default/{sso_client.client_id}"
+            ),
+            issuer=issuer,
+            attributes=sso_client.attributes,
+        )
+        try:
+            self.secret_manager.write(target_secret, secret_data.model_dump())
+        except Exception:
+            logger.exception(
+                f"Failed to persist secret for {client_name}; "
+                "rolling back Keycloak client registration"
+            )
+            try:
+                keycloak.delete_client(
+                    client_id=sso_client.client_id,
+                    registration_access_token=sso_client.registration_access_token,
+                )
+            except Exception:
+                logger.exception(
+                    f"Rollback also failed for {client_name}; "
+                    f"Keycloak client {sso_client.client_id} may be orphaned"
+                )
+            raise
+
     def _create_sso_client(
         self,
         action: SsoClientActionCreate,
@@ -131,51 +184,61 @@ class SsoClientService:
             )
             return False
 
-        keycloak = keycloak_instances[cluster.auth.issuer]
-        sso_client = keycloak.register_client(
+        self._register_and_persist_client(
             client_name=action.sso_client_id,
             redirect_uris=[
                 console_url_to_oauth_url(cluster.console_url, cluster.auth.name)
             ],
             group_filter_regex=cluster.auth.group_filter_regex,
-        )
-        secret_data = SsoClientSecret(
-            client_id=sso_client.client_id,
-            client_name=action.sso_client_id,
-            client_secret=sso_client.client_secret,
-            redirect_uris=sso_client.redirect_uris,
-            registration_access_token=sso_client.registration_access_token,
-            registration_client_uri=(
-                f"{cluster.auth.issuer}/clients-registrations/default/{sso_client.client_id}"
-            ),
             issuer=cluster.auth.issuer,
-            attributes=sso_client.attributes,
+            keycloak=keycloak_instances[cluster.auth.issuer],
+            target_secret=Secret(
+                secret_manager_url=vault_target.secret_manager_url,
+                path=f"{vault_target.path}/{action.sso_client_id}",
+            ),
+        )
+        return True
+
+    def create_manual(
+        self, request: SsoClientCreateManualRequest
+    ) -> SsoClientCreateManualResult:
+        """Register a one-off SSO client (not tied to an OCM cluster) and store it in Vault.
+
+        Used for ad-hoc client creation (e.g. via qontract-cli), as opposed to the
+        cluster-driven reconcile() flow. The Vault path is server-derived (not
+        caller-specified) so OPA can restrict the calling token's role tightly.
+        """
+        keycloak_instances = build_keycloak_instances(
+            [request.keycloak_instance], self.cache, self.secret_manager
+        )
+        keycloak = keycloak_instances[request.keycloak_instance.url]
+        target_secret = Secret(
+            secret_manager_url=self.settings.secrets.default_provider_url,
+            path=f"app-sre/creds/rhidp/manual/{request.client_name}",
         )
         try:
-            self.secret_manager.write(
-                Secret(
-                    secret_manager_url=vault_target.secret_manager_url,
-                    path=f"{vault_target.path}/{action.sso_client_id}",
-                ),
-                secret_data.model_dump(),
+            self._register_and_persist_client(
+                client_name=request.client_name,
+                redirect_uris=request.redirect_uris,
+                group_filter_regex=request.group_filter_regex,
+                issuer=request.keycloak_instance.url,
+                keycloak=keycloak,
+                target_secret=target_secret,
             )
-        except Exception:
-            logger.exception(
-                f"Failed to persist secret for {action.sso_client_id}; "
-                "rolling back Keycloak client registration"
+        except Exception as e:
+            logger.exception(f"Failed to create SSO client {request.client_name}")
+            return SsoClientCreateManualResult(
+                status=TaskStatus.FAILED,
+                errors=[f"Failed to create SSO client {request.client_name}: {e}"],
             )
-            try:
-                keycloak.delete_client(
-                    client_id=sso_client.client_id,
-                    registration_access_token=sso_client.registration_access_token,
-                )
-            except Exception:
-                logger.exception(
-                    f"Rollback also failed for {action.sso_client_id}; "
-                    f"Keycloak client {sso_client.client_id} may be orphaned"
-                )
-            raise
-        return True
+        finally:
+            keycloak.close()
+
+        return SsoClientCreateManualResult(
+            status=TaskStatus.SUCCESS,
+            applied_count=1,
+            vault_secret_path=target_secret.path,
+        )
 
     def _delete_sso_client(
         self,

--- a/qontract_api/qontract_api/integrations/sso_client/tasks.py
+++ b/qontract_api/qontract_api/integrations/sso_client/tasks.py
@@ -13,7 +13,11 @@ from qontract_utils.events import Event
 from qontract_api.cache.factory import get_cache
 from qontract_api.config import settings
 from qontract_api.event_manager import get_event_manager
-from qontract_api.integrations.sso_client.schemas import SsoClientTaskResult
+from qontract_api.integrations.sso_client.schemas import (
+    SsoClientCreateManualRequest,
+    SsoClientCreateManualResult,
+    SsoClientTaskResult,
+)
 from qontract_api.integrations.sso_client.service import SsoClientService
 from qontract_api.logger import get_logger
 from qontract_api.models import TaskStatus
@@ -117,5 +121,70 @@ def reconcile_sso_client_task(
                 )
         except Exception:
             logger.exception(f"Task {request_id} failed to publish events")
+
+    return result
+
+
+def generate_manual_create_lock_key(
+    _self: Task,
+    request: SsoClientCreateManualRequest,
+    **_: Any,
+) -> str:
+    """Lock key based on client_name to prevent concurrent duplicate creation."""
+    return request.client_name
+
+
+@celery_app.task(bind=True, name="sso-client.create-manual", acks_late=True)
+@deduplicated_task(lock_key_fn=generate_manual_create_lock_key, timeout=600)
+def create_manual_sso_client_task(
+    self: Any,  # Celery Task instance (bind=True)
+    request: SsoClientCreateManualRequest,
+    *,
+    dry_run: bool = False,  # ruff: ignore[unused-function-argument] - consumed by @deduplicated_task's kwargs.get("dry_run")
+) -> SsoClientCreateManualResult:
+    """Create a one-off SSO client, not tied to any OCM cluster (background task)."""
+    request_id = self.request.id
+
+    try:
+        cache = get_cache()
+        secret_manager = get_secret_manager(cache=cache)
+        event_manager = get_event_manager()
+
+        service = SsoClientService(
+            cache=cache,
+            secret_manager=secret_manager,
+            settings=settings,
+        )
+
+        result = service.create_manual(request)
+    except Exception as err:
+        logger.exception(f"Task {request_id} failed with error")
+        return SsoClientCreateManualResult(
+            status=TaskStatus.FAILED,
+            errors=[f"Unexpected {err=}"],
+        )
+
+    logger.info(
+        f"Task {request_id} completed",
+        status=result.status,
+        vault_secret_path=result.vault_secret_path,
+        errors=result.errors,
+    )
+
+    if result.status == TaskStatus.SUCCESS and event_manager:
+        try:
+            event_manager.publish_event(
+                Event(
+                    source=__name__,
+                    type="qontract-api.sso-client.create-manual",
+                    data={
+                        "client_name": request.client_name,
+                        "vault_secret_path": result.vault_secret_path,
+                    },
+                    datacontenttype="application/json",
+                )
+            )
+        except Exception:
+            logger.exception(f"Task {request_id} failed to publish event")
 
     return result

--- a/qontract_api/tests/integrations/sso_client/test_router.py
+++ b/qontract_api/tests/integrations/sso_client/test_router.py
@@ -192,7 +192,7 @@ def test_get_manual_task_status(
     expected_result = SsoClientCreateManualResult(
         status=TaskStatus.SUCCESS,
         applied_count=1,
-        vault_secret_path="app-sre/creds/rhidp/manual/my-manual-client",
+        vault_secret_path="app-sre/integrations-throughput/rhidp/manual/my-manual-client",
     )
     mock_wait.return_value = expected_result
 
@@ -202,5 +202,5 @@ def test_get_manual_task_status(
     assert response.json()["status"] == TaskStatus.SUCCESS.value
     assert (
         response.json()["vault_secret_path"]
-        == "app-sre/creds/rhidp/manual/my-manual-client"
+        == "app-sre/integrations-throughput/rhidp/manual/my-manual-client"
     )

--- a/qontract_api/tests/integrations/sso_client/test_router.py
+++ b/qontract_api/tests/integrations/sso_client/test_router.py
@@ -10,6 +10,8 @@ from qontract_api.auth import create_access_token
 from qontract_api.constants import REQUEST_ID_HEADER
 from qontract_api.integrations.sso_client.domain import KeycloakInstanceSecret
 from qontract_api.integrations.sso_client.schemas import (
+    SsoClientCreateManualRequest,
+    SsoClientCreateManualResult,
     SsoClientReconcileRequest,
     SsoClientTaskResult,
 )
@@ -17,6 +19,7 @@ from qontract_api.models import Secret, TaskStatus, TokenData
 from qontract_api.tasks import QUEUE_MR_CHECK, QUEUE_PROD
 
 ENDPOINT = "/api/v1/integrations/sso-client/reconcile"
+MANUAL_ENDPOINT = "/api/v1/integrations/sso-client/manual"
 
 
 @pytest.fixture
@@ -120,3 +123,84 @@ def test_get_task_status(
 
     assert response.status_code == HTTPStatus.OK
     assert response.json()["status"] == TaskStatus.SUCCESS.value
+
+
+@pytest.fixture
+def sample_create_manual_request() -> SsoClientCreateManualRequest:
+    return SsoClientCreateManualRequest(
+        client_name="my-manual-client",
+        redirect_uris=["https://example.org/login"],
+        keycloak_instance=KeycloakInstanceSecret(
+            url="https://issuer.example.com",
+            secret=Secret(
+                secret_manager_url="https://vault.corp.redhat.com:8200",
+                path="apps/sso-iat/share-with/app/ai-app-sre/iat",
+            ),
+        ),
+    )
+
+
+@patch("qontract_api.integrations.sso_client.router.create_manual_sso_client_task")
+def test_post_manual_queues_task(
+    mock_task: MagicMock,
+    client: TestClient,
+    auth_headers: dict[str, str],
+    sample_create_manual_request: SsoClientCreateManualRequest,
+) -> None:
+    """Test POST /manual queues a Celery task and returns task ID."""
+    response = client.post(
+        MANUAL_ENDPOINT,
+        json=sample_create_manual_request.model_dump(),
+        headers=auth_headers,
+    )
+
+    assert response.status_code == HTTPStatus.ACCEPTED
+    data = response.json()
+    request_id = response.headers[REQUEST_ID_HEADER]
+    assert data["id"] == request_id
+    assert data["status"] == TaskStatus.PENDING.value
+    assert f"/manual/{request_id}" in data["status_url"]
+
+    mock_task.apply_async.assert_called_once()
+    call_kwargs = mock_task.apply_async.call_args.kwargs["kwargs"]
+    assert call_kwargs["request"].client_name == "my-manual-client"
+    assert mock_task.apply_async.call_args.kwargs["queue"] == QUEUE_PROD
+
+
+def test_post_manual_requires_auth(
+    client: TestClient, sample_create_manual_request: SsoClientCreateManualRequest
+) -> None:
+    response = client.post(
+        MANUAL_ENDPOINT, json=sample_create_manual_request.model_dump()
+    )
+    assert response.status_code == HTTPStatus.UNAUTHORIZED
+
+
+def test_post_manual_invalid_body(
+    client: TestClient, auth_headers: dict[str, str]
+) -> None:
+    response = client.post(
+        MANUAL_ENDPOINT, json={"invalid": "body"}, headers=auth_headers
+    )
+    assert response.status_code == HTTPStatus.UNPROCESSABLE_ENTITY
+
+
+@patch("qontract_api.integrations.sso_client.router.wait_for_task_completion")
+def test_get_manual_task_status(
+    mock_wait: MagicMock, client: TestClient, auth_headers: dict[str, str]
+) -> None:
+    expected_result = SsoClientCreateManualResult(
+        status=TaskStatus.SUCCESS,
+        applied_count=1,
+        vault_secret_path="app-sre/creds/rhidp/manual/my-manual-client",
+    )
+    mock_wait.return_value = expected_result
+
+    response = client.get(f"{MANUAL_ENDPOINT}/test-task-id", headers=auth_headers)
+
+    assert response.status_code == HTTPStatus.OK
+    assert response.json()["status"] == TaskStatus.SUCCESS.value
+    assert (
+        response.json()["vault_secret_path"]
+        == "app-sre/creds/rhidp/manual/my-manual-client"
+    )

--- a/qontract_api/tests/integrations/sso_client/test_service.py
+++ b/qontract_api/tests/integrations/sso_client/test_service.py
@@ -486,7 +486,10 @@ def test_create_manual_success(
 
     assert result.status == TaskStatus.SUCCESS
     assert result.applied_count == 1
-    assert result.vault_secret_path == "app-sre/creds/rhidp/manual/my-manual-client"
+    assert (
+        result.vault_secret_path
+        == "app-sre/integrations-throughput/rhidp/manual/my-manual-client"
+    )
 
     mock_keycloak_instance.register_client.assert_called_once_with(
         client_name="my-manual-client",
@@ -496,7 +499,10 @@ def test_create_manual_success(
     mock_secret_manager.write.assert_called_once()
     written_secret, written_data = mock_secret_manager.write.call_args.args
     assert written_secret.secret_manager_url == settings.secrets.default_provider_url
-    assert written_secret.path == "app-sre/creds/rhidp/manual/my-manual-client"
+    assert (
+        written_secret.path
+        == "app-sre/integrations-throughput/rhidp/manual/my-manual-client"
+    )
     assert written_data["client_id"] == "my-manual-client"
     assert written_data["issuer"] == ISSUER_URL
     mock_keycloak_instance.close.assert_called_once_with()

--- a/qontract_api/tests/integrations/sso_client/test_service.py
+++ b/qontract_api/tests/integrations/sso_client/test_service.py
@@ -18,6 +18,7 @@ from qontract_api.integrations.sso_client.domain import (
 from qontract_api.integrations.sso_client.schemas import (
     SsoClientActionCreate,
     SsoClientActionDelete,
+    SsoClientCreateManualRequest,
 )
 from qontract_api.integrations.sso_client.service import SsoClientService
 from qontract_api.models import Secret, TaskStatus
@@ -459,6 +460,77 @@ def test_create_rollback_failure_does_not_mask_original_write_error(
         client_id="my-cluster-org-1-redhat-sso-issuer.example.com",
         registration_access_token="rat",
     )
+
+
+def test_create_manual_success(
+    service: SsoClientService,
+    settings: Settings,
+    mock_secret_manager: MagicMock,
+    mock_keycloak_instance: MagicMock,
+) -> None:
+    mock_keycloak_instance.register_client.return_value = KeycloakSsoClient(
+        client_id="my-manual-client",
+        client_secret="s3cr3t",
+        redirect_uris=["https://example.org/login"],
+        registration_access_token="rat",
+        attributes={},
+    )
+
+    result = service.create_manual(
+        SsoClientCreateManualRequest(
+            client_name="my-manual-client",
+            redirect_uris=["https://example.org/login"],
+            keycloak_instance=KEYCLOAK_SECRET,
+        )
+    )
+
+    assert result.status == TaskStatus.SUCCESS
+    assert result.applied_count == 1
+    assert result.vault_secret_path == "app-sre/creds/rhidp/manual/my-manual-client"
+
+    mock_keycloak_instance.register_client.assert_called_once_with(
+        client_name="my-manual-client",
+        redirect_uris=["https://example.org/login"],
+        group_filter_regex=None,
+    )
+    mock_secret_manager.write.assert_called_once()
+    written_secret, written_data = mock_secret_manager.write.call_args.args
+    assert written_secret.secret_manager_url == settings.secrets.default_provider_url
+    assert written_secret.path == "app-sre/creds/rhidp/manual/my-manual-client"
+    assert written_data["client_id"] == "my-manual-client"
+    assert written_data["issuer"] == ISSUER_URL
+    mock_keycloak_instance.close.assert_called_once_with()
+
+
+def test_create_manual_rollback_on_write_failure(
+    service: SsoClientService,
+    mock_secret_manager: MagicMock,
+    mock_keycloak_instance: MagicMock,
+) -> None:
+    mock_secret_manager.write.side_effect = RuntimeError("vault write failed")
+    mock_keycloak_instance.register_client.return_value = KeycloakSsoClient(
+        client_id="my-manual-client",
+        client_secret="s3cr3t",
+        redirect_uris=["https://example.org/login"],
+        registration_access_token="rat",
+        attributes={},
+    )
+
+    result = service.create_manual(
+        SsoClientCreateManualRequest(
+            client_name="my-manual-client",
+            redirect_uris=["https://example.org/login"],
+            keycloak_instance=KEYCLOAK_SECRET,
+        )
+    )
+
+    assert result.status == TaskStatus.FAILED
+    assert result.vault_secret_path is None
+    assert "vault write failed" in result.errors[0]
+    mock_keycloak_instance.delete_client.assert_called_once_with(
+        client_id="my-manual-client", registration_access_token="rat"
+    )
+    mock_keycloak_instance.close.assert_called_once_with()
 
 
 def test_reconcile_exposes_metrics(

--- a/qontract_api/tests/tasks/test_sso_client.py
+++ b/qontract_api/tests/tasks/test_sso_client.py
@@ -11,10 +11,14 @@ from qontract_api.integrations.sso_client.schemas import (
     SsoClientAction,
     SsoClientActionCreate,
     SsoClientActionDelete,
+    SsoClientCreateManualRequest,
+    SsoClientCreateManualResult,
     SsoClientTaskResult,
 )
 from qontract_api.integrations.sso_client.tasks import (
+    create_manual_sso_client_task,
     generate_lock_key,
+    generate_manual_create_lock_key,
     reconcile_sso_client_task,
 )
 from qontract_api.models import Secret, TaskStatus
@@ -235,6 +239,103 @@ def test_task_returns_failed_result_on_unexpected_exception(
     result = _task_func()(
         mock_self, "prod", [], [KEYCLOAK_SECRET], VAULT_TARGET, dry_run=False
     )
+
+    assert result.status == TaskStatus.FAILED
+    assert "connection refused" in result.errors[0]
+
+
+# ---------------------------------------------------------------------------
+# create_manual_sso_client_task
+# ---------------------------------------------------------------------------
+
+CREATE_MANUAL_REQUEST = SsoClientCreateManualRequest(
+    client_name="my-manual-client",
+    redirect_uris=["https://example.org/login"],
+    keycloak_instance=KEYCLOAK_SECRET,
+)
+
+
+def _manual_task_func() -> Callable:
+    """Return the unwrapped task function (bypasses Celery + deduplication decorators)."""
+    return inspect.unwrap(create_manual_sso_client_task)
+
+
+def test_generate_manual_create_lock_key() -> None:
+    key = generate_manual_create_lock_key(MagicMock(), CREATE_MANUAL_REQUEST)
+    assert key == "my-manual-client"
+
+
+@patch("qontract_api.integrations.sso_client.tasks.get_event_manager")
+@patch("qontract_api.integrations.sso_client.tasks.get_secret_manager")
+@patch("qontract_api.integrations.sso_client.tasks.get_cache")
+@patch("qontract_api.integrations.sso_client.tasks.SsoClientService")
+def test_manual_publishes_event_on_success(
+    mock_service_cls: MagicMock,
+    mock_get_cache: MagicMock,
+    mock_get_secret_manager: MagicMock,
+    mock_get_event_manager: MagicMock,
+    mock_self: MagicMock,
+) -> None:
+    mock_service_cls.return_value.create_manual.return_value = (
+        SsoClientCreateManualResult(
+            status=TaskStatus.SUCCESS,
+            applied_count=1,
+            vault_secret_path="app-sre/creds/rhidp/manual/my-manual-client",
+        )
+    )
+    mock_event_manager = MagicMock()
+    mock_get_event_manager.return_value = mock_event_manager
+
+    result = _manual_task_func()(mock_self, CREATE_MANUAL_REQUEST)
+
+    assert result.status == TaskStatus.SUCCESS
+    mock_event_manager.publish_event.assert_called_once()
+    published = mock_event_manager.publish_event.call_args[0][0]
+    assert published.type == "qontract-api.sso-client.create-manual"
+    assert published.data["client_name"] == "my-manual-client"
+
+
+@patch("qontract_api.integrations.sso_client.tasks.get_event_manager")
+@patch("qontract_api.integrations.sso_client.tasks.get_secret_manager")
+@patch("qontract_api.integrations.sso_client.tasks.get_cache")
+@patch("qontract_api.integrations.sso_client.tasks.SsoClientService")
+def test_manual_no_event_published_on_failure(
+    mock_service_cls: MagicMock,
+    mock_get_cache: MagicMock,
+    mock_get_secret_manager: MagicMock,
+    mock_get_event_manager: MagicMock,
+    mock_self: MagicMock,
+) -> None:
+    mock_service_cls.return_value.create_manual.return_value = (
+        SsoClientCreateManualResult(
+            status=TaskStatus.FAILED, errors=["Keycloak unreachable"]
+        )
+    )
+    mock_event_manager = MagicMock()
+    mock_get_event_manager.return_value = mock_event_manager
+
+    result = _manual_task_func()(mock_self, CREATE_MANUAL_REQUEST)
+
+    assert result.status == TaskStatus.FAILED
+    mock_event_manager.publish_event.assert_not_called()
+
+
+@patch("qontract_api.integrations.sso_client.tasks.get_event_manager")
+@patch("qontract_api.integrations.sso_client.tasks.get_secret_manager")
+@patch("qontract_api.integrations.sso_client.tasks.get_cache")
+@patch("qontract_api.integrations.sso_client.tasks.SsoClientService")
+def test_manual_task_returns_failed_result_on_unexpected_exception(
+    mock_service_cls: MagicMock,
+    mock_get_cache: MagicMock,
+    mock_get_secret_manager: MagicMock,
+    mock_get_event_manager: MagicMock,
+    mock_self: MagicMock,
+) -> None:
+    mock_service_cls.return_value.create_manual.side_effect = RuntimeError(
+        "connection refused"
+    )
+
+    result = _manual_task_func()(mock_self, CREATE_MANUAL_REQUEST)
 
     assert result.status == TaskStatus.FAILED
     assert "connection refused" in result.errors[0]

--- a/qontract_api/tests/tasks/test_sso_client.py
+++ b/qontract_api/tests/tasks/test_sso_client.py
@@ -276,12 +276,10 @@ def test_manual_publishes_event_on_success(
     mock_get_event_manager: MagicMock,
     mock_self: MagicMock,
 ) -> None:
-    mock_service_cls.return_value.create_manual.return_value = (
-        SsoClientCreateManualResult(
-            status=TaskStatus.SUCCESS,
-            applied_count=1,
-            vault_secret_path="app-sre/creds/rhidp/manual/my-manual-client",
-        )
+    mock_service_cls.return_value.create_manual.return_value = SsoClientCreateManualResult(
+        status=TaskStatus.SUCCESS,
+        applied_count=1,
+        vault_secret_path="app-sre/integrations-throughput/rhidp/manual/my-manual-client",
     )
     mock_event_manager = MagicMock()
     mock_get_event_manager.return_value = mock_event_manager

--- a/qontract_api/tests/test_config.py
+++ b/qontract_api/tests/test_config.py
@@ -1,6 +1,7 @@
 """Tests for configuration settings."""
 
 import pytest
+from pydantic import ValidationError
 
 from qontract_api.config import Secret, Settings
 
@@ -98,6 +99,25 @@ def test_subscriber_settings_defaults() -> None:
     assert subscriber.slack_token is None
     assert subscriber.qontract_api_url == "http://qontract-api:8080"
     assert subscriber.qontract_api_token == ""
+
+
+def test_sso_client_settings_default_manual_vault_path_prefix() -> None:
+    """Test SsoClientSettings defaults manual_vault_path_prefix to the writable RHIDP prefix."""
+    from qontract_api.config import SsoClientSettings
+
+    sso_client = SsoClientSettings()
+    assert (
+        sso_client.manual_vault_path_prefix
+        == "app-sre/integrations-throughput/rhidp/manual"
+    )
+
+
+def test_sso_client_settings_rejects_empty_manual_vault_path_prefix() -> None:
+    """Test SsoClientSettings rejects an empty manual_vault_path_prefix."""
+    from qontract_api.config import SsoClientSettings
+
+    with pytest.raises(ValidationError):
+        SsoClientSettings(manual_vault_path_prefix="")
 
 
 def test_slack_settings_backwards_compatible() -> None:

--- a/qontract_api_client/qontract_api_client/client.py
+++ b/qontract_api_client/qontract_api_client/client.py
@@ -525,6 +525,34 @@ async def slack_usergroups_task_status(
     return result
 
 
+@client.post("/api/v1/integrations/sso-client/manual")
+async def sso_client_create_manual(
+    result: schemas.SsoClientTaskResponse, data: schemas.SsoClientCreateManualRequest
+) -> schemas.SsoClientTaskResponse:
+    """Sso Client Create Manual
+
+        Queue ad-hoc SSO client creation (not tied to an OCM cluster).
+
+    Used by qontract-cli for one-off client creation. Always queues a
+    background task and returns immediately with a task_id. Use
+    GET /manual/{task_id} to retrieve the result.
+    """
+    return result
+
+
+@client.get("/api/v1/integrations/sso-client/manual/{task_id}")
+async def sso_client_create_manual_task_status(
+    result: schemas.SsoClientCreateManualResult,
+    task_id: str,
+    timeout: int | None = None,
+) -> schemas.SsoClientCreateManualResult:
+    """Sso Client Create Manual Task Status
+
+    Retrieve ad-hoc SSO client creation result (blocking or non-blocking).
+    """
+    return result
+
+
 @client.post("/api/v1/integrations/sso-client/reconcile")
 async def sso_client(
     result: schemas.SsoClientTaskResponse, data: schemas.SsoClientReconcileRequest

--- a/qontract_api_client/qontract_api_client/schemas.py
+++ b/qontract_api_client/qontract_api_client/schemas.py
@@ -892,6 +892,21 @@ class SsoClientCluster(pydantic.BaseModel):
     rhidp_enabled: bool
 
 
+class SsoClientCreateManualRequest(pydantic.BaseModel):
+    client_name: str
+    group_filter_regex: str | None = None
+    keycloak_instance: KeycloakInstanceSecret
+    redirect_uris: list[str]
+
+
+class SsoClientCreateManualResult(pydantic.BaseModel):
+    actions: list[str] = []
+    applied_count: int = 0
+    errors: list[str] = []
+    status: TaskStatus
+    vault_secret_path: str | None = None
+
+
 class SsoClientReconcileRequest(pydantic.BaseModel):
     clusters: list[SsoClientCluster]
     dry_run: bool = True

--- a/tools/qontract_cli.py
+++ b/tools/qontract_cli.py
@@ -4348,7 +4348,12 @@ RHIDP_KEYCLOAK_INSTANCES = {
 
 
 @sso_client.command()
-@click.argument("client-name", required=True)
+@click.option(
+    "--client-name",
+    help="The name of the SSO client",
+    required=True,
+    prompt=True,
+)
 @click.option(
     "--environment",
     type=click.Choice(sorted(RHIDP_KEYCLOAK_INSTANCES)),

--- a/tools/qontract_cli.py
+++ b/tools/qontract_cli.py
@@ -21,6 +21,7 @@ from pathlib import Path
 from statistics import median
 from textwrap import dedent
 from typing import TYPE_CHECKING, Any, cast
+from urllib.parse import urlparse
 
 import boto3
 import click
@@ -145,7 +146,6 @@ from reconcile.utils.gitlab_api import (
 )
 from reconcile.utils.glitchtip.client import GlitchtipClient
 from reconcile.utils.gql import GqlApiSingleton
-from reconcile.utils.json import json_dumps
 from reconcile.utils.keycloak import (
     KeycloakAPI,
     SSOClient,
@@ -4328,14 +4328,33 @@ def sso_client(ctx: click.Context) -> None:
     """SSO client commands"""
 
 
+# Red Hat SSO (Keycloak) realms usable with `sso-client create`. The Initial
+# Access Token for each lives in vault.corp.redhat.com - qontract-api already
+# holds AppRole credentials for it and reads it server-side, so the CLI never
+# needs direct vault.corp access. Keep in sync with the `--keycloak-instances`
+# extraArgs in data/integrations/qontract-reconcile-rhidp-sso-client.yml.
+RHIDP_KEYCLOAK_INSTANCES = {
+    "prod": {
+        "url": "https://auth.redhat.com/auth/realms/EmployeeIDP",
+        "secret_manager_url": "https://vault.corp.redhat.com:8200",
+        "path": "apps/sso-iat/share-with/app/ai-app-sre/iat",
+    },
+    "stage": {
+        "url": "https://auth.stage.redhat.com/auth/realms/EmployeeIDP",
+        "secret_manager_url": "https://vault.corp.redhat.com:8200",
+        "path": "apps/sso-iat/share-with/app/ai-app-sre/iat-stage",
+    },
+}
+
+
 @sso_client.command()
 @click.argument("client-name", required=True)
 @click.option(
-    "--keycloak-instance-vault-path",
-    help="Path to the keycloak secret in vault",
-    default="app-sre/creds/rhidp/auth.redhat.com",
-    required=True,
+    "--environment",
+    type=click.Choice(sorted(RHIDP_KEYCLOAK_INSTANCES)),
+    default="prod",
     show_default=True,
+    help="Red Hat SSO (Keycloak) environment to register the client with",
 )
 @click.option(
     "--redirect-uri",
@@ -4344,32 +4363,84 @@ def sso_client(ctx: click.Context) -> None:
     required=True,
     prompt=True,
 )
+@click.option(
+    "--group-filter-regex",
+    help="Optional group filter regex for the SSO client",
+    default=None,
+)
+@click.option(
+    "--timeout",
+    help="Seconds to wait for qontract-api to finish creating the client",
+    default=60,
+    show_default=True,
+)
 @click.pass_context
 def create(
     ctx: click.Context,
     client_name: str,
-    keycloak_instance_vault_path: str,
+    environment: str,
     redirect_uri: tuple[str],
+    group_filter_regex: str | None,
+    timeout: int,
 ) -> None:
-    """Create a new SSO client"""
-    vault_settings = get_app_interface_vault_settings()
-    secret_reader = create_secret_reader(use_vault=vault_settings.vault)
+    """Create a new SSO client via qontract-api.
 
-    keycloak_secret = secret_reader.read_all({"path": keycloak_instance_vault_path})
-    keycloak_api = KeycloakAPI(
-        url=keycloak_secret["url"],
-        initial_access_token=keycloak_secret["initial-access-token"],
-    )
-    sso_client = keycloak_api.register_client(
-        client_name=client_name,
-        redirect_uris=redirect_uri,
-    )
+    qontract-api registers the client with Keycloak and stores its secret in
+    Vault server-side - unlike the old flow, there is nothing left to save
+    manually.
+    """
+    api_config = config.get_config().get("qontract-api", {})
+    server = api_config.get("server")
+    token = api_config.get("token")
+    if not server or not token:
+        click.secho(
+            "Missing [qontract-api] server/token in the --config TOML.",
+            fg="red",
+        )
+        sys.exit(1)
+
+    keycloak_instance = RHIDP_KEYCLOAK_INSTANCES[environment]
+    with requests.Session() as session:
+        session.auth = BearerTokenAuth(token)
+
+        create_response = session.post(
+            f"{server}/api/v1/integrations/sso-client/manual",
+            json={
+                "client_name": client_name,
+                "redirect_uris": list(redirect_uri),
+                "group_filter_regex": group_filter_regex,
+                "keycloak_instance": {
+                    "url": keycloak_instance["url"],
+                    "secret": {
+                        "secret_manager_url": keycloak_instance["secret_manager_url"],
+                        "path": keycloak_instance["path"],
+                    },
+                },
+            },
+            timeout=30,
+        )
+        create_response.raise_for_status()
+        status_path = urlparse(create_response.json()["status_url"]).path
+
+        result_response = session.get(
+            f"{server}{status_path}",
+            params={"timeout": timeout},
+            timeout=timeout + 10,
+        )
+    result_response.raise_for_status()
+    result = result_response.json()
+
+    if result["status"] != "success":
+        click.secho(
+            f"Failed to create SSO client: {'; '.join(result.get('errors', []))}",
+            fg="red",
+        )
+        sys.exit(1)
+
     click.secho(
-        "SSO client created successfully. Please save the following JSON in Vault!",
-        bg="red",
-        fg="white",
+        f"SSO client created successfully. Secret stored in Vault at: {result['vault_secret_path']}",
+        fg="green",
     )
-    print(json_dumps(sso_client, indent=2))
 
 
 @sso_client.command()

--- a/tools/test/test_qontract_cli.py
+++ b/tools/test/test_qontract_cli.py
@@ -700,7 +700,7 @@ def test_sso_client_create_success(
         json=Mock(
             return_value={
                 "status": "success",
-                "vault_secret_path": "app-sre/creds/rhidp/manual/my-client",
+                "vault_secret_path": "app-sre/integrations-throughput/rhidp/manual/my-client",
             }
         )
     )
@@ -712,7 +712,7 @@ def test_sso_client_create_success(
     )
 
     assert result.exit_code == 0
-    assert "app-sre/creds/rhidp/manual/my-client" in result.output
+    assert "app-sre/integrations-throughput/rhidp/manual/my-client" in result.output
 
     post_kwargs = mock_requests_session.post.call_args.kwargs
     assert (
@@ -753,7 +753,7 @@ def test_sso_client_create_stage_environment(
         json=Mock(
             return_value={
                 "status": "success",
-                "vault_secret_path": "app-sre/creds/rhidp/manual/my-client",
+                "vault_secret_path": "app-sre/integrations-throughput/rhidp/manual/my-client",
             }
         )
     )

--- a/tools/test/test_qontract_cli.py
+++ b/tools/test/test_qontract_cli.py
@@ -708,7 +708,13 @@ def test_sso_client_create_success(
     runner = CliRunner()
     result = runner.invoke(
         qontract_cli.sso_client,
-        ["create", "my-client", "--redirect-uri", "https://example.org/login"],
+        [
+            "create",
+            "--client-name",
+            "my-client",
+            "--redirect-uri",
+            "https://example.org/login",
+        ],
     )
 
     assert result.exit_code == 0
@@ -763,6 +769,7 @@ def test_sso_client_create_stage_environment(
         qontract_cli.sso_client,
         [
             "create",
+            "--client-name",
             "my-client",
             "--environment",
             "stage",
@@ -802,7 +809,13 @@ def test_sso_client_create_task_failure_exits_nonzero(
     runner = CliRunner()
     result = runner.invoke(
         qontract_cli.sso_client,
-        ["create", "my-client", "--redirect-uri", "https://example.org/login"],
+        [
+            "create",
+            "--client-name",
+            "my-client",
+            "--redirect-uri",
+            "https://example.org/login",
+        ],
     )
 
     assert result.exit_code != 0
@@ -817,7 +830,13 @@ def test_sso_client_create_requires_qontract_api_config(
     runner = CliRunner()
     result = runner.invoke(
         qontract_cli.sso_client,
-        ["create", "my-client", "--redirect-uri", "https://example.org/login"],
+        [
+            "create",
+            "--client-name",
+            "my-client",
+            "--redirect-uri",
+            "https://example.org/login",
+        ],
     )
 
     assert result.exit_code != 0

--- a/tools/test/test_qontract_cli.py
+++ b/tools/test/test_qontract_cli.py
@@ -665,3 +665,160 @@ def test_rds_attr_falls_through_when_key_absent() -> None:
     defaults: dict = {"engine": "postgres"}
     assert qontract_cli.rds_attr("engine", overrides, defaults) == "postgres"
     assert qontract_cli.rds_attr("engine", {"engine": "mysql"}, defaults) == "mysql"
+
+
+@pytest.fixture
+def mock_qontract_api_config(mocker: MockerFixture) -> Mock:
+    return mocker.patch(
+        "tools.qontract_cli.config.get_config",
+        return_value={
+            "qontract-api": {
+                "server": "https://qontract-api.example.com",
+                "token": "tok",
+            }
+        },
+    )
+
+
+@pytest.fixture
+def mock_requests_session(mocker: MockerFixture) -> Mock:
+    mock_session_cls = mocker.patch("tools.qontract_cli.requests.Session")
+    return mock_session_cls.return_value.__enter__.return_value
+
+
+def test_sso_client_create_success(
+    mock_qontract_api_config: Mock, mock_requests_session: Mock
+) -> None:
+    mock_requests_session.post.return_value = Mock(
+        json=Mock(
+            return_value={
+                "status_url": "https://internal-host/api/v1/integrations/sso-client/manual/task-123"
+            }
+        )
+    )
+    mock_requests_session.get.return_value = Mock(
+        json=Mock(
+            return_value={
+                "status": "success",
+                "vault_secret_path": "app-sre/creds/rhidp/manual/my-client",
+            }
+        )
+    )
+
+    runner = CliRunner()
+    result = runner.invoke(
+        qontract_cli.sso_client,
+        ["create", "my-client", "--redirect-uri", "https://example.org/login"],
+    )
+
+    assert result.exit_code == 0
+    assert "app-sre/creds/rhidp/manual/my-client" in result.output
+
+    post_kwargs = mock_requests_session.post.call_args.kwargs
+    assert (
+        mock_requests_session.post.call_args.args[0]
+        == "https://qontract-api.example.com/api/v1/integrations/sso-client/manual"
+    )
+    assert post_kwargs["json"]["client_name"] == "my-client"
+    assert post_kwargs["json"]["redirect_uris"] == ["https://example.org/login"]
+    assert post_kwargs["json"]["keycloak_instance"] == {
+        "url": qontract_cli.RHIDP_KEYCLOAK_INSTANCES["prod"]["url"],
+        "secret": {
+            "secret_manager_url": qontract_cli.RHIDP_KEYCLOAK_INSTANCES["prod"][
+                "secret_manager_url"
+            ],
+            "path": qontract_cli.RHIDP_KEYCLOAK_INSTANCES["prod"]["path"],
+        },
+    }
+
+    get_args, get_kwargs = mock_requests_session.get.call_args
+    assert (
+        get_args[0]
+        == "https://qontract-api.example.com/api/v1/integrations/sso-client/manual/task-123"
+    )
+    assert get_kwargs["params"] == {"timeout": 60}
+
+
+def test_sso_client_create_stage_environment(
+    mock_qontract_api_config: Mock, mock_requests_session: Mock
+) -> None:
+    mock_requests_session.post.return_value = Mock(
+        json=Mock(
+            return_value={
+                "status_url": "https://internal-host/api/v1/integrations/sso-client/manual/task-123"
+            }
+        )
+    )
+    mock_requests_session.get.return_value = Mock(
+        json=Mock(
+            return_value={
+                "status": "success",
+                "vault_secret_path": "app-sre/creds/rhidp/manual/my-client",
+            }
+        )
+    )
+
+    runner = CliRunner()
+    result = runner.invoke(
+        qontract_cli.sso_client,
+        [
+            "create",
+            "my-client",
+            "--environment",
+            "stage",
+            "--redirect-uri",
+            "https://example.org/login",
+        ],
+    )
+
+    assert result.exit_code == 0
+    post_kwargs = mock_requests_session.post.call_args.kwargs
+    assert (
+        post_kwargs["json"]["keycloak_instance"]["url"]
+        == qontract_cli.RHIDP_KEYCLOAK_INSTANCES["stage"]["url"]
+    )
+
+
+def test_sso_client_create_task_failure_exits_nonzero(
+    mock_qontract_api_config: Mock, mock_requests_session: Mock
+) -> None:
+    mock_requests_session.post.return_value = Mock(
+        json=Mock(
+            return_value={
+                "status_url": "https://internal-host/api/v1/integrations/sso-client/manual/task-123"
+            }
+        )
+    )
+    mock_requests_session.get.return_value = Mock(
+        json=Mock(
+            return_value={
+                "status": "failed",
+                "errors": ["Keycloak unreachable"],
+                "vault_secret_path": None,
+            }
+        )
+    )
+
+    runner = CliRunner()
+    result = runner.invoke(
+        qontract_cli.sso_client,
+        ["create", "my-client", "--redirect-uri", "https://example.org/login"],
+    )
+
+    assert result.exit_code != 0
+    assert "Keycloak unreachable" in result.output
+
+
+def test_sso_client_create_requires_qontract_api_config(
+    mocker: MockerFixture,
+) -> None:
+    mocker.patch("tools.qontract_cli.config.get_config", return_value={})
+
+    runner = CliRunner()
+    result = runner.invoke(
+        qontract_cli.sso_client,
+        ["create", "my-client", "--redirect-uri", "https://example.org/login"],
+    )
+
+    assert result.exit_code != 0
+    assert "Missing [qontract-api]" in result.output


### PR DESCRIPTION
## Summary

- `qontract-cli sso-client create` broke after APPSRE-13596 moved `rhidp-sso-client` to qontract-api, which now reads the Keycloak Initial Access Token (IAT) directly from `vault.corp.redhat.com` instead of the old manually-synced copy in the AppSRE vault.
- Instead of teaching the CLI to talk to `vault.corp` directly (which would require distributing vault.corp AppRole credentials to every human running the CLI), this adds a `POST/GET /sso-client/manual` endpoint to qontract-api that registers the client with Keycloak and stores its secret in Vault server-side — qontract-api already holds AppRole credentials for both `vault.devshift.net` and `vault.corp.redhat.com`.
- The CLI now calls this endpoint via a plain synchronous `requests` call (not the async generated `qontract_api_client`) and prints back the Vault path (`app-sre/integrations-throughput/rhidp/manual/<client_name>`) instead of the raw client secret — nothing left to store manually.
- `sso-client remove` is unchanged; it never touched the IAT/vault.corp, so it wasn't affected by APPSRE-13596.

## Changes

- `qontract_api`: new `SsoClientCreateManualRequest`/`Result` schemas, `SsoClientService.create_manual` (shares the register+persist+rollback logic with the existing cluster-reconcile path via a new `_register_and_persist_client` helper), `create_manual_sso_client_task` Celery task, and the new router endpoints. Regenerated `openapi.json` and `qontract_api_client`.
- The Vault target path lives under `app-sre/integrations-throughput/rhidp/manual/<client_name>` — the prefix the qontract-api Vault AppRole is actually granted write access to (`app-sre/creds/*` is read-only for it) — and is configurable via `Settings.sso_client.manual_vault_path_prefix` (validated non-empty).
- `tools/qontract_cli.py`: `sso-client create` rewritten to call the new endpoint (`--environment prod|stage`, new `--group-filter-regex` flag, `--client-name` now an explicit prompted option instead of a positional arg), dropped the now-stale `--keycloak-instance-vault-path` option.
- Companion app-interface MR adds the OPA policy role for the new endpoint and updates the SOP.

Closes APPSRE-15195

## Test plan

- [x] `qontract_api`: `make test` (mypy, ruff, full pytest suite passes)
- [x] `qontract_api_client`: `make test` (generated client verified in sync with the new endpoint)
- [x] Root: new/updated CLI tests in `tools/test/test_qontract_cli.py` pass
- [ ] Manual smoke test against stage once the companion app-interface MR (OPA policy + Vault token) is deployed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added asynchronous manual SSO client creation through the API.
  * Added task-status retrieval with optional polling timeouts.
  * Added production and staging environment selection, optional group filtering, and configurable CLI timeouts.
  * Vault secret storage is handled automatically.
  * Added failure reporting and cleanup when creation cannot be completed.
  * Updated the CLI to submit requests through the API and accept the client name as an option.

* **Tests**
  * Added coverage for API authentication, validation, task processing, CLI workflows, and failure scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->