### PR TITLE
feat(rhidp): add ignored status to fully exclude clusters from RHIDP reconciliation

### DIFF
--- a/docs/integrations/ocm-oidc-idp.md
+++ b/docs/integrations/ocm-oidc-idp.md
@@ -24,10 +24,10 @@ Desired state is compiled from two sources:
 1. **OCM cluster labels** under the `sre-capabilities.rhidp` namespace, discovered via qontract-api's `/external/ocm/clusters` endpoint and interpreted client-side (label interpretation is deliberately kept out of qontract-api, which stays domain-agnostic):
    - `sre-capabilities.rhidp.name` — auth/IDP name (falls back to `--default-auth-name`)
    - `sre-capabilities.rhidp.issuer` — Keycloak issuer URL (falls back to `--default-auth-issuer-url`)
-   - `sre-capabilities.rhidp.status` — `enabled` / `disabled` / `enforced` / `sso-client-only` (the deprecated bare `sre-capabilities.rhidp` label takes precedence over `.status` when both are set; missing entirely defaults to `disabled`). The client translates this into two plain booleans sent to the server — `oidc_enabled` (`status` not in `{disabled, sso-client-only}`) and `enforced` (`status == enforced`) — so the server has zero knowledge of label/status semantics.
+   - `sre-capabilities.rhidp.status` — `enabled` / `disabled` / `enforced` / `sso-client-only` / `ignored` (the deprecated bare `sre-capabilities.rhidp` label takes precedence over `.status` when both are set; missing entirely defaults to `disabled`). The client translates this into two plain booleans sent to the server — `oidc_enabled` (`status` not in `{disabled, sso-client-only}`) and `enforced` (`status == enforced`) — so the server has zero knowledge of label/status semantics.
    - `sre-capabilities.rhidp.group-filter-regex` — optional; if set, the desired IDP's claims map a `groups` claim to the `filtered_groups` Keycloak client scope
-   - Clusters without a console URL, or with external auth enabled, can never have an OIDC identity provider configured and are excluded entirely
-   - Clusters are sent to qontract-api regardless of `oidc_enabled` (not just enabled ones) so a cluster that becomes disabled still has its stale identity provider cleaned up
+   - Clusters without a console URL, with external auth enabled, or labeled `ignored`, can never have an OIDC identity provider configured and are excluded entirely
+   - Clusters are sent to qontract-api regardless of `oidc_enabled` (not just enabled ones) so a cluster that becomes disabled still has its stale identity provider cleaned up. `ignored` clusters are the one exception — they're dropped client-side before qontract-api ever sees them, so no cleanup happens for them (the intent is to stop touching the cluster entirely, not just leave a stale IDP in place)
 2. **Vault secret** written by `sso-client-api` (read server-side, not client-side): `client_id`, `client_secret`, `issuer`, `attributes["group-filter-regex"]`. If the stored `issuer` doesn't match the cluster's configured issuer, or the secret is missing/malformed, that cluster's OIDC config is skipped for this reconcile (logged, not a fatal error)
 3. **CLI parameters** — which Vault path to read SSO client secrets from (must match the same path `sso-client-api` writes to), and default auth name/issuer for clusters without explicit labels
 
@@ -290,7 +290,7 @@ The integration can perform these reconciliation actions:
 **Issue: A cluster's identity provider is never created**
 
 - **Symptom:** No `create` action appears for a cluster you expect to have RHIDP OIDC enabled
-- **Cause:** `sso-client-api` hasn't registered a Keycloak client for that cluster yet (no Vault secret at the expected path), or the cluster's `sre-capabilities.rhidp.status` label resolves to `disabled`/`sso-client-only`
+- **Cause:** `sso-client-api` hasn't registered a Keycloak client for that cluster yet (no Vault secret at the expected path), or the cluster's `sre-capabilities.rhidp.status` label resolves to `disabled`/`sso-client-only`/`ignored`
 - **Solution:** Confirm `sso-client-api` has successfully reconciled that cluster first (this integration only configures OCM, never Keycloak), and check the cluster's OCM labels
 
 **Issue: Foreign identity providers keep reappearing in the diff but are never deleted**

