### PR TITLE
fix(openshift-upgrade-watcher): log cluster name on per-cluster error

### DIFF
--- a/reconcile/openshift_upgrade_watcher.py
+++ b/reconcile/openshift_upgrade_watcher.py
@@ -109,14 +109,18 @@ def notify_upgrades_start(
 ) -> None:
     now = utc_now()
     for cluster in clusters:
-        if cluster.spec and not cluster.spec.hypershift:
-            upgrade_at, version = _get_start_osd(oc_map, cluster.name)
-        elif cluster.spec and cluster.spec.q_id:
-            upgrade_at, version = _get_start_hypershift(
-                ocm_map.get(cluster.name)._ocm_client, cluster.spec.q_id
-            )
-        else:
-            continue
+        try:
+            if cluster.spec and not cluster.spec.hypershift:
+                upgrade_at, version = _get_start_osd(oc_map, cluster.name)
+            elif cluster.spec and cluster.spec.q_id:
+                upgrade_at, version = _get_start_hypershift(
+                    ocm_map.get(cluster.name)._ocm_client, cluster.spec.q_id
+                )
+            else:
+                continue
+        except Exception:
+            logging.exception(f"[{cluster.name}] Failed to get upgrade start info.")
+            raise
 
         if upgrade_at and version:
             upgrade_at_obj = from_utc_iso_format(upgrade_at)

--- a/reconcile/test/test_openshift_upgrade_watcher.py
+++ b/reconcile/test/test_openshift_upgrade_watcher.py
@@ -164,6 +164,34 @@ def test_new_upgrade_already_notified(
     assert state.add.call_count == 0
 
 
+def test_new_upgrade_error_logs_cluster_name(
+    mocker: MockerFixture,
+    caplog: pytest.LogCaptureFixture,
+    state: MagicMock,
+    slack: MagicMock,
+    ouw_oc_map: MagicMock,
+    ouw_ocm_map: MagicMock,
+    mock_utc_now: MagicMock,
+) -> None:
+    """If getting the upgrade start info fails, the cluster name is logged
+    and the exception still propagates"""
+    mock_utc_now.return_value = upgrade_at - timedelta(hours=1)
+    gso = mocker.patch(
+        "reconcile.openshift_upgrade_watcher._get_start_osd", autospec=True
+    )
+    gso.side_effect = RuntimeError("boom")
+    cluster = load_cluster("cluster1.yml")
+    with pytest.raises(RuntimeError, match="boom"):
+        ouw.notify_upgrades_start(
+            ocm_map=ouw_ocm_map,
+            oc_map=ouw_oc_map,
+            clusters=[cluster],
+            state=state,
+            slack=slack,
+        )
+    assert cluster.name in caplog.text
+
+
 @pytest.fixture
 def clusters() -> list[ClusterV1]:
     cluster = load_cluster("cluster1.yml")


### PR DESCRIPTION
## Summary
- `notify_upgrades_start` now logs the cluster name (via `logging.exception`) before re-raising when fetching a cluster's upgrade start info fails, instead of crashing the whole run with no indication of which cluster was responsible.
- Prompted by a live incident where `openshift-upgrade-watcher` (shard 0-1) crashed on every run for over an hour with `kubernetes.dynamic.exceptions.ForbiddenError: 403` after a newly onboarded ROSA cluster got its automation token before its dedicated-admin RBAC for `upgradeconfigs` had finished provisioning — identifying the offending cluster required correlating app-interface commit history with CloudWatch timestamps, since the cluster name wasn't logged anywhere.
- Behavior is unchanged otherwise: the exception still propagates and the integration still exits non-zero.

## Test plan
- [x] `uv run pytest reconcile/test/test_openshift_upgrade_watcher.py` — 11 passed, including new `test_new_upgrade_error_logs_cluster_name`
- [x] `uv run ruff check` / `ruff format --check`
- [x] `uv run mypy`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling when checking upgrade status for clusters.
  * Failures now include the affected cluster name in logs while still being reported to the caller.

* **Tests**
  * Added coverage to verify upgrade lookup errors are logged with the relevant cluster name and propagated correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->