### PR TITLE
fix(endpoint-monitoring): drop Probe.monitoring.coreos.com, rhobs only

### DIFF
--- a/reconcile/blackbox_exporter_endpoint_monitoring.py
+++ b/reconcile/blackbox_exporter_endpoint_monitoring.py
@@ -17,7 +17,7 @@ QONTRACT_INTEGRATION_VERSION = make_semver(0, 1, 0)
 
 PROVIDER = "blackbox-exporter"
 COO_NAMESPACE_NAME = "app-sre-observability-per-cluster"
-MANAGED_TYPES = ["Probe.monitoring.coreos.com", "Probe.monitoring.rhobs"]
+MANAGED_TYPES = ["Probe.monitoring.rhobs"]
 
 LOG = logging.getLogger(__name__)
 
@@ -89,17 +89,6 @@ def build_probe(
         spec["scrapeTimeout"] = provider.timeout
 
     namespace = blackbox_exporter.namespace
-
-    coreos_body: dict[str, Any] = {
-        "apiVersion": "monitoring.coreos.com/v1",
-        "kind": "Probe",
-        "metadata": {
-            "name": provider.name,
-            "namespace": namespace.get("name"),
-            "labels": {"prometheus": "app-sre"},
-        },
-        "spec": spec,
-    }
     coo_namespace: dict[str, Any] = {**namespace, "name": COO_NAMESPACE_NAME}
     rhobs_body: dict[str, Any] = {
         "apiVersion": "monitoring.rhobs/v1",
@@ -112,12 +101,6 @@ def build_probe(
         "spec": spec,
     }
     return [
-        (
-            OpenshiftResource(
-                coreos_body, QONTRACT_INTEGRATION, QONTRACT_INTEGRATION_VERSION
-            ),
-            namespace,
-        ),
         (
             OpenshiftResource(
                 rhobs_body, QONTRACT_INTEGRATION, QONTRACT_INTEGRATION_VERSION

--- a/reconcile/closedbox_endpoint_monitoring_base.py
+++ b/reconcile/closedbox_endpoint_monitoring_base.py
@@ -168,7 +168,7 @@ def run_for_provider(
             internal=internal,
             integration=integration,
             integration_version=integration_version,
-            override_managed_types=managed_types or ["Probe.monitoring.coreos.com"],
+            override_managed_types=managed_types or ["Probe.monitoring.rhobs"],
         )
         if defer:
             defer(oc_map.cleanup)

--- a/reconcile/signalfx_endpoint_monitoring.py
+++ b/reconcile/signalfx_endpoint_monitoring.py
@@ -18,7 +18,7 @@ LOG = logging.getLogger(__name__)
 
 PROVIDER = "signalfx"
 COO_NAMESPACE_NAME = "app-sre-observability-per-cluster"
-MANAGED_TYPES = ["Probe.monitoring.coreos.com", "Probe.monitoring.rhobs"]
+MANAGED_TYPES = ["Probe.monitoring.rhobs"]
 
 
 def run(dry_run: bool, thread_pool_size: int, internal: bool) -> None:
@@ -80,17 +80,6 @@ def build_probe(
         spec["scrapeTimeout"] = provider.timeout
 
     namespace = signalfx.namespace
-
-    coreos_body: dict[str, Any] = {
-        "apiVersion": "monitoring.coreos.com/v1",
-        "kind": "Probe",
-        "metadata": {
-            "name": provider.name,
-            "namespace": namespace.get("name"),
-            "labels": {"prometheus": "app-sre"},
-        },
-        "spec": spec,
-    }
     coo_namespace: dict[str, Any] = {**namespace, "name": COO_NAMESPACE_NAME}
     rhobs_body: dict[str, Any] = {
         "apiVersion": "monitoring.rhobs/v1",
@@ -103,12 +92,6 @@ def build_probe(
         "spec": spec,
     }
     return [
-        (
-            OpenshiftResource(
-                coreos_body, QONTRACT_INTEGRATION, QONTRACT_INTEGRATION_VERSION
-            ),
-            namespace,
-        ),
         (
             OpenshiftResource(
                 rhobs_body, QONTRACT_INTEGRATION, QONTRACT_INTEGRATION_VERSION

--- a/reconcile/test/test_closedbox_endpoint_monitoring.py
+++ b/reconcile/test/test_closedbox_endpoint_monitoring.py
@@ -84,11 +84,12 @@ def test_blackbox_exporter_probe_building(mocker: MockerFixture) -> None:
     provider_endpoints = endpoints.get(provider)
     assert provider_endpoints is not None
     probes = blackbox_exporter_probe_builder(provider, provider_endpoints)
-    assert len(probes) == 2
+    assert len(probes) == 1
 
-    probe_resource, namespace = probes[0]
-    assert probe_resource.body["apiVersion"] == "monitoring.coreos.com/v1"
-    assert namespace["name"] == "openshift-customer-monitoring"
+    # verify COO rhobs probe
+    probe_resource, coo_namespace = probes[0]
+    assert probe_resource.body["apiVersion"] == "monitoring.rhobs/v1"
+    assert coo_namespace["name"] == "app-sre-observability-per-cluster"
 
     # verify prober url decomposition
     spec = probe_resource.body.get("spec", {})
@@ -110,13 +111,6 @@ def test_blackbox_exporter_probe_building(mocker: MockerFixture) -> None:
     assert "https://test1.url" in spec["targets"]["staticConfig"]["static"]
     assert "https://test2.url" in spec["targets"]["staticConfig"]["static"]
 
-    # verify COO rhobs probe
-    coo_probe, coo_namespace = probes[1]
-    assert coo_probe.body["apiVersion"] == "monitoring.rhobs/v1"
-    assert coo_namespace["name"] == "app-sre-observability-per-cluster"
-    assert coo_namespace["cluster"] == namespace["cluster"]
-    assert coo_probe.body["spec"] == spec
-
 
 def test_signalfx_probe_building(mocker: MockerFixture) -> None:
     ep_query = mocker.patch.object(queries, "get_service_monitoring_endpoints")
@@ -129,10 +123,12 @@ def test_signalfx_probe_building(mocker: MockerFixture) -> None:
     provider_endpoints = endpoints.get(provider)
     assert provider_endpoints is not None
     probes = signalfx_probe_builder(provider, provider_endpoints)
-    assert len(probes) == 2
+    assert len(probes) == 1
 
-    probe_resource, namespace = probes[0]
-    assert probe_resource.body["apiVersion"] == "monitoring.coreos.com/v1"
+    # verify COO rhobs probe
+    probe_resource, coo_namespace = probes[0]
+    assert probe_resource.body["apiVersion"] == "monitoring.rhobs/v1"
+    assert coo_namespace["name"] == "app-sre-observability-per-cluster"
 
     # verify prober url decomposition
     spec = probe_resource.body.get("spec", {})
@@ -170,27 +166,8 @@ def test_signalfx_probe_building(mocker: MockerFixture) -> None:
         "targetLabel": "instance",
     } in spec["targets"]["staticConfig"]["relabelingConfigs"]
 
-    # verify COO rhobs probe
-    coo_probe, coo_namespace = probes[1]
-    assert coo_probe.body["apiVersion"] == "monitoring.rhobs/v1"
-    assert coo_namespace["name"] == "app-sre-observability-per-cluster"
-    assert coo_namespace["cluster"] == namespace["cluster"]
-    assert coo_probe.body["spec"] == spec
 
-
-@pytest.mark.parametrize(
-    "probe_idx,expected_namespace,expected_resource_type",
-    [
-        (0, "openshift-customer-monitoring", "Probe.monitoring.coreos.com"),
-        (1, "app-sre-observability-per-cluster", "Probe.monitoring.rhobs"),
-    ],
-)
-def test_blackbox_exporter_filling_desired_state(
-    mocker: MockerFixture,
-    probe_idx: int,
-    expected_namespace: str,
-    expected_resource_type: str,
-) -> None:
+def test_blackbox_exporter_filling_desired_state(mocker: MockerFixture) -> None:
     ep_query = mocker.patch.object(queries, "get_service_monitoring_endpoints")
     ep_query.return_value = get_endpoint_fixtures("test_endpoint.yaml")
     add_desired_mock = mocker.patch.object(ResourceInventory, "add_desired")
@@ -198,32 +175,21 @@ def test_blackbox_exporter_filling_desired_state(
     endpoints = get_endpoints(BLACKBOX_EXPORTER_PROVIDER)
     provider = next(iter(endpoints.keys()))
     probes = blackbox_exporter_probe_builder(provider, endpoints[provider])
-    probe, ns = probes[probe_idx]
+    assert len(probes) == 1
+    probe, ns = probes[0]
     fill_desired_state(ns, probe, ResourceInventory())
 
     assert add_desired_mock.call_count == 1
     add_desired_mock.assert_called_with(
         cluster="app-sre-stage-01",
-        namespace=expected_namespace,
-        resource_type=expected_resource_type,
+        namespace="app-sre-observability-per-cluster",
+        resource_type="Probe.monitoring.rhobs",
         name="blackbox-exporter-http-2xx",
         value=ANY,
     )
 
 
-@pytest.mark.parametrize(
-    "probe_idx,expected_namespace,expected_resource_type",
-    [
-        (0, "openshift-customer-monitoring", "Probe.monitoring.coreos.com"),
-        (1, "app-sre-observability-per-cluster", "Probe.monitoring.rhobs"),
-    ],
-)
-def test_signalfx_filling_desired_state(
-    mocker: MockerFixture,
-    probe_idx: int,
-    expected_namespace: str,
-    expected_resource_type: str,
-) -> None:
+def test_signalfx_filling_desired_state(mocker: MockerFixture) -> None:
     ep_query = mocker.patch.object(queries, "get_service_monitoring_endpoints")
     ep_query.return_value = get_endpoint_fixtures("test_endpoint.yaml")
     add_desired_mock = mocker.patch.object(ResourceInventory, "add_desired")
@@ -231,15 +197,15 @@ def test_signalfx_filling_desired_state(
     endpoints = get_endpoints(SIGNALFX_PROVIDER)
     provider = next(iter(endpoints.keys()))
     probes = signalfx_probe_builder(provider, endpoints[provider])
-    assert len(probes) == 2
-    probe, ns = probes[probe_idx]
+    assert len(probes) == 1
+    probe, ns = probes[0]
     fill_desired_state(ns, probe, ResourceInventory())
 
     assert add_desired_mock.call_count == 1
     add_desired_mock.assert_called_with(
         cluster="app-sre-stage-01",
-        namespace=expected_namespace,
-        resource_type=expected_resource_type,
+        namespace="app-sre-observability-per-cluster",
+        resource_type="Probe.monitoring.rhobs",
         name="signalfx-exporter-http-2xx",
         value=ANY,
     )


### PR DESCRIPTION
## Summary
- blackbox-exporter and signalfx endpoint monitoring integrations currently dual-write `Probe` resources to both `monitoring.coreos.com/v1` and `monitoring.rhobs/v1` (added in #5610 for the COO parallel run)
- Now that COO is in place, stop emitting/managing the `monitoring.coreos.com` variant so `monitoring.rhobs` is the only reconciled API version for these Probes
- `PrometheusRule.monitoring.coreos.com` handling in `openshift_resources_base.py` is intentionally left untouched — out of scope for this change (still needed)

The existing `Probe.monitoring.coreos.com` resources left behind in-cluster are not cleaned up by this change — they're removed manually as part of the per-cluster COO decommission procedure, which is already a manual process, so this isn't a gap.

Ref: [APPSRE-15201](https://redhat.atlassian.net/browse/APPSRE-15201)

## Test plan
- [x] `pytest reconcile/test/test_closedbox_endpoint_monitoring.py` — 9 passed
- [x] `ruff check` / `ruff format --check` — clean
- [x] `mypy` on changed files — no issues

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Changes**
  - Endpoint monitoring integrations now manage only `monitoring.rhobs` Probe resources.
  - Legacy `monitoring.coreos.com` Probe resources are no longer created or managed.
  - Default Probe handling now targets the Cluster Observability Operator resource type.
  - Monitoring configurations produce one Probe per endpoint in the observability namespace, simplifying resource deployment and management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->