### PR TITLE
fix(github-owners): stop rate-limit alert storm, add retry (APPSRE-15206)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -216,6 +216,7 @@ Do NOT create a barrel re-export `models.py` — import directly from `domain.py
 - Fatal errors (auth failures, timeouts, 500s) must be appended to the `errors` list — the task must report FAILURE, not SUCCESS, when clusters are silently skipped
 - Implement defensive desired-state handling: distinguish transient failures (Vault secret pending) from genuine misconfigurations. A transient failure should not cause deletions
 - Per-cluster error isolation: one failed cluster should not abort reconciliation for others
+- **Carve-out for externally-imposed, self-healing throttling** (e.g. a shared API rate limit): report SUCCESS with a warning log instead of FAILURE, and do not append to `errors`. Unlike a generic transient failure, the reset time is known upfront, there is no action an operator can take before it, and the alert that FAILURE would trigger is not actionable. Only applies when the condition is detected via a typed exception (not inferred from a generic error) — see `github-owners`'s `GithubRateLimitExceededError` handling in `qontract_api/qontract_api/integrations/github_owners/service.py` for the reference implementation
 
 ## Testing Guidelines
 

--- a/qontract_api/qontract_api/github/github_org_workspace_client.py
+++ b/qontract_api/qontract_api/github/github_org_workspace_client.py
@@ -123,11 +123,11 @@ class GithubOrgWorkspaceClient:
             return cached.members
 
         with self._cache.lock(cache_key):
-            if cached := self._cache.get_obj(cache_key, CachedOrgMembers):
-                return cached.members
-
             if marker := self._cache.get_obj(rate_limit_key, RateLimitMarker):
                 raise GithubRateLimitExceededError(marker.reset_at)
+
+            if cached := self._cache.get_obj(cache_key, CachedOrgMembers):
+                return cached.members
 
             try:
                 admin_members = self._api.get_admin_members(org_name)

--- a/qontract_api/qontract_api/github/github_org_workspace_client.py
+++ b/qontract_api/qontract_api/github/github_org_workspace_client.py
@@ -84,6 +84,23 @@ class GithubOrgWorkspaceClient:
         except RuntimeError as e:
             logger.warning(f"Could not acquire lock to clear cache for {org_name}: {e}")
 
+    def _cache_rate_limit_marker(
+        self, org_name: str, exc: GithubRateLimitExceededError
+    ) -> None:
+        """Cache a rate-limit marker so subsequent calls short-circuit until reset."""
+        ttl = max(
+            1,
+            min(
+                int((exc.reset_at - datetime.now(UTC)).total_seconds()),
+                self._settings.github_org.members_cache_ttl,
+            ),
+        )
+        self._cache.set_obj(
+            self._rate_limit_key(org_name),
+            RateLimitMarker(reset_at=exc.reset_at),
+            ttl,
+        )
+
     def get_current_members(self, org_name: str) -> list[str]:
         """Get the combined set of admin members + pending invitations (cached).
 
@@ -113,18 +130,7 @@ class GithubOrgWorkspaceClient:
                 admin_members = self._api.get_admin_members(org_name)
                 pending_invitations = self._api.get_pending_invitations(org_name)
             except GithubRateLimitExceededError as e:
-                ttl = max(
-                    1,
-                    min(
-                        int((e.reset_at - datetime.now(UTC)).total_seconds()),
-                        self._settings.github_org.members_cache_ttl,
-                    ),
-                )
-                self._cache.set_obj(
-                    rate_limit_key,
-                    RateLimitMarker(reset_at=e.reset_at),
-                    ttl,
-                )
+                self._cache_rate_limit_marker(org_name, e)
                 raise
 
             combined = sorted(set(admin_members) | set(pending_invitations))
@@ -143,5 +149,9 @@ class GithubOrgWorkspaceClient:
             org_name: GitHub organization name
             username: GitHub username to add as admin
         """
-        self._api.add_member_as_admin(org_name, username)
+        try:
+            self._api.add_member_as_admin(org_name, username)
+        except GithubRateLimitExceededError as e:
+            self._cache_rate_limit_marker(org_name, e)
+            raise
         self._clear_cache(org_name)

--- a/qontract_api/qontract_api/github/github_org_workspace_client.py
+++ b/qontract_api/qontract_api/github/github_org_workspace_client.py
@@ -114,17 +114,20 @@ class GithubOrgWorkspaceClient:
             Sorted list of lowercase GitHub usernames (admins + pending invitees)
         """
         cache_key = self._cache_key(org_name)
+        rate_limit_key = self._rate_limit_key(org_name)
+
+        if marker := self._cache.get_obj(rate_limit_key, RateLimitMarker):
+            raise GithubRateLimitExceededError(marker.reset_at)
 
         if cached := self._cache.get_obj(cache_key, CachedOrgMembers):
             return cached.members
 
-        rate_limit_key = self._rate_limit_key(org_name)
-        if marker := self._cache.get_obj(rate_limit_key, RateLimitMarker):
-            raise GithubRateLimitExceededError(marker.reset_at)
-
         with self._cache.lock(cache_key):
             if cached := self._cache.get_obj(cache_key, CachedOrgMembers):
                 return cached.members
+
+            if marker := self._cache.get_obj(rate_limit_key, RateLimitMarker):
+                raise GithubRateLimitExceededError(marker.reset_at)
 
             try:
                 admin_members = self._api.get_admin_members(org_name)

--- a/qontract_api/qontract_api/github/github_org_workspace_client.py
+++ b/qontract_api/qontract_api/github/github_org_workspace_client.py
@@ -8,9 +8,11 @@ This layer sits between the stateless GithubOrgApi and business logic, providing
 
 from __future__ import annotations
 
+from datetime import UTC, datetime
 from typing import TYPE_CHECKING
 
 from pydantic import BaseModel, Field
+from qontract_utils.github_org import GithubRateLimitExceededError
 
 from qontract_api.logger import get_logger
 
@@ -27,6 +29,16 @@ class CachedOrgMembers(BaseModel, frozen=True):
     """Cached combined list of admin members + pending invitations."""
 
     members: list[str] = Field(default_factory=list)
+
+
+class RateLimitMarker(BaseModel, frozen=True):
+    """Marks that GitHub's API rate limit was exhausted for an org's credential.
+
+    Cached with a TTL derived from the rate limit reset time so subsequent
+    reconcile cycles short-circuit instead of repeating a doomed GitHub call.
+    """
+
+    reset_at: datetime
 
 
 class GithubOrgWorkspaceClient:
@@ -59,6 +71,10 @@ class GithubOrgWorkspaceClient:
     def _cache_key(org_name: str) -> str:
         return f"github-org:{org_name}:members"
 
+    @staticmethod
+    def _rate_limit_key(org_name: str) -> str:
+        return f"github-org:{org_name}:rate-limited"
+
     def _clear_cache(self, org_name: str) -> None:
         """Clear cached members for the given org."""
         cache_key = self._cache_key(org_name)
@@ -85,12 +101,31 @@ class GithubOrgWorkspaceClient:
         if cached := self._cache.get_obj(cache_key, CachedOrgMembers):
             return cached.members
 
+        rate_limit_key = self._rate_limit_key(org_name)
+        if marker := self._cache.get_obj(rate_limit_key, RateLimitMarker):
+            raise GithubRateLimitExceededError(marker.reset_at)
+
         with self._cache.lock(cache_key):
             if cached := self._cache.get_obj(cache_key, CachedOrgMembers):
                 return cached.members
 
-            admin_members = self._api.get_admin_members(org_name)
-            pending_invitations = self._api.get_pending_invitations(org_name)
+            try:
+                admin_members = self._api.get_admin_members(org_name)
+                pending_invitations = self._api.get_pending_invitations(org_name)
+            except GithubRateLimitExceededError as e:
+                ttl = max(
+                    1,
+                    min(
+                        int((e.reset_at - datetime.now(UTC)).total_seconds()),
+                        self._settings.github_org.members_cache_ttl,
+                    ),
+                )
+                self._cache.set_obj(
+                    rate_limit_key,
+                    RateLimitMarker(reset_at=e.reset_at),
+                    ttl,
+                )
+                raise
 
             combined = sorted(set(admin_members) | set(pending_invitations))
             cached_obj = CachedOrgMembers(members=combined)

--- a/qontract_api/qontract_api/integrations/github_owners/service.py
+++ b/qontract_api/qontract_api/integrations/github_owners/service.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 from qontract_utils.differ import diff_iterables
+from qontract_utils.github_org import GithubRateLimitExceededError
 
 from qontract_api.integrations.github_owners.schemas import (
     GithubOwnerActionAddOwner,
@@ -159,6 +160,12 @@ class GithubOwnersService:
                 github_client = self._create_github_org_client(org)
                 org_actions = self._calculate_actions(org, github_client)
                 all_actions.extend(org_actions)
+            except GithubRateLimitExceededError as e:
+                logger.warning(
+                    f"{org.org_name}: skipped this cycle, "
+                    f"GitHub rate limit resets at {e.reset_at.isoformat()}"
+                )
+                continue
             except Exception as e:
                 error_msg = (
                     f"{org.org_name}: Unexpected error during diff calculation: {e}"
@@ -172,6 +179,12 @@ class GithubOwnersService:
                     try:
                         self._execute_action(github_client, action)
                         applied_actions.append(action)
+                    except GithubRateLimitExceededError as e:
+                        logger.warning(
+                            f"{action.org_name}/{action.username}: skipped this "
+                            f"cycle, GitHub rate limit resets at "
+                            f"{e.reset_at.isoformat()}"
+                        )
                     except Exception as e:
                         error_msg = (
                             f"{action.org_name}/{action.username}: "

--- a/qontract_api/qontract_api/integrations/github_owners/service.py
+++ b/qontract_api/qontract_api/integrations/github_owners/service.py
@@ -185,6 +185,9 @@ class GithubOwnersService:
                             f"cycle, GitHub rate limit resets at "
                             f"{e.reset_at.isoformat()}"
                         )
+                        # Shared credential is exhausted - every remaining
+                        # action for this org would fail the same way.
+                        break
                     except Exception as e:
                         error_msg = (
                             f"{action.org_name}/{action.username}: "

--- a/qontract_api/tests/github/conftest.py
+++ b/qontract_api/tests/github/conftest.py
@@ -1,0 +1,26 @@
+from unittest.mock import MagicMock
+
+import pytest
+from qontract_utils.github_org.api import GithubOrgApi
+
+from qontract_api.cache.base import CacheBackend
+from qontract_api.config import Settings
+
+
+@pytest.fixture
+def mock_github_org_api() -> MagicMock:
+    return MagicMock(spec=GithubOrgApi)
+
+
+@pytest.fixture
+def mock_cache() -> MagicMock:
+    m = MagicMock(spec=CacheBackend)
+    m.get_obj.return_value = None
+    m.lock.return_value.__enter__ = MagicMock()
+    m.lock.return_value.__exit__ = MagicMock(return_value=False)
+    return m
+
+
+@pytest.fixture
+def mock_settings() -> Settings:
+    return Settings()

--- a/qontract_api/tests/github/test_github_org_workspace_client.py
+++ b/qontract_api/tests/github/test_github_org_workspace_client.py
@@ -129,3 +129,49 @@ def test_short_circuits_when_marker_present(
     mock_cache.lock.assert_not_called()
     mock_github_org_api.get_admin_members.assert_not_called()
     mock_github_org_api.get_pending_invitations.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# add_member_as_admin — rate limit while applying a mutation
+# ---------------------------------------------------------------------------
+
+
+def test_add_member_as_admin_sets_marker_and_reraises_on_rate_limit(
+    client: GithubOrgWorkspaceClient,
+    mock_github_org_api: MagicMock,
+    mock_cache: MagicMock,
+) -> None:
+    """A rate limit hit while applying a mutation must also cache the marker.
+
+    Otherwise the next cycle reuses the (already-cached) stale member list
+    and regenerates the same doomed action - the mitigation would only cover
+    the read path, not the write path.
+    """
+    reset_at = datetime.now(UTC) + timedelta(seconds=120)
+    mock_github_org_api.add_member_as_admin.side_effect = GithubRateLimitExceededError(
+        reset_at
+    )
+
+    with pytest.raises(GithubRateLimitExceededError):
+        client.add_member_as_admin(ORG_NAME, "alice")
+
+    mock_cache.set_obj.assert_called_once()
+    key, marker, _ttl = mock_cache.set_obj.call_args[0]
+    assert key == f"github-org:{ORG_NAME}:rate-limited"
+    assert marker == RateLimitMarker(reset_at=reset_at)
+
+
+def test_add_member_as_admin_does_not_clear_members_cache_on_rate_limit(
+    client: GithubOrgWorkspaceClient,
+    mock_github_org_api: MagicMock,
+    mock_cache: MagicMock,
+) -> None:
+    reset_at = datetime.now(UTC) + timedelta(seconds=120)
+    mock_github_org_api.add_member_as_admin.side_effect = GithubRateLimitExceededError(
+        reset_at
+    )
+
+    with pytest.raises(GithubRateLimitExceededError):
+        client.add_member_as_admin(ORG_NAME, "alice")
+
+    mock_cache.delete.assert_not_called()

--- a/qontract_api/tests/github/test_github_org_workspace_client.py
+++ b/qontract_api/tests/github/test_github_org_workspace_client.py
@@ -44,12 +44,12 @@ def test_members_cache_hit_still_returns(
     mock_github_org_api: MagicMock,
     mock_cache: MagicMock,
 ) -> None:
-    mock_cache.get_obj.return_value = CachedOrgMembers(members=["alice"])
+    mock_cache.get_obj.side_effect = [None, CachedOrgMembers(members=["alice"])]
 
     members = client.get_current_members(ORG_NAME)
 
     assert members == ["alice"]
-    assert mock_cache.get_obj.call_count == 1
+    assert mock_cache.get_obj.call_count == 2
     mock_cache.lock.assert_not_called()
     mock_github_org_api.get_admin_members.assert_not_called()
     mock_github_org_api.get_pending_invitations.assert_not_called()
@@ -120,13 +120,67 @@ def test_short_circuits_when_marker_present(
     mock_cache: MagicMock,
 ) -> None:
     reset_at = datetime.now(UTC) + timedelta(seconds=60)
-    mock_cache.get_obj.side_effect = [None, RateLimitMarker(reset_at=reset_at)]
+    mock_cache.get_obj.side_effect = [RateLimitMarker(reset_at=reset_at)]
 
     with pytest.raises(GithubRateLimitExceededError) as exc_info:
         client.get_current_members(ORG_NAME)
 
     assert exc_info.value.reset_at == reset_at
     mock_cache.lock.assert_not_called()
+    mock_github_org_api.get_admin_members.assert_not_called()
+    mock_github_org_api.get_pending_invitations.assert_not_called()
+
+
+def test_marker_takes_priority_over_stale_members_cache(
+    client: GithubOrgWorkspaceClient,
+    mock_github_org_api: MagicMock,
+    mock_cache: MagicMock,
+) -> None:
+    """A rate-limit marker must short-circuit even when a stale members cache exists.
+
+    A write hitting the rate limit caches the marker but does not clear the
+    (still valid) members cache. If the members-cache lookup ran first, it
+    would return the stale list without ever consulting the marker, so the
+    org would not be skipped and the same doomed mutation would be retried.
+    """
+    reset_at = datetime.now(UTC) + timedelta(seconds=60)
+    mock_cache.get_obj.side_effect = [
+        RateLimitMarker(reset_at=reset_at),
+        CachedOrgMembers(members=["alice"]),
+    ]
+
+    with pytest.raises(GithubRateLimitExceededError) as exc_info:
+        client.get_current_members(ORG_NAME)
+
+    assert exc_info.value.reset_at == reset_at
+    mock_cache.lock.assert_not_called()
+    mock_github_org_api.get_admin_members.assert_not_called()
+    mock_github_org_api.get_pending_invitations.assert_not_called()
+
+
+def test_marker_rechecked_after_acquiring_lock(
+    client: GithubOrgWorkspaceClient,
+    mock_github_org_api: MagicMock,
+    mock_cache: MagicMock,
+) -> None:
+    """A marker written while waiting on the lock must still short-circuit.
+
+    Simulates: no marker and no cached members before the lock, but by the
+    time the lock is acquired another caller has already cached the marker
+    (e.g. a concurrent write just hit the rate limit).
+    """
+    reset_at = datetime.now(UTC) + timedelta(seconds=60)
+    mock_cache.get_obj.side_effect = [
+        None,  # marker check before member-cache hit
+        None,  # member-cache check before lock
+        None,  # member-cache check after acquiring lock
+        RateLimitMarker(reset_at=reset_at),  # marker recheck after acquiring lock
+    ]
+
+    with pytest.raises(GithubRateLimitExceededError) as exc_info:
+        client.get_current_members(ORG_NAME)
+
+    assert exc_info.value.reset_at == reset_at
     mock_github_org_api.get_admin_members.assert_not_called()
     mock_github_org_api.get_pending_invitations.assert_not_called()
 

--- a/qontract_api/tests/github/test_github_org_workspace_client.py
+++ b/qontract_api/tests/github/test_github_org_workspace_client.py
@@ -1,0 +1,131 @@
+"""Unit tests for GithubOrgWorkspaceClient."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from typing import TYPE_CHECKING
+from unittest.mock import MagicMock
+
+import pytest
+from qontract_utils.github_org import GithubRateLimitExceededError
+
+from qontract_api.github.github_org_workspace_client import (
+    CachedOrgMembers,
+    GithubOrgWorkspaceClient,
+    RateLimitMarker,
+)
+
+if TYPE_CHECKING:
+    from qontract_api.config import Settings
+
+ORG_NAME = "my-org"
+
+
+@pytest.fixture
+def client(
+    mock_github_org_api: MagicMock,
+    mock_cache: MagicMock,
+    mock_settings: Settings,
+) -> GithubOrgWorkspaceClient:
+    return GithubOrgWorkspaceClient(
+        github_org_api=mock_github_org_api,
+        cache=mock_cache,
+        settings=mock_settings,
+    )
+
+
+# ---------------------------------------------------------------------------
+# get_current_members — members cache hit (regression)
+# ---------------------------------------------------------------------------
+
+
+def test_members_cache_hit_still_returns(
+    client: GithubOrgWorkspaceClient,
+    mock_github_org_api: MagicMock,
+    mock_cache: MagicMock,
+) -> None:
+    mock_cache.get_obj.return_value = CachedOrgMembers(members=["alice"])
+
+    members = client.get_current_members(ORG_NAME)
+
+    assert members == ["alice"]
+    assert mock_cache.get_obj.call_count == 1
+    mock_cache.lock.assert_not_called()
+    mock_github_org_api.get_admin_members.assert_not_called()
+    mock_github_org_api.get_pending_invitations.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# get_current_members — rate limit while fetching from GitHub
+# ---------------------------------------------------------------------------
+
+
+def test_sets_marker_and_reraises_on_rate_limit(
+    client: GithubOrgWorkspaceClient,
+    mock_github_org_api: MagicMock,
+    mock_cache: MagicMock,
+) -> None:
+    reset_at = datetime.now(UTC) + timedelta(seconds=120)
+    mock_github_org_api.get_admin_members.side_effect = GithubRateLimitExceededError(
+        reset_at
+    )
+
+    with pytest.raises(GithubRateLimitExceededError):
+        client.get_current_members(ORG_NAME)
+
+    mock_cache.set_obj.assert_called_once()
+    key, marker, _ttl = mock_cache.set_obj.call_args[0]
+    assert key == f"github-org:{ORG_NAME}:rate-limited"
+    assert marker == RateLimitMarker(reset_at=reset_at)
+
+
+def test_marker_ttl_derived_from_reset(
+    client: GithubOrgWorkspaceClient,
+    mock_github_org_api: MagicMock,
+    mock_cache: MagicMock,
+) -> None:
+    reset_at = datetime.now(UTC) + timedelta(seconds=120)
+    mock_github_org_api.get_admin_members.side_effect = GithubRateLimitExceededError(
+        reset_at
+    )
+
+    with pytest.raises(GithubRateLimitExceededError):
+        client.get_current_members(ORG_NAME)
+
+    ttl = mock_cache.set_obj.call_args[0][2]
+    assert 110 <= ttl <= 120
+
+
+def test_marker_ttl_capped_at_members_cache_ttl(
+    client: GithubOrgWorkspaceClient,
+    mock_github_org_api: MagicMock,
+    mock_cache: MagicMock,
+    mock_settings: Settings,
+) -> None:
+    reset_at = datetime.now(UTC) + timedelta(seconds=100_000)
+    mock_github_org_api.get_admin_members.side_effect = GithubRateLimitExceededError(
+        reset_at
+    )
+
+    with pytest.raises(GithubRateLimitExceededError):
+        client.get_current_members(ORG_NAME)
+
+    ttl = mock_cache.set_obj.call_args[0][2]
+    assert ttl == mock_settings.github_org.members_cache_ttl
+
+
+def test_short_circuits_when_marker_present(
+    client: GithubOrgWorkspaceClient,
+    mock_github_org_api: MagicMock,
+    mock_cache: MagicMock,
+) -> None:
+    reset_at = datetime.now(UTC) + timedelta(seconds=60)
+    mock_cache.get_obj.side_effect = [None, RateLimitMarker(reset_at=reset_at)]
+
+    with pytest.raises(GithubRateLimitExceededError) as exc_info:
+        client.get_current_members(ORG_NAME)
+
+    assert exc_info.value.reset_at == reset_at
+    mock_cache.lock.assert_not_called()
+    mock_github_org_api.get_admin_members.assert_not_called()
+    mock_github_org_api.get_pending_invitations.assert_not_called()

--- a/qontract_api/tests/github/test_github_org_workspace_client.py
+++ b/qontract_api/tests/github/test_github_org_workspace_client.py
@@ -173,7 +173,6 @@ def test_marker_rechecked_after_acquiring_lock(
     mock_cache.get_obj.side_effect = [
         None,  # marker check before member-cache hit
         None,  # member-cache check before lock
-        None,  # member-cache check after acquiring lock
         RateLimitMarker(reset_at=reset_at),  # marker recheck after acquiring lock
     ]
 

--- a/qontract_api/tests/integrations/test_github_owners_service.py
+++ b/qontract_api/tests/integrations/test_github_owners_service.py
@@ -1,8 +1,10 @@
 """Unit tests for GithubOwnersService."""
 
+from datetime import UTC, datetime, timedelta
 from unittest.mock import MagicMock
 
 import pytest
+from qontract_utils.github_org import GithubRateLimitExceededError
 
 from qontract_api.config import Settings
 from qontract_api.github import GithubOrgWorkspaceClient
@@ -206,6 +208,80 @@ def test_reconcile_multiple_orgs(
     assert len(result.actions) == 2
     org_names = {a.org_name for a in result.actions}
     assert org_names == {"org-a", "org-b"}
+
+
+def test_reconcile_skips_rate_limited_org_without_error(
+    service: GithubOwnersService,
+    test_org: GithubOrgDesiredState,
+    mock_github_client: MagicMock,
+) -> None:
+    """A rate-limited org is skipped for this cycle without recording an error."""
+    reset_at = datetime.now(UTC) + timedelta(minutes=5)
+    mock_github_client.get_current_members.side_effect = GithubRateLimitExceededError(
+        reset_at
+    )
+
+    result = service.reconcile(organizations=[test_org], dry_run=True)
+
+    assert result.status == TaskStatus.SUCCESS
+    assert result.errors == []
+    assert result.actions == []
+
+
+def test_reconcile_rate_limited_one_org_others_succeed(
+    service: GithubOwnersService,
+    test_token: Secret,
+    mock_github_client_factory: MagicMock,
+) -> None:
+    """A rate-limited org does not prevent other orgs from being reconciled."""
+    reset_at = datetime.now(UTC) + timedelta(minutes=5)
+    rate_limited_client = MagicMock(spec=GithubOrgWorkspaceClient)
+    rate_limited_client.get_current_members.side_effect = GithubRateLimitExceededError(
+        reset_at
+    )
+    ok_client = MagicMock(spec=GithubOrgWorkspaceClient)
+    ok_client.get_current_members.return_value = []
+    mock_github_client_factory.create_workspace_client.side_effect = [
+        rate_limited_client,
+        ok_client,
+    ]
+
+    orgs = [
+        GithubOrgDesiredState(org_name="org-a", token=test_token, owners=["alice"]),
+        GithubOrgDesiredState(org_name="org-b", token=test_token, owners=["bob"]),
+    ]
+
+    result = service.reconcile(organizations=orgs, dry_run=True)
+
+    assert result.status == TaskStatus.SUCCESS
+    assert result.errors == []
+    assert len(result.actions) == 1
+    assert result.actions[0].org_name == "org-b"
+
+
+def test_reconcile_rate_limit_during_apply_not_dry_run(
+    service: GithubOwnersService,
+    test_token: Secret,
+    mock_github_client: MagicMock,
+) -> None:
+    """A rate limit hit while applying an action is skipped, not recorded as an error."""
+    reset_at = datetime.now(UTC) + timedelta(minutes=5)
+    mock_github_client.get_current_members.return_value = []
+    mock_github_client.add_member_as_admin.side_effect = GithubRateLimitExceededError(
+        reset_at
+    )
+
+    org = GithubOrgDesiredState(
+        org_name="my-org",
+        token=test_token,
+        owners=["alice"],
+    )
+
+    result = service.reconcile(organizations=[org], dry_run=False)
+
+    assert result.status == TaskStatus.SUCCESS
+    assert result.errors == []
+    assert result.applied_count == 0
 
 
 def test_owners_are_normalized(test_token: Secret) -> None:

--- a/qontract_api/tests/integrations/test_github_owners_service.py
+++ b/qontract_api/tests/integrations/test_github_owners_service.py
@@ -284,6 +284,32 @@ def test_reconcile_rate_limit_during_apply_not_dry_run(
     assert result.applied_count == 0
 
 
+def test_reconcile_stops_remaining_actions_for_org_after_rate_limit(
+    service: GithubOwnersService,
+    test_token: Secret,
+    mock_github_client: MagicMock,
+) -> None:
+    """Once rate-limited mid-apply, remaining actions for that org must be skipped."""
+    reset_at = datetime.now(UTC) + timedelta(minutes=5)
+    mock_github_client.get_current_members.return_value = []
+    mock_github_client.add_member_as_admin.side_effect = GithubRateLimitExceededError(
+        reset_at
+    )
+
+    org = GithubOrgDesiredState(
+        org_name="my-org",
+        token=test_token,
+        owners=["alice", "bob"],
+    )
+
+    result = service.reconcile(organizations=[org], dry_run=False)
+
+    assert result.status == TaskStatus.SUCCESS
+    assert result.errors == []
+    assert result.applied_count == 0
+    mock_github_client.add_member_as_admin.assert_called_once()
+
+
 def test_owners_are_normalized(test_token: Secret) -> None:
     """GithubOrgDesiredState normalizes owners to lowercase sorted."""
     org = GithubOrgDesiredState(

--- a/qontract_utils/qontract_utils/github_org/__init__.py
+++ b/qontract_utils/qontract_utils/github_org/__init__.py
@@ -1,5 +1,5 @@
 """GitHub organization API client."""
 
-from qontract_utils.github_org.api import GithubOrgApi
+from qontract_utils.github_org.api import GithubOrgApi, GithubRateLimitExceededError
 
-__all__ = ["GithubOrgApi"]
+__all__ = ["GithubOrgApi", "GithubRateLimitExceededError"]

--- a/qontract_utils/qontract_utils/github_org/api.py
+++ b/qontract_utils/qontract_utils/github_org/api.py
@@ -62,7 +62,7 @@ def _reset_at_from_headers(headers: Mapping[str, str]) -> datetime:
     also carry an HTTP-date per RFC 9110, which `int()` cannot parse.
     """
     if retry_after := headers.get("retry-after"):
-        with suppress(ValueError):
+        with suppress(ValueError, OverflowError):
             return datetime.now(UTC) + timedelta(seconds=int(retry_after))
     if reset := headers.get("x-ratelimit-reset"):
         with suppress(ValueError, OSError, OverflowError):

--- a/qontract_utils/qontract_utils/github_org/api.py
+++ b/qontract_utils/qontract_utils/github_org/api.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 import contextvars
 import time
 from collections.abc import Mapping
+from contextlib import suppress
 from dataclasses import dataclass
 from datetime import UTC, datetime, timedelta
 from http import HTTPStatus
@@ -57,13 +58,33 @@ def _reset_at_from_headers(headers: Mapping[str, str]) -> datetime:
     Prefers `Retry-After` (used for GitHub's secondary rate limit, seconds
     from now) over `X-RateLimit-Reset` (used for the primary rate limit, an
     absolute epoch timestamp). Falls back to a conservative default when
-    neither header is present.
+    neither header is present or a value fails to parse - `Retry-After` may
+    also carry an HTTP-date per RFC 9110, which `int()` cannot parse.
     """
     if retry_after := headers.get("retry-after"):
-        return datetime.now(UTC) + timedelta(seconds=int(retry_after))
+        with suppress(ValueError):
+            return datetime.now(UTC) + timedelta(seconds=int(retry_after))
     if reset := headers.get("x-ratelimit-reset"):
-        return datetime.fromtimestamp(int(reset), tz=UTC)
+        with suppress(ValueError, OSError, OverflowError):
+            return datetime.fromtimestamp(int(reset), tz=UTC)
     return datetime.now(UTC) + timedelta(seconds=_DEFAULT_RATE_LIMIT_FALLBACK_SECONDS)
+
+
+def _is_rate_limit_response(status_code: int, headers: Mapping[str, str]) -> bool:
+    """Match GitHub's primary and secondary rate-limit response shapes.
+
+    Primary: 403 with `X-RateLimit-Remaining: 0`. Secondary (abuse detection,
+    concurrent-request limits): 403 or 429, often with `Retry-After` but NOT
+    necessarily zeroing the primary quota's `X-RateLimit-Remaining` (it's a
+    separate bucket) - see
+    https://docs.github.com/en/rest/using-the-rest-api/rate-limits-for-the-rest-api
+    """
+    if status_code == HTTPStatus.TOO_MANY_REQUESTS:
+        return True
+    return status_code == HTTPStatus.FORBIDDEN and (
+        headers.get("x-ratelimit-remaining") == "0"
+        or headers.get("retry-after") is not None
+    )
 
 
 def _rate_limit_reset_at(exc: BaseException) -> datetime | None:
@@ -75,14 +96,13 @@ def _rate_limit_reset_at(exc: BaseException) -> datetime | None:
     """
     if isinstance(exc, RateLimitExceededException):
         return _reset_at_from_headers(exc.headers or {})
-    if isinstance(exc, GithubException) and exc.status == HTTPStatus.TOO_MANY_REQUESTS:
+    if isinstance(exc, GithubException) and _is_rate_limit_response(
+        exc.status, exc.headers or {}
+    ):
         return _reset_at_from_headers(exc.headers or {})
     if isinstance(exc, requests.HTTPError) and exc.response is not None:
         response = exc.response
-        if response.status_code == HTTPStatus.TOO_MANY_REQUESTS or (
-            response.status_code == HTTPStatus.FORBIDDEN
-            and response.headers.get("X-RateLimit-Remaining") == "0"
-        ):
+        if _is_rate_limit_response(response.status_code, response.headers):
             return _reset_at_from_headers(response.headers)
     return None
 

--- a/qontract_utils/qontract_utils/github_org/api.py
+++ b/qontract_utils/qontract_utils/github_org/api.py
@@ -12,20 +12,119 @@ from __future__ import annotations
 
 import contextvars
 import time
+from collections.abc import Mapping
 from dataclasses import dataclass
+from datetime import UTC, datetime, timedelta
+from http import HTTPStatus
 from typing import Any
 
 import requests
 import structlog
 from github import Github
+from github.GithubException import GithubException, RateLimitExceededException
 from github.NamedUser import NamedUser
 from prometheus_client import Counter, Histogram
 
-from qontract_utils.hooks import Hooks, invoke_with_hooks, with_hooks
+from qontract_utils.hooks import Hooks, RetryConfig, invoke_with_hooks, with_hooks
 from qontract_utils.metrics import DEFAULT_BUCKETS_EXTERNAL_API
 from qontract_utils.user_agent import DEFAULT_USER_AGENT
 
 logger = structlog.get_logger(__name__)
+
+# GitHub resets its primary rate limit window hourly. Used as a conservative
+# fallback when a rate-limit response carries neither a Retry-After nor an
+# X-RateLimit-Reset header.
+_DEFAULT_RATE_LIMIT_FALLBACK_SECONDS = 3600
+
+
+class GithubRateLimitExceededError(Exception):
+    """Raised when GitHub's primary or secondary API rate limit is exhausted.
+
+    Retrying before `reset_at` is futile - the caller should back off instead.
+    """
+
+    def __init__(self, reset_at: datetime, message: str | None = None) -> None:
+        self.reset_at = reset_at
+        super().__init__(
+            message
+            or f"GitHub API rate limit exceeded; resets at {reset_at.isoformat()}"
+        )
+
+
+def _reset_at_from_headers(headers: Mapping[str, str]) -> datetime:
+    """Derive the rate-limit reset time from response/exception headers.
+
+    Prefers `Retry-After` (used for GitHub's secondary rate limit, seconds
+    from now) over `X-RateLimit-Reset` (used for the primary rate limit, an
+    absolute epoch timestamp). Falls back to a conservative default when
+    neither header is present.
+    """
+    if retry_after := headers.get("retry-after"):
+        return datetime.now(UTC) + timedelta(seconds=int(retry_after))
+    if reset := headers.get("x-ratelimit-reset"):
+        return datetime.fromtimestamp(int(reset), tz=UTC)
+    return datetime.now(UTC) + timedelta(seconds=_DEFAULT_RATE_LIMIT_FALLBACK_SECONDS)
+
+
+def _rate_limit_reset_at(exc: BaseException) -> datetime | None:
+    """Return the rate-limit reset time if `exc` is a GitHub rate limit error.
+
+    Returns None for any other exception. Shared by the error hook (which
+    converts the exception) and the retry predicate (which must never retry
+    it), so the two can never disagree on what counts as a rate limit.
+    """
+    if isinstance(exc, RateLimitExceededException):
+        return _reset_at_from_headers(exc.headers or {})
+    if isinstance(exc, GithubException) and exc.status == HTTPStatus.TOO_MANY_REQUESTS:
+        return _reset_at_from_headers(exc.headers or {})
+    if isinstance(exc, requests.HTTPError) and exc.response is not None:
+        response = exc.response
+        if response.status_code == HTTPStatus.TOO_MANY_REQUESTS or (
+            response.status_code == HTTPStatus.FORBIDDEN
+            and response.headers.get("X-RateLimit-Remaining") == "0"
+        ):
+            return _reset_at_from_headers(response.headers)
+    return None
+
+
+# Server-side statuses worth a quick retry (distinct from client errors like
+# 401/404/422, which won't succeed on retry, and from 403/429 rate limits,
+# which are handled separately and must never be retried).
+_RETRYABLE_HTTP_STATUSES = frozenset(
+    {
+        HTTPStatus.INTERNAL_SERVER_ERROR,
+        HTTPStatus.BAD_GATEWAY,
+        HTTPStatus.SERVICE_UNAVAILABLE,
+        HTTPStatus.GATEWAY_TIMEOUT,
+    }
+)
+
+
+def _should_retry(exc: Exception) -> bool:
+    """Retry transient network/server errors; never retry rate limits.
+
+    Retrying a rate-limited request before GitHub's reset window is
+    guaranteed to fail and only burns more of the shared quota, so those
+    fail fast via `_rate_limit_error_hook` instead of being retried here.
+    """
+    if _rate_limit_reset_at(exc) is not None:
+        return False
+    if isinstance(exc, requests.ConnectionError | requests.Timeout):
+        return True
+    if isinstance(exc, requests.HTTPError) and exc.response is not None:
+        return exc.response.status_code in _RETRYABLE_HTTP_STATUSES
+    return isinstance(exc, GithubException) and exc.status in _RETRYABLE_HTTP_STATUSES
+
+
+_RETRY_CONFIG = RetryConfig(
+    on=_should_retry,
+    attempts=3,
+    timeout=5.0,
+    wait_initial=0.5,
+    wait_max=5.0,
+    wait_jitter=1.0,
+)
+
 
 # Prometheus metrics (following qontract_reconcile_external_api_<component>_requests_total convention)
 github_org_request = Counter(
@@ -91,9 +190,25 @@ def _request_log_hook(context: GithubOrgApiCallContext) -> None:
     )
 
 
+def _rate_limit_error_hook(_context: GithubOrgApiCallContext, exc: Exception) -> None:
+    """Convert GitHub rate-limit errors into GithubRateLimitExceededError.
+
+    Runs as an error hook, receiving the exception that triggered it, so all
+    three API methods share one detection path instead of each catching
+    PyGithub/requests exceptions individually. Shares detection logic with
+    `_should_retry` via `_rate_limit_reset_at` so the two can never disagree
+    on what counts as a rate limit. Raising here replaces the original
+    exception for the caller.
+    """
+    if (reset_at := _rate_limit_reset_at(exc)) is not None:
+        raise GithubRateLimitExceededError(reset_at) from exc
+
+
 _DEFAULT_HOOKS = Hooks(
     pre_hooks=[_metrics_hook, _request_log_hook, _latency_start_hook],
     post_hooks=[_latency_end_hook],
+    error_hooks=[_rate_limit_error_hook],
+    retry_config=_RETRY_CONFIG,
 )
 
 

--- a/qontract_utils/qontract_utils/hooks.py
+++ b/qontract_utils/qontract_utils/hooks.py
@@ -247,7 +247,11 @@ class Hooks(BaseModel, frozen=True):
 
     pre_hooks: list[Callable[..., None]] = Field(default_factory=list)
     post_hooks: list[Callable[..., None]] = Field(default_factory=list)
+    # Called as hook(*hook_args, exc) - i.e. (exception,) with no context, or
+    # (context, exception) with one - so a hook can inspect/convert the
+    # exception that triggered it.
     error_hooks: list[Callable[..., None]] = Field(default_factory=list)
+    # Called as hook(*hook_args, attempt_num) - same trailing-arg convention.
     retry_hooks: list[Callable[..., None]] = Field(default_factory=list)
     retry_config: RetryConfig | None = None
 
@@ -512,9 +516,9 @@ class InvokeWithHooksMethod:
 
             try:
                 yield from self.func(*prepend_args, *args, **kwargs)
-            except Exception:
+            except Exception as exc:
                 for hook in hooks.error_hooks:
-                    hook(*hook_args)
+                    hook(*hook_args, exc)
                 raise
             finally:
                 for hook in hooks.post_hooks:
@@ -569,9 +573,9 @@ class InvokeWithHooksMethod:
 
                         # Execute method - no yield, just return!
                         return self.func(*prepend_args, *args, **kwargs)
-            except Exception:
+            except Exception as exc:
                 for hook in hooks.error_hooks:
-                    hook(*hook_args)
+                    hook(*hook_args, exc)
                 raise
             finally:
                 # Post hooks

--- a/qontract_utils/tests/hooks/test_direct_invocation.py
+++ b/qontract_utils/tests/hooks/test_direct_invocation.py
@@ -76,7 +76,7 @@ def test_invoke_with_error_hooks() -> None:
     def pre_hook() -> None:
         execution_order.append("pre")
 
-    def error_hook() -> None:
+    def error_hook(exc: Exception) -> None:
         execution_order.append("error")
 
     def post_hook() -> None:

--- a/qontract_utils/tests/hooks/test_generator.py
+++ b/qontract_utils/tests/hooks/test_generator.py
@@ -76,7 +76,7 @@ def test_generator_post_hooks_fire_on_close() -> None:
         def __init__(self) -> None:
             self._hooks = Hooks(
                 post_hooks=[lambda: execution_order.append("post")],
-                error_hooks=[lambda: execution_order.append("error")],
+                error_hooks=[lambda _exc: execution_order.append("error")],
                 retry_config=NO_RETRY_CONFIG,
             )
 
@@ -97,7 +97,7 @@ def test_generator_post_hooks_fire_on_close() -> None:
 def test_generator_error_hooks_fire_on_exception() -> None:
     execution_order: list[str] = []
 
-    def error_hook() -> None:
+    def error_hook(_exc: Exception) -> None:
         execution_order.append("error")
 
     def post_hook() -> None:

--- a/qontract_utils/tests/hooks/test_instance_methods.py
+++ b/qontract_utils/tests/hooks/test_instance_methods.py
@@ -124,7 +124,7 @@ def test_error_hook_on_exception() -> None:
     """Test error-hooks are executed when an exception occurs."""
     execution_order: list[str] = []
 
-    def error_hook() -> None:
+    def error_hook(_exc: Exception) -> None:
         execution_order.append("error")
 
     class TestApi:
@@ -147,10 +147,10 @@ def test_multiple_error_hooks() -> None:
     """Test multiple error-hooks are executed in order."""
     execution_order: list[str] = []
 
-    def error_hook_1() -> None:
+    def error_hook_1(_exc: Exception) -> None:
         execution_order.append("error1")
 
-    def error_hook_2() -> None:
+    def error_hook_2(_exc: Exception) -> None:
         execution_order.append("error2")
 
     class TestApi:
@@ -175,7 +175,7 @@ def test_error_hooks_not_called_on_success() -> None:
     """Test error-hooks are NOT executed when no exception occurs."""
     execution_order: list[str] = []
 
-    def error_hook() -> None:
+    def error_hook(_exc: Exception) -> None:
         execution_order.append("error")
 
     class TestApi:
@@ -195,7 +195,7 @@ def test_post_hooks_called_after_error_hooks() -> None:
     """Test post-hooks are executed after error-hooks."""
     execution_order: list[str] = []
 
-    def error_hook() -> None:
+    def error_hook(_exc: Exception) -> None:
         execution_order.append("error")
 
     def post_hook() -> None:
@@ -231,7 +231,7 @@ def test_full_lifecycle_no_error() -> None:
     def post_hook() -> None:
         execution_order.append("post")
 
-    def error_hook() -> None:
+    def error_hook(_exc: Exception) -> None:
         execution_order.append("error")
 
     class TestApi:
@@ -262,7 +262,7 @@ def test_full_lifecycle_with_error() -> None:
     def post_hook() -> None:
         execution_order.append("post")
 
-    def error_hook() -> None:
+    def error_hook(_exc: Exception) -> None:
         execution_order.append("error")
 
     class TestApi:
@@ -332,7 +332,7 @@ def test_context_modification_in_error_hook() -> None:
     """Test error-hooks can access context during error."""
     context_data: dict[str, Any] = {}
 
-    def error_hook(ctx: dict[str, Any]) -> None:
+    def error_hook(ctx: dict[str, Any], _exc: Exception) -> None:
         ctx["error_handled"] = True
         # Store context for verification
         context_data.update(ctx)
@@ -409,7 +409,7 @@ def test_exception_in_post_hook() -> None:
 def test_exception_in_error_hook() -> None:
     """Test exceptions in error-hooks are propagated (last one wins)."""
 
-    def error_hook() -> None:
+    def error_hook(_exc: Exception) -> None:
         raise ValueError("error-hook error")
 
     class TestApi:
@@ -498,14 +498,13 @@ def test_post_hook_executes_even_after_main_error() -> None:
 def test_exception_in_first_error_hook_stops_processing() -> None:
     """Test when first error hook raises, it stops processing other error hooks."""
 
-    def error_hook_1() -> None:
+    def error_hook_1(_exc: Exception) -> None:
         raise ValueError("error1")
 
     context_data: dict[str, Any] = {}
 
-    def error_hook_2(ctx: dict[str, Any]) -> None:
-        ctx["hook2_called"] = True
-        context_data.update(ctx)
+    def error_hook_2(_exc: Exception) -> None:
+        context_data["hook2_called"] = True
 
     class TestApi:
         def __init__(self) -> None:
@@ -572,7 +571,7 @@ def test_complex_context_type() -> None:
     def post_hook(ctx: RequestContext) -> None:
         ctx.status = "completed"
 
-    def error_hook(ctx: RequestContext) -> None:
+    def error_hook(ctx: RequestContext, _exc: Exception) -> None:
         ctx.status = "failed"
 
     context = RequestContext(request_id="123")

--- a/qontract_utils/tests/hooks/test_retry.py
+++ b/qontract_utils/tests/hooks/test_retry.py
@@ -193,7 +193,7 @@ def test_error_hooks_only_on_final_failure(enable_retry: None) -> None:
     error_hook_calls = {"count": 0}
     execution_count = {"count": 0}
 
-    def error_hook() -> None:
+    def error_hook(exc: Exception) -> None:
         error_hook_calls["count"] += 1
 
     class TestApi:
@@ -221,7 +221,7 @@ def test_error_hooks_on_exhausted_retries(enable_retry: None) -> None:
     """Test error-hooks called when all retries exhausted."""
     error_hook_calls = {"count": 0}
 
-    def error_hook() -> None:
+    def error_hook(exc: Exception) -> None:
         error_hook_calls["count"] += 1
 
     class TestApi:
@@ -306,7 +306,7 @@ def test_retry_with_full_hook_lifecycle(enable_retry: None) -> None:
     def post_hook() -> None:
         execution_log.append("post")
 
-    def error_hook() -> None:
+    def error_hook(exc: Exception) -> None:
         execution_log.append("error")
 
     def retry_hook(attempt: int) -> None:
@@ -439,7 +439,7 @@ def test_retry_config_override_still_calls_hooks() -> None:
     def post_hook() -> None:
         execution_log.append("post")
 
-    def error_hook() -> None:
+    def error_hook(exc: Exception) -> None:
         execution_log.append("error")
 
     class TestApi:

--- a/qontract_utils/tests/hooks/test_standalone_decorator.py
+++ b/qontract_utils/tests/hooks/test_standalone_decorator.py
@@ -42,7 +42,7 @@ def test_standalone_function_with_all_hooks() -> None:
     def post_hook() -> None:
         execution_order.append("post")
 
-    def error_hook() -> None:
+    def error_hook(exc: Exception) -> None:
         execution_order.append("error")
 
     @invoke_with_hooks(

--- a/qontract_utils/tests/hooks/test_with_hooks_decorator.py
+++ b/qontract_utils/tests/hooks/test_with_hooks_decorator.py
@@ -253,10 +253,10 @@ def test_merges_error_hooks() -> None:
     """Test that decorator error hooks are merged with user error hooks."""
     execution_order: list[str] = []
 
-    def decorator_error_hook(_ctx: Any) -> None:
+    def decorator_error_hook(_ctx: Any, _exc: Exception) -> None:
         execution_order.append("decorator_error")
 
-    def user_error_hook(_ctx: Any) -> None:
+    def user_error_hook(_ctx: Any, _exc: Exception) -> None:
         execution_order.append("user_error")
 
     @with_hooks(

--- a/qontract_utils/tests/test_github_org_api.py
+++ b/qontract_utils/tests/test_github_org_api.py
@@ -172,6 +172,25 @@ def test_reset_at_fallback_on_non_numeric_retry_after() -> None:
     assert before + fallback <= exc_info.value.reset_at <= after + fallback
 
 
+def test_reset_at_fallback_on_oversized_retry_after() -> None:
+    """An oversized-but-numeric Retry-After must not raise OverflowError."""
+    api = GithubOrgApi(token="token", base_url="https://api.github.com")
+    org = MagicMock()
+    org.get_members.side_effect = RateLimitExceededException(
+        403, {"message": "rate limit"}, {"retry-after": str(10**20)}
+    )
+    api._gh = MagicMock()
+    api._gh.get_organization.return_value = org
+
+    before = datetime.now(UTC)
+    with pytest.raises(GithubRateLimitExceededError) as exc_info:
+        api.get_admin_members("my-org")
+    after = datetime.now(UTC)
+
+    fallback = timedelta(seconds=_DEFAULT_RATE_LIMIT_FALLBACK_SECONDS)
+    assert before + fallback <= exc_info.value.reset_at <= after + fallback
+
+
 def test_reset_at_fallback_on_non_numeric_ratelimit_reset() -> None:
     """A non-numeric X-RateLimit-Reset must not raise ValueError - fall back."""
     api = GithubOrgApi(token="token", base_url="https://api.github.com")

--- a/qontract_utils/tests/test_github_org_api.py
+++ b/qontract_utils/tests/test_github_org_api.py
@@ -1,7 +1,19 @@
 """Tests for qontract_utils.github_org.api."""
 
+from datetime import UTC, datetime, timedelta
+from unittest.mock import MagicMock
+
+import pytest
+import requests
+from github.GithubException import GithubException, RateLimitExceededException
+from github.NamedUser import NamedUser
 from pytest_httpserver import HTTPServer
-from qontract_utils.github_org.api import GithubOrgApi
+from qontract_utils.github_org.api import (
+    _DEFAULT_RATE_LIMIT_FALLBACK_SECONDS,
+    GithubOrgApi,
+    GithubRateLimitExceededError,
+)
+from werkzeug import Response
 
 INVITATIONS_PATH = "/orgs/my-org/invitations"
 
@@ -28,3 +40,238 @@ def test_custom_user_agent_overrides_default(httpserver: HTTPServer) -> None:
 
     request = next(req for req, _ in httpserver.log if req.path == INVITATIONS_PATH)
     assert request.headers["User-Agent"] == "qontract-api/1.2.3"
+
+
+def test_paginated_get_raises_rate_limit_error_on_403_remaining_zero(
+    httpserver: HTTPServer,
+) -> None:
+    api = GithubOrgApi(token="token", base_url=httpserver.url_for(""))
+    reset_epoch = int(datetime(2026, 9, 4, 17, 22, 2, tzinfo=UTC).timestamp())
+    httpserver.expect_request(INVITATIONS_PATH, method="GET").respond_with_json(
+        {"message": "API rate limit exceeded"},
+        status=403,
+        headers={"X-RateLimit-Remaining": "0", "X-RateLimit-Reset": str(reset_epoch)},
+    )
+
+    with pytest.raises(GithubRateLimitExceededError) as exc_info:
+        api.get_pending_invitations("my-org")
+
+    assert exc_info.value.reset_at == datetime.fromtimestamp(reset_epoch, tz=UTC)
+
+
+def test_paginated_get_raises_rate_limit_error_on_429(
+    httpserver: HTTPServer,
+) -> None:
+    api = GithubOrgApi(token="token", base_url=httpserver.url_for(""))
+    httpserver.expect_request(INVITATIONS_PATH, method="GET").respond_with_json(
+        {"message": "secondary rate limit"},
+        status=429,
+        headers={"Retry-After": "30"},
+    )
+
+    before = datetime.now(UTC)
+    with pytest.raises(GithubRateLimitExceededError) as exc_info:
+        api.get_pending_invitations("my-org")
+    after = datetime.now(UTC)
+
+    assert (
+        before + timedelta(seconds=30)
+        <= exc_info.value.reset_at
+        <= after + timedelta(seconds=30)
+    )
+
+
+def test_paginated_get_403_without_ratelimit_raises_httperror(
+    httpserver: HTTPServer,
+) -> None:
+    api = GithubOrgApi(token="token", base_url=httpserver.url_for(""))
+    httpserver.expect_request(INVITATIONS_PATH, method="GET").respond_with_json(
+        {"message": "Forbidden"},
+        status=403,
+        headers={"X-RateLimit-Remaining": "42"},
+    )
+
+    with pytest.raises(requests.HTTPError):
+        api.get_pending_invitations("my-org")
+
+
+def test_get_admin_members_raises_rate_limit_error() -> None:
+    api = GithubOrgApi(token="token", base_url="https://api.github.com")
+    reset_epoch = 1788542522
+    org = MagicMock()
+    org.get_members.side_effect = RateLimitExceededException(
+        403, {"message": "rate limit"}, {"x-ratelimit-reset": str(reset_epoch)}
+    )
+    api._gh = MagicMock()
+    api._gh.get_organization.return_value = org
+
+    with pytest.raises(GithubRateLimitExceededError) as exc_info:
+        api.get_admin_members("my-org")
+
+    assert exc_info.value.reset_at == datetime.fromtimestamp(reset_epoch, tz=UTC)
+
+
+def test_add_member_as_admin_raises_rate_limit_error_on_429() -> None:
+    api = GithubOrgApi(token="token", base_url="https://api.github.com")
+    org = MagicMock()
+    org.add_to_members.side_effect = GithubException(
+        429, {"message": "secondary rate limit"}, {"retry-after": "15"}
+    )
+    api._gh = MagicMock()
+    api._gh.get_organization.return_value = org
+    api._gh.get_user.return_value = MagicMock(spec=NamedUser)
+
+    before = datetime.now(UTC)
+    with pytest.raises(GithubRateLimitExceededError) as exc_info:
+        api.add_member_as_admin("my-org", "alice")
+    after = datetime.now(UTC)
+
+    assert (
+        before + timedelta(seconds=15)
+        <= exc_info.value.reset_at
+        <= after + timedelta(seconds=15)
+    )
+
+
+def test_reset_at_fallback_when_headers_missing() -> None:
+    api = GithubOrgApi(token="token", base_url="https://api.github.com")
+    org = MagicMock()
+    org.get_members.side_effect = RateLimitExceededException(
+        403, {"message": "rate limit"}, {}
+    )
+    api._gh = MagicMock()
+    api._gh.get_organization.return_value = org
+
+    before = datetime.now(UTC)
+    with pytest.raises(GithubRateLimitExceededError) as exc_info:
+        api.get_admin_members("my-org")
+    after = datetime.now(UTC)
+
+    fallback = timedelta(seconds=_DEFAULT_RATE_LIMIT_FALLBACK_SECONDS)
+    assert before + fallback <= exc_info.value.reset_at <= after + fallback
+
+
+@pytest.mark.usefixtures("enable_retry")
+def test_rate_limit_is_not_retried(httpserver: HTTPServer) -> None:
+    """A rate-limited request must fail on the first attempt, never retried."""
+    api = GithubOrgApi(token="token", base_url=httpserver.url_for(""))
+    httpserver.expect_request(INVITATIONS_PATH, method="GET").respond_with_json(
+        {"message": "API rate limit exceeded"},
+        status=403,
+        headers={"X-RateLimit-Remaining": "0", "X-RateLimit-Reset": "9999999999"},
+    )
+
+    with pytest.raises(GithubRateLimitExceededError):
+        api.get_pending_invitations("my-org")
+
+    assert len(httpserver.log) == 1
+
+
+@pytest.mark.usefixtures("enable_retry")
+def test_transient_server_error_is_retried_then_succeeds(
+    httpserver: HTTPServer,
+) -> None:
+    """A transient 503 must be retried and the call must succeed once it clears.
+
+    `enable_retry` forces exactly 3 attempts (see tests/conftest.py), so the
+    handler is written to succeed on the 3rd call regardless of
+    `_RETRY_CONFIG.attempts`.
+    """
+    call_count = {"n": 0}
+
+    def handler(_request: object) -> Response:
+        call_count["n"] += 1
+        if call_count["n"] < 3:
+            return Response(status=503)
+        return Response(response="[]", content_type="application/json")
+
+    httpserver.expect_request(INVITATIONS_PATH, method="GET").respond_with_handler(
+        handler
+    )
+    api = GithubOrgApi(token="token", base_url=httpserver.url_for(""))
+
+    result = api.get_pending_invitations("my-org")
+
+    assert result == []
+    assert call_count["n"] == 3
+
+
+@pytest.mark.usefixtures("enable_retry")
+def test_persistent_server_error_exhausts_retries_and_raises(
+    httpserver: HTTPServer,
+) -> None:
+    """A persistent 503 must be retried up to the configured limit, then raise."""
+    api = GithubOrgApi(token="token", base_url=httpserver.url_for(""))
+    httpserver.expect_request(INVITATIONS_PATH, method="GET").respond_with_json(
+        {"message": "Service Unavailable"}, status=503
+    )
+
+    with pytest.raises(requests.HTTPError):
+        api.get_pending_invitations("my-org")
+
+    assert len(httpserver.log) == 3
+
+
+@pytest.mark.usefixtures("enable_retry")
+def test_transient_connection_error_is_retried_and_succeeds(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A network-level connection error must be retried, not fail immediately."""
+    api = GithubOrgApi(token="token", base_url="https://api.github.com")
+    call_count = {"n": 0}
+
+    def flaky_get(*_args: object, **_kwargs: object) -> requests.Response:
+        call_count["n"] += 1
+        if call_count["n"] < 2:
+            raise requests.ConnectionError("connection reset by peer")
+        response = requests.Response()
+        response.status_code = 200
+        response._content = b"[]"
+        return response
+
+    monkeypatch.setattr("qontract_utils.github_org.api.requests.get", flaky_get)
+
+    result = api.get_pending_invitations("my-org")
+
+    assert result == []
+    assert call_count["n"] == 2
+
+
+@pytest.mark.usefixtures("enable_retry")
+def test_persistent_connection_error_exhausts_retries(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A persistent connection error must exhaust retries, then propagate."""
+    api = GithubOrgApi(token="token", base_url="https://api.github.com")
+    call_count = {"n": 0}
+
+    def always_fails(*_args: object, **_kwargs: object) -> requests.Response:
+        call_count["n"] += 1
+        raise requests.ConnectionError("connection reset by peer")
+
+    monkeypatch.setattr("qontract_utils.github_org.api.requests.get", always_fails)
+
+    with pytest.raises(requests.ConnectionError):
+        api.get_pending_invitations("my-org")
+
+    assert call_count["n"] == 3
+
+
+@pytest.mark.usefixtures("enable_retry")
+def test_transient_pygithub_server_error_is_retried_and_succeeds() -> None:
+    """A 5xx GithubException from PyGithub must be retried, not fail immediately."""
+    api = GithubOrgApi(token="token", base_url="https://api.github.com")
+    member = MagicMock()
+    member.login = "Alice"
+    org = MagicMock()
+    org.get_members.side_effect = [
+        GithubException(502, {"message": "Bad Gateway"}, {}),
+        [member],
+    ]
+    api._gh = MagicMock()
+    api._gh.get_organization.return_value = org
+
+    result = api.get_admin_members("my-org")
+
+    assert result == ["alice"]
+    assert org.get_members.call_count == 2

--- a/qontract_utils/tests/test_github_org_api.py
+++ b/qontract_utils/tests/test_github_org_api.py
@@ -151,6 +151,69 @@ def test_reset_at_fallback_when_headers_missing() -> None:
     assert before + fallback <= exc_info.value.reset_at <= after + fallback
 
 
+def test_reset_at_fallback_on_non_numeric_retry_after() -> None:
+    """A non-numeric Retry-After (an HTTP-date, which HTTP allows) must not raise."""
+    api = GithubOrgApi(token="token", base_url="https://api.github.com")
+    org = MagicMock()
+    org.get_members.side_effect = RateLimitExceededException(
+        403,
+        {"message": "rate limit"},
+        {"retry-after": "Wed, 21 Oct 2026 07:28:00 GMT"},
+    )
+    api._gh = MagicMock()
+    api._gh.get_organization.return_value = org
+
+    before = datetime.now(UTC)
+    with pytest.raises(GithubRateLimitExceededError) as exc_info:
+        api.get_admin_members("my-org")
+    after = datetime.now(UTC)
+
+    fallback = timedelta(seconds=_DEFAULT_RATE_LIMIT_FALLBACK_SECONDS)
+    assert before + fallback <= exc_info.value.reset_at <= after + fallback
+
+
+def test_reset_at_fallback_on_non_numeric_ratelimit_reset() -> None:
+    """A non-numeric X-RateLimit-Reset must not raise ValueError - fall back."""
+    api = GithubOrgApi(token="token", base_url="https://api.github.com")
+    org = MagicMock()
+    org.get_members.side_effect = RateLimitExceededException(
+        403, {"message": "rate limit"}, {"x-ratelimit-reset": "not-a-number"}
+    )
+    api._gh = MagicMock()
+    api._gh.get_organization.return_value = org
+
+    before = datetime.now(UTC)
+    with pytest.raises(GithubRateLimitExceededError) as exc_info:
+        api.get_admin_members("my-org")
+    after = datetime.now(UTC)
+
+    fallback = timedelta(seconds=_DEFAULT_RATE_LIMIT_FALLBACK_SECONDS)
+    assert before + fallback <= exc_info.value.reset_at <= after + fallback
+
+
+def test_secondary_limit_403_without_remaining_zero_is_rate_limit(
+    httpserver: HTTPServer,
+) -> None:
+    """A secondary-limit 403+Retry-After without remaining=0 is still a rate limit."""
+    api = GithubOrgApi(token="token", base_url=httpserver.url_for(""))
+    httpserver.expect_request(INVITATIONS_PATH, method="GET").respond_with_json(
+        {"message": "You have exceeded a secondary rate limit"},
+        status=403,
+        headers={"Retry-After": "30"},
+    )
+
+    before = datetime.now(UTC)
+    with pytest.raises(GithubRateLimitExceededError) as exc_info:
+        api.get_pending_invitations("my-org")
+    after = datetime.now(UTC)
+
+    assert (
+        before + timedelta(seconds=30)
+        <= exc_info.value.reset_at
+        <= after + timedelta(seconds=30)
+    )
+
+
 @pytest.mark.usefixtures("enable_retry")
 def test_rate_limit_is_not_retried(httpserver: HTTPServer) -> None:
     """A rate-limited request must fail on the first attempt, never retried."""


### PR DESCRIPTION
## Summary

`github-owners.reconcile` (qontract-api Celery task) shares a GitHub API credential's rate limit with two legacy integrations (`saas-metrics-exporter`, `openshift-saas-deploy-trigger-moving-commits`). When the shared quota is exhausted, the task retried on its normal ~60s schedule and reported `FAILURE` every cycle, firing the `qontract-api-task-failure` alert repeatedly and paging the IC for a condition that is not actionable and self-recovers once GitHub resets the quota at the top of the hour.

Scoped to an in-repo code fix only (no changes to the alert definition, token provisioning, or the legacy integrations — see [APPSRE-15206](https://redhat.atlassian.net/browse/APPSRE-15206) for the full analysis and out-of-scope items).

### Hooks enhancement (`qontract_utils/qontract_utils/hooks.py`)

Before this PR, `error_hooks` were only ever called with the pre/post-hook context (`hook(*hook_args)`) — a hook that wanted to know *what* exception triggered it had to reach for `sys.exc_info()` from inside the hook body, which is implicit and easy to get wrong (e.g. it silently returns `None` if called outside an active exception context). `retry_hooks` already had precedent for a trailing argument (`retry_hook(*hook_args, attempt.num)`), so `error_hooks` now follow the same convention: `hook(*hook_args, exc)` — i.e. `hook(exc)` with no context, or `hook(context, exc)` with one. This is what makes the GitHub rate-limit detection below possible as a single shared hook instead of duplicated `try/except` blocks in every API method.

### GitHub rate-limit handling

- **`qontract_utils/qontract_utils/github_org/api.py`**: detects GitHub's primary (403 + `X-RateLimit-Remaining: 0`) and secondary (429, or 403 + `Retry-After` on a separate quota bucket) rate limits via a shared `error_hook`, raising a typed `GithubRateLimitExceededError` carrying the reset time. Adds a predicate-based `retry_config` that retries transient network/server errors (connection errors, timeouts, 5xx) but never retries a rate limit — retrying before the reset window is guaranteed to fail and only burns more of the shared quota.
- **`qontract_api/qontract_api/github/github_org_workspace_client.py`**: caches a rate-limit marker per org (on both the read path and the write path) so subsequent reconcile cycles short-circuit instead of repeating a doomed GitHub call.
- **`qontract_api/qontract_api/integrations/github_owners/service.py`**: treats a rate-limited org as a skip (logged, not recorded as an error) and stops trying further actions for that org once its shared credential is exhausted, so the task reports `SUCCESS` and the alert stops firing. Documented as a sanctioned carve-out to AGENTS.md's "silently-skipped units must FAIL" convention, since the reset time is known upfront and no operator action is possible before it.

### Review fixes (coderabbitai, fishi0x01, hemslo)

- Non-numeric rate-limit header values (e.g. an HTTP-date `Retry-After`, which HTTP allows) no longer raise `ValueError` out of the error hook — they fall back to the conservative default instead of masquerading as a generic task failure.
- An oversized-but-numeric `Retry-After` (e.g. `10**20`) no longer raises `OverflowError` from `timedelta(seconds=...)` — same fallback applies.
- A rate limit hit while applying an action now stops the remaining actions for that org (shared credential, guaranteed to fail the same way) instead of burning more quota.
- The rate-limit marker is now also cached when `add_member_as_admin` (the write path) hits a rate limit, not just `get_current_members` (the read path) — previously the stale members cache would regenerate the same doomed action every cycle.
- Secondary-limit 403 responses without `X-RateLimit-Remaining: 0` (a separate quota bucket per GitHub's docs) are now correctly classified as rate limits instead of falling through as generic errors.
- `get_current_members`'s locked path now checks the rate-limit marker before the members cache (matching the outer, pre-lock check order), closing a race where a marker written while a caller waited on the lock could be shadowed by a concurrently-populated members cache and return stale data.

## Test plan

- [x] `cd qontract_utils && make test` (789 passed, ruff + mypy clean)
- [x] `cd qontract_api && make test` (809 passed, ruff + mypy clean)
- [x] Tests confirm: rate limits fail fast with zero retries (including the secondary-limit, malformed-header, and oversized-header shapes); connection errors, 503s, and PyGithub 5xx errors are retried and recover; persistent versions of each exhaust retries and propagate correctly; the apply loop stops after the first rate limit in an org; the marker is cached on both read and write rate-limit hits
- [x] Regression: existing `github-owners` service/task tests (generic error handling, dry-run/non-dry-run, multi-org reconciliation) still pass unchanged

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added GitHub rate-limit detection with reset-time reporting and temporary caching.
  * Rate-limited organizations and actions are skipped until access is expected to recover.
  * Processing continues for unaffected organizations.
  * Error hooks now receive the original exception for improved diagnostics.

* **Bug Fixes**
  * Prevented rate-limit errors from being reported as reconciliation failures.
  * Improved handling of invalid or oversized retry timing headers.

* **Tests**
  * Expanded coverage for rate limits, caching, and error-hook behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
