### PR TITLE
fix(openshift-namespaces): skip delete for namespaces already Terminating

### DIFF
--- a/qontract_api/qontract_api/integrations/openshift_namespaces/service.py
+++ b/qontract_api/qontract_api/integrations/openshift_namespaces/service.py
@@ -107,7 +107,7 @@ class OpenShiftNamespacesService:
                     actions.append(
                         CreateNamespaceAction(cluster=cluster_name, namespace=ns.name)
                     )
-                case (True, True):
+                case (True, True) if not ws_client.is_namespace_terminating(ns.name):
                     actions.append(
                         DeleteNamespaceAction(cluster=cluster_name, namespace=ns.name)
                     )

--- a/qontract_api/qontract_api/kubernetes/workspace_client.py
+++ b/qontract_api/qontract_api/kubernetes/workspace_client.py
@@ -21,10 +21,14 @@ if TYPE_CHECKING:
 logger = get_logger(__name__)
 
 
+_TERMINATING_PHASE = "Terminating"
+
+
 class CachedNamespaceNames(BaseModel, frozen=True):
-    """Cached set of all namespace names on a cluster."""
+    """Cached set of all namespace names on a cluster, plus those Terminating."""
 
     names: frozenset[str]
+    terminating: frozenset[str] = frozenset()
 
 
 class KubernetesWorkspaceClient:
@@ -50,16 +54,16 @@ class KubernetesWorkspaceClient:
     def _cache_key_namespace_names(self) -> str:
         return f"kubernetes:{self._cluster_name}:namespace_names"
 
-    def _get_namespace_names(self) -> frozenset[str]:
-        """Get the cached set of namespace names, or fetch and cache it."""
+    def _get_namespace_state(self) -> CachedNamespaceNames:
+        """Get the cached namespace names and Terminating state, or fetch and cache it."""
         cache_key = self._cache_key_namespace_names()
 
         if cached := self._cache.get_obj(cache_key, CachedNamespaceNames):
-            return cached.names
+            return cached
 
         with self._cache.lock(cache_key):
             if cached := self._cache.get_obj(cache_key, CachedNamespaceNames):
-                return cached.names
+                return cached
 
             namespaces = self._api.list_namespaces()
             names = frozenset(
@@ -67,12 +71,21 @@ class KubernetesWorkspaceClient:
                 for ns in namespaces
                 if ns.metadata and ns.metadata.name
             )
+            terminating = frozenset(
+                ns.metadata.name
+                for ns in namespaces
+                if ns.metadata
+                and ns.metadata.name
+                and ns.status
+                and ns.status.phase == _TERMINATING_PHASE
+            )
+            state = CachedNamespaceNames(names=names, terminating=terminating)
             self._cache.set_obj(
                 cache_key,
-                CachedNamespaceNames(names=names),
+                state,
                 self._settings.kubernetes.namespace_cache_ttl,
             )
-            return names
+            return state
 
     def _invalidate_namespace_cache(self) -> None:
         cache_key = self._cache_key_namespace_names()
@@ -81,7 +94,11 @@ class KubernetesWorkspaceClient:
 
     def namespace_exists(self, name: str) -> bool:
         """Check if a namespace exists (cached via full namespace listing)."""
-        return name in self._get_namespace_names()
+        return name in self._get_namespace_state().names
+
+    def is_namespace_terminating(self, name: str) -> bool:
+        """Check if a namespace is already in the Terminating phase (cached)."""
+        return name in self._get_namespace_state().terminating
 
     def create_namespace(self, name: str) -> Namespace:
         """Create a namespace and invalidate cache."""

--- a/qontract_api/qontract_api/kubernetes/workspace_client.py
+++ b/qontract_api/qontract_api/kubernetes/workspace_client.py
@@ -52,7 +52,9 @@ class KubernetesWorkspaceClient:
         self._settings = settings
 
     def _cache_key_namespace_names(self) -> str:
-        return f"kubernetes:{self._cluster_name}:namespace_names"
+        # v2: adds `terminating` — versioned so pre-upgrade cache entries
+        # (missing the field) are never mistaken for having none.
+        return f"kubernetes:{self._cluster_name}:namespace_names:v2"
 
     def _get_namespace_state(self) -> CachedNamespaceNames:
         """Get the cached namespace names and Terminating state, or fetch and cache it."""

--- a/qontract_api/tests/integrations/openshift_namespaces/test_service.py
+++ b/qontract_api/tests/integrations/openshift_namespaces/test_service.py
@@ -65,6 +65,7 @@ def test_delete_namespace_when_exists(
 ) -> None:
     """Namespace marked for deletion and exists → DeleteNamespaceAction."""
     mock_ws_client.namespace_exists.return_value = True
