### PR TITLE
chore: retrigger Konflux through trivial change for MR 5792

### DIFF
--- a/reconcile/gitlab_housekeeping.py
+++ b/reconcile/gitlab_housekeeping.py
@@ -704,7 +704,7 @@ def _try_rebase(
     gl: GitLabApi,
     mr: ProjectMergeRequest,
 ) -> bool:
-    """Attempt to rebase an MR. Returns True on success, False on failure."""
+    """Attempt to rebase a MR. Returns True on success, False on failure."""
     try:
         logging.info(["rebase", gl.project.name, mr.iid])
         if not dry_run:


### PR DESCRIPTION
Retriggering CI for[ MR 5792 ](https://github.com/app-sre/qontract-reconcile/pull/5792)through a trivial change, having problems with Konflux and don't fully understand whats going on. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Corrected grammar in internal rebase documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->