### PR TITLE
fix(rhcs-certs): surface CA errorCode/errorReason in PEM extraction failure

### DIFF
--- a/reconcile/test/fixtures/rhcsv2_certs/invalid_response_ldap_constraint_violation.html
+++ b/reconcile/test/fixtures/rhcsv2_certs/invalid_response_ldap_constraint_violation.html
@@ -1,0 +1,57 @@
+<!-- --- BEGIN COPYRIGHT BLOCK ---
+     This program is free software; you can redistribute it and/or modify
+     it under the terms of the GNU General Public License as published by
+     the Free Software Foundation; version 2 of the License.
+     This program is distributed in the hope that it will be useful,
+     but WITHOUT ANY WARRANTY; without even the implied warranty of
+     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+     GNU General Public License for more details.
+     You should have received a copy of the GNU General Public License along
+     with this program; if not, write to the Free Software Foundation, Inc.,
+     51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+     Copyright (C) 2007 Red Hat, Inc.
+     All rights reserved.
+     --- END COPYRIGHT BLOCK --- -->
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">
+<html>
+<head>
+<script type="text/javascript">
+errorReason="LDAPException caught from operation. Constraint violation";
+errorCode="1";
+</script>
+<script src="/pki/js/jquery.js"></script>
+<script src="/pki/js/jquery.i18n.properties.js"></script>
+<script src="/pki/js/underscore.js"></script>
+<script src="/pki/js/backbone.js"></script>
+<script src="/pki/js/pki.js"></script>
+<script src="/pki/js/pki-banner.js"></script>
+</head>
+<font size="+1" face="PrimaSans BT, Verdana, Arial, Helvetica, sans-serif">
+Certificate Profile
+</font><br>
+  <Font size="-1" face="PrimaSans BT, Verdana, Arial, Helvetica, sans-serif">
+<p>
+</font>
+<table border="0" cellspacing="0" cellpadding="0" background="/pki/images/hr.gif"
+width="100%">
+  <tr>
+    <td>&nbsp;</td>
+  </tr>
+</table>
+<font size="-1" face="PrimaSans BT, Verdana, Arial, Helvetica, sans-serif">
+<script language=javascript>
+var autoImport = 'false';
+if (errorCode == 0) { // processed
+  document.write('Congratulations, your request has been processed successfully ');
+} else if (errorCode == 1) { // not submitted
+  document.write('Sorry, your request is not submitted. The reason is "' + errorReason + '".');
+} else if (errorCode == 2) { // pending
+  document.write('Congratulations, your request has been successfully submitted. ');
+} else if (errorCode == 3) { // rejected
+  document.write('Sorry, your request has been rejected. The reason is "' + errorReason + '"');
+} else { // unknown state
+  document.write('Sorry, your request is not submitted. The error code is "' + errorReason + '".');
+}
+</script>
+</font>
+</html>

--- a/reconcile/test/test_utils_rhcsv2_certs.py
+++ b/reconcile/test/test_utils_rhcsv2_certs.py
@@ -43,6 +43,19 @@ def test_extract_cert_invalid_cert_format(fx: Callable) -> None:
         extract_cert(html_response)
 
 
+def test_extract_cert_surfaces_ca_error_detail(fx: Callable) -> None:
+    html_response = fx("invalid_response_ldap_constraint_violation.html")
+    with pytest.raises(
+        ValueError,
+        match=(
+            r"Could not extract certificate PEM from response "
+            r"\(CA errorCode=1: LDAPException caught from operation\. "
+            r"Constraint violation\)"
+        ),
+    ):
+        extract_cert(html_response)
+
+
 def test_get_cert_expiry() -> None:
     # Test certificate with known expiry: Jan 1 00:00:00 2025 GMT (1735689600 Unix timestamp)
     # Base certificate generated with openssl:

--- a/reconcile/utils/rhcsv2_certs.py
+++ b/reconcile/utils/rhcsv2_certs.py
@@ -66,7 +66,14 @@ def extract_cert(text: str) -> re.Match:
         re.DOTALL,
     )
     if not cert_pem:
-        raise ValueError("Could not extract certificate PEM from response")
+        error_code = re.search(r'errorCode\s*=\s*"([^"]*)"', text)
+        error_reason = re.search(r'errorReason\s*=\s*"([^"]*)"', text)
+        detail = (
+            f" (CA errorCode={error_code.group(1)}: {error_reason.group(1)})"
+            if error_code and error_reason
+            else ""
+        )
+        raise ValueError(f"Could not extract certificate PEM from response{detail}")
     return cert_pem
 
 


### PR DESCRIPTION
## What
When `extract_cert()` can't find the `b64_cert` block in the CA webform's response, include the CA's own `errorCode`/`errorReason` (always present in the response, success or failure) in the raised exception.

## Why
Debugging a live `openshift-rhcs-certs` failure (ASIC-738 area, `hcc-parsec-stage` service account) required manually replaying the CA request to see the actual rejection reason — the reconcile log only showed `Could not extract certificate PEM from response`, with no indication that the CA had returned `LDAPException caught from operation. Constraint violation` for that account. Surfacing this detail makes the failure self-diagnosing from logs/Slack alone.

## Validation
Added a fixture from the real response captured during that investigation and a new test asserting the detail is included. Full `test_utils_rhcsv2_certs.py` suite passes (5 passed).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Certificate enrollment errors now include the CA error code and detailed reason when certificate data cannot be extracted.
  * Improved diagnostics for LDAP constraint violations and similar certificate authority errors.

* **Tests**
  * Added regression coverage for preserving CA error details in reported failures.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->