--- a/docs/integrations/rhidp-sso-client.md
+++ b/docs/integrations/rhidp-sso-client.md
@@ -25,10 +25,10 @@ Desired state is compiled client-side from two sources:
 1. **OCM cluster labels** under the `sre-capabilities.rhidp` namespace, discovered via qontract-api's `/external/ocm/clusters` endpoint and interpreted client-side (label interpretation is deliberately kept out of qontract-api, which stays domain-agnostic):
    - `sre-capabilities.rhidp.name` — auth name (falls back to `--default-auth-name`)
    - `sre-capabilities.rhidp.issuer` — Keycloak issuer URL (falls back to `--default-auth-issuer-url`)
-   - `sre-capabilities.rhidp.status` — `enabled` / `disabled` / `enforced` / `sso-client-only` (the deprecated bare `sre-capabilities.rhidp` label takes precedence over `.status` when both are set; missing entirely defaults to `disabled`)
+   - `sre-capabilities.rhidp.status` — `enabled` / `disabled` / `enforced` / `sso-client-only` / `ignored` (the deprecated bare `sre-capabilities.rhidp` label takes precedence over `.status` when both are set; missing entirely defaults to `disabled`)
    - `sre-capabilities.rhidp.group-filter-regex` — optional group filter regex passed through to Keycloak