+    mock_ws_client.is_namespace_terminating.return_value = False
 
     result = service.reconcile(
         cluster_clients={"prod-1": mock_ws_client},
@@ -202,6 +203,22 @@ def test_missing_client_for_cluster(
     assert result.status == TaskStatus.FAILED
 
 
+def test_no_action_when_namespace_terminating(
+    service: OpenShiftNamespacesService,
+    mock_ws_client: MagicMock,
+) -> None:
+    """Namespace marked for deletion but already Terminating → no repeated delete."""
+    mock_ws_client.namespace_exists.return_value = True
+    mock_ws_client.is_namespace_terminating.return_value = True
+
+    result = service.reconcile(
+        cluster_clients={"prod-1": mock_ws_client},
+        cluster_namespaces={"prod-1": [DesiredNamespace(name="stuck-ns", delete=True)]},
+    )
+
+    assert result.actions == []
+
+
 def test_mix_create_and_delete(
     service: OpenShiftNamespacesService,
     mock_ws_client: MagicMock,
@@ -212,6 +229,7 @@ def test_mix_create_and_delete(
         return name == "existing"
 
     mock_ws_client.namespace_exists.side_effect = exists_side_effect
+    mock_ws_client.is_namespace_terminating.return_value = False
 
     result = service.reconcile(
         cluster_clients={"prod-1": mock_ws_client},

--- a/qontract_api/tests/kubernetes/test_workspace_client.py
+++ b/qontract_api/tests/kubernetes/test_workspace_client.py
@@ -134,6 +134,36 @@ def test_is_namespace_terminating_cache_hit(
     mock_kubernetes_api.list_namespaces.assert_not_called()
 
 
+def test_legacy_pre_version_cache_entry_is_ignored(
+    mock_kubernetes_api: MagicMock,
+    mock_cache: MagicMock,
+    mock_settings: Settings,
+) -> None:
+    """Legacy pre-versioning cache entries are never read as-is.
+
+    A cache entry from before the `terminating` field existed would default
+    to an empty set and mask a namespace that's actually Terminating. The
+    versioned key ensures it's treated as a miss and refreshed from a live
+    listing instead.
+    """
+    legacy_key = "kubernetes:test-cluster:namespace_names"
+    legacy_entry = CachedNamespaceNames(names=frozenset({"stuck-ns"}))
+
+    def get_obj(key: str, cls: type) -> CachedNamespaceNames | None:
+        return legacy_entry if key == legacy_key else None
+
+    mock_cache.get_obj.side_effect = get_obj
+    mock_kubernetes_api.list_namespaces.return_value = [
+        _mock_namespace("stuck-ns", phase="Terminating"),
+    ]
+    client = _make_client(mock_kubernetes_api, mock_cache, mock_settings)
+
+    assert client.is_namespace_terminating("stuck-ns") is True
+    mock_kubernetes_api.list_namespaces.assert_called_once()
+    cache_key_used = mock_cache.set_obj.call_args[0][0]
+    assert cache_key_used != legacy_key
+
+
 def test_namespace_exists_double_check_locking(
     mock_kubernetes_api: MagicMock,
     mock_cache: MagicMock,
@@ -203,7 +233,9 @@ def test_create_namespace_delegates_and_invalidates(
     client.create_namespace("new-ns")
 
     mock_kubernetes_api.create_namespace.assert_called_once_with("new-ns")
-    mock_cache.delete.assert_called_once_with("kubernetes:test-cluster:namespace_names")
+    mock_cache.delete.assert_called_once_with(
+        "kubernetes:test-cluster:namespace_names:v2"
+    )
 
 
 def test_delete_namespace_delegates_and_invalidates(
@@ -216,7 +248,9 @@ def test_delete_namespace_delegates_and_invalidates(
     client.delete_namespace("old-ns")
 
     mock_kubernetes_api.delete_namespace.assert_called_once_with("old-ns")
-    mock_cache.delete.assert_called_once_with("kubernetes:test-cluster:namespace_names")
+    mock_cache.delete.assert_called_once_with(
+        "kubernetes:test-cluster:namespace_names:v2"
+    )
 
 
 def test_list_namespaces_delegates_no_cache(

--- a/qontract_api/tests/kubernetes/test_workspace_client.py
+++ b/qontract_api/tests/kubernetes/test_workspace_client.py
@@ -25,9 +25,10 @@ def _make_client(
     )
 
 
-def _mock_namespace(name: str) -> MagicMock:
+def _mock_namespace(name: str, phase: str | None = "Active") -> MagicMock:
     ns = MagicMock()
     ns.metadata.name = name
+    ns.status.phase = phase
     return ns
 
 
@@ -80,6 +81,57 @@ def test_namespace_exists_cache_miss(
     cached_value = mock_cache.set_obj.call_args[0][1]
     assert isinstance(cached_value, CachedNamespaceNames)
     assert cached_value.names == frozenset({"ns-a", "ns-b"})
+    assert cached_value.terminating == frozenset()
+
+
+def test_namespace_exists_true_when_terminating(
+    mock_kubernetes_api: MagicMock,
+    mock_cache: MagicMock,
+    mock_settings: Settings,
+) -> None:
+    """A Terminating namespace still counts as existing."""
+    mock_cache.get_obj.return_value = None
+    mock_kubernetes_api.list_namespaces.return_value = [
+        _mock_namespace("stuck-ns", phase="Terminating"),
+    ]
+    client = _make_client(mock_kubernetes_api, mock_cache, mock_settings)
+
+    assert client.namespace_exists("stuck-ns") is True
+
+
+def test_is_namespace_terminating_cache_miss_populates_terminating_set(
+    mock_kubernetes_api: MagicMock,
+    mock_cache: MagicMock,
+    mock_settings: Settings,
+) -> None:
+    """Cache miss classifies namespaces by status.phase == Terminating."""
+    mock_cache.get_obj.return_value = None
+    mock_kubernetes_api.list_namespaces.return_value = [
+        _mock_namespace("stuck-ns", phase="Terminating"),
+        _mock_namespace("active-ns", phase="Active"),
+    ]
+    client = _make_client(mock_kubernetes_api, mock_cache, mock_settings)
+
+    assert client.is_namespace_terminating("stuck-ns") is True
+    assert client.is_namespace_terminating("active-ns") is False
+    cached_value = mock_cache.set_obj.call_args[0][1]
+    assert isinstance(cached_value, CachedNamespaceNames)
+    assert cached_value.terminating == frozenset({"stuck-ns"})
+
+
+def test_is_namespace_terminating_cache_hit(
+    mock_kubernetes_api: MagicMock,
+    mock_cache: MagicMock,
+    mock_settings: Settings,
+) -> None:
+    """Cache hit returns terminating state without listing namespaces again."""
+    mock_cache.get_obj.return_value = CachedNamespaceNames(
+        names=frozenset({"stuck-ns"}), terminating=frozenset({"stuck-ns"})
+    )
+    client = _make_client(mock_kubernetes_api, mock_cache, mock_settings)
+
+    assert client.is_namespace_terminating("stuck-ns") is True
+    mock_kubernetes_api.list_namespaces.assert_not_called()
 
 
 def test_namespace_exists_double_check_locking(


### PR DESCRIPTION
## Summary

- The `openshift-namespaces` qontract-api integration decided whether to delete a namespace based only on existence, not `status.phase`. A namespace stuck in `Terminating` still exists as a Kubernetes resource, so the integration reissued the delete on every reconcile cycle — causing continuous retries and noisy `qontract-api-bot` notifications (observed on `argocd` / `appsrep09ue1`).
- `KubernetesWorkspaceClient` now caches which namespaces are `Terminating` alongside their names (`CachedNamespaceNames.terminating`), and exposes `is_namespace_terminating()`.
- `OpenShiftNamespacesService._calculate_cluster_actions` now skips emitting a `DeleteNamespaceAction` when the namespace is already `Terminating`.
- The namespace-state cache key is versioned (`...namespace_names:v2`) so cache entries written before this fix (missing the `terminating` field) are never misread as "not terminating" during the up-to-1-hour TTL window after rollout.
- The legacy `reconcile/openshift_namespaces.py` has the same underlying pattern, but per `AGENTS.md` that module is a read-only reference implementation during the qontract-api migration, so it's left out of scope here (flagged as a follow-up if it's still actively relied upon).

Fixes [APPSRE-15191](https://redhat.atlassian.net/browse/APPSRE-15191).

## Test plan

- [x] Added `test_no_action_when_namespace_terminating` in `qontract_api/tests/integrations/openshift_namespaces/test_service.py` — written first to reproduce the bug (confirmed failing against the old code), now passes.
- [x] Added `test_namespace_exists_true_when_terminating`, `test_is_namespace_terminating_cache_miss_populates_terminating_set`, `test_is_namespace_terminating_cache_hit`, `test_legacy_pre_version_cache_entry_is_ignored` in `qontract_api/tests/kubernetes/test_workspace_client.py`.
- [x] Updated existing tests (`test_delete_namespace_when_exists`, `test_mix_create_and_delete`) to explicitly stub the new `is_namespace_terminating` call.
- [x] `uv run pytest qontract_api/tests/kubernetes/test_workspace_client.py qontract_api/tests/integrations/openshift_namespaces/` — 47 passed.
- [x] `uv run ruff check` / `ruff format --check` on changed files — clean.
- [x] `uv run mypy` (strict) on changed files — clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented deletion actions from being scheduled for namespaces already in the process of terminating.
  * Improved namespace status detection so terminating namespaces are recognized as existing and handled correctly.
  * Reduced repeated Kubernetes API lookups through cached termination status.

* **Tests**
  * Added coverage for terminating namespace detection, caching, and deletion behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->