-   - Clusters without a console URL, or with external auth enabled, can never get an SSO client and are excluded entirely
-   - Clusters are sent to qontract-api regardless of `status` (not just enabled ones) so the `rhidp_managed_clusters` metric reflects every discovered cluster, matching legacy semantics — only `rhidp_enabled=true` clusters are actually reconciled server-side
+   - Clusters without a console URL, with external auth enabled, or labeled `ignored`, can never get an SSO client and are excluded entirely
+   - Clusters are sent to qontract-api regardless of `status` (not just enabled ones) so the `rhidp_managed_clusters` metric reflects every discovered cluster, matching legacy semantics — only `rhidp_enabled=true` clusters are actually reconciled server-side. `ignored` clusters are the one exception — they're dropped client-side before qontract-api ever sees them, so they aren't counted toward `rhidp_managed_clusters` either
 2. **CLI parameters** — which Keycloak instances exist (issuer URL + Vault secret reference for the instance's initial-access-token), which Vault path to store SSO client secrets under, and default auth name/issuer for clusters without explicit labels
 
 ## Architecture

--- a/reconcile/rhidp_api/common.py
+++ b/reconcile/rhidp_api/common.py
@@ -43,6 +43,8 @@ class StatusValue(StrEnum):
     ENFORCED = "enforced"
     # rhidp is enabled and oidc is skipped
     RHIDP_ONLY = "sso-client-only"
+    # ignore this server completely
+    IGNORED = "ignored"
 
 
 def get_ocm_environments(env_name: str | None) -> list[OCMEnvironment]:

--- a/reconcile/rhidp_api/ocm_oidc_idp/integration.py
+++ b/reconcile/rhidp_api/ocm_oidc_idp/integration.py
@@ -74,6 +74,8 @@ def build_clusters(
     semantics (oidc_enabled/enforced), mirror reconcile/rhidp/common.py::ClusterAuth
     exactly. Clusters without a console URL or with external auth enabled are
     excluded entirely, mirroring reconcile/rhidp/common.py::build_cluster_objects.
+    Clusters labeled `ignored` are excluded entirely too - unlike `disabled`, which
+    is still sent so the server can clean up a stale identity provider.
     """
     result: list[OcmOidcIdpCluster] = []
     for cluster in clusters:
@@ -81,6 +83,9 @@ def build_clusters(
             continue
 
         labels: dict[str, Any] = cluster.labels or {}
+        if labels.get(STATUS_LABEL_KEY) == StatusValue.IGNORED.value:
+            continue
+
         status = (
             labels.get(RHIDP_NAMESPACE_LABEL_KEY)
             or labels.get(STATUS_LABEL_KEY)

--- a/reconcile/rhidp_api/sso_client/integration.py
+++ b/reconcile/rhidp_api/sso_client/integration.py
@@ -72,7 +72,9 @@ def build_clusters(
     Label interpretation stays client-side: which labels mean what, and the default
     fallbacks, mirror reconcile/rhidp/common.py::build_cluster_objects exactly. Clusters
     without a console URL or with external auth enabled can never get an SSO client and
-    are excluded entirely (not even counted toward rhidp_managed_clusters).
+    are excluded entirely (not even counted toward rhidp_managed_clusters). Clusters
+    labeled `ignored` are excluded the same way - unlike `disabled`, which is still
+    sent so it's still counted toward rhidp_managed_clusters.
     """
     result: list[SsoClientCluster] = []
     for cluster in clusters:
@@ -80,6 +82,9 @@ def build_clusters(
             continue
 
         labels: dict[str, Any] = cluster.labels or {}
+        if labels.get(STATUS_LABEL_KEY) == StatusValue.IGNORED.value:
+            continue
+
         status = (
             labels.get(RHIDP_NAMESPACE_LABEL_KEY)
             or labels.get(STATUS_LABEL_KEY)

--- a/reconcile/test/test_ocm_oidc_idp_api.py
+++ b/reconcile/test/test_ocm_oidc_idp_api.py
@@ -168,6 +168,22 @@ def test_build_clusters_status_label_maps_to_oidc_flags(
     assert result[0].auth.enforced is expected_enforced
 
 
+def test_build_clusters_excludes_ignored_clusters() -> None:
+    result = build_clusters(
+        [
+            make_ocm_cluster(
+                name="ignored-cluster",
+                labels={"sre-capabilities.rhidp.status": "ignored"},
+            ),
+            make_ocm_cluster(name="not-ignored-cluster"),
+        ],
+        "redhat-sso",
+        "https://default-issuer.example.com",
+    )
+
+    assert [cluster.name for cluster in result] == ["not-ignored-cluster"]
+
+
 def test_build_clusters_deprecated_bare_rhidp_label_takes_precedence() -> None:
     result = build_clusters(
         [

--- a/reconcile/test/test_rhidp_sso_client_api.py
+++ b/reconcile/test/test_rhidp_sso_client_api.py
@@ -122,6 +122,21 @@ class TestBuildClusters:
         assert result[0].rhidp_enabled is True
         assert result[0].auth.group_filter_regex == "^team-.*$"
 
+    def test_excludes_ignored_clusters(self) -> None:
+        result = build_clusters(
+            [
+                make_ocm_cluster(
+                    name="ignored-cluster",
+                    labels={"sre-capabilities.rhidp.status": "ignored"},
+                ),
+                make_ocm_cluster(name="not-ignored-cluster"),
+            ],
+            "redhat-sso",
+            "https://default-issuer.example.com",
+        )
+
+        assert [cluster.name for cluster in result] == ["not-ignored-cluster"]
+
     def test_deprecated_bare_rhidp_label_takes_precedence(self) -> None:
         result = build_clusters(
             [


### PR DESCRIPTION
## Summary
- Add `StatusValue.IGNORED` (`ignored`) to `reconcile/rhidp_api/common.py`, a new value for the `sre-capabilities.rhidp.status` OCM label.
- `ocm-oidc-idp-api` and `rhidp-sso-client-api` now drop clusters labeled `ignored` entirely in `build_clusters()`, before they're ever sent to qontract-api - unlike `disabled`, which is still sent so the server can clean up a stale identity provider/SSO client.
- This lets us stop reconciling clusters whose OCM `sts_user_role` isn't linked to the tenant's Red Hat account (see APPSRE-15204) without any further AppSRE interaction, once the label is set.
- Updated `docs/integrations/ocm-oidc-idp.md` and `docs/integrations/rhidp-sso-client.md` to document the new status value and its cleanup semantics.

## Test plan
- Added `test_build_clusters_excludes_ignored_clusters` (ocm-oidc-idp) and `test_excludes_ignored_clusters` (sso-client) covering that an `ignored`-labeled cluster is dropped while a sibling cluster is still processed.
- `uv run pytest reconcile/test/test_ocm_oidc_idp_api.py reconcile/test/test_rhidp_sso_client_api.py reconcile/test/cluster_auth_rhidp/` - 35 passed
- `uv run ruff check` / `uv run ruff format --check` / `uv run mypy` on all touched files - clean

Context: https://redhat-internal.slack.com/archives/CKN746TDW/p1788521498827369

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for the `ignored` RHIDP cluster status.
  - Ignored clusters are excluded from identity provider and SSO client discovery.
  - Disabled clusters remain eligible for stale identity-provider cleanup and managed-cluster metrics.

- **Documentation**
  - Updated integration guidance and troubleshooting information for ignored and disabled clusters.

- **Tests**
  - Added coverage confirming ignored clusters are excluded while other eligible clusters remain included.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->