### PR TITLE
feat(slack-usergroups): resolve github org members into usergroups

### DIFF
--- a/docs/integrations/slack-usergroups.md
+++ b/docs/integrations/slack-usergroups.md
@@ -1,10 +1,10 @@
 # Slack Usergroups Integration
 
-**Last Updated:** 2025-11-26
+**Last Updated:** 2026-09-08
 
 ## Description
 
-This integration manages Slack usergroups across multiple workspaces (Slack instances) by reconciling desired state from app-interface with current state in Slack. It supports Slack Usergroup management based on roles, schedules, git repository ownership, and PagerDuty on-call rotations. The integration uses a client-server architecture where GraphQL queries happen client-side and reconciliation logic runs server-side via qontract-api.
+This integration manages Slack usergroups across multiple workspaces (Slack instances) by reconciling desired state from app-interface with current state in Slack. It supports Slack Usergroup management based on roles, schedules, git repository ownership, PagerDuty on-call rotations, and GitHub organization membership. The integration uses a client-server architecture where GraphQL queries happen client-side and reconciliation logic runs server-side via qontract-api.
 
 ## Features
 
@@ -14,6 +14,7 @@ This integration manages Slack usergroups across multiple workspaces (Slack inst
   - Time-based on-call schedules (with active time window filtering)
   - Git repository OWNERS files (GitHub/GitLab)
   - PagerDuty schedules and escalation policies
+  - GitHub organization members (e.g. to broadcast to all members of an org)
   - Cluster access roles (automatic cluster-specific usergroups)
 - Update usergroup metadata (description, default channels)
 - Whitelist-based management (only reconciles explicitly managed usergroups)
@@ -22,7 +23,7 @@ This integration manages Slack usergroups across multiple workspaces (Slack inst
 
 ## Desired State Details
 
-The desired state for Slack usergroup membership is compiled from **five different sources**, each with specific inclusion conditions. All sources are combined using set union logic (no duplicates), and the final user list is sorted alphabetically.
+The desired state for Slack usergroup membership is compiled from **six different sources**, each with specific inclusion conditions. All sources are combined using set union logic (no duplicates), and the final user list is sorted alphabetically.
 
 ### User Sources
 
@@ -66,7 +67,35 @@ Users are included from PagerDuty if:
 - `/api/v1/external/pagerduty-schedule-users`
 - `/api/v1/external/pagerduty-escalation-policy-users`
 
-#### 5. Cluster Access (Automatic Cluster Usergroups)
+#### 5. GitHub Organization Members (`/access/permission-1.yml.github`)
+
+All members of a GitHub organization are included. This is intended for
+broadcasting to an entire organization (e.g. security announcements) without
+maintaining an explicit member list in app-interface.
+
+Configuration provides the organization `name` and a Vault `token` reference
+with read access to the org's membership.
+
+**User Mapping (two stages, GitHub login → org_username):**
+
+1. **app-interface `github_username`** — a member is mapped to the app-interface
+   user whose `github_username` matches the GitHub login (compared
+   case-insensitively).
+2. **LDAP `rhatSocialURL` fallback** — remaining unmapped logins are resolved
+   via the FreeIPA `rhatSocialURL` attribute (`Github->https://github.com/<login>`),
+   which maps the GitHub login to the user's LDAP `uid` (the app-interface
+   `org_username`). The full map is cached server-side.
+
+Members that resolve to neither an app-interface `github_username` nor an LDAP
+`rhatSocialURL` entry are **logged and skipped** (one warning per unresolved
+login); they do not block reconciliation of the rest of the usergroup.
+
+**API Endpoints:**
+
+- `/api/v1/external/github-org/members`
+- `/api/v1/external/ldap/github-usernames`
+
+#### 6. Cluster Access (Automatic Cluster Usergroups)
 
 **Automatic Generation:** No explicit permission needed - generated from cluster access roles
 
@@ -107,6 +136,8 @@ After compiling users from all sources, the following validation and filtering o
 - Only users with `org_username` field are included
 - For PagerDuty, RedHat users no longer require an app-interface user file (`/access/user-*.yml`)
 - GitHub username mapping for OWNERS files requires `user.github_username` field
+- GitHub organization members are mapped via `user.github_username`, falling back
+  to the LDAP `rhatSocialURL` attribute; unresolved members are logged and skipped
 - `tag_on_merge_requests` filtering for git OWNERS (default: true)
 - `tag_on_cluster_updates` filtering for cluster usergroups (default: true)
 
@@ -121,13 +152,14 @@ After compiling users from all sources, the following validation and filtering o
 **Client-Side ([reconcile/slack_usergroups_api.py](../../reconcile/slack_usergroups_api.py)):**
 
 - Fetches desired state:
-  - from app-interface (GraphQL) permissions, users, clusters, and roles
-  - from qontract-api external endpoints (VCS repo owners, PagerDuty)
+  - from app-interface (GraphQL) permissions, users, clusters, roles, and LDAP settings
+  - from qontract-api external endpoints (VCS repo owners, PagerDuty, GitHub org members)
 - Compiles usergroup membership from multiple sources:
   - Roles (with expiration filtering)
   - Time-based schedules (filters by active time windows)
   - Git OWNERS files (via qontract-api external endpoints)
   - PagerDuty schedules and escalation policies (via qontract-api)
+  - GitHub organization members (via qontract-api, mapped via github_username/LDAP)
   - Cluster access roles (generates cluster-specific usergroups)
 - Transforms data to API request format
 - Calls qontract-api reconciliation endpoint
@@ -485,6 +517,8 @@ The integration uses GraphQL queries to fetch desired state from app-interface. 
    - Time-based schedules (filtered by active time window)
    - Git OWNERS files (via qontract-api `/api/v1/external/vcs-repo-owners`)
    - PagerDuty schedules/policies (via qontract-api `/api/v1/external/pagerduty-*`)
+   - GitHub org members (via qontract-api `/api/v1/external/github-org/members`,
+     mapped via `github_username` then `/api/v1/external/ldap/github-usernames`)
    - Cluster access roles
 3. Build `SlackWorkspace` objects with usergroups
 4. POST to `/reconcile` endpoint (queue task)

--- a/docs/integrations/slack-usergroups.md
+++ b/docs/integrations/slack-usergroups.md
@@ -87,8 +87,10 @@ with read access to the org's membership.
    `org_username`). The full map is cached server-side.
 
 Members that resolve to neither an app-interface `github_username` nor an LDAP
-`rhatSocialURL` entry are **logged and skipped** (one warning per unresolved
-login); they do not block reconciliation of the rest of the usergroup.
+`rhatSocialURL` entry are **logged and skipped**: a single aggregated warning is
+emitted per organization, listing every unresolved login (with its
+`github.com` profile URL) so the MR author sees them in the app-interface MR
+check output. They do not block reconciliation of the rest of the usergroup.
 
 **API Endpoints:**
 

--- a/helm/qontract-reconcile/templates/template.yaml
+++ b/helm/qontract-reconcile/templates/template.yaml
@@ -196,7 +196,7 @@ objects:
               @type grep
               <exclude>
                 key message
-                pattern /could not map GitHub member /
+                pattern /could not map \d+ GitHub member/
               </exclude>
             </filter>
 

--- a/helm/qontract-reconcile/templates/template.yaml
+++ b/helm/qontract-reconcile/templates/template.yaml
@@ -196,6 +196,14 @@ objects:
               @type grep
               <exclude>
                 key message
+                pattern /could not map GitHub member /
+              </exclude>
+            </filter>
+
+            <filter integration>
+              @type grep
+              <exclude>
+                key message
                 pattern /Certificate did not match expected hostname/
               </exclude>
             </filter>

--- a/openshift/qontract-manager-fedramp.yaml
+++ b/openshift/qontract-manager-fedramp.yaml
@@ -116,7 +116,7 @@ objects:
               @type grep
               <exclude>
                 key message
-                pattern /could not map GitHub member /
+                pattern /could not map \d+ GitHub member/
               </exclude>
             </filter>
 

--- a/openshift/qontract-manager-fedramp.yaml
+++ b/openshift/qontract-manager-fedramp.yaml
@@ -116,6 +116,14 @@ objects:
               @type grep
               <exclude>
                 key message
+                pattern /could not map GitHub member /
+              </exclude>
+            </filter>
+
+            <filter integration>
+              @type grep
+              <exclude>
+                key message
                 pattern /Certificate did not match expected hostname/
               </exclude>
             </filter>

--- a/openshift/qontract-manager.yaml
+++ b/openshift/qontract-manager.yaml
@@ -95,7 +95,7 @@ objects:
               @type grep
               <exclude>
                 key message
-                pattern /could not map GitHub member /
+                pattern /could not map \d+ GitHub member/
               </exclude>
             </filter>
 

--- a/openshift/qontract-manager.yaml
+++ b/openshift/qontract-manager.yaml
@@ -95,6 +95,14 @@ objects:
               @type grep
               <exclude>
                 key message
+                pattern /could not map GitHub member /
+              </exclude>
+            </filter>
+
+            <filter integration>
+              @type grep
+              <exclude>
+                key message
                 pattern /Certificate did not match expected hostname/
               </exclude>
             </filter>

--- a/qontract_api/openapi.json
+++ b/qontract_api/openapi.json
@@ -662,6 +662,21 @@
         "title": "GithubOrgDesiredState",
         "type": "object"
       },
+      "GithubOrgMembersResponse": {
+        "description": "Response with all members of a GitHub organization.",
+        "properties": {
+          "members": {
+            "description": "GitHub usernames (original case) of all organization members",
+            "items": {
+              "type": "string"
+            },
+            "title": "Members",
+            "type": "array"
+          }
+        },
+        "title": "GithubOrgMembersResponse",
+        "type": "object"
+      },
       "GithubOwnerActionAddOwner": {
         "description": "Action: Add a user as an org admin (owner).\n\nNote: Owner removal is intentionally NOT supported. The integration only\nadds owners and never removes them, preserving the behavior of the original\ngithub-owners reconcile integration. This is a deliberate safety decision \u2014\nremoving org admins is a high-impact operation that requires explicit manual\nreview rather than automated removal.",
         "properties": {
@@ -2195,6 +2210,65 @@
           "base_dn"
         ],
         "title": "LdapDirectSecret",
+        "type": "object"
+      },
+      "LdapGithubUser": {
+        "description": "Resolved mapping of a single GitHub username to an LDAP uid.",
+        "properties": {
+          "github_username": {
+            "description": "GitHub username (as requested)",
+            "title": "Github Username",
+            "type": "string"
+          },
+          "org_username": {
+            "description": "LDAP uid (app-interface org_username)",
+            "title": "Org Username",
+            "type": "string"
+          }
+        },
+        "required": [
+          "github_username",
+          "org_username"
+        ],
+        "title": "LdapGithubUser",
+        "type": "object"
+      },
+      "LdapGithubUsernamesRequest": {
+        "description": "Request to resolve GitHub usernames to LDAP uids via rhatSocialURL.",
+        "properties": {
+          "logins": {
+            "description": "GitHub usernames to resolve to LDAP uids",
+            "items": {
+              "type": "string"
+            },
+            "title": "Logins",
+            "type": "array"
+          },
+          "secret": {
+            "$ref": "#/components/schemas/LdapDirectSecret",
+            "description": "Vault secret reference for LDAP credentials"
+          }
+        },
+        "required": [
+          "logins",
+          "secret"
+        ],
+        "title": "LdapGithubUsernamesRequest",
+        "type": "object"
+      },
+      "LdapGithubUsernamesResponse": {
+        "description": "Response with resolved GitHub-username -> uid mappings.\n\nOnly contains entries for requested logins that were found in LDAP;\nunresolved logins are omitted.",
+        "properties": {
+          "users": {
+            "description": "Resolved GitHub username to org_username mappings",
+            "items": {
+              "$ref": "#/components/schemas/LdapGithubUser"
+            },
+            "title": "Users",
+            "type": "array"
+          }
+        },
+        "title": "LdapGithubUsernamesResponse",
         "type": "object"
       },
       "LdapUserStatus": {
@@ -4438,6 +4512,141 @@
   },
   "openapi": "3.1.0",
   "paths": {
+    "/api/v1/external/github-org/members": {
+      "get": {
+        "description": "Get all members of a GitHub organization.\n\nLists every member of the organization (any role) using the GitHub API\ntoken resolved from Vault. Results are cached for performance (TTL\nconfigured in settings).",
+        "operationId": "github-org-members",
+        "parameters": [
+          {
+            "description": "Secret Manager URL",
+            "in": "query",
+            "name": "secret_manager_url",
+            "required": true,
+            "schema": {
+              "description": "Secret Manager URL",
+              "title": "Secret Manager Url",
+              "type": "string"
+            }
+          },
+          {
+            "description": "Path to the secret",
+            "in": "query",
+            "name": "path",
+            "required": true,
+            "schema": {
+              "description": "Path to the secret",
+              "title": "Path",
+              "type": "string"
+            }
+          },
+          {
+            "description": "Specific field within the secret",
+            "in": "query",
+            "name": "field",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Specific field within the secret",
+              "title": "Field"
+            }
+          },
+          {
+            "description": "Version of the secret",
+            "in": "query",
+            "name": "version",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "integer"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Version of the secret",
+              "title": "Version"
+            }
+          },
+          {
+            "description": "GitHub organization name",
+            "in": "query",
+            "name": "org_name",
+            "required": true,
+            "schema": {
+              "description": "GitHub organization name",
+              "title": "Org Name",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GithubOrgMembersResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "summary": "Get Org Members",
+        "tags": [
+          "external"
+        ]
+      }
+    },
+    "/api/v1/external/ldap/github-usernames": {
+      "post": {
+        "description": "Resolve GitHub usernames to LDAP uids via the rhatSocialURL attribute.\n\nMaps each requested GitHub username to the app-interface org_username (LDAP\nuid) of the user whose rhatSocialURL points at that GitHub account. The\nfull map is cached for performance; unresolved logins are omitted from the\nresponse.\n\nArgs:\n    request: GitHub usernames to resolve and the Vault secret reference\n    cache: Cache dependency\n    secret_manager: Secret manager dependency\n\nReturns:\n    LdapGithubUsernamesResponse with resolved username -> org_username pairs",
+        "operationId": "ldap-github-usernames",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/LdapGithubUsernamesRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/LdapGithubUsernamesResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "summary": "Resolve Github Usernames",
+        "tags": [
+          "external"
+        ]
+      }
+    },
     "/api/v1/external/ldap/users/check": {
       "post": {
         "description": "Check which usernames exist in LDAP (cached, FreeIPA-authenticated).\n\nQueries LDAP directly using FreeIPA service account credentials\nresolved from Vault. Results are cached for performance.\n\nArgs:\n    request: Request with usernames to check and Vault secret reference\n    cache: Cache dependency\n    secret_manager: Secret manager dependency\n\nReturns:\n    LdapUsersCheckResponse with existence status per username",

--- a/qontract_api/openapi.json
+++ b/qontract_api/openapi.json
@@ -674,6 +674,9 @@
             "type": "array"
           }
         },
+        "required": [
+          "members"
+        ],
         "title": "GithubOrgMembersResponse",
         "type": "object"
       },
@@ -2268,6 +2271,9 @@
             "type": "array"
           }
         },
+        "required": [
+          "users"
+        ],
         "title": "LdapGithubUsernamesResponse",
         "type": "object"
       },

--- a/qontract_api/qontract_api/config.py
+++ b/qontract_api/qontract_api/config.py
@@ -283,6 +283,11 @@ class LdapSettings(BaseModel):
         description="LDAP users check cache TTL in seconds (six hours)",
     )
 
+    github_usernames_cache_ttl: int = Field(
+        default=6 * 60 * 60,
+        description="LDAP GitHub-username -> uid map cache TTL in seconds (six hours)",
+    )
+
 
 class OcmSettings(BaseModel):
     """OCM API and integration configuration."""

--- a/qontract_api/qontract_api/external/github_org/__init__.py
+++ b/qontract_api/qontract_api/external/github_org/__init__.py
@@ -1,0 +1,5 @@
+"""GitHub organization external API endpoints for org membership."""
+
+from qontract_api.external.github_org import router
+
+__all__ = ["router"]

--- a/qontract_api/qontract_api/external/github_org/router.py
+++ b/qontract_api/qontract_api/external/github_org/router.py
@@ -1,0 +1,67 @@
+"""FastAPI router for GitHub organization external API endpoints.
+
+Provides cached, read-only access to GitHub organization membership
+(see ADR-013: external calls through qontract-api).
+"""
+
+from __future__ import annotations
+
+from typing import Annotated
+
+from fastapi import APIRouter, Query
+
+from qontract_api.config import settings
+from qontract_api.dependencies import CacheDep, SecretManagerDep, UserDep
+from qontract_api.external.github_org.schemas import (
+    GithubOrgMembersParams,
+    GithubOrgMembersResponse,
+)
+from qontract_api.github.github_org_client_factory import GithubOrgClientFactory
+from qontract_api.logger import get_logger
+
+logger = get_logger(__name__)
+
+router = APIRouter(
+    prefix="/external/github-org",
+    tags=["external"],
+)
+
+
+@router.get(
+    "/members",
+    operation_id="github-org-members",
+)
+def get_org_members(
+    cache: CacheDep,
+    secret_manager: SecretManagerDep,
+    _user: UserDep,
+    params: Annotated[
+        GithubOrgMembersParams,
+        Query(description="GitHub organization members query parameters"),
+    ],
+) -> GithubOrgMembersResponse:
+    """Get all members of a GitHub organization.
+
+    Lists every member of the organization (any role) using the GitHub API
+    token resolved from Vault. Results are cached for performance (TTL
+    configured in settings).
+    """
+    logger.info(
+        f"Fetching members for GitHub org {params.org_name}",
+        org=params.org_name,
+    )
+
+    client = GithubOrgClientFactory(
+        cache=cache,
+        settings=settings,
+    ).create_workspace_client(token=secret_manager.read(params))
+
+    members = client.get_all_members(params.org_name)
+
+    logger.info(
+        f"Found {len(members)} members for GitHub org {params.org_name}",
+        org=params.org_name,
+        members_count=len(members),
+    )
+
+    return GithubOrgMembersResponse(members=members)

--- a/qontract_api/qontract_api/external/github_org/schemas.py
+++ b/qontract_api/qontract_api/external/github_org/schemas.py
@@ -20,6 +20,6 @@ class GithubOrgMembersResponse(BaseModel, frozen=True):
     """Response with all members of a GitHub organization."""
 
     members: list[str] = Field(
-        default_factory=list,
+        ...,
         description="GitHub usernames (original case) of all organization members",
     )

--- a/qontract_api/qontract_api/external/github_org/schemas.py
+++ b/qontract_api/qontract_api/external/github_org/schemas.py
@@ -1,0 +1,25 @@
+"""API schemas for the GitHub organization external integration."""
+
+from pydantic import BaseModel, Field
+
+from qontract_api.models import Secret
+
+
+class GithubOrgMembersParams(Secret):
+    """Query parameters for the GitHub org members endpoint.
+
+    Inherits the Vault secret reference fields (secret_manager_url, path,
+    field, version) from Secret; the referenced secret holds the GitHub API
+    token used to list organization members.
+    """
+
+    org_name: str = Field(..., description="GitHub organization name")
+
+
+class GithubOrgMembersResponse(BaseModel, frozen=True):
+    """Response with all members of a GitHub organization."""
+
+    members: list[str] = Field(
+        default_factory=list,
+        description="GitHub usernames (original case) of all organization members",
+    )

--- a/qontract_api/qontract_api/external/ldap/ldap_workspace_client.py
+++ b/qontract_api/qontract_api/external/ldap/ldap_workspace_client.py
@@ -27,6 +27,12 @@ class CachedUserCheck(BaseModel, frozen=True):
     result: list[LdapUserStatus]
 
 
+class CachedGithubUsernames(BaseModel, frozen=True):
+    """Cached GitHub-username -> uid map (for two-tier cache serialization)."""
+
+    mapping: dict[str, str]
+
+
 class LdapWorkspaceClient:
     """Caching + locking layer for direct LDAP operations (FreeIPA).
 
@@ -101,3 +107,56 @@ class LdapWorkspaceClient:
                 ttl=self.settings.ldap.users_cache_ttl,
             )
             return result
+
+    def _github_usernames_cache_key(self) -> str:
+        """Cache key for the full GitHub-username -> uid map of this server."""
+        return f"ldap:{self.cache_key_prefix}:github-usernames"
+
+    def _get_github_username_map(self) -> dict[str, str]:
+        """Return the full GitHub-username -> uid map (cached, locked)."""
+        cache_key = self._github_usernames_cache_key()
+
+        if cached := self.cache.get_obj(cache_key, CachedGithubUsernames):
+            return cached.mapping
+
+        with self.cache.lock(cache_key):
+            if cached := self.cache.get_obj(cache_key, CachedGithubUsernames):
+                return cached.mapping
+
+            with self.api:
+                mapping = self.api.get_github_usernames()
+
+            self.cache.set_obj(
+                cache_key,
+                CachedGithubUsernames(mapping=mapping),
+                ttl=self.settings.ldap.github_usernames_cache_ttl,
+            )
+            return mapping
+
+    def resolve_github_usernames(self, logins: Iterable[str]) -> dict[str, str]:
+        """Resolve GitHub usernames to LDAP uids via rhatSocialURL (cached).
+
+        The full GitHub-username -> uid map is fetched from LDAP once per TTL
+        window and cached; individual lookups are then served from it.
+        Matching is case-insensitive (GitHub usernames are), and only requested
+        logins found in LDAP are returned - unresolved logins are omitted.
+
+        Args:
+            logins: GitHub usernames to resolve
+
+        Returns:
+            Mapping of the requested GitHub username to its LDAP uid
+            (app-interface org_username)
+        """
+        requested = set(logins)
+        if not requested:
+            return {}
+
+        mapping = self._get_github_username_map()
+        lookup = {login.lower(): uid for login, uid in mapping.items()}
+
+        return {
+            login: lookup[login.lower()]
+            for login in requested
+            if login.lower() in lookup
+        }

--- a/qontract_api/qontract_api/external/ldap/ldap_workspace_client.py
+++ b/qontract_api/qontract_api/external/ldap/ldap_workspace_client.py
@@ -28,9 +28,14 @@ class CachedUserCheck(BaseModel, frozen=True):
 
 
 class CachedGithubUsernames(BaseModel, frozen=True):
-    """Cached GitHub-username -> uid map (for two-tier cache serialization)."""
+    """Cached GitHub-login -> uid(s) map (for two-tier cache serialization).
 
-    mapping: dict[str, str]
+    Each lowercased login maps to the sorted list of uids that claim it; a login
+    with more than one uid is ambiguous and resolved (skipped + logged) per
+    request, not at build time.
+    """
+
+    mapping: dict[str, list[str]]
 
 
 class LdapWorkspaceClient:
@@ -112,8 +117,8 @@ class LdapWorkspaceClient:
         """Cache key for the full GitHub-username -> uid map of this server."""
         return f"ldap:{self.cache_key_prefix}:github-usernames"
 
-    def _get_github_username_map(self) -> dict[str, str]:
-        """Return the full GitHub-username -> uid map (cached, locked)."""
+    def _get_github_username_map(self) -> dict[str, list[str]]:
+        """Return the full GitHub-login -> uid(s) map (cached, locked)."""
         cache_key = self._github_usernames_cache_key()
 
         if cached := self.cache.get_obj(cache_key, CachedGithubUsernames):
@@ -136,10 +141,16 @@ class LdapWorkspaceClient:
     def resolve_github_usernames(self, logins: Iterable[str]) -> dict[str, str]:
         """Resolve GitHub usernames to LDAP uids via rhatSocialURL (cached).
 
-        The full GitHub-username -> uid map is fetched from LDAP once per TTL
-        window and cached; individual lookups are then served from it.
-        Matching is case-insensitive (GitHub usernames are), and only requested
-        logins found in LDAP are returned - unresolved logins are omitted.
+        The full GitHub-login -> uid(s) map is fetched from LDAP once per TTL
+        window and cached; individual lookups are then served from it. Matching
+        is case-insensitive (GitHub logins are), and only requested logins found
+        in LDAP are returned - unresolved logins are omitted.
+
+        A requested login that maps to more than one uid is ambiguous: LDAP
+        result order must not decide identity, so it is skipped and logged. The
+        ambiguity check is scoped to the *requested* logins, so unrelated
+        ambiguous directory entries (organizations/repos claimed by several
+        associates) never appear in the logs.
 
         Args:
             logins: GitHub usernames to resolve
@@ -153,10 +164,17 @@ class LdapWorkspaceClient:
             return {}
 
         mapping = self._get_github_username_map()
-        lookup = {login.lower(): uid for login, uid in mapping.items()}
 
-        return {
-            login: lookup[login.lower()]
-            for login in requested
-            if login.lower() in lookup
-        }
+        resolved: dict[str, str] = {}
+        for login in requested:
+            if not (uids := mapping.get(login.lower())):
+                continue
+            if len(uids) > 1:
+                logger.warning(
+                    "Ambiguous GitHub login maps to multiple LDAP uids; skipping",
+                    github_login=login,
+                    uids=uids,
+                )
+                continue
+            resolved[login] = uids[0]
+        return resolved

--- a/qontract_api/qontract_api/external/ldap/router.py
+++ b/qontract_api/qontract_api/external/ldap/router.py
@@ -14,6 +14,9 @@ from qontract_api.external.ldap.ldap_factory import (
     create_ldap_workspace_client,
 )
 from qontract_api.external.ldap.schemas import (
+    LdapGithubUser,
+    LdapGithubUsernamesRequest,
+    LdapGithubUsernamesResponse,
     LdapUsersCheckRequest,
     LdapUsersCheckResponse,
 )
@@ -66,3 +69,51 @@ def check_users_exist(
     )
 
     return LdapUsersCheckResponse(users=result)
+
+
+@router.post(
+    "/github-usernames",
+    operation_id="ldap-github-usernames",
+)
+def resolve_github_usernames(
+    request: LdapGithubUsernamesRequest,
+    cache: CacheDep,
+    secret_manager: SecretManagerDep,
+    _user: UserDep,
+) -> LdapGithubUsernamesResponse:
+    """Resolve GitHub usernames to LDAP uids via the rhatSocialURL attribute.
+
+    Maps each requested GitHub username to the app-interface org_username (LDAP
+    uid) of the user whose rhatSocialURL points at that GitHub account. The
+    full map is cached for performance; unresolved logins are omitted from the
+    response.
+
+    Args:
+        request: GitHub usernames to resolve and the Vault secret reference
+        cache: Cache dependency
+        secret_manager: Secret manager dependency
+
+    Returns:
+        LdapGithubUsernamesResponse with resolved username -> org_username pairs
+    """
+    client = create_ldap_workspace_client(
+        secret=request.secret,
+        cache=cache,
+        secret_manager=secret_manager,
+        settings=settings,
+    )
+
+    resolved = client.resolve_github_usernames(request.logins)
+
+    logger.info(
+        f"Resolved {len(resolved)}/{len(request.logins)} GitHub usernames via LDAP",
+        requested=len(request.logins),
+        resolved=len(resolved),
+    )
+
+    return LdapGithubUsernamesResponse(
+        users=[
+            LdapGithubUser(github_username=login, org_username=uid)
+            for login, uid in resolved.items()
+        ]
+    )

--- a/qontract_api/qontract_api/external/ldap/schemas.py
+++ b/qontract_api/qontract_api/external/ldap/schemas.py
@@ -44,3 +44,34 @@ class LdapUsersCheckResponse(BaseModel, frozen=True):
         default_factory=list,
         description="Existence status for each requested username",
     )
+
+
+class LdapGithubUsernamesRequest(BaseModel, frozen=True):
+    """Request to resolve GitHub usernames to LDAP uids via rhatSocialURL."""
+
+    logins: list[str] = Field(
+        ..., description="GitHub usernames to resolve to LDAP uids"
+    )
+    secret: LdapDirectSecret = Field(
+        ..., description="Vault secret reference for LDAP credentials"
+    )
+
+
+class LdapGithubUser(BaseModel, frozen=True):
+    """Resolved mapping of a single GitHub username to an LDAP uid."""
+
+    github_username: str = Field(..., description="GitHub username (as requested)")
+    org_username: str = Field(..., description="LDAP uid (app-interface org_username)")
+
+
+class LdapGithubUsernamesResponse(BaseModel, frozen=True):
+    """Response with resolved GitHub-username -> uid mappings.
+
+    Only contains entries for requested logins that were found in LDAP;
+    unresolved logins are omitted.
+    """
+
+    users: list[LdapGithubUser] = Field(
+        default_factory=list,
+        description="Resolved GitHub username to org_username mappings",
+    )

--- a/qontract_api/qontract_api/external/ldap/schemas.py
+++ b/qontract_api/qontract_api/external/ldap/schemas.py
@@ -72,6 +72,6 @@ class LdapGithubUsernamesResponse(BaseModel, frozen=True):
     """
 
     users: list[LdapGithubUser] = Field(
-        default_factory=list,
+        ...,
         description="Resolved GitHub username to org_username mappings",
     )

--- a/qontract_api/qontract_api/github/github_org_workspace_client.py
+++ b/qontract_api/qontract_api/github/github_org_workspace_client.py
@@ -80,13 +80,23 @@ class GithubOrgWorkspaceClient:
         return f"github-org:{org_name}:rate-limited"
 
     def _clear_cache(self, org_name: str) -> None:
-        """Clear cached members for the given org."""
-        cache_key = self._cache_key(org_name)
-        try:
-            with self._cache.lock(cache_key):
-                self._cache.delete(cache_key)
-        except RuntimeError as e:
-            logger.warning(f"Could not acquire lock to clear cache for {org_name}: {e}")
+        """Clear both cached member lists for the given org.
+
+        A mutation changes both the admins/invitations list (``:members``) and
+        the full membership list (``:all-members``), so both keys must be
+        invalidated - each under a lock scoped to that key.
+        """
+        for cache_key in (
+            self._cache_key(org_name),
+            self._all_members_cache_key(org_name),
+        ):
+            try:
+                with self._cache.lock(cache_key):
+                    self._cache.delete(cache_key)
+            except RuntimeError as e:
+                logger.warning(
+                    f"Could not acquire lock to clear cache for {org_name}: {e}"
+                )
 
     def _cache_rate_limit_marker(
         self, org_name: str, exc: GithubRateLimitExceededError

--- a/qontract_api/qontract_api/github/github_org_workspace_client.py
+++ b/qontract_api/qontract_api/github/github_org_workspace_client.py
@@ -72,6 +72,10 @@ class GithubOrgWorkspaceClient:
         return f"github-org:{org_name}:members"
 
     @staticmethod
+    def _all_members_cache_key(org_name: str) -> str:
+        return f"github-org:{org_name}:all-members"
+
+    @staticmethod
     def _rate_limit_key(org_name: str) -> str:
         return f"github-org:{org_name}:rate-limited"
 
@@ -144,6 +148,49 @@ class GithubOrgWorkspaceClient:
                 self._settings.github_org.members_cache_ttl,
             )
             return combined
+
+    def get_all_members(self, org_name: str) -> list[str]:
+        """Get all organization members (any role), cached.
+
+        Unlike `get_current_members` (admins + pending invitations), this
+        returns every member of the organization. Logins are returned in their
+        original case exactly as GitHub reports them; callers that need
+        case-insensitive comparison must lowercase on their side.
+
+        Args:
+            org_name: GitHub organization name
+
+        Returns:
+            Sorted list of GitHub usernames (original case) of all org members
+        """
+        cache_key = self._all_members_cache_key(org_name)
+        rate_limit_key = self._rate_limit_key(org_name)
+
+        if marker := self._cache.get_obj(rate_limit_key, RateLimitMarker):
+            raise GithubRateLimitExceededError(marker.reset_at)
+
+        if cached := self._cache.get_obj(cache_key, CachedOrgMembers):
+            return cached.members
+
+        with self._cache.lock(cache_key):
+            if marker := self._cache.get_obj(rate_limit_key, RateLimitMarker):
+                raise GithubRateLimitExceededError(marker.reset_at)
+
+            if cached := self._cache.get_obj(cache_key, CachedOrgMembers):
+                return cached.members
+
+            try:
+                members = self._api.get_members(org_name)
+            except GithubRateLimitExceededError as e:
+                self._cache_rate_limit_marker(org_name, e)
+                raise
+
+            self._cache.set_obj(
+                cache_key,
+                CachedOrgMembers(members=members),
+                self._settings.github_org.members_cache_ttl,
+            )
+            return members
 
     def add_member_as_admin(self, org_name: str, username: str) -> None:
         """Add a user as org admin and invalidate the member cache.

--- a/qontract_api/qontract_api/routers/api_v1.py
+++ b/qontract_api/qontract_api/routers/api_v1.py
@@ -13,6 +13,7 @@ Structure:
 
 from fastapi import APIRouter
 
+from qontract_api.external.github_org import router as github_org_router
 from qontract_api.external.ldap import router as ldap_router
 from qontract_api.external.ocm import router as ocm_router
 from qontract_api.external.pagerduty import router as pagerduty_router
@@ -29,6 +30,7 @@ api_v1_router.include_router(pagerduty_router.router)
 api_v1_router.include_router(slack_router.router)
 api_v1_router.include_router(vcs_router.router)
 api_v1_router.include_router(ldap_router.router)
+api_v1_router.include_router(github_org_router.router)
 api_v1_router.include_router(ocm_router.router)
 
 # Future routers will be added here:

--- a/qontract_api/tests/external/github_org/test_github_org_members_router.py
+++ b/qontract_api/tests/external/github_org/test_github_org_members_router.py
@@ -78,11 +78,13 @@ def test_get_org_members_resolves_token_from_secret(
     mock_client.get_all_members.return_value = []
     mock_factory.return_value.create_workspace_client.return_value = mock_client
 
+    from qontract_api.main import app
+
     api_client.get(MEMBERS_ENDPOINT, params=QUERY_PARAMS, headers=auth_headers)
 
     # secret_manager.read(params) is used to resolve the token
-    api_client.app.state.secret_manager.read.assert_called_once()
-    read_arg = api_client.app.state.secret_manager.read.call_args[0][0]
+    app.state.secret_manager.read.assert_called_once()
+    read_arg = app.state.secret_manager.read.call_args[0][0]
     assert read_arg.path == "secret/github/my-org"
     assert read_arg.org_name == "my-org"
 

--- a/qontract_api/tests/external/github_org/test_github_org_members_router.py
+++ b/qontract_api/tests/external/github_org/test_github_org_members_router.py
@@ -1,0 +1,96 @@
+"""Tests for the GitHub org members router endpoint."""
+
+from collections.abc import Generator
+from http import HTTPStatus
+from unittest.mock import MagicMock, Mock, patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+from qontract_api.auth import create_access_token
+from qontract_api.models import TokenData
+
+
+@pytest.fixture
+def api_client() -> Generator[TestClient]:
+    """Create test client with mocked cache and secret_manager."""
+    from qontract_api.main import app
+
+    app.state.cache = Mock()
+    app.state.secret_manager = Mock()
+
+    yield TestClient(app, raise_server_exceptions=False)
+
+    if hasattr(app.state, "cache"):
+        del app.state.cache
+    if hasattr(app.state, "secret_manager"):
+        del app.state.secret_manager
+
+
+@pytest.fixture
+def auth_headers() -> dict[str, str]:
+    """Create authentication headers with valid JWT token."""
+    token_data = TokenData(sub="testuser")
+    test_token = create_access_token(data=token_data)
+    return {"Authorization": f"Bearer {test_token}"}
+
+
+MEMBERS_ENDPOINT = "/api/v1/external/github-org/members"
+
+QUERY_PARAMS = {
+    "org_name": "my-org",
+    "secret_manager_url": "https://vault.example.com",
+    "path": "secret/github/my-org",
+    "field": "token",
+}
+
+
+@patch("qontract_api.external.github_org.router.GithubOrgClientFactory")
+def test_get_org_members_returns_members(
+    mock_factory: MagicMock,
+    api_client: TestClient,
+    auth_headers: dict[str, str],
+) -> None:
+    """GET /members returns all org members (case preserved)."""
+    mock_client = MagicMock()
+    mock_client.get_all_members.return_value = ["Bob", "alice", "Charlie"]
+    mock_factory.return_value.create_workspace_client.return_value = mock_client
+
+    response = api_client.get(
+        MEMBERS_ENDPOINT,
+        params=QUERY_PARAMS,
+        headers=auth_headers,
+    )
+
+    assert response.status_code == HTTPStatus.OK
+    assert response.json()["members"] == ["Bob", "alice", "Charlie"]
+    mock_client.get_all_members.assert_called_once_with("my-org")
+
+
+@patch("qontract_api.external.github_org.router.GithubOrgClientFactory")
+def test_get_org_members_resolves_token_from_secret(
+    mock_factory: MagicMock,
+    api_client: TestClient,
+    auth_headers: dict[str, str],
+) -> None:
+    """The GitHub token is resolved from the Vault secret reference."""
+    mock_client = MagicMock()
+    mock_client.get_all_members.return_value = []
+    mock_factory.return_value.create_workspace_client.return_value = mock_client
+
+    api_client.get(MEMBERS_ENDPOINT, params=QUERY_PARAMS, headers=auth_headers)
+
+    # secret_manager.read(params) is used to resolve the token
+    api_client.app.state.secret_manager.read.assert_called_once()
+    read_arg = api_client.app.state.secret_manager.read.call_args[0][0]
+    assert read_arg.path == "secret/github/my-org"
+    assert read_arg.org_name == "my-org"
+
+
+def test_get_org_members_requires_auth(api_client: TestClient) -> None:
+    """Requests without a valid token are rejected."""
+    response = api_client.get(MEMBERS_ENDPOINT, params=QUERY_PARAMS)
+    assert response.status_code in {
+        HTTPStatus.UNAUTHORIZED,
+        HTTPStatus.FORBIDDEN,
+    }

--- a/qontract_api/tests/external/github_org/test_github_org_members_router.py
+++ b/qontract_api/tests/external/github_org/test_github_org_members_router.py
@@ -8,6 +8,7 @@ import pytest
 from fastapi.testclient import TestClient
 
 from qontract_api.auth import create_access_token
+from qontract_api.external.github_org.schemas import GithubOrgMembersParams
 from qontract_api.models import TokenData
 
 
@@ -37,12 +38,12 @@ def auth_headers() -> dict[str, str]:
 
 MEMBERS_ENDPOINT = "/api/v1/external/github-org/members"
 
-QUERY_PARAMS = {
-    "org_name": "my-org",
-    "secret_manager_url": "https://vault.example.com",
-    "path": "secret/github/my-org",
-    "field": "token",
-}
+QUERY_PARAMS = GithubOrgMembersParams(
+    org_name="my-org",
+    secret_manager_url="https://vault.example.com",
+    path="secret/github/my-org",
+    field="token",
+).model_dump(mode="json", exclude_none=True)
 
 
 @patch("qontract_api.external.github_org.router.GithubOrgClientFactory")

--- a/qontract_api/tests/external/ldap/test_ldap_github_usernames_router.py
+++ b/qontract_api/tests/external/ldap/test_ldap_github_usernames_router.py
@@ -8,6 +8,10 @@ import pytest
 from fastapi.testclient import TestClient
 
 from qontract_api.auth import create_access_token
+from qontract_api.external.ldap.schemas import (
+    LdapDirectSecret,
+    LdapGithubUsernamesRequest,
+)
 from qontract_api.models import TokenData
 
 
@@ -37,16 +41,18 @@ def auth_headers() -> dict[str, str]:
 
 LDAP_GITHUB_USERNAMES_ENDPOINT = "/api/v1/external/ldap/github-usernames"
 
-LDAP_GITHUB_USERNAMES_REQUEST = {
-    "logins": ["AliceGH", "bob", "unknown"],
-    "secret": {
-        "secret_manager_url": "https://vault.example.com",
-        "path": "secret/ldap/freeipa",
-        "field": "bind_password",
-        "server_url": "ldap://freeipa.example.com",
-        "base_dn": "dc=example,dc=com",
-    },
-}
+LDAP_SECRET = LdapDirectSecret(
+    secret_manager_url="https://vault.example.com",
+    path="secret/ldap/freeipa",
+    field="bind_password",
+    server_url="ldap://freeipa.example.com",
+    base_dn="dc=example,dc=com",
+)
+
+LDAP_GITHUB_USERNAMES_REQUEST = LdapGithubUsernamesRequest(
+    logins=["AliceGH", "bob", "unknown"],
+    secret=LDAP_SECRET,
+).model_dump(mode="json")
 
 
 @patch("qontract_api.external.ldap.router.create_ldap_workspace_client")
@@ -93,10 +99,9 @@ def test_resolve_github_usernames_passes_secret(
 
     api_client.post(
         LDAP_GITHUB_USERNAMES_ENDPOINT,
-        json={
-            "logins": [],
-            "secret": LDAP_GITHUB_USERNAMES_REQUEST["secret"],
-        },
+        json=LdapGithubUsernamesRequest(logins=[], secret=LDAP_SECRET).model_dump(
+            mode="json"
+        ),
         headers=auth_headers,
     )
 
@@ -120,10 +125,9 @@ def test_resolve_github_usernames_empty_result(
 
     response = api_client.post(
         LDAP_GITHUB_USERNAMES_ENDPOINT,
-        json={
-            "logins": ["unknown"],
-            "secret": LDAP_GITHUB_USERNAMES_REQUEST["secret"],
-        },
+        json=LdapGithubUsernamesRequest(
+            logins=["unknown"], secret=LDAP_SECRET
+        ).model_dump(mode="json"),
         headers=auth_headers,
     )
 

--- a/qontract_api/tests/external/ldap/test_ldap_github_usernames_router.py
+++ b/qontract_api/tests/external/ldap/test_ldap_github_usernames_router.py
@@ -1,0 +1,131 @@
+"""Tests for LDAP github-usernames resolution router endpoint."""
+
+from collections.abc import Generator
+from http import HTTPStatus
+from unittest.mock import MagicMock, Mock, patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+from qontract_api.auth import create_access_token
+from qontract_api.models import TokenData
+
+
+@pytest.fixture
+def api_client() -> Generator[TestClient]:
+    """Create test client with mocked cache and secret_manager."""
+    from qontract_api.main import app
+
+    app.state.cache = Mock()
+    app.state.secret_manager = Mock()
+
+    yield TestClient(app, raise_server_exceptions=False)
+
+    if hasattr(app.state, "cache"):
+        del app.state.cache
+    if hasattr(app.state, "secret_manager"):
+        del app.state.secret_manager
+
+
+@pytest.fixture
+def auth_headers() -> dict[str, str]:
+    """Create authentication headers with valid JWT token."""
+    token_data = TokenData(sub="testuser")
+    test_token = create_access_token(data=token_data)
+    return {"Authorization": f"Bearer {test_token}"}
+
+
+LDAP_GITHUB_USERNAMES_ENDPOINT = "/api/v1/external/ldap/github-usernames"
+
+LDAP_GITHUB_USERNAMES_REQUEST = {
+    "logins": ["AliceGH", "bob", "unknown"],
+    "secret": {
+        "secret_manager_url": "https://vault.example.com",
+        "path": "secret/ldap/freeipa",
+        "field": "bind_password",
+        "server_url": "ldap://freeipa.example.com",
+        "base_dn": "dc=example,dc=com",
+    },
+}
+
+
+@patch("qontract_api.external.ldap.router.create_ldap_workspace_client")
+def test_resolve_github_usernames_returns_pairs(
+    mock_factory: MagicMock,
+    api_client: TestClient,
+    auth_headers: dict[str, str],
+) -> None:
+    """Test POST /github-usernames returns resolved github_username -> org_username."""
+    mock_client = MagicMock()
+    mock_client.resolve_github_usernames.return_value = {
+        "AliceGH": "alice",
+        "bob": "bob",
+    }
+    mock_factory.return_value = mock_client
+
+    response = api_client.post(
+        LDAP_GITHUB_USERNAMES_ENDPOINT,
+        json=LDAP_GITHUB_USERNAMES_REQUEST,
+        headers=auth_headers,
+    )
+
+    assert response.status_code == HTTPStatus.OK
+    data = response.json()
+    resolved = {u["github_username"]: u["org_username"] for u in data["users"]}
+    assert resolved == {"AliceGH": "alice", "bob": "bob"}
+    mock_client.resolve_github_usernames.assert_called_once_with([
+        "AliceGH",
+        "bob",
+        "unknown",
+    ])
+
+
+@patch("qontract_api.external.ldap.router.create_ldap_workspace_client")
+def test_resolve_github_usernames_passes_secret(
+    mock_factory: MagicMock,
+    api_client: TestClient,
+    auth_headers: dict[str, str],
+) -> None:
+    """Test POST /github-usernames passes the Vault secret to the factory."""
+    mock_client = MagicMock()
+    mock_client.resolve_github_usernames.return_value = {}
+    mock_factory.return_value = mock_client
+
+    api_client.post(
+        LDAP_GITHUB_USERNAMES_ENDPOINT,
+        json={
+            "logins": [],
+            "secret": LDAP_GITHUB_USERNAMES_REQUEST["secret"],
+        },
+        headers=auth_headers,
+    )
+
+    mock_factory.assert_called_once()
+    call_kwargs = mock_factory.call_args.kwargs
+    assert call_kwargs["secret"].server_url == "ldap://freeipa.example.com"
+    assert call_kwargs["secret"].base_dn == "dc=example,dc=com"
+    assert call_kwargs["secret"].path == "secret/ldap/freeipa"
+
+
+@patch("qontract_api.external.ldap.router.create_ldap_workspace_client")
+def test_resolve_github_usernames_empty_result(
+    mock_factory: MagicMock,
+    api_client: TestClient,
+    auth_headers: dict[str, str],
+) -> None:
+    """Test POST /github-usernames returns an empty list when nothing resolves."""
+    mock_client = MagicMock()
+    mock_client.resolve_github_usernames.return_value = {}
+    mock_factory.return_value = mock_client
+
+    response = api_client.post(
+        LDAP_GITHUB_USERNAMES_ENDPOINT,
+        json={
+            "logins": ["unknown"],
+            "secret": LDAP_GITHUB_USERNAMES_REQUEST["secret"],
+        },
+        headers=auth_headers,
+    )
+
+    assert response.status_code == HTTPStatus.OK
+    assert response.json()["users"] == []

--- a/qontract_api/tests/external/ldap/test_ldap_workspace_client.py
+++ b/qontract_api/tests/external/ldap/test_ldap_workspace_client.py
@@ -9,6 +9,7 @@ from qontract_utils.ldap_api.models import LdapUser
 from qontract_api.cache.base import CacheBackend
 from qontract_api.config import LdapSettings, Settings
 from qontract_api.external.ldap.ldap_workspace_client import (
+    CachedGithubUsernames,
     CachedUserCheck,
     LdapWorkspaceClient,
 )
@@ -156,3 +157,114 @@ def test_check_users_exist_empty_input(
     assert result == []
     mock_api.get_users.assert_not_called()
     mock_cache.get_obj.assert_not_called()
+
+
+# --- resolve_github_usernames ---
+
+
+def test_resolve_github_usernames_calls_api_and_matches(
+    workspace_client: LdapWorkspaceClient,
+    mock_api: MagicMock,
+) -> None:
+    """Test resolve_github_usernames delegates to LdapApi and returns matches."""
+    mock_api.__enter__ = MagicMock(return_value=mock_api)
+    mock_api.__exit__ = MagicMock(return_value=False)
+    mock_api.get_github_usernames.return_value = {"AliceGH": "alice", "bob": "bob"}
+
+    result = workspace_client.resolve_github_usernames(["AliceGH", "bob"])
+
+    assert result == {"AliceGH": "alice", "bob": "bob"}
+    mock_api.get_github_usernames.assert_called_once()
+
+
+def test_resolve_github_usernames_case_insensitive(
+    workspace_client: LdapWorkspaceClient,
+    mock_api: MagicMock,
+) -> None:
+    """Test resolve_github_usernames matches logins case-insensitively."""
+    mock_api.__enter__ = MagicMock(return_value=mock_api)
+    mock_api.__exit__ = MagicMock(return_value=False)
+    mock_api.get_github_usernames.return_value = {"AliceGH": "alice"}
+
+    # Requested with different casing than stored in LDAP
+    result = workspace_client.resolve_github_usernames(["alicegh"])
+
+    # The requested login is echoed back (not the LDAP casing), mapped to uid
+    assert result == {"alicegh": "alice"}
+
+
+def test_resolve_github_usernames_omits_unresolved(
+    workspace_client: LdapWorkspaceClient,
+    mock_api: MagicMock,
+) -> None:
+    """Test resolve_github_usernames omits logins not found in LDAP."""
+    mock_api.__enter__ = MagicMock(return_value=mock_api)
+    mock_api.__exit__ = MagicMock(return_value=False)
+    mock_api.get_github_usernames.return_value = {"AliceGH": "alice"}
+
+    result = workspace_client.resolve_github_usernames(["AliceGH", "unknown"])
+
+    assert result == {"AliceGH": "alice"}
+
+
+def test_resolve_github_usernames_empty_input(
+    workspace_client: LdapWorkspaceClient,
+    mock_api: MagicMock,
+    mock_cache: MagicMock,
+) -> None:
+    """Test resolve_github_usernames with empty input returns empty and skips work."""
+    result = workspace_client.resolve_github_usernames([])
+
+    assert result == {}
+    mock_api.get_github_usernames.assert_not_called()
+    mock_cache.get_obj.assert_not_called()
+
+
+def test_resolve_github_usernames_cache_hit(
+    workspace_client: LdapWorkspaceClient,
+    mock_cache: MagicMock,
+    mock_api: MagicMock,
+) -> None:
+    """Test resolve_github_usernames serves the map from cache without an API call."""
+    mock_cache.get_obj.return_value = CachedGithubUsernames(
+        mapping={"AliceGH": "alice"}
+    )
+
+    result = workspace_client.resolve_github_usernames(["AliceGH"])
+
+    assert result == {"AliceGH": "alice"}
+    mock_api.get_github_usernames.assert_not_called()
+
+
+def test_resolve_github_usernames_caches_map_with_ttl(
+    workspace_client: LdapWorkspaceClient,
+    mock_cache: MagicMock,
+    mock_api: MagicMock,
+    ldap_settings: Settings,
+) -> None:
+    """Test resolve_github_usernames caches the full map with the configured TTL."""
+    mock_api.__enter__ = MagicMock(return_value=mock_api)
+    mock_api.__exit__ = MagicMock(return_value=False)
+    mock_api.get_github_usernames.return_value = {"AliceGH": "alice"}
+
+    workspace_client.resolve_github_usernames(["AliceGH"])
+
+    mock_cache.set_obj.assert_called_once()
+    call_args = mock_cache.set_obj.call_args
+    assert call_args[1]["ttl"] == ldap_settings.ldap.github_usernames_cache_ttl
+
+
+def test_resolve_github_usernames_double_check_locking(
+    workspace_client: LdapWorkspaceClient,
+    mock_cache: MagicMock,
+    mock_api: MagicMock,
+) -> None:
+    """Test resolve_github_usernames uses double-check locking on cache miss."""
+    cached = CachedGithubUsernames(mapping={"AliceGH": "alice"})
+    mock_cache.get_obj.side_effect = [None, cached]
+
+    result = workspace_client.resolve_github_usernames(["AliceGH"])
+
+    assert result == {"AliceGH": "alice"}
+    mock_api.get_github_usernames.assert_not_called()
+    mock_cache.lock.assert_called_once()

--- a/qontract_api/tests/external/ldap/test_ldap_workspace_client.py
+++ b/qontract_api/tests/external/ldap/test_ldap_workspace_client.py
@@ -312,7 +312,7 @@ def test_resolve_github_usernames_no_log_for_non_requested_ambiguous(
     """
     mock_cache.get_obj.return_value = CachedGithubUsernames(
         mapping={
-            "stackrox": ["chsheth", "jvmartin"],  # ambiguous, but not requested
+            "example-org": ["carol", "dave"],  # ambiguous, but not requested
             "alicegh": ["alice"],
         }
     )

--- a/qontract_api/tests/external/ldap/test_ldap_workspace_client.py
+++ b/qontract_api/tests/external/ldap/test_ldap_workspace_client.py
@@ -1,6 +1,6 @@
 """Tests for LdapWorkspaceClient (Layer 2 - caching + locking for direct LDAP)."""
 
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 import pytest
 from qontract_utils.ldap_api import LdapApi
@@ -169,7 +169,10 @@ def test_resolve_github_usernames_calls_api_and_matches(
     """Test resolve_github_usernames delegates to LdapApi and returns matches."""
     mock_api.__enter__ = MagicMock(return_value=mock_api)
     mock_api.__exit__ = MagicMock(return_value=False)
-    mock_api.get_github_usernames.return_value = {"AliceGH": "alice", "bob": "bob"}
+    mock_api.get_github_usernames.return_value = {
+        "alicegh": ["alice"],
+        "bob": ["bob"],
+    }
 
     result = workspace_client.resolve_github_usernames(["AliceGH", "bob"])
 
@@ -184,7 +187,7 @@ def test_resolve_github_usernames_case_insensitive(
     """Test resolve_github_usernames matches logins case-insensitively."""
     mock_api.__enter__ = MagicMock(return_value=mock_api)
     mock_api.__exit__ = MagicMock(return_value=False)
-    mock_api.get_github_usernames.return_value = {"AliceGH": "alice"}
+    mock_api.get_github_usernames.return_value = {"alicegh": ["alice"]}
 
     # Requested with different casing than stored in LDAP
     result = workspace_client.resolve_github_usernames(["alicegh"])
@@ -200,7 +203,7 @@ def test_resolve_github_usernames_omits_unresolved(
     """Test resolve_github_usernames omits logins not found in LDAP."""
     mock_api.__enter__ = MagicMock(return_value=mock_api)
     mock_api.__exit__ = MagicMock(return_value=False)
-    mock_api.get_github_usernames.return_value = {"AliceGH": "alice"}
+    mock_api.get_github_usernames.return_value = {"alicegh": ["alice"]}
 
     result = workspace_client.resolve_github_usernames(["AliceGH", "unknown"])
 
@@ -227,7 +230,7 @@ def test_resolve_github_usernames_cache_hit(
 ) -> None:
     """Test resolve_github_usernames serves the map from cache without an API call."""
     mock_cache.get_obj.return_value = CachedGithubUsernames(
-        mapping={"AliceGH": "alice"}
+        mapping={"alicegh": ["alice"]}
     )
 
     result = workspace_client.resolve_github_usernames(["AliceGH"])
@@ -245,7 +248,7 @@ def test_resolve_github_usernames_caches_map_with_ttl(
     """Test resolve_github_usernames caches the full map with the configured TTL."""
     mock_api.__enter__ = MagicMock(return_value=mock_api)
     mock_api.__exit__ = MagicMock(return_value=False)
-    mock_api.get_github_usernames.return_value = {"AliceGH": "alice"}
+    mock_api.get_github_usernames.return_value = {"alicegh": ["alice"]}
 
     workspace_client.resolve_github_usernames(["AliceGH"])
 
@@ -260,7 +263,7 @@ def test_resolve_github_usernames_double_check_locking(
     mock_api: MagicMock,
 ) -> None:
     """Test resolve_github_usernames uses double-check locking on cache miss."""
-    cached = CachedGithubUsernames(mapping={"AliceGH": "alice"})
+    cached = CachedGithubUsernames(mapping={"alicegh": ["alice"]})
     mock_cache.get_obj.side_effect = [None, cached]
 
     result = workspace_client.resolve_github_usernames(["AliceGH"])
@@ -268,3 +271,56 @@ def test_resolve_github_usernames_double_check_locking(
     assert result == {"AliceGH": "alice"}
     mock_api.get_github_usernames.assert_not_called()
     mock_cache.lock.assert_called_once()
+
+
+def test_resolve_github_usernames_skips_and_logs_ambiguous_requested(
+    workspace_client: LdapWorkspaceClient,
+    mock_cache: MagicMock,
+) -> None:
+    """A requested login mapping to >1 uid is skipped and logged once.
+
+    LDAP result order must not decide identity, so an ambiguous requested login
+    is omitted from the result. The warning names the requested login and all
+    candidate uids so it is actionable.
+    """
+    mock_cache.get_obj.return_value = CachedGithubUsernames(
+        mapping={"shared-gh": ["alice", "mallory"], "bob-gh": ["bob"]}
+    )
+
+    with patch(
+        "qontract_api.external.ldap.ldap_workspace_client.logger"
+    ) as mock_logger:
+        result = workspace_client.resolve_github_usernames(["Shared-GH", "bob-gh"])
+
+    # Ambiguous login dropped; unambiguous one resolved.
+    assert result == {"bob-gh": "bob"}
+    mock_logger.warning.assert_called_once()
+    _, kwargs = mock_logger.warning.call_args
+    assert kwargs["github_login"] == "Shared-GH"
+    assert kwargs["uids"] == ["alice", "mallory"]
+
+
+def test_resolve_github_usernames_no_log_for_non_requested_ambiguous(
+    workspace_client: LdapWorkspaceClient,
+    mock_cache: MagicMock,
+) -> None:
+    """Ambiguity outside the requested logins produces no warning.
+
+    The directory holds many ambiguous logins (orgs/repos claimed by several
+    associates) that are irrelevant to the org being reconciled. Only requested
+    logins are considered, so those never spam the logs.
+    """
+    mock_cache.get_obj.return_value = CachedGithubUsernames(
+        mapping={
+            "stackrox": ["chsheth", "jvmartin"],  # ambiguous, but not requested
+            "alicegh": ["alice"],
+        }
+    )
+
+    with patch(
+        "qontract_api.external.ldap.ldap_workspace_client.logger"
+    ) as mock_logger:
+        result = workspace_client.resolve_github_usernames(["AliceGH"])
+
+    assert result == {"AliceGH": "alice"}
+    mock_logger.warning.assert_not_called()

--- a/qontract_api/tests/github/test_github_org_workspace_client.py
+++ b/qontract_api/tests/github/test_github_org_workspace_client.py
@@ -298,3 +298,27 @@ def test_add_member_as_admin_does_not_clear_members_cache_on_rate_limit(
         client.add_member_as_admin(ORG_NAME, "alice")
 
     mock_cache.delete.assert_not_called()
+
+
+def test_add_member_as_admin_clears_both_member_caches(
+    client: GithubOrgWorkspaceClient,
+    mock_github_org_api: MagicMock,
+    mock_cache: MagicMock,
+) -> None:
+    """A successful mutation must invalidate BOTH cached member lists.
+
+    get_current_members writes the ':members' key and get_all_members writes
+    ':all-members'; adding a member changes both. Clearing only ':members'
+    would leave get_all_members (used by slack-usergroups) stale until TTL.
+    """
+    client.add_member_as_admin(ORG_NAME, "alice")
+
+    mock_github_org_api.add_member_as_admin.assert_called_once_with(ORG_NAME, "alice")
+    deleted_keys = {c.args[0] for c in mock_cache.delete.call_args_list}
+    assert deleted_keys == {
+        f"github-org:{ORG_NAME}:members",
+        f"github-org:{ORG_NAME}:all-members",
+    }
+    # Every delete happens under a lock scoped to the same key.
+    locked_keys = {c.args[0] for c in mock_cache.lock.call_args_list}
+    assert locked_keys == deleted_keys

--- a/qontract_api/tests/github/test_github_org_workspace_client.py
+++ b/qontract_api/tests/github/test_github_org_workspace_client.py
@@ -185,6 +185,76 @@ def test_marker_rechecked_after_acquiring_lock(
 
 
 # ---------------------------------------------------------------------------
+# get_all_members — all org members (any role)
+# ---------------------------------------------------------------------------
+
+
+def test_get_all_members_cache_miss_fetches_and_caches(
+    client: GithubOrgWorkspaceClient,
+    mock_github_org_api: MagicMock,
+    mock_cache: MagicMock,
+    mock_settings: Settings,
+) -> None:
+    mock_github_org_api.get_members.return_value = ["Bob", "alice"]
+
+    members = client.get_all_members(ORG_NAME)
+
+    # returned verbatim from the API (case preserved, no lowercasing here)
+    assert members == ["Bob", "alice"]
+    mock_github_org_api.get_members.assert_called_once_with(ORG_NAME)
+    key, cached_obj, ttl = mock_cache.set_obj.call_args[0]
+    assert key == f"github-org:{ORG_NAME}:all-members"
+    assert cached_obj == CachedOrgMembers(members=["Bob", "alice"])
+    assert ttl == mock_settings.github_org.members_cache_ttl
+
+
+def test_get_all_members_cache_hit_skips_api(
+    client: GithubOrgWorkspaceClient,
+    mock_github_org_api: MagicMock,
+    mock_cache: MagicMock,
+) -> None:
+    mock_cache.get_obj.side_effect = [None, CachedOrgMembers(members=["alice"])]
+
+    members = client.get_all_members(ORG_NAME)
+
+    assert members == ["alice"]
+    mock_cache.lock.assert_not_called()
+    mock_github_org_api.get_members.assert_not_called()
+
+
+def test_get_all_members_short_circuits_when_marker_present(
+    client: GithubOrgWorkspaceClient,
+    mock_github_org_api: MagicMock,
+    mock_cache: MagicMock,
+) -> None:
+    reset_at = datetime.now(UTC) + timedelta(seconds=60)
+    mock_cache.get_obj.side_effect = [RateLimitMarker(reset_at=reset_at)]
+
+    with pytest.raises(GithubRateLimitExceededError) as exc_info:
+        client.get_all_members(ORG_NAME)
+
+    assert exc_info.value.reset_at == reset_at
+    mock_cache.lock.assert_not_called()
+    mock_github_org_api.get_members.assert_not_called()
+
+
+def test_get_all_members_sets_marker_and_reraises_on_rate_limit(
+    client: GithubOrgWorkspaceClient,
+    mock_github_org_api: MagicMock,
+    mock_cache: MagicMock,
+) -> None:
+    reset_at = datetime.now(UTC) + timedelta(seconds=120)
+    mock_github_org_api.get_members.side_effect = GithubRateLimitExceededError(reset_at)
+
+    with pytest.raises(GithubRateLimitExceededError):
+        client.get_all_members(ORG_NAME)
+
+    key, marker, _ttl = mock_cache.set_obj.call_args[0]
+    assert key == f"github-org:{ORG_NAME}:rate-limited"
+    assert marker == RateLimitMarker(reset_at=reset_at)
+
+
+# ---------------------------------------------------------------------------
 # add_member_as_admin — rate limit while applying a mutation
 # ---------------------------------------------------------------------------
 

--- a/qontract_api_client/qontract_api_client/client.py
+++ b/qontract_api_client/qontract_api_client/client.py
@@ -7,6 +7,51 @@ from . import config, schemas
 client = clientele_api.APIClient(config=config.Config())
 
 
+@client.get("/api/v1/external/github-org/members")
+async def github_org_members(
+    result: schemas.GithubOrgMembersResponse,
+    secret_manager_url: str,
+    path: str,
+    org_name: str,
+    field: str | None = None,
+    version: int | None = None,
+) -> schemas.GithubOrgMembersResponse:
+    """Get Org Members
+
+        Get all members of a GitHub organization.
+
+    Lists every member of the organization (any role) using the GitHub API
+    token resolved from Vault. Results are cached for performance (TTL
+    configured in settings).
+    """
+    return result
+
+
+@client.post("/api/v1/external/ldap/github-usernames")
+async def ldap_github_usernames(
+    result: schemas.LdapGithubUsernamesResponse,
+    data: schemas.LdapGithubUsernamesRequest,
+) -> schemas.LdapGithubUsernamesResponse:
+    """Resolve Github Usernames
+
+        Resolve GitHub usernames to LDAP uids via the rhatSocialURL attribute.
+
+    Maps each requested GitHub username to the app-interface org_username (LDAP
+    uid) of the user whose rhatSocialURL points at that GitHub account. The
+    full map is cached for performance; unresolved logins are omitted from the
+    response.
+
+    Args:
+        request: GitHub usernames to resolve and the Vault secret reference
+        cache: Cache dependency
+        secret_manager: Secret manager dependency
+
+    Returns:
+        LdapGithubUsernamesResponse with resolved username -> org_username pairs
+    """
+    return result
+
+
 @client.post("/api/v1/external/ldap/users/check")
 async def ldap_users_check(
     result: schemas.LdapUsersCheckResponse, data: schemas.LdapUsersCheckRequest

--- a/qontract_api_client/qontract_api_client/schemas.py
+++ b/qontract_api_client/qontract_api_client/schemas.py
@@ -137,6 +137,10 @@ class GithubOrgDesiredState(pydantic.BaseModel):
     token: Secret
 
 
+class GithubOrgMembersResponse(pydantic.BaseModel):
+    members: list[str]
+
+
 class GithubOwnerActionAddOwner(pydantic.BaseModel):
     action_type: typing.Literal["add_owner"] = "add_owner"
     org_name: str
@@ -466,6 +470,20 @@ class LdapDirectSecret(pydantic.BaseModel):
     secret_manager_url: str
     server_url: str
     version: int | None = None
+
+
+class LdapGithubUser(pydantic.BaseModel):
+    github_username: str
+    org_username: str
+
+
+class LdapGithubUsernamesRequest(pydantic.BaseModel):
+    logins: list[str]
+    secret: LdapDirectSecret
+
+
+class LdapGithubUsernamesResponse(pydantic.BaseModel):
+    users: list[LdapGithubUser]
 
 
 class LdapUserStatus(pydantic.BaseModel):

--- a/qontract_utils/qontract_utils/github_org/api.py
+++ b/qontract_utils/qontract_utils/github_org/api.py
@@ -318,6 +318,28 @@ class GithubOrgApi:
 
     @invoke_with_hooks(
         lambda self, org_name: GithubOrgApiCallContext(  # ruff: ignore[unused-lambda-argument]
+            method="org.get_members", verb="GET", org=org_name
+        )
+    )
+    def get_members(self, org_name: str) -> list[str]:
+        """Fetch all members of a GitHub organization (any role).
+
+        Unlike `get_admin_members`, this returns every organization member
+        regardless of role and preserves the login casing exactly as GitHub
+        reports it - callers that need case-insensitive comparison must
+        lowercase on their side.
+
+        Args:
+            org_name: GitHub organization name
+
+        Returns:
+            Sorted list of GitHub usernames (original case) of all org members
+        """
+        org = self._gh.get_organization(org_name)
+        return sorted(m.login for m in org.get_members())
+
+    @invoke_with_hooks(
+        lambda self, org_name: GithubOrgApiCallContext(  # ruff: ignore[unused-lambda-argument]
             method="org.get_pending_invitations", verb="GET", org=org_name
         )
     )

--- a/qontract_utils/qontract_utils/ldap_api/api.py
+++ b/qontract_utils/qontract_utils/ldap_api/api.py
@@ -323,6 +323,11 @@ class LdapApi:
         skipped (see `_parse_github_login`). Logins keep their original casing;
         callers normalise for comparison.
 
+        A GitHub login that resolves (case-insensitively) to more than one
+        distinct uid is ambiguous - LDAP result order is not an
+        identity-selection rule - so it is omitted from the mapping and logged,
+        rather than letting an arbitrary entry win.
+
         Returns:
             Mapping of GitHub username to LDAP uid (org_username)
 
@@ -336,11 +341,26 @@ class LdapApi:
         )
         self._check_ldap_response(status)
 
-        mapping: dict[str, str] = {}
+        # Collect the distinct uids per case-insensitive login so ambiguous
+        # mappings can be detected instead of silently overwritten. The
+        # first-seen original casing is preserved as the map key.
+        by_login: dict[str, tuple[str, set[str]]] = {}
         for r in results:
             attributes = r["attributes"]
             uid = attributes["uid"][0]
             for value in attributes.get("rhatSocialURL", []):
                 if login := _parse_github_login(value):
-                    mapping[login] = uid
+                    _, uids = by_login.setdefault(login.lower(), (login, set()))
+                    uids.add(uid)
+
+        mapping: dict[str, str] = {}
+        for original, uids in by_login.values():
+            if len(uids) > 1:
+                logger.warning(
+                    "Ambiguous GitHub login maps to multiple LDAP uids; skipping",
+                    github_login=original,
+                    uids=sorted(uids),
+                )
+                continue
+            mapping[original] = next(iter(uids))
         return mapping

--- a/qontract_utils/qontract_utils/ldap_api/api.py
+++ b/qontract_utils/qontract_utils/ldap_api/api.py
@@ -129,6 +129,13 @@ _GITHUB_USERNAME_RE = re.compile(r"[A-Za-z0-9-]{1,39}")
 # path segment is not reliably a username.
 _GITHUB_HOSTS = frozenset({"github.com", "www.github.com"})
 
+# 389 Directory Server caps a single search response at ~2000 entries by
+# default and returns LDAP_SIZELIMIT_EXCEEDED past that. Broad searches must
+# follow the RFC 2696 paged-results cookie until the server signals no more
+# pages. `_PAGED_RESULTS_CONTROL` is the paged-results control OID.
+_LDAP_PAGE_SIZE = 1000
+_PAGED_RESULTS_CONTROL = "1.2.840.113556.1.4.319"
+
 
 def _parse_github_login(social_url: str) -> str | None:
     """Extract a GitHub login from a single `rhatSocialURL` attribute value.
@@ -237,6 +244,37 @@ class LdapApi:
                 f"LDAP operation failed (error {error_code}: {error_desc})"
             )
 
+    def _paged_search(
+        self, search_base: str, search_filter: str, attributes: list[str]
+    ) -> list[dict]:
+        """Run an LDAP search across all pages, following the paged cookie.
+
+        Uses RFC 2696 paged results so broad searches survive the server's
+        per-response size limit (389 DS defaults to ~2000 entries). Aggregates
+        the entries from every page.
+        """
+        entries: list[dict] = []
+        cookie: bytes | None = None
+        while True:
+            _, status, page, _ = self._connection.search(
+                search_base,
+                search_filter,
+                attributes=attributes,
+                paged_size=_LDAP_PAGE_SIZE,
+                paged_cookie=cookie,
+            )
+            self._check_ldap_response(status)
+            entries.extend(page)
+            cookie = (
+                status.get("controls", {})
+                .get(_PAGED_RESULTS_CONTROL, {})
+                .get("value", {})
+                .get("cookie")
+            )
+            if not cookie:
+                break
+        return entries
+
     @invoke_with_hooks(
         lambda: LdapApiCallContext(method="get_users"),
         retry_config=_LDAP_RETRY_CONFIG,
@@ -328,18 +366,21 @@ class LdapApi:
         identity-selection rule - so it is omitted from the mapping and logged,
         rather than letting an arbitrary entry win.
 
+        The search is paged (RFC 2696) so it survives the directory server's
+        per-response size limit - the broad filter can match more entries than
+        389 DS returns in a single response.
+
         Returns:
             Mapping of GitHub username to LDAP uid (org_username)
 
         Raises:
             LdapApiError: If the LDAP search fails
         """
-        _, status, results, _ = self._connection.search(
+        results = self._paged_search(
             f"cn=users,cn=accounts,{self.base_dn}",
             "(&(objectclass=person)(rhatSocialURL=Github->*github.com/*))",
             attributes=["uid", "rhatSocialURL"],
         )
-        self._check_ldap_response(status)
 
         # Collect the distinct uids per case-insensitive login so ambiguous
         # mappings can be detected instead of silently overwritten. The

--- a/qontract_utils/qontract_utils/ldap_api/api.py
+++ b/qontract_utils/qontract_utils/ldap_api/api.py
@@ -141,11 +141,18 @@ def _parse_github_login(social_url: str) -> str | None:
     """Extract a GitHub login from a single `rhatSocialURL` attribute value.
 
     Values have the form ``<Social>-><URL>`` (e.g.
-    ``Github->http://github.com/chassing``). Returns the first path segment of
-    ``github.com/<login>`` URLs whose social label is ``Github``; returns None
-    for any non-GitHub label, non-github.com host (``*.github.io`` Pages, gist,
-    custom domains), or empty/malformed login. The login is returned with its
-    original casing - callers normalise for comparison.
+    ``Github->http://github.com/chassing``). Only a *bare* profile URL -
+    ``github.com/<login>`` with exactly one path segment - establishes a login.
+    Repo / sub-path URLs (``github.com/<owner>/<repo>``) are rejected: their
+    first segment is not reliably the linking user (it may be an organization
+    they belong to or another user's repository they contribute to), so trusting
+    it would attribute someone else's login to this user. A user who owns a repo
+    also links their bare profile, so no genuine login is lost.
+
+    Returns None for any non-GitHub label, non-github.com host (``*.github.io``
+    Pages, gist, custom domains), multi-segment path, or empty/malformed login.
+    The login is returned with its original casing - callers normalise for
+    comparison.
     """
     label, sep, url = social_url.partition("->")
     if not sep or label.strip().lower() != "github":
@@ -155,8 +162,16 @@ def _parse_github_login(social_url: str) -> str | None:
     if parsed.hostname not in _GITHUB_HOSTS:
         return None
 
-    segment = parsed.path.strip("/").split("/", 1)[0].strip().rstrip("\x00").strip()
-    if not segment or not _GITHUB_USERNAME_RE.fullmatch(segment):
+    segments = [
+        cleaned
+        for raw in parsed.path.split("/")
+        if (cleaned := raw.strip().rstrip("\x00").strip())
+    ]
+    if len(segments) != 1:
+        return None
+
+    segment = segments[0]
+    if not _GITHUB_USERNAME_RE.fullmatch(segment):
         return None
     return segment
 
@@ -351,27 +366,28 @@ class LdapApi:
         lambda: LdapApiCallContext(method="get_github_usernames"),
         retry_config=_LDAP_RETRY_CONFIG,
     )
-    def get_github_usernames(self) -> dict[str, str]:
-        """Build a GitHub-username -> LDAP uid map from `rhatSocialURL`.
+    def get_github_usernames(self) -> dict[str, list[str]]:
+        """Build a GitHub-login -> LDAP uid(s) map from `rhatSocialURL`.
 
         Searches the active users container for entries whose `rhatSocialURL`
-        holds a `Github->...github.com/<login>` value and maps the parsed
-        GitHub login to the user's uid (which is the app-interface
-        org_username). Values that are not GitHub github.com user URLs are
-        skipped (see `_parse_github_login`). Logins keep their original casing;
-        callers normalise for comparison.
+        holds a bare `Github->...github.com/<login>` value and groups the parsed
+        GitHub login to every uid that claims it. Values that are not bare
+        github.com user URLs are skipped (see `_parse_github_login`).
 
-        A GitHub login that resolves (case-insensitively) to more than one
-        distinct uid is ambiguous - LDAP result order is not an
-        identity-selection rule - so it is omitted from the mapping and logged,
-        rather than letting an arbitrary entry win.
+        Login keys are lowercased (GitHub logins are case-insensitive) and each
+        maps to the sorted list of distinct uids seen for it. This layer only
+        extracts data: a login claimed by more than one uid is *not* resolved
+        here - deciding what to do with such ambiguity is the caller's policy,
+        applied to the specific logins it requested rather than to the whole
+        directory (see `LdapWorkspaceClient.resolve_github_usernames`).
 
         The search is paged (RFC 2696) so it survives the directory server's
         per-response size limit - the broad filter can match more entries than
         389 DS returns in a single response.
 
         Returns:
-            Mapping of GitHub username to LDAP uid (org_username)
+            Mapping of lowercased GitHub login to the sorted list of LDAP uids
+            (org_usernames) that claim it
 
         Raises:
             LdapApiError: If the LDAP search fails
@@ -382,26 +398,12 @@ class LdapApi:
             attributes=["uid", "rhatSocialURL"],
         )
 
-        # Collect the distinct uids per case-insensitive login so ambiguous
-        # mappings can be detected instead of silently overwritten. The
-        # first-seen original casing is preserved as the map key.
-        by_login: dict[str, tuple[str, set[str]]] = {}
+        by_login: dict[str, set[str]] = defaultdict(set[str])
         for r in results:
             attributes = r["attributes"]
             uid = attributes["uid"][0]
             for value in attributes.get("rhatSocialURL", []):
                 if login := _parse_github_login(value):
-                    _, uids = by_login.setdefault(login.lower(), (login, set()))
-                    uids.add(uid)
+                    by_login[login.lower()].add(uid)
 
-        mapping: dict[str, str] = {}
-        for original, uids in by_login.values():
-            if len(uids) > 1:
-                logger.warning(
-                    "Ambiguous GitHub login maps to multiple LDAP uids; skipping",
-                    github_login=original,
-                    uids=sorted(uids),
-                )
-                continue
-            mapping[original] = next(iter(uids))
-        return mapping
+        return {login: sorted(uids) for login, uids in by_login.items()}

--- a/qontract_utils/qontract_utils/ldap_api/api.py
+++ b/qontract_utils/qontract_utils/ldap_api/api.py
@@ -1,12 +1,14 @@
 """LDAP API client with hook system for metrics, logging, and latency tracking."""
 
 import contextvars
+import re
 import time
 import types
 from collections import defaultdict
 from collections.abc import Collection, Iterable
 from dataclasses import dataclass
 from typing import Self
+from urllib.parse import urlparse
 
 import structlog
 from ldap3 import NONE, SAFE_SYNC, Connection, Server
@@ -115,6 +117,41 @@ _LDAP_RETRY_CONFIG = RetryConfig(
     wait_max=5.0,
     wait_jitter=1.0,
 )
+
+
+# GitHub usernames: alphanumerics and single hyphens, max 39 chars. We only
+# validate the character set here (not the full hyphen rules) - a value that
+# survives this is safe to compare against real org members.
+_GITHUB_USERNAME_RE = re.compile(r"[A-Za-z0-9-]{1,39}")
+
+# Hosts whose first path segment is a GitHub user login. `*.github.io` (Pages),
+# custom domains and `gist.github.com` are intentionally excluded: their first
+# path segment is not reliably a username.
+_GITHUB_HOSTS = frozenset({"github.com", "www.github.com"})
+
+
+def _parse_github_login(social_url: str) -> str | None:
+    """Extract a GitHub login from a single `rhatSocialURL` attribute value.
+
+    Values have the form ``<Social>-><URL>`` (e.g.
+    ``Github->http://github.com/chassing``). Returns the first path segment of
+    ``github.com/<login>`` URLs whose social label is ``Github``; returns None
+    for any non-GitHub label, non-github.com host (``*.github.io`` Pages, gist,
+    custom domains), or empty/malformed login. The login is returned with its
+    original casing - callers normalise for comparison.
+    """
+    label, sep, url = social_url.partition("->")
+    if not sep or label.strip().lower() != "github":
+        return None
+
+    parsed = urlparse(url.strip().rstrip("\x00").strip())
+    if parsed.hostname not in _GITHUB_HOSTS:
+        return None
+
+    segment = parsed.path.strip("/").split("/", 1)[0].strip().rstrip("\x00").strip()
+    if not segment or not _GITHUB_USERNAME_RE.fullmatch(segment):
+        return None
+    return segment
 
 
 def _get_cn_from_dn(dn: str) -> str:
@@ -271,3 +308,39 @@ class LdapApi:
             )
             for dn, members in groups_and_members.items()
         ]
+
+    @invoke_with_hooks(
+        lambda: LdapApiCallContext(method="get_github_usernames"),
+        retry_config=_LDAP_RETRY_CONFIG,
+    )
+    def get_github_usernames(self) -> dict[str, str]:
+        """Build a GitHub-username -> LDAP uid map from `rhatSocialURL`.
+
+        Searches the active users container for entries whose `rhatSocialURL`
+        holds a `Github->...github.com/<login>` value and maps the parsed
+        GitHub login to the user's uid (which is the app-interface
+        org_username). Values that are not GitHub github.com user URLs are
+        skipped (see `_parse_github_login`). Logins keep their original casing;
+        callers normalise for comparison.
+
+        Returns:
+            Mapping of GitHub username to LDAP uid (org_username)
+
+        Raises:
+            LdapApiError: If the LDAP search fails
+        """
+        _, status, results, _ = self._connection.search(
+            f"cn=users,cn=accounts,{self.base_dn}",
+            "(&(objectclass=person)(rhatSocialURL=Github->*github.com/*))",
+            attributes=["uid", "rhatSocialURL"],
+        )
+        self._check_ldap_response(status)
+
+        mapping: dict[str, str] = {}
+        for r in results:
+            attributes = r["attributes"]
+            uid = attributes["uid"][0]
+            for value in attributes.get("rhatSocialURL", []):
+                if login := _parse_github_login(value):
+                    mapping[login] = uid
+        return mapping

--- a/qontract_utils/tests/ldap_api/test_ldap_api.py
+++ b/qontract_utils/tests/ldap_api/test_ldap_api.py
@@ -746,6 +746,74 @@ def test_get_github_usernames_skips_unparseable_values(
     assert result == {}
 
 
+def test_get_github_usernames_omits_ambiguous_logins(
+    mock_ldap3: MagicMock, ldap_api: LdapApi
+) -> None:
+    """Ambiguous logins (same github login, different uids) are omitted."""
+    mock_ldap3.connection.search.return_value = (
+        True,
+        {"result": 0, "description": "success"},
+        [
+            # Two distinct users claim the same GitHub login (case-insensitive)
+            {
+                "attributes": {
+                    "uid": ["alice"],
+                    "rhatSocialURL": ["Github->https://github.com/shared-gh"],
+                }
+            },
+            {
+                "attributes": {
+                    "uid": ["mallory"],
+                    "rhatSocialURL": ["Github->https://github.com/Shared-GH"],
+                }
+            },
+            # An unambiguous mapping is still returned
+            {
+                "attributes": {
+                    "uid": ["bob"],
+                    "rhatSocialURL": ["Github->https://github.com/bob-gh"],
+                }
+            },
+        ],
+        None,
+    )
+
+    with ldap_api:
+        result = ldap_api.get_github_usernames()
+
+    # The ambiguous login is dropped (LDAP order must not decide identity);
+    # the unambiguous one survives.
+    assert result == {"bob-gh": "bob"}
+
+
+def test_get_github_usernames_keeps_duplicate_same_uid(
+    mock_ldap3: MagicMock, ldap_api: LdapApi
+) -> None:
+    """A login repeated for the SAME uid (any casing) is not ambiguous."""
+    mock_ldap3.connection.search.return_value = (
+        True,
+        {"result": 0, "description": "success"},
+        [
+            {
+                "attributes": {
+                    "uid": ["alice"],
+                    "rhatSocialURL": [
+                        "Github->https://github.com/AliceGH",
+                        "Github->https://github.com/alicegh",
+                    ],
+                }
+            },
+        ],
+        None,
+    )
+
+    with ldap_api:
+        result = ldap_api.get_github_usernames()
+
+    # First-seen casing is preserved; the mapping resolves to the single uid.
+    assert result == {"AliceGH": "alice"}
+
+
 def test_get_github_usernames_search_failure_raises_error(
     mock_ldap3: MagicMock, ldap_api: LdapApi
 ) -> None:

--- a/qontract_utils/tests/ldap_api/test_ldap_api.py
+++ b/qontract_utils/tests/ldap_api/test_ldap_api.py
@@ -617,9 +617,8 @@ def test_get_group_members_escapes_special_characters(
         # https and www variants
         ("Github->https://github.com/chassing", "chassing"),
         ("Github->https://www.github.com/chassing", "chassing"),
-        # Trailing slash and extra path segments -> first segment only
+        # Trailing slash -> single (bare) path segment is still a profile
         ("Github->https://github.com/chassing/", "chassing"),
-        ("Github->https://github.com/chassing/repo", "chassing"),
         # Casing of the login is preserved (callers normalise)
         ("Github->https://github.com/ChAsSiNg", "ChAsSiNg"),
         # Label matching is case-insensitive / whitespace-tolerant
@@ -645,6 +644,12 @@ def test_parse_github_login_valid(social_url: str, expected: str) -> None:
         # Empty login (no path segment)
         "Github->https://github.com/",
         "Github->https://github.com",
+        # Repo / sub-path URLs: the first segment is NOT reliably the linking
+        # user's profile (it may be an org they contribute to or another user's
+        # repo), so only bare `github.com/<login>` establishes a login.
+        "Github->https://github.com/chassing/repo",
+        "Github->https://github.com/openshift/cluster-kube-apiserver-operator",
+        "Github->https://github.com/util-linux/util-linux",
         # Excluded hosts: Pages, gist, custom domain
         "Github->https://chassing.github.io/",
         "Github->https://gist.github.com/chassing",
@@ -671,7 +676,7 @@ def test_parse_github_login_strips_null_bytes() -> None:
 def test_get_github_usernames_builds_mapping(
     mock_ldap3: MagicMock, ldap_api: LdapApi
 ) -> None:
-    """Test get_github_usernames maps parsed logins to uids, preserving case."""
+    """Test get_github_usernames maps parsed logins (lowercased) to uid lists."""
     mock_ldap3.connection.search.return_value = (
         True,
         {"result": 0, "description": "success"},
@@ -698,7 +703,8 @@ def test_get_github_usernames_builds_mapping(
     with ldap_api:
         result = ldap_api.get_github_usernames()
 
-    assert result == {"AliceGH": "alice", "bob-gh": "bob"}
+    # Keys are lowercased logins; values are the distinct uids per login.
+    assert result == {"alicegh": ["alice"], "bob-gh": ["bob"]}
 
 
 def test_get_github_usernames_scopes_and_filters(
@@ -748,10 +754,15 @@ def test_get_github_usernames_skips_unparseable_values(
     assert result == {}
 
 
-def test_get_github_usernames_omits_ambiguous_logins(
+def test_get_github_usernames_groups_uids_per_login(
     mock_ldap3: MagicMock, ldap_api: LdapApi
 ) -> None:
-    """Ambiguous logins (same github login, different uids) are omitted."""
+    """All uids that claim a login (case-insensitively) are grouped, not dropped.
+
+    The api layer only extracts data; deciding what to do with an ambiguous
+    login (>1 uid) is the caller's policy, scoped to the logins it actually
+    requested, so this layer returns every uid it saw.
+    """
     mock_ldap3.connection.search.return_value = (
         True,
         {"result": 0, "description": "success"},
@@ -769,7 +780,6 @@ def test_get_github_usernames_omits_ambiguous_logins(
                     "rhatSocialURL": ["Github->https://github.com/Shared-GH"],
                 }
             },
-            # An unambiguous mapping is still returned
             {
                 "attributes": {
                     "uid": ["bob"],
@@ -783,15 +793,14 @@ def test_get_github_usernames_omits_ambiguous_logins(
     with ldap_api:
         result = ldap_api.get_github_usernames()
 
-    # The ambiguous login is dropped (LDAP order must not decide identity);
-    # the unambiguous one survives.
-    assert result == {"bob-gh": "bob"}
+    # Login key is lowercased; the two claimants are grouped and sorted.
+    assert result == {"shared-gh": ["alice", "mallory"], "bob-gh": ["bob"]}
 
 
 def test_get_github_usernames_keeps_duplicate_same_uid(
     mock_ldap3: MagicMock, ldap_api: LdapApi
 ) -> None:
-    """A login repeated for the SAME uid (any casing) is not ambiguous."""
+    """A login repeated for the SAME uid (any casing) yields a single uid."""
     mock_ldap3.connection.search.return_value = (
         True,
         {"result": 0, "description": "success"},
@@ -812,8 +821,47 @@ def test_get_github_usernames_keeps_duplicate_same_uid(
     with ldap_api:
         result = ldap_api.get_github_usernames()
 
-    # First-seen casing is preserved; the mapping resolves to the single uid.
-    assert result == {"AliceGH": "alice"}
+    # Login lowercased; the single uid is not duplicated.
+    assert result == {"alicegh": ["alice"]}
+
+
+def test_get_github_usernames_ignores_repo_urls(
+    mock_ldap3: MagicMock, ldap_api: LdapApi
+) -> None:
+    """Repo / sub-path URLs never establish a login (misattribution fix).
+
+    A user whose only GitHub link is a repo they contribute to must not have
+    that repo's owner attributed to them, otherwise the owner would resolve to
+    the wrong Red Hat identity. Only bare `github.com/<login>` counts.
+    """
+    mock_ldap3.connection.search.return_value = (
+        True,
+        {"result": 0, "description": "success"},
+        [
+            # Only contributes to someone else's repo -> nothing extracted
+            {
+                "attributes": {
+                    "uid": ["carol"],
+                    "rhatSocialURL": [
+                        "Github->https://github.com/openshift/cluster-kube-apiserver-operator"
+                    ],
+                }
+            },
+            # Bare profile -> extracted
+            {
+                "attributes": {
+                    "uid": ["dave"],
+                    "rhatSocialURL": ["Github->https://github.com/dave-gh"],
+                }
+            },
+        ],
+        None,
+    )
+
+    with ldap_api:
+        result = ldap_api.get_github_usernames()
+
+    assert result == {"dave-gh": ["dave"]}
 
 
 def test_get_github_usernames_paginates_across_pages(
@@ -868,7 +916,7 @@ def test_get_github_usernames_paginates_across_pages(
         result = ldap_api.get_github_usernames()
 
     # Entries from both pages are merged.
-    assert result == {"AliceGH": "alice", "bob-gh": "bob"}
+    assert result == {"alicegh": ["alice"], "bob-gh": ["bob"]}
     assert mock_ldap3.connection.search.call_count == 2
 
     first_call, second_call = mock_ldap3.connection.search.call_args_list

--- a/qontract_utils/tests/ldap_api/test_ldap_api.py
+++ b/qontract_utils/tests/ldap_api/test_ldap_api.py
@@ -8,6 +8,8 @@ import pytest
 from pydantic import ValidationError
 from qontract_utils.hooks import Hooks
 from qontract_utils.ldap_api.api import (
+    _LDAP_PAGE_SIZE,
+    _PAGED_RESULTS_CONTROL,
     LdapApi,
     LdapApiCallContext,
     LdapApiError,
@@ -812,6 +814,69 @@ def test_get_github_usernames_keeps_duplicate_same_uid(
 
     # First-seen casing is preserved; the mapping resolves to the single uid.
     assert result == {"AliceGH": "alice"}
+
+
+def test_get_github_usernames_paginates_across_pages(
+    mock_ldap3: MagicMock, ldap_api: LdapApi
+) -> None:
+    """The broad search is paged: results from every page are aggregated.
+
+    389 Directory Server caps a single search at ~2000 entries and returns
+    LDAP_SIZELIMIT_EXCEEDED past that, so the mapping must follow the paged
+    results cookie until the server signals no more pages.
+    """
+    mock_ldap3.connection.search.side_effect = [
+        (
+            True,
+            {
+                "result": 0,
+                "description": "success",
+                "controls": {
+                    _PAGED_RESULTS_CONTROL: {"value": {"cookie": b"next-page"}}
+                },
+            },
+            [
+                {
+                    "attributes": {
+                        "uid": ["alice"],
+                        "rhatSocialURL": ["Github->https://github.com/AliceGH"],
+                    }
+                }
+            ],
+            None,
+        ),
+        (
+            True,
+            {
+                "result": 0,
+                "description": "success",
+                "controls": {_PAGED_RESULTS_CONTROL: {"value": {"cookie": b""}}},
+            },
+            [
+                {
+                    "attributes": {
+                        "uid": ["bob"],
+                        "rhatSocialURL": ["Github->https://github.com/bob-gh"],
+                    }
+                }
+            ],
+            None,
+        ),
+    ]
+
+    with ldap_api:
+        result = ldap_api.get_github_usernames()
+
+    # Entries from both pages are merged.
+    assert result == {"AliceGH": "alice", "bob-gh": "bob"}
+    assert mock_ldap3.connection.search.call_count == 2
+
+    first_call, second_call = mock_ldap3.connection.search.call_args_list
+    # First page requests a fresh cursor; second page forwards the cookie.
+    assert first_call[1]["paged_size"] == _LDAP_PAGE_SIZE
+    assert first_call[1]["paged_cookie"] is None
+    assert second_call[1]["paged_size"] == _LDAP_PAGE_SIZE
+    assert second_call[1]["paged_cookie"] == b"next-page"
 
 
 def test_get_github_usernames_search_failure_raises_error(

--- a/qontract_utils/tests/ldap_api/test_ldap_api.py
+++ b/qontract_utils/tests/ldap_api/test_ldap_api.py
@@ -7,7 +7,12 @@ from unittest.mock import MagicMock, call, patch
 import pytest
 from pydantic import ValidationError
 from qontract_utils.hooks import Hooks
-from qontract_utils.ldap_api.api import LdapApi, LdapApiCallContext, LdapApiError
+from qontract_utils.ldap_api.api import (
+    LdapApi,
+    LdapApiCallContext,
+    LdapApiError,
+    _parse_github_login,
+)
 from qontract_utils.ldap_api.models import LdapGroup, LdapUser
 
 
@@ -597,3 +602,182 @@ def test_get_group_members_escapes_special_characters(
     assert f"(memberOf={dn_with_parens})" not in filter_str
     assert "\\28" in filter_str  # ( -> \28
     assert "\\29" in filter_str  # ) -> \29
+
+
+# --- _parse_github_login ---
+
+
+@pytest.mark.parametrize(
+    ("social_url", "expected"),
+    [
+        # Canonical form as stored in FreeIPA
+        ("Github->http://github.com/chassing", "chassing"),
+        # https and www variants
+        ("Github->https://github.com/chassing", "chassing"),
+        ("Github->https://www.github.com/chassing", "chassing"),
+        # Trailing slash and extra path segments -> first segment only
+        ("Github->https://github.com/chassing/", "chassing"),
+        ("Github->https://github.com/chassing/repo", "chassing"),
+        # Casing of the login is preserved (callers normalise)
+        ("Github->https://github.com/ChAsSiNg", "ChAsSiNg"),
+        # Label matching is case-insensitive / whitespace-tolerant
+        ("github->https://github.com/chassing", "chassing"),
+        (" GitHub -> https://github.com/chassing ", "chassing"),
+        # Hyphenated login (valid GitHub username)
+        ("Github->https://github.com/red-hat", "red-hat"),
+    ],
+)
+def test_parse_github_login_valid(social_url: str, expected: str) -> None:
+    """Test _parse_github_login extracts the login from valid github.com URLs."""
+    assert _parse_github_login(social_url) == expected
+
+
+@pytest.mark.parametrize(
+    "social_url",
+    [
+        # Non-GitHub social label
+        "Twitter->https://twitter.com/chassing",
+        "LinkedIn->https://github.com/chassing",  # wrong label, right host
+        # Missing separator
+        "https://github.com/chassing",
+        # Empty login (no path segment)
+        "Github->https://github.com/",
+        "Github->https://github.com",
+        # Excluded hosts: Pages, gist, custom domain
+        "Github->https://chassing.github.io/",
+        "Github->https://gist.github.com/chassing",
+        "Github->https://example.com/chassing",
+        # Login with invalid characters (underscore not allowed)
+        "Github->https://github.com/bad_name",
+        # Empty string
+        "",
+    ],
+)
+def test_parse_github_login_invalid(social_url: str) -> None:
+    """Test _parse_github_login returns None for non-github.com user URLs."""
+    assert _parse_github_login(social_url) is None
+
+
+def test_parse_github_login_strips_null_bytes() -> None:
+    """Test _parse_github_login tolerates trailing null bytes (seen in LDAP values)."""
+    assert _parse_github_login("Github->https://github.com/chassing\x00") == "chassing"
+
+
+# --- get_github_usernames ---
+
+
+def test_get_github_usernames_builds_mapping(
+    mock_ldap3: MagicMock, ldap_api: LdapApi
+) -> None:
+    """Test get_github_usernames maps parsed logins to uids, preserving case."""
+    mock_ldap3.connection.search.return_value = (
+        True,
+        {"result": 0, "description": "success"},
+        [
+            {
+                "attributes": {
+                    "uid": ["alice"],
+                    "rhatSocialURL": ["Github->https://github.com/AliceGH"],
+                }
+            },
+            {
+                "attributes": {
+                    "uid": ["bob"],
+                    "rhatSocialURL": [
+                        "Twitter->https://twitter.com/bob",
+                        "Github->http://github.com/bob-gh",
+                    ],
+                }
+            },
+        ],
+        None,
+    )
+
+    with ldap_api:
+        result = ldap_api.get_github_usernames()
+
+    assert result == {"AliceGH": "alice", "bob-gh": "bob"}
+
+
+def test_get_github_usernames_scopes_and_filters(
+    mock_ldap3: MagicMock, ldap_api: LdapApi
+) -> None:
+    """Test get_github_usernames searches the active users container with a filter."""
+    mock_ldap3.connection.search.return_value = (
+        True,
+        {"result": 0, "description": "success"},
+        [],
+        None,
+    )
+
+    with ldap_api:
+        ldap_api.get_github_usernames()
+
+    call_args = mock_ldap3.connection.search.call_args
+    assert call_args[0][0] == "cn=users,cn=accounts,dc=example,dc=com"
+    filter_str = call_args[0][1]
+    assert "(objectclass=person)" in filter_str
+    assert "rhatSocialURL=Github->*github.com/*" in filter_str
+    assert call_args[1]["attributes"] == ["uid", "rhatSocialURL"]
+
+
+def test_get_github_usernames_skips_unparseable_values(
+    mock_ldap3: MagicMock, ldap_api: LdapApi
+) -> None:
+    """Test get_github_usernames drops users whose social URLs aren't github.com logins."""
+    mock_ldap3.connection.search.return_value = (
+        True,
+        {"result": 0, "description": "success"},
+        [
+            {
+                "attributes": {
+                    "uid": ["carol"],
+                    "rhatSocialURL": ["Github->https://gist.github.com/carol"],
+                }
+            },
+            {"attributes": {"uid": ["dave"], "rhatSocialURL": []}},
+        ],
+        None,
+    )
+
+    with ldap_api:
+        result = ldap_api.get_github_usernames()
+
+    assert result == {}
+
+
+def test_get_github_usernames_search_failure_raises_error(
+    mock_ldap3: MagicMock, ldap_api: LdapApi
+) -> None:
+    """Test get_github_usernames raises LdapApiError on search failure."""
+    mock_ldap3.connection.search.return_value = (
+        False,
+        {"result": 53, "description": "Server Unwilling to Perform"},
+        [],
+        None,
+    )
+
+    with ldap_api, pytest.raises(LdapApiError, match="LDAP operation failed"):
+        ldap_api.get_github_usernames()
+
+
+def test_get_github_usernames_calls_hooks(
+    mock_ldap3: MagicMock, ldap_api: LdapApi
+) -> None:
+    """Test get_github_usernames triggers hooks with correct context."""
+    pre_hook = MagicMock()
+    ldap_api._hooks = Hooks(pre_hooks=[pre_hook])
+    mock_ldap3.connection.search.return_value = (
+        True,
+        {"result": 0, "description": "success"},
+        [],
+        None,
+    )
+
+    with ldap_api:
+        ldap_api.get_github_usernames()
+
+    pre_hook.assert_called_once()
+    context = pre_hook.call_args[0][0]
+    assert isinstance(context, LdapApiCallContext)
+    assert context.method == "get_github_usernames"

--- a/qontract_utils/tests/test_github_org_api.py
+++ b/qontract_utils/tests/test_github_org_api.py
@@ -95,6 +95,40 @@ def test_paginated_get_403_without_ratelimit_raises_httperror(
         api.get_pending_invitations("my-org")
 
 
+def test_get_members_preserves_case_and_sorts() -> None:
+    api = GithubOrgApi(token="token", base_url="https://api.github.com")
+    org = MagicMock()
+    org.get_members.return_value = [
+        MagicMock(login="Bob"),
+        MagicMock(login="alice"),
+        MagicMock(login="Charlie"),
+    ]
+    api._gh = MagicMock()
+    api._gh.get_organization.return_value = org
+
+    members = api.get_members("my-org")
+
+    # original case preserved (no lowercasing), deterministic sort order
+    assert members == sorted(["Bob", "alice", "Charlie"])
+    org.get_members.assert_called_once_with()
+
+
+def test_get_members_raises_rate_limit_error() -> None:
+    api = GithubOrgApi(token="token", base_url="https://api.github.com")
+    reset_epoch = 1788542522
+    org = MagicMock()
+    org.get_members.side_effect = RateLimitExceededException(
+        403, {"message": "rate limit"}, {"x-ratelimit-reset": str(reset_epoch)}
+    )
+    api._gh = MagicMock()
+    api._gh.get_organization.return_value = org
+
+    with pytest.raises(GithubRateLimitExceededError) as exc_info:
+        api.get_members("my-org")
+
+    assert exc_info.value.reset_at == datetime.fromtimestamp(reset_epoch, tz=UTC)
+
+
 def test_get_admin_members_raises_rate_limit_error() -> None:
     api = GithubOrgApi(token="token", base_url="https://api.github.com")
     reset_epoch = 1788542522

--- a/reconcile/gql_definitions/introspection.json
+++ b/reconcile/gql_definitions/introspection.json
@@ -35516,6 +35516,18 @@
                             "deprecationReason": null
                         },
                         {
+                            "name": "github",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "OBJECT",
+                                "name": "GithubOrg_v1",
+                                "ofType": null
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
                             "name": "channels",
                             "description": null,
                             "args": [],

--- a/reconcile/gql_definitions/slack_usergroups_api/permissions.gql
+++ b/reconcile/gql_definitions/slack_usergroups_api/permissions.gql
@@ -23,6 +23,12 @@ query SlackUsergroupApiPermission {
         scheduleID
         escalationPolicyID
       }
+      github {
+        name
+        token {
+          ...VaultSecret
+        }
+      }
       roles {
         users {
           ...User

--- a/reconcile/gql_definitions/slack_usergroups_api/permissions.py
+++ b/reconcile/gql_definitions/slack_usergroups_api/permissions.py
@@ -61,6 +61,12 @@ query SlackUsergroupApiPermission {
         scheduleID
         escalationPolicyID
       }
+      github {
+        name
+        token {
+          ...VaultSecret
+        }
+      }
       roles {
         users {
           ...User
@@ -119,6 +125,11 @@ class PagerDutyTargetV1(ConfiguredBaseModel):
     escalation_policy_id: Optional[str] = Field(..., alias="escalationPolicyID")
 
 
+class GithubOrgV1(ConfiguredBaseModel):
+    name: str = Field(..., alias="name")
+    token: VaultSecret = Field(..., alias="token")
+
+
 class RoleV1(ConfiguredBaseModel):
     users: list[User] = Field(..., alias="users")
 
@@ -154,6 +165,7 @@ class PermissionSlackUsergroupV1(PermissionV1):
     owners_from_repos: Optional[list[str]] = Field(..., alias="ownersFromRepos")
     skip: Optional[bool] = Field(..., alias="skip")
     pagerduty: Optional[list[PagerDutyTargetV1]] = Field(..., alias="pagerduty")
+    github: Optional[GithubOrgV1] = Field(..., alias="github")
     roles: Optional[list[RoleV1]] = Field(..., alias="roles")
     schedule: Optional[ScheduleV1] = Field(..., alias="schedule")
     workspace: SlackWorkspaceV1 = Field(..., alias="workspace")

--- a/reconcile/slack_usergroups_api.py
+++ b/reconcile/slack_usergroups_api.py
@@ -22,6 +22,8 @@ from typing import TYPE_CHECKING, Any, Protocol
 
 from pydantic import BaseModel
 from qontract_api_client.client import (
+    github_org_members,
+    ldap_github_usernames,
     pagerduty_escalation_policy_users,
     pagerduty_schedule_users,
     slack_usergroups,
@@ -29,6 +31,8 @@ from qontract_api_client.client import (
 )
 from qontract_api_client.schemas import (
     EscalationPolicyUsersResponse,
+    LdapDirectSecret,
+    LdapGithubUsernamesRequest,
     NotificationAddUser,
     NotificationRemoveUser,
     ScheduleUsersResponse,
@@ -52,6 +56,7 @@ from reconcile.gql_definitions.slack_usergroups_api.clusters import (
     query as clusters_query,
 )
 from reconcile.gql_definitions.slack_usergroups_api.permissions import (
+    GithubOrgV1,
     PagerDutyTargetV1,
     PermissionSlackUsergroupV1,
     RoleV1,
@@ -70,6 +75,7 @@ from reconcile.gql_definitions.slack_usergroups_api.roles import (
 from reconcile.gql_definitions.slack_usergroups_api.roles import query as roles_query
 from reconcile.gql_definitions.slack_usergroups_api.users import UserV1
 from reconcile.gql_definitions.slack_usergroups_api.users import query as users_query
+from reconcile.typed_queries.ldap_settings import get_ldap_settings
 from reconcile.typed_queries.vcs import Vcs, get_vcs_instances
 from reconcile.utils import expiration, gql
 from reconcile.utils.datetime_util import ensure_utc, utc_now
@@ -81,6 +87,8 @@ from reconcile.utils.runtime.integration import (
 
 if TYPE_CHECKING:
     from collections.abc import Callable, Coroutine, Iterable, Mapping
+
+    from reconcile.gql_definitions.common.ldap_settings import LdapSettingsV1
 
 QONTRACT_INTEGRATION = "slack-usergroups-api"
 INTEGRATION_VERSION = "0.1.0"
@@ -377,11 +385,125 @@ class SlackUsergroupsIntegration(
             for user in resp.users or []
         ]
 
+    async def _resolve_github_logins_via_ldap(
+        self,
+        logins: list[str],
+        ldap_settings: LdapSettingsV1,
+    ) -> dict[str, str]:
+        """Resolve GitHub logins to org_usernames via LDAP rhatSocialURL.
+
+        Args:
+            logins: GitHub logins not resolvable via app-interface github_username
+            ldap_settings: App-interface LDAP settings (server, base DN, creds)
+
+        Returns:
+            Mapping of the requested GitHub login to its org_username, containing
+            only logins found in LDAP (unresolved logins are omitted).
+        """
+        if not logins:
+            return {}
+        if not ldap_settings.credentials:
+            raise RuntimeError("LDAP credentials not found in settings")
+
+        with self.log_api_exceptions():
+            response = await ldap_github_usernames(
+                LdapGithubUsernamesRequest(
+                    logins=logins,
+                    secret=LdapDirectSecret(
+                        secret_manager_url=self.secret_manager_url,
+                        path=ldap_settings.credentials.path,
+                        field=ldap_settings.credentials.field,
+                        version=ldap_settings.credentials.version,
+                        server_url=ldap_settings.server_url,
+                        base_dn=ldap_settings.base_dn,
+                    ),
+                ),
+            )
+        return {u.github_username: u.org_username for u in response.users or []}
+
+    async def compile_users_from_github_org(
+        self,
+        github_org: GithubOrgV1 | None,
+        app_interface_users: list[UserV1],
+        ldap_settings: LdapSettingsV1,
+    ) -> list[str]:
+        """Extract Slack identities from a GitHub organization's membership.
+
+        Members are mapped to app-interface users via their github_username
+        first, then via the LDAP rhatSocialURL attribute for the remainder.
+        Members that resolve to neither are logged and skipped.
+
+        Args:
+            github_org: GitHub org reference (name + API token) or None
+            app_interface_users: List of all app-interface users
+            ldap_settings: App-interface LDAP settings for the fallback lookup
+
+        Returns:
+            List of Slack identities for the resolvable org members
+        """
+        if not github_org:
+            return []
+
+        with self.log_api_exceptions():
+            response = await github_org_members(
+                secret_manager_url=self.secret_manager_url,
+                path=github_org.token.path,
+                field=github_org.token.field,
+                version=github_org.token.version,
+                org_name=github_org.name,
+            )
+        if not (members := response.members):
+            return []
+
+        users_map = {user.org_username: user for user in app_interface_users}
+        # Compare case-insensitively: GitHub logins keep their original casing
+        # in both app-interface and the org membership listing.
+        gh_to_org_username = {
+            user.github_username.lower(): user.org_username
+            for user in app_interface_users
+        }
+
+        # login -> org_username, resolved via app-interface github_username first
+        resolved: dict[str, str] = {}
+        unresolved: list[str] = []
+        for login in members:
+            if org_username := gh_to_org_username.get(login.lower()):
+                resolved[login] = org_username
+            else:
+                unresolved.append(login)
+
+        # Fall back to LDAP rhatSocialURL for members without a github_username
+        resolved.update(
+            await self._resolve_github_logins_via_ldap(unresolved, ldap_settings)
+        )
+
+        slack_identities: set[str] = set()
+        for login in members:
+            if not (org_username := resolved.get(login)):
+                logging.warning(
+                    f"[{github_org.name}] could not map GitHub member '{login}' "
+                    "to an org user, skipping. If this is a Red Hat associate, "
+                    f"add their GitHub profile (https://github.com/{login}) to "
+                    "their Rover page (https://rover.redhat.com) so it can be "
+                    "resolved via LDAP."
+                )
+                continue
+            # Honor an app-interface user's Slack identity override
+            # (gov_slack_email_local_part); otherwise the org_username - the
+            # LDAP-resolved uid - is itself the Slack identity.
+            if user := users_map.get(org_username):
+                slack_identities.add(slack_identity(user))
+            else:
+                slack_identities.add(org_username)
+
+        return sorted(slack_identities)
+
     async def _process_permission(
         self,
         permission: PermissionSlackUsergroupV1,
         app_interface_users: list[UserV1],
         vcs_instances: Iterable[Vcs],
+        ldap_settings: LdapSettingsV1,
         desired_workspace_name: str | None,
         desired_usergroup_name: str | None,
     ) -> tuple[str, SlackUsergroup] | None:
@@ -426,6 +548,14 @@ class SlackUsergroupsIntegration(
                 app_interface_users=app_interface_users,
             )
         )
+        # Add users from Github org (if configured)
+        users.update(
+            await self.compile_users_from_github_org(
+                github_org=permission.github,
+                app_interface_users=app_interface_users,
+                ldap_settings=ldap_settings,
+            )
+        )
 
         # Create config and usergroup
         notifications: list[NotificationAddUser | NotificationRemoveUser] = []
@@ -453,6 +583,7 @@ class SlackUsergroupsIntegration(
         permissions: list[PermissionSlackUsergroupV1],
         app_interface_users: list[UserV1],
         vcs_instances: Iterable[Vcs],
+        ldap_settings: LdapSettingsV1,
         desired_workspace_name: str | None = None,
         desired_usergroup_name: str | None = None,
     ) -> list[SlackWorkspace]:
@@ -463,6 +594,7 @@ class SlackUsergroupsIntegration(
                 permission,
                 app_interface_users,
                 vcs_instances,
+                ldap_settings,
                 desired_workspace_name,
                 desired_usergroup_name,
             )
@@ -649,11 +781,13 @@ class SlackUsergroupsIntegration(
         clusters = self.get_clusters(query_func=gqlapi.query)
         roles = self.get_roles(query_func=gqlapi.query)
         vcs_instances = get_vcs_instances(query_func=gqlapi.query)
+        ldap_settings = get_ldap_settings(query_func=gqlapi.query)
 
         workspaces = await self.compile_desired_state_from_permissions(
             permissions=permissions,
             app_interface_users=users,
             vcs_instances=vcs_instances,
+            ldap_settings=ldap_settings,
             desired_workspace_name=self.params.workspace_name,
             desired_usergroup_name=self.params.usergroup_name,
         )

--- a/reconcile/slack_usergroups_api.py
+++ b/reconcile/slack_usergroups_api.py
@@ -478,15 +478,10 @@ class SlackUsergroupsIntegration(
         )
 
         slack_identities: set[str] = set()
+        unmapped: list[str] = []
         for login in members:
             if not (org_username := resolved.get(login)):
-                logging.warning(
-                    f"[{github_org.name}] could not map GitHub member '{login}' "
-                    "to an org user, skipping. If this is a Red Hat associate, "
-                    f"add their GitHub profile (https://github.com/{login}) to "
-                    "their Rover page (https://rover.redhat.com) so it can be "
-                    "resolved via LDAP."
-                )
+                unmapped.append(login)
                 continue
             # Honor an app-interface user's Slack identity override
             # (gov_slack_email_local_part); otherwise the org_username - the
@@ -495,6 +490,21 @@ class SlackUsergroupsIntegration(
                 slack_identities.add(slack_identity(user))
             else:
                 slack_identities.add(org_username)
+
+        if unmapped:
+            # One aggregated warning per org keeps the #reconcile channel quiet
+            # (fluentd filters it out there), while still listing every unmapped
+            # login + profile URL so the MR author sees them in the
+            # app-interface MR check output.
+            profiles = ", ".join(
+                f"{login} (https://github.com/{login})" for login in sorted(unmapped)
+            )
+            logging.warning(
+                f"[{github_org.name}] could not map {len(unmapped)} GitHub "
+                f"member(s) to an org user, skipping: {profiles}. If any of them "
+                "is a Red Hat associate, add their GitHub profile to their Rover "
+                "page (https://rover.redhat.com) so it can be resolved via LDAP."
+            )
 
         return sorted(slack_identities)
 

--- a/reconcile/test/fixtures/helm/aws_account_shard_disabled.yml
+++ b/reconcile/test/fixtures/helm/aws_account_shard_disabled.yml
@@ -81,6 +81,14 @@ objects:
               @type grep
               <exclude>
                 key message
+                pattern /could not map GitHub member /
+              </exclude>
+            </filter>
+
+            <filter integration>
+              @type grep
+              <exclude>
+                key message
                 pattern /Certificate did not match expected hostname/
               </exclude>
             </filter>
@@ -281,6 +289,14 @@ objects:
               <exclude>
                 key message
                 pattern /request_id: /
+              </exclude>
+            </filter>
+
+            <filter integration>
+              @type grep
+              <exclude>
+                key message
+                pattern /could not map GitHub member /
               </exclude>
             </filter>
 

--- a/reconcile/test/fixtures/helm/aws_account_shard_disabled.yml
+++ b/reconcile/test/fixtures/helm/aws_account_shard_disabled.yml
@@ -81,7 +81,7 @@ objects:
               @type grep
               <exclude>
                 key message
-                pattern /could not map GitHub member /
+                pattern /could not map \d+ GitHub member/
               </exclude>
             </filter>
 
@@ -296,7 +296,7 @@ objects:
               @type grep
               <exclude>
                 key message
-                pattern /could not map GitHub member /
+                pattern /could not map \d+ GitHub member/
               </exclude>
             </filter>
 

--- a/reconcile/test/fixtures/helm/aws_account_shard_spec_override.yml
+++ b/reconcile/test/fixtures/helm/aws_account_shard_spec_override.yml
@@ -81,6 +81,14 @@ objects:
               @type grep
               <exclude>
                 key message
+                pattern /could not map GitHub member /
+              </exclude>
+            </filter>
+
+            <filter integration>
+              @type grep
+              <exclude>
+                key message
                 pattern /Certificate did not match expected hostname/
               </exclude>
             </filter>
@@ -281,6 +289,14 @@ objects:
               <exclude>
                 key message
                 pattern /request_id: /
+              </exclude>
+            </filter>
+
+            <filter integration>
+              @type grep
+              <exclude>
+                key message
+                pattern /could not map GitHub member /
               </exclude>
             </filter>
 

--- a/reconcile/test/fixtures/helm/aws_account_shard_spec_override.yml
+++ b/reconcile/test/fixtures/helm/aws_account_shard_spec_override.yml
@@ -81,7 +81,7 @@ objects:
               @type grep
               <exclude>
                 key message
-                pattern /could not map GitHub member /
+                pattern /could not map \d+ GitHub member/
               </exclude>
             </filter>
 
@@ -296,7 +296,7 @@ objects:
               @type grep
               <exclude>
                 key message
-                pattern /could not map GitHub member /
+                pattern /could not map \d+ GitHub member/
               </exclude>
             </filter>
 

--- a/reconcile/test/fixtures/helm/aws_account_shards.yml
+++ b/reconcile/test/fixtures/helm/aws_account_shards.yml
@@ -81,6 +81,14 @@ objects:
               @type grep
               <exclude>
                 key message
+                pattern /could not map GitHub member /
+              </exclude>
+            </filter>
+
+            <filter integration>
+              @type grep
+              <exclude>
+                key message
                 pattern /Certificate did not match expected hostname/
               </exclude>
             </filter>
@@ -281,6 +289,14 @@ objects:
               <exclude>
                 key message
                 pattern /request_id: /
+              </exclude>
+            </filter>
+
+            <filter integration>
+              @type grep
+              <exclude>
+                key message
+                pattern /could not map GitHub member /
               </exclude>
             </filter>
 

--- a/reconcile/test/fixtures/helm/aws_account_shards.yml
+++ b/reconcile/test/fixtures/helm/aws_account_shards.yml
@@ -81,7 +81,7 @@ objects:
               @type grep
               <exclude>
                 key message
-                pattern /could not map GitHub member /
+                pattern /could not map \d+ GitHub member/
               </exclude>
             </filter>
 
@@ -296,7 +296,7 @@ objects:
               @type grep
               <exclude>
                 key message
-                pattern /could not map GitHub member /
+                pattern /could not map \d+ GitHub member/
               </exclude>
             </filter>
 

--- a/reconcile/test/fixtures/helm/basic.yml
+++ b/reconcile/test/fixtures/helm/basic.yml
@@ -81,7 +81,7 @@ objects:
               @type grep
               <exclude>
                 key message
-                pattern /could not map GitHub member /
+                pattern /could not map \d+ GitHub member/
               </exclude>
             </filter>
 

--- a/reconcile/test/fixtures/helm/basic.yml
+++ b/reconcile/test/fixtures/helm/basic.yml
@@ -81,6 +81,14 @@ objects:
               @type grep
               <exclude>
                 key message
+                pattern /could not map GitHub member /
+              </exclude>
+            </filter>
+
+            <filter integration>
+              @type grep
+              <exclude>
+                key message
                 pattern /Certificate did not match expected hostname/
               </exclude>
             </filter>

--- a/reconcile/test/fixtures/helm/cache.yml
+++ b/reconcile/test/fixtures/helm/cache.yml
@@ -90,6 +90,14 @@ objects:
               @type grep
               <exclude>
                 key message
+                pattern /could not map GitHub member /
+              </exclude>
+            </filter>
+
+            <filter integration>
+              @type grep
+              <exclude>
+                key message
                 pattern /Certificate did not match expected hostname/
               </exclude>
             </filter>

--- a/reconcile/test/fixtures/helm/cache.yml
+++ b/reconcile/test/fixtures/helm/cache.yml
@@ -90,7 +90,7 @@ objects:
               @type grep
               <exclude>
                 key message
-                pattern /could not map GitHub member /
+                pattern /could not map \d+ GitHub member/
               </exclude>
             </filter>
 

--- a/reconcile/test/fixtures/helm/cache_storage_vars.yml
+++ b/reconcile/test/fixtures/helm/cache_storage_vars.yml
@@ -90,6 +90,14 @@ objects:
               @type grep
               <exclude>
                 key message
+                pattern /could not map GitHub member /
+              </exclude>
+            </filter>
+
+            <filter integration>
+              @type grep
+              <exclude>
+                key message
                 pattern /Certificate did not match expected hostname/
               </exclude>
             </filter>

--- a/reconcile/test/fixtures/helm/cache_storage_vars.yml
+++ b/reconcile/test/fixtures/helm/cache_storage_vars.yml
@@ -90,7 +90,7 @@ objects:
               @type grep
               <exclude>
                 key message
-                pattern /could not map GitHub member /
+                pattern /could not map \d+ GitHub member/
               </exclude>
             </filter>
 

--- a/reconcile/test/fixtures/helm/command.yml
+++ b/reconcile/test/fixtures/helm/command.yml
@@ -81,7 +81,7 @@ objects:
               @type grep
               <exclude>
                 key message
-                pattern /could not map GitHub member /
+                pattern /could not map \d+ GitHub member/
               </exclude>
             </filter>
 

--- a/reconcile/test/fixtures/helm/command.yml
+++ b/reconcile/test/fixtures/helm/command.yml
@@ -81,6 +81,14 @@ objects:
               @type grep
               <exclude>
                 key message
+                pattern /could not map GitHub member /
+              </exclude>
+            </filter>
+
+            <filter integration>
+              @type grep
+              <exclude>
+                key message
                 pattern /Certificate did not match expected hostname/
               </exclude>
             </filter>

--- a/reconcile/test/fixtures/helm/disable_unleash.yml
+++ b/reconcile/test/fixtures/helm/disable_unleash.yml
@@ -81,7 +81,7 @@ objects:
               @type grep
               <exclude>
                 key message
-                pattern /could not map GitHub member /
+                pattern /could not map \d+ GitHub member/
               </exclude>
             </filter>
 

--- a/reconcile/test/fixtures/helm/disable_unleash.yml
+++ b/reconcile/test/fixtures/helm/disable_unleash.yml
@@ -81,6 +81,14 @@ objects:
               @type grep
               <exclude>
                 key message
+                pattern /could not map GitHub member /
+              </exclude>
+            </filter>
+
+            <filter integration>
+              @type grep
+              <exclude>
+                key message
                 pattern /Certificate did not match expected hostname/
               </exclude>
             </filter>

--- a/reconcile/test/fixtures/helm/enable_google_chat.yml
+++ b/reconcile/test/fixtures/helm/enable_google_chat.yml
@@ -90,6 +90,14 @@ objects:
               @type grep
               <exclude>
                 key message
+                pattern /could not map GitHub member /
+              </exclude>
+            </filter>
+
+            <filter integration>
+              @type grep
+              <exclude>
+                key message
                 pattern /Certificate did not match expected hostname/
               </exclude>
             </filter>

--- a/reconcile/test/fixtures/helm/enable_google_chat.yml
+++ b/reconcile/test/fixtures/helm/enable_google_chat.yml
@@ -90,7 +90,7 @@ objects:
               @type grep
               <exclude>
                 key message
-                pattern /could not map GitHub member /
+                pattern /could not map \d+ GitHub member/
               </exclude>
             </filter>
 

--- a/reconcile/test/fixtures/helm/environment_aware.yml
+++ b/reconcile/test/fixtures/helm/environment_aware.yml
@@ -81,7 +81,7 @@ objects:
               @type grep
               <exclude>
                 key message
-                pattern /could not map GitHub member /
+                pattern /could not map \d+ GitHub member/
               </exclude>
             </filter>
 

--- a/reconcile/test/fixtures/helm/environment_aware.yml
+++ b/reconcile/test/fixtures/helm/environment_aware.yml
@@ -81,6 +81,14 @@ objects:
               @type grep
               <exclude>
                 key message
+                pattern /could not map GitHub member /
+              </exclude>
+            </filter>
+
+            <filter integration>
+              @type grep
+              <exclude>
+                key message
                 pattern /Certificate did not match expected hostname/
               </exclude>
             </filter>

--- a/reconcile/test/fixtures/helm/exclude_service.yml
+++ b/reconcile/test/fixtures/helm/exclude_service.yml
@@ -81,7 +81,7 @@ objects:
               @type grep
               <exclude>
                 key message
-                pattern /could not map GitHub member /
+                pattern /could not map \d+ GitHub member/
               </exclude>
             </filter>
 

--- a/reconcile/test/fixtures/helm/exclude_service.yml
+++ b/reconcile/test/fixtures/helm/exclude_service.yml
@@ -81,6 +81,14 @@ objects:
               @type grep
               <exclude>
                 key message
+                pattern /could not map GitHub member /
+              </exclude>
+            </filter>
+
+            <filter integration>
+              @type grep
+              <exclude>
+                key message
                 pattern /Certificate did not match expected hostname/
               </exclude>
             </filter>

--- a/reconcile/test/fixtures/helm/extra_args.yml
+++ b/reconcile/test/fixtures/helm/extra_args.yml
@@ -81,7 +81,7 @@ objects:
               @type grep
               <exclude>
                 key message
-                pattern /could not map GitHub member /
+                pattern /could not map \d+ GitHub member/
               </exclude>
             </filter>
 

--- a/reconcile/test/fixtures/helm/extra_args.yml
+++ b/reconcile/test/fixtures/helm/extra_args.yml
@@ -81,6 +81,14 @@ objects:
               @type grep
               <exclude>
                 key message
+                pattern /could not map GitHub member /
+              </exclude>
+            </filter>
+
+            <filter integration>
+              @type grep
+              <exclude>
+                key message
                 pattern /Certificate did not match expected hostname/
               </exclude>
             </filter>

--- a/reconcile/test/fixtures/helm/extra_args_with_embedded_quotes.yml
+++ b/reconcile/test/fixtures/helm/extra_args_with_embedded_quotes.yml
@@ -81,7 +81,7 @@ objects:
               @type grep
               <exclude>
                 key message
-                pattern /could not map GitHub member /
+                pattern /could not map \d+ GitHub member/
               </exclude>
             </filter>
 

--- a/reconcile/test/fixtures/helm/extra_args_with_embedded_quotes.yml
+++ b/reconcile/test/fixtures/helm/extra_args_with_embedded_quotes.yml
@@ -81,6 +81,14 @@ objects:
               @type grep
               <exclude>
                 key message
+                pattern /could not map GitHub member /
+              </exclude>
+            </filter>
+
+            <filter integration>
+              @type grep
+              <exclude>
+                key message
                 pattern /Certificate did not match expected hostname/
               </exclude>
             </filter>

--- a/reconcile/test/fixtures/helm/extra_env.yml
+++ b/reconcile/test/fixtures/helm/extra_env.yml
@@ -81,7 +81,7 @@ objects:
               @type grep
               <exclude>
                 key message
-                pattern /could not map GitHub member /
+                pattern /could not map \d+ GitHub member/
               </exclude>
             </filter>
 

--- a/reconcile/test/fixtures/helm/extra_env.yml
+++ b/reconcile/test/fixtures/helm/extra_env.yml
@@ -81,6 +81,14 @@ objects:
               @type grep
               <exclude>
                 key message
+                pattern /could not map GitHub member /
+              </exclude>
+            </filter>
+
+            <filter integration>
+              @type grep
+              <exclude>
+                key message
                 pattern /Certificate did not match expected hostname/
               </exclude>
             </filter>

--- a/reconcile/test/fixtures/helm/integrations_manager.yml
+++ b/reconcile/test/fixtures/helm/integrations_manager.yml
@@ -81,7 +81,7 @@ objects:
               @type grep
               <exclude>
                 key message
-                pattern /could not map GitHub member /
+                pattern /could not map \d+ GitHub member/
               </exclude>
             </filter>
 

--- a/reconcile/test/fixtures/helm/integrations_manager.yml
+++ b/reconcile/test/fixtures/helm/integrations_manager.yml
@@ -81,6 +81,14 @@ objects:
               @type grep
               <exclude>
                 key message
+                pattern /could not map GitHub member /
+              </exclude>
+            </filter>
+
+            <filter integration>
+              @type grep
+              <exclude>
+                key message
                 pattern /Certificate did not match expected hostname/
               </exclude>
             </filter>

--- a/reconcile/test/fixtures/helm/internal_certificates.yml
+++ b/reconcile/test/fixtures/helm/internal_certificates.yml
@@ -97,7 +97,7 @@ objects:
               @type grep
               <exclude>
                 key message
-                pattern /could not map GitHub member /
+                pattern /could not map \d+ GitHub member/
               </exclude>
             </filter>
 

--- a/reconcile/test/fixtures/helm/internal_certificates.yml
+++ b/reconcile/test/fixtures/helm/internal_certificates.yml
@@ -97,6 +97,14 @@ objects:
               @type grep
               <exclude>
                 key message
+                pattern /could not map GitHub member /
+              </exclude>
+            </filter>
+
+            <filter integration>
+              @type grep
+              <exclude>
+                key message
                 pattern /Certificate did not match expected hostname/
               </exclude>
             </filter>

--- a/reconcile/test/fixtures/helm/logs_slack.yml
+++ b/reconcile/test/fixtures/helm/logs_slack.yml
@@ -95,7 +95,7 @@ objects:
               @type grep
               <exclude>
                 key message
-                pattern /could not map GitHub member /
+                pattern /could not map \d+ GitHub member/
               </exclude>
             </filter>
 

--- a/reconcile/test/fixtures/helm/logs_slack.yml
+++ b/reconcile/test/fixtures/helm/logs_slack.yml
@@ -95,6 +95,14 @@ objects:
               @type grep
               <exclude>
                 key message
+                pattern /could not map GitHub member /
+              </exclude>
+            </filter>
+
+            <filter integration>
+              @type grep
+              <exclude>
+                key message
                 pattern /Certificate did not match expected hostname/
               </exclude>
             </filter>

--- a/reconcile/test/fixtures/helm/shards.yml
+++ b/reconcile/test/fixtures/helm/shards.yml
@@ -81,6 +81,14 @@ objects:
               @type grep
               <exclude>
                 key message
+                pattern /could not map GitHub member /
+              </exclude>
+            </filter>
+
+            <filter integration>
+              @type grep
+              <exclude>
+                key message
                 pattern /Certificate did not match expected hostname/
               </exclude>
             </filter>
@@ -279,6 +287,14 @@ objects:
               <exclude>
                 key message
                 pattern /request_id: /
+              </exclude>
+            </filter>
+
+            <filter integration>
+              @type grep
+              <exclude>
+                key message
+                pattern /could not map GitHub member /
               </exclude>
             </filter>
 

--- a/reconcile/test/fixtures/helm/shards.yml
+++ b/reconcile/test/fixtures/helm/shards.yml
@@ -81,7 +81,7 @@ objects:
               @type grep
               <exclude>
                 key message
-                pattern /could not map GitHub member /
+                pattern /could not map \d+ GitHub member/
               </exclude>
             </filter>
 
@@ -294,7 +294,7 @@ objects:
               @type grep
               <exclude>
                 key message
-                pattern /could not map GitHub member /
+                pattern /could not map \d+ GitHub member/
               </exclude>
             </filter>
 

--- a/reconcile/test/fixtures/helm/sleep_duration.yml
+++ b/reconcile/test/fixtures/helm/sleep_duration.yml
@@ -81,7 +81,7 @@ objects:
               @type grep
               <exclude>
                 key message
-                pattern /could not map GitHub member /
+                pattern /could not map \d+ GitHub member/
               </exclude>
             </filter>
 

--- a/reconcile/test/fixtures/helm/sleep_duration.yml
+++ b/reconcile/test/fixtures/helm/sleep_duration.yml
@@ -81,6 +81,14 @@ objects:
               @type grep
               <exclude>
                 key message
+                pattern /could not map GitHub member /
+              </exclude>
+            </filter>
+
+            <filter integration>
+              @type grep
+              <exclude>
+                key message
                 pattern /Certificate did not match expected hostname/
               </exclude>
             </filter>

--- a/reconcile/test/fixtures/helm/state.yml
+++ b/reconcile/test/fixtures/helm/state.yml
@@ -81,7 +81,7 @@ objects:
               @type grep
               <exclude>
                 key message
-                pattern /could not map GitHub member /
+                pattern /could not map \d+ GitHub member/
               </exclude>
             </filter>
 

--- a/reconcile/test/fixtures/helm/state.yml
+++ b/reconcile/test/fixtures/helm/state.yml
@@ -81,6 +81,14 @@ objects:
               @type grep
               <exclude>
                 key message
+                pattern /could not map GitHub member /
+              </exclude>
+            </filter>
+
+            <filter integration>
+              @type grep
+              <exclude>
+                key message
                 pattern /Certificate did not match expected hostname/
               </exclude>
             </filter>

--- a/reconcile/test/fixtures/helm/storage.yml
+++ b/reconcile/test/fixtures/helm/storage.yml
@@ -81,7 +81,7 @@ objects:
               @type grep
               <exclude>
                 key message
-                pattern /could not map GitHub member /
+                pattern /could not map \d+ GitHub member/
               </exclude>
             </filter>
 

--- a/reconcile/test/fixtures/helm/storage.yml
+++ b/reconcile/test/fixtures/helm/storage.yml
@@ -81,6 +81,14 @@ objects:
               @type grep
               <exclude>
                 key message
+                pattern /could not map GitHub member /
+              </exclude>
+            </filter>
+
+            <filter integration>
+              @type grep
+              <exclude>
+                key message
                 pattern /Certificate did not match expected hostname/
               </exclude>
             </filter>

--- a/reconcile/test/fixtures/helm/trigger.yml
+++ b/reconcile/test/fixtures/helm/trigger.yml
@@ -81,7 +81,7 @@ objects:
               @type grep
               <exclude>
                 key message
-                pattern /could not map GitHub member /
+                pattern /could not map \d+ GitHub member/
               </exclude>
             </filter>
 

--- a/reconcile/test/fixtures/helm/trigger.yml
+++ b/reconcile/test/fixtures/helm/trigger.yml
@@ -81,6 +81,14 @@ objects:
               @type grep
               <exclude>
                 key message
+                pattern /could not map GitHub member /
+              </exclude>
+            </filter>
+
+            <filter integration>
+              @type grep
+              <exclude>
+                key message
                 pattern /Certificate did not match expected hostname/
               </exclude>
             </filter>

--- a/reconcile/test/test_slack_usergroups_api.py
+++ b/reconcile/test/test_slack_usergroups_api.py
@@ -1,0 +1,1275 @@
+"""Tests for the slack-usergroups-api client-side integration.
+
+Covers the standalone helpers, the desired-state compilation from every user
+source (roles, schedules, git OWNERS files, PagerDuty, GitHub org members,
+cluster access), permission processing, workspace assembly, and the async_run
+orchestration (dry-run vs apply, polling, error handling).
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from qontract_api_client.schemas import (
+    EscalationPolicyUsersResponse,
+    GithubOrgMembersResponse,
+    LdapGithubUser,
+    LdapGithubUsernamesResponse,
+    PagerDutyUser,
+    RepoOwnersResponse,
+    ScheduleUsersResponse,
+    SlackUsergroup,
+    SlackUsergroupActionCreate,
+    SlackUsergroupActionUpdateMetadata,
+    SlackUsergroupActionUpdateUsers,
+    SlackUsergroupConfig,
+    SlackUsergroupsTaskResponse,
+    SlackUsergroupsTaskResult,
+    TaskStatus,
+    VCSProvider,
+)
+from qontract_utils.vcs import Provider
+
+from reconcile.gql_definitions.common.ldap_settings import LdapSettingsV1
+from reconcile.gql_definitions.fragments.user import User
+from reconcile.gql_definitions.fragments.vault_secret import (
+    VaultSecret as LdapVaultSecret,
+)
+from reconcile.gql_definitions.slack_usergroups_api.clusters import (
+    ClusterV1 as EnabledClusterV1,
+)
+from reconcile.gql_definitions.slack_usergroups_api.clusters import (
+    DisableClusterAutomationsV1,
+)
+from reconcile.gql_definitions.slack_usergroups_api.permissions import (
+    GithubOrgV1,
+    PagerDutyInstanceV1,
+    PagerDutyTargetV1,
+    PermissionSlackUsergroupV1,
+    RoleV1,
+    ScheduleEntryV1,
+    ScheduleV1,
+    SlackUsergroupNotificationV1,
+    SlackWorkspaceIntegrationV1,
+    SlackWorkspaceV1,
+    VaultSecret,
+)
+from reconcile.gql_definitions.slack_usergroups_api.roles import (
+    AccessV1,
+    NamespaceV1,
+    NamespaceV1_ClusterV1,
+)
+from reconcile.gql_definitions.slack_usergroups_api.roles import (
+    ClusterV1 as AccessClusterV1,
+)
+from reconcile.gql_definitions.slack_usergroups_api.roles import (
+    RoleV1 as ClusterAccessRole,
+)
+from reconcile.gql_definitions.slack_usergroups_api.roles import (
+    UserV1 as ClusterAccessUser,
+)
+from reconcile.gql_definitions.slack_usergroups_api.users import UserV1
+from reconcile.slack_usergroups_api import (
+    QONTRACT_INTEGRATION,
+    SlackUsergroupsIntegration,
+    SlackUsergroupsIntegrationParams,
+    SlackWorkspace,
+    get_token_from_url,
+    slack_identity,
+)
+from reconcile.typed_queries.vcs import Vcs
+
+if TYPE_CHECKING:
+    from collections.abc import Generator
+
+_MOD = "reconcile.slack_usergroups_api"
+
+
+# --- factories ---
+
+
+def _vault_secret(path: str = "secret/token", field: str = "token") -> VaultSecret:
+    return VaultSecret(path=path, field=field, version=None, format=None)
+
+
+def _frag_user(
+    org_username: str,
+    *,
+    github_username: str = "",
+    pagerduty_username: str | None = None,
+    tag_on_merge_requests: bool | None = None,
+    gov_slack_email_local_part: str | None = None,
+) -> User:
+    return User(
+        name=org_username,
+        org_username=org_username,
+        github_username=github_username or f"{org_username}-gh",
+        pagerduty_username=pagerduty_username,
+        tag_on_merge_requests=tag_on_merge_requests,
+        gov_slack_email_local_part=gov_slack_email_local_part,
+    )
+
+
+def _app_user(
+    org_username: str,
+    github_username: str,
+    *,
+    pagerduty_username: str | None = None,
+    tag_on_merge_requests: bool | None = None,
+    gov_slack_email_local_part: str | None = None,
+) -> UserV1:
+    return UserV1(
+        name=org_username,
+        org_username=org_username,
+        github_username=github_username,
+        pagerduty_username=pagerduty_username,
+        tag_on_merge_requests=tag_on_merge_requests,
+        gov_slack_email_local_part=gov_slack_email_local_part,
+        tag_on_cluster_updates=None,
+        roles=None,
+    )
+
+
+def _cluster_user(
+    org_username: str,
+    *,
+    tag_on_cluster_updates: bool | None = None,
+) -> ClusterAccessUser:
+    return ClusterAccessUser(
+        name=org_username,
+        org_username=org_username,
+        github_username=f"{org_username}-gh",
+        pagerduty_username=None,
+        tag_on_merge_requests=None,
+        gov_slack_email_local_part=None,
+        tag_on_cluster_updates=tag_on_cluster_updates,
+    )
+
+
+def _github_org() -> GithubOrgV1:
+    return GithubOrgV1(name="my-org", token=_vault_secret("secret/github/token"))
+
+
+def _ldap_settings(*, with_credentials: bool = True) -> LdapSettingsV1:
+    return LdapSettingsV1(
+        serverUrl="ldap://freeipa.example.com",
+        baseDn="dc=example,dc=com",
+        credentials=LdapVaultSecret(
+            path="secret/ldap/bind",
+            field="password",
+            version=None,
+            format=None,
+        )
+        if with_credentials
+        else None,
+    )
+
+
+def _workspace(
+    *,
+    name: str = "coreos",
+    managed: list[str] | None = None,
+    with_integration: bool = True,
+) -> SlackWorkspaceV1:
+    integrations = None
+    if with_integration:
+        integrations = [
+            SlackWorkspaceIntegrationV1(
+                name="slack-usergroups",
+                token=_vault_secret("secret/slack/token"),
+                channel="#general",
+            )
+        ]
+    return SlackWorkspaceV1(
+        path="/dependencies/slack/coreos.yml",
+        name=name,
+        integrations=integrations,
+        managedUsergroups=managed if managed is not None else ["team-handle"],
+    )
+
+
+def _permission(
+    *,
+    handle: str = "team-handle",
+    skip: bool | None = None,
+    roles: list[RoleV1] | None = None,
+    schedule: ScheduleV1 | None = None,
+    pagerduty: list[PagerDutyTargetV1] | None = None,
+    github: GithubOrgV1 | None = None,
+    owners_from_repos: list[str] | None = None,
+    notifications: list[SlackUsergroupNotificationV1] | None = None,
+    channels: list[str] | None = None,
+    workspace: SlackWorkspaceV1 | None = None,
+) -> PermissionSlackUsergroupV1:
+    return PermissionSlackUsergroupV1(
+        service="slack-usergroup",
+        channels=channels if channels is not None else ["#team"],
+        description="Team handle",
+        handle=handle,
+        notifications=notifications,
+        ownersFromRepos=owners_from_repos,
+        skip=skip,
+        pagerduty=pagerduty,
+        github=github,
+        roles=roles,
+        schedule=schedule,
+        workspace=workspace or _workspace(managed=[handle]),
+    )
+
+
+@pytest.fixture
+def integration() -> Generator[SlackUsergroupsIntegration]:
+    inst = SlackUsergroupsIntegration(
+        SlackUsergroupsIntegrationParams(workspace_name=None, usergroup_name=None)
+    )
+    with patch.object(
+        type(inst),
+        "secret_manager_url",
+        new_callable=lambda: property(lambda self: "https://vault.example.com"),
+    ):
+        yield inst
+
+
+# --- slack_identity ---
+
+
+def test_slack_identity_prefers_gov_slack() -> None:
+    user = _frag_user("alice", gov_slack_email_local_part="alice.gov")
+    assert slack_identity(user) == "alice.gov"
+
+
+def test_slack_identity_falls_back_to_org_username() -> None:
+    user = _frag_user("alice")
+    assert slack_identity(user) == "alice"
+
+
+# --- get_token_from_url ---
+
+
+def _vcs(name: str, url: str, provider: Provider, *, default: bool = False) -> Vcs:
+    return Vcs(
+        name=name,
+        url=url,
+        default=default,
+        token=_vault_secret(f"secret/{name}"),
+        provider=provider,
+    )
+
+
+def test_get_token_from_url_github_exact_match() -> None:
+    from qontract_utils.vcs import get_default_registry
+
+    instances = [
+        _vcs("app-sre", "https://github.com/app-sre", Provider.GITHUB),
+        _vcs("other", "https://github.com/other", Provider.GITHUB),
+    ]
+    token = get_token_from_url(
+        get_default_registry(),
+        instances,
+        "https://github.com/app-sre/qontract-reconcile",
+    )
+    assert token.path == "secret/app-sre"
+
+
+def test_get_token_from_url_github_default_fallback() -> None:
+    from qontract_utils.vcs import get_default_registry
+
+    instances = [
+        _vcs(
+            "default-gh", "https://github.com/somewhere", Provider.GITHUB, default=True
+        ),
+    ]
+    token = get_token_from_url(
+        get_default_registry(),
+        instances,
+        "https://github.com/unknown-org/repo",
+    )
+    assert token.path == "secret/default-gh"
+
+
+def test_get_token_from_url_gitlab_match() -> None:
+    from qontract_utils.vcs import get_default_registry
+
+    instances = [
+        _vcs("gitlab", "https://gitlab.cee.redhat.com", Provider.GITLAB),
+    ]
+    token = get_token_from_url(
+        get_default_registry(),
+        instances,
+        "https://gitlab.cee.redhat.com/service/app-interface",
+    )
+    assert token.path == "secret/gitlab"
+
+
+def test_get_token_from_url_no_match_raises() -> None:
+    from qontract_utils.vcs import get_default_registry
+
+    # gitlab provider has no default fallback and no instance matches the owner URL
+    with pytest.raises(ValueError, match="No matching VCS instance"):
+        get_token_from_url(
+            get_default_registry(),
+            [],
+            "https://gitlab.cee.redhat.com/service/other",
+        )
+
+
+# --- name + static getters ---
+
+
+def test_integration_name(integration: SlackUsergroupsIntegration) -> None:
+    assert integration.name == QONTRACT_INTEGRATION == "slack-usergroups-api"
+
+
+def test_get_permissions_filters_slack_usergroup_type() -> None:
+    slack_perm = _permission()
+    other_perm = MagicMock()  # a non-slack PermissionV1
+    query_result = MagicMock()
+    query_result.permissions = [slack_perm, other_perm]
+    with patch(f"{_MOD}.permissions_query", return_value=query_result):
+        result = SlackUsergroupsIntegration.get_permissions(MagicMock())
+    assert result == [slack_perm]
+
+
+def test_get_permissions_empty() -> None:
+    query_result = MagicMock()
+    query_result.permissions = []
+    with patch(f"{_MOD}.permissions_query", return_value=query_result):
+        assert SlackUsergroupsIntegration.get_permissions(MagicMock()) == []
+
+
+def test_get_users() -> None:
+    users = [_app_user("alice", "alice-gh")]
+    query_result = MagicMock()
+    query_result.users = users
+    with patch(f"{_MOD}.users_query", return_value=query_result):
+        assert SlackUsergroupsIntegration.get_users(MagicMock()) == users
+
+
+def test_get_clusters_filters_disabled() -> None:
+    enabled = EnabledClusterV1(name="enabled", auth=[], disable=None)
+    disabled = EnabledClusterV1(
+        name="disabled",
+        auth=[],
+        disable=DisableClusterAutomationsV1(integrations=["slack-usergroups"]),
+    )
+    query_result = MagicMock()
+    query_result.clusters = [enabled, disabled]
+    with patch(f"{_MOD}.clusters_query", return_value=query_result):
+        result = SlackUsergroupsIntegration.get_clusters(MagicMock())
+    assert [c.name for c in result] == ["enabled"]
+
+
+def test_get_roles_filters_expired() -> None:
+    active = ClusterAccessRole(
+        name="active",
+        access=None,
+        expirationDate=None,
+        users=[],
+        tag_on_cluster_updates=None,
+    )
+    expired = ClusterAccessRole(
+        name="expired",
+        access=None,
+        expirationDate="2000-01-01",
+        users=[],
+        tag_on_cluster_updates=None,
+    )
+    query_result = MagicMock()
+    query_result.roles = [active, expired]
+    with patch(f"{_MOD}.roles_query", return_value=query_result):
+        result = SlackUsergroupsIntegration.get_roles(MagicMock())
+    assert [r.name for r in result] == ["active"]
+
+
+# --- compile_users_from_schedule ---
+
+
+def test_compile_users_from_schedule_none() -> None:
+    assert SlackUsergroupsIntegration.compile_users_from_schedule(None) == []
+
+
+def test_compile_users_from_schedule_active_window() -> None:
+    schedule = ScheduleV1(
+        schedule=[
+            ScheduleEntryV1(
+                start="2000-01-01 00:00",
+                end="2100-01-01 00:00",
+                users=[_frag_user("alice"), _frag_user("bob")],
+            )
+        ]
+    )
+    result = SlackUsergroupsIntegration.compile_users_from_schedule(schedule)
+    assert sorted(result) == ["alice", "bob"]
+
+
+def test_compile_users_from_schedule_inactive_window() -> None:
+    schedule = ScheduleV1(
+        schedule=[
+            ScheduleEntryV1(
+                start="2000-01-01 00:00",
+                end="2000-01-02 00:00",
+                users=[_frag_user("alice")],
+            )
+        ]
+    )
+    assert SlackUsergroupsIntegration.compile_users_from_schedule(schedule) == []
+
+
+# --- compile_users_from_roles ---
+
+
+def test_compile_users_from_roles_none() -> None:
+    assert SlackUsergroupsIntegration.compile_users_from_roles(None) == []
+
+
+def test_compile_users_from_roles() -> None:
+    roles = [
+        RoleV1(users=[_frag_user("alice", gov_slack_email_local_part="alice.gov")]),
+        RoleV1(users=[_frag_user("bob")]),
+    ]
+    result = SlackUsergroupsIntegration.compile_users_from_roles(roles)
+    assert sorted(result) == ["alice.gov", "bob"]
+
+
+# --- compute_cluster_user_group + include_user_to_cluster_usergroup ---
+
+
+def test_compute_cluster_user_group() -> None:
+    assert (
+        SlackUsergroupsIntegration.compute_cluster_user_group("app-sre-prod")
+        == "app-sre-prod-cluster"
+    )
+
+
+def _cluster_role(tag: bool | None) -> ClusterAccessRole:
+    return ClusterAccessRole(
+        name="r", access=None, expirationDate=None, users=[], tag_on_cluster_updates=tag
+    )
+
+
+@pytest.mark.parametrize(
+    ("user_tag", "role_tag", "expected"),
+    [
+        (True, False, True),  # user override wins
+        (False, True, False),  # user override wins
+        (None, True, True),  # fall back to role
+        (None, False, False),  # role disables
+        (None, None, True),  # default include
+    ],
+)
+def test_include_user_to_cluster_usergroup(
+    user_tag: bool | None, role_tag: bool | None, expected: bool
+) -> None:
+    user = _cluster_user("alice", tag_on_cluster_updates=user_tag)
+    role = _cluster_role(role_tag)
+    assert (
+        SlackUsergroupsIntegration.include_user_to_cluster_usergroup(user, role)
+        is expected
+    )
+
+
+# --- fetch_owners ---
+
+
+@pytest.mark.asyncio
+async def test_fetch_owners_github_maps_login(
+    integration: SlackUsergroupsIntegration,
+) -> None:
+    users = [_app_user("alice", "AliceGH")]
+    gh_to_org = {"alicegh": "alice"}
+    users_map = {"alice": users[0]}
+    with patch(f"{_MOD}.vcs_repo_owners", new_callable=AsyncMock) as mock_owners:
+        mock_owners.return_value = RepoOwnersResponse(
+            approvers=["alicegh"], reviewers=[], provider=VCSProvider.GITHUB
+        )
+        result = await integration.fetch_owners(
+            "https://github.com/org/repo",
+            _vault_secret(),
+            gh_to_org,
+            users_map,
+        )
+    assert result == ["alice"]
+    # default ref is master
+    assert mock_owners.call_args.kwargs["ref"] == "master"
+
+
+@pytest.mark.asyncio
+async def test_fetch_owners_parses_branch_ref(
+    integration: SlackUsergroupsIntegration,
+) -> None:
+    with patch(f"{_MOD}.vcs_repo_owners", new_callable=AsyncMock) as mock_owners:
+        mock_owners.return_value = RepoOwnersResponse(
+            approvers=[], reviewers=[], provider=VCSProvider.GITHUB
+        )
+        await integration.fetch_owners(
+            "https://github.com/org/repo:main",
+            _vault_secret(),
+            {},
+            {},
+        )
+    assert mock_owners.call_args.kwargs["repo_url"] == "https://github.com/org/repo"
+    assert mock_owners.call_args.kwargs["ref"] == "main"
+
+
+@pytest.mark.asyncio
+async def test_fetch_owners_gitlab_uses_org_username(
+    integration: SlackUsergroupsIntegration,
+) -> None:
+    users = [_app_user("alice", "AliceGH")]
+    users_map = {"alice": users[0]}
+    with patch(f"{_MOD}.vcs_repo_owners", new_callable=AsyncMock) as mock_owners:
+        mock_owners.return_value = RepoOwnersResponse(
+            approvers=["alice"], reviewers=[], provider=VCSProvider.GITLAB
+        )
+        result = await integration.fetch_owners(
+            "https://gitlab.example.com/org/repo",
+            _vault_secret(),
+            {},
+            users_map,
+        )
+    assert result == ["alice"]
+
+
+@pytest.mark.asyncio
+async def test_fetch_owners_excludes_tag_on_merge_requests_false(
+    integration: SlackUsergroupsIntegration,
+) -> None:
+    users = [_app_user("alice", "AliceGH", tag_on_merge_requests=False)]
+    users_map = {"alice": users[0]}
+    with patch(f"{_MOD}.vcs_repo_owners", new_callable=AsyncMock) as mock_owners:
+        mock_owners.return_value = RepoOwnersResponse(
+            approvers=["alice"], reviewers=[], provider=VCSProvider.GITLAB
+        )
+        result = await integration.fetch_owners(
+            "https://gitlab.example.com/org/repo",
+            _vault_secret(),
+            {},
+            users_map,
+        )
+    assert result == []
+
+
+# --- compile_users_from_git_owners ---
+
+
+@pytest.mark.asyncio
+async def test_compile_users_from_git_owners_none(
+    integration: SlackUsergroupsIntegration,
+) -> None:
+    result = await integration.compile_users_from_git_owners(
+        urls=None, vcs_instances=[], app_interface_users=[]
+    )
+    assert result == []
+
+
+@pytest.mark.asyncio
+async def test_compile_users_from_git_owners_aggregates_unique(
+    integration: SlackUsergroupsIntegration,
+) -> None:
+    users = [_app_user("alice", "AliceGH"), _app_user("bob", "BobGH")]
+    with (
+        patch(f"{_MOD}.get_token_from_url", return_value=_vault_secret()),
+        patch(f"{_MOD}.vcs_repo_owners", new_callable=AsyncMock) as mock_owners,
+    ):
+        mock_owners.side_effect = [
+            RepoOwnersResponse(
+                approvers=["alicegh"], reviewers=["bobgh"], provider=VCSProvider.GITHUB
+            ),
+            RepoOwnersResponse(
+                approvers=["alicegh"], reviewers=[], provider=VCSProvider.GITHUB
+            ),
+        ]
+        result = await integration.compile_users_from_git_owners(
+            urls=["https://github.com/o/r1", "https://github.com/o/r2"],
+            vcs_instances=[],
+            app_interface_users=users,
+        )
+    assert sorted(result) == ["alice", "bob"]
+
+
+# --- compile_users_from_pagerduty_schedules ---
+
+
+@pytest.mark.asyncio
+async def test_compile_users_from_pagerduty_none(
+    integration: SlackUsergroupsIntegration,
+) -> None:
+    result = await integration.compile_users_from_pagerduty_schedules(
+        pagerduties=None, app_interface_users=[]
+    )
+    assert result == []
+
+
+@pytest.mark.asyncio
+async def test_compile_users_from_pagerduty_maps_usernames(
+    integration: SlackUsergroupsIntegration,
+) -> None:
+    instance = PagerDutyInstanceV1(token=_vault_secret("secret/pd"))
+    pagerduties = [
+        PagerDutyTargetV1(
+            name="sched",
+            instance=instance,
+            scheduleID="SCHED1",
+            escalationPolicyID=None,
+        ),
+        PagerDutyTargetV1(
+            name="policy",
+            instance=instance,
+            scheduleID=None,
+            escalationPolicyID="POLICY1",
+        ),
+    ]
+    users = [_app_user("alice", "AliceGH", pagerduty_username="alice-pd")]
+    with (
+        patch(f"{_MOD}.pagerduty_schedule_users", new_callable=AsyncMock) as mock_sched,
+        patch(
+            f"{_MOD}.pagerduty_escalation_policy_users", new_callable=AsyncMock
+        ) as mock_policy,
+    ):
+        mock_sched.return_value = ScheduleUsersResponse(
+            users=[PagerDutyUser(username="alice-pd")]
+        )
+        mock_policy.return_value = EscalationPolicyUsersResponse(
+            users=[PagerDutyUser(username="carol")]
+        )
+        result = await integration.compile_users_from_pagerduty_schedules(
+            pagerduties=pagerduties, app_interface_users=users
+        )
+    # alice-pd maps to org_username alice; carol has no mapping -> passthrough
+    assert sorted(result) == ["alice", "carol"]
+
+
+# --- GitHub org membership (APPSRE-15221) ---
+
+
+@pytest.mark.asyncio
+async def test_github_org_none_returns_empty(
+    integration: SlackUsergroupsIntegration,
+) -> None:
+    with (
+        patch(f"{_MOD}.github_org_members", new_callable=AsyncMock) as mock_members,
+        patch(f"{_MOD}.ldap_github_usernames", new_callable=AsyncMock) as mock_ldap,
+    ):
+        result = await integration.compile_users_from_github_org(
+            github_org=None,
+            app_interface_users=[_app_user("alice", "alice-gh")],
+            ldap_settings=_ldap_settings(),
+        )
+    assert result == []
+    mock_members.assert_not_called()
+    mock_ldap.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_github_org_resolves_via_app_interface(
+    integration: SlackUsergroupsIntegration,
+) -> None:
+    users = [
+        _app_user("alice", "AliceGH"),
+        _app_user("bob", "bob-gh", gov_slack_email_local_part="bob.gov"),
+    ]
+    with (
+        patch(f"{_MOD}.github_org_members", new_callable=AsyncMock) as mock_members,
+        patch(f"{_MOD}.ldap_github_usernames", new_callable=AsyncMock) as mock_ldap,
+    ):
+        mock_members.return_value = GithubOrgMembersResponse(
+            members=["alicegh", "bob-gh"]
+        )
+        result = await integration.compile_users_from_github_org(
+            github_org=_github_org(),
+            app_interface_users=users,
+            ldap_settings=_ldap_settings(),
+        )
+    assert result == ["alice", "bob.gov"]
+    mock_ldap.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_github_org_falls_back_to_ldap(
+    integration: SlackUsergroupsIntegration,
+) -> None:
+    users = [_app_user("alice", "AliceGH"), _app_user("carol", "carol-old")]
+    with (
+        patch(f"{_MOD}.github_org_members", new_callable=AsyncMock) as mock_members,
+        patch(f"{_MOD}.ldap_github_usernames", new_callable=AsyncMock) as mock_ldap,
+    ):
+        mock_members.return_value = GithubOrgMembersResponse(
+            members=["AliceGH", "carol-gh"]
+        )
+        mock_ldap.return_value = LdapGithubUsernamesResponse(
+            users=[LdapGithubUser(github_username="carol-gh", org_username="carol")]
+        )
+        result = await integration.compile_users_from_github_org(
+            github_org=_github_org(),
+            app_interface_users=users,
+            ldap_settings=_ldap_settings(),
+        )
+    assert result == ["alice", "carol"]
+    mock_ldap.assert_called_once()
+    request = mock_ldap.call_args.args[0]
+    assert request.logins == ["carol-gh"]
+    assert request.secret.server_url == "ldap://freeipa.example.com"
+    assert request.secret.base_dn == "dc=example,dc=com"
+
+
+@pytest.mark.asyncio
+async def test_github_org_ldap_resolved_user_not_in_app_interface(
+    integration: SlackUsergroupsIntegration,
+) -> None:
+    """A member resolvable only via LDAP (not an app-interface user) must still
+    be added, using their org_username as the Slack identity."""
+    users = [_app_user("alice", "AliceGH")]
+    with (
+        patch(f"{_MOD}.github_org_members", new_callable=AsyncMock) as mock_members,
+        patch(f"{_MOD}.ldap_github_usernames", new_callable=AsyncMock) as mock_ldap,
+    ):
+        mock_members.return_value = GithubOrgMembersResponse(
+            members=["AliceGH", "jiprocha"]
+        )
+        mock_ldap.return_value = LdapGithubUsernamesResponse(
+            users=[LdapGithubUser(github_username="jiprocha", org_username="jiprocha")]
+        )
+        result = await integration.compile_users_from_github_org(
+            github_org=_github_org(),
+            app_interface_users=users,
+            ldap_settings=_ldap_settings(),
+        )
+    assert result == ["alice", "jiprocha"]
+
+
+@pytest.mark.asyncio
+async def test_github_org_logs_and_skips_unresolved(
+    integration: SlackUsergroupsIntegration,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    users = [_app_user("alice", "AliceGH")]
+    with (
+        patch(f"{_MOD}.github_org_members", new_callable=AsyncMock) as mock_members,
+        patch(f"{_MOD}.ldap_github_usernames", new_callable=AsyncMock) as mock_ldap,
+    ):
+        mock_members.return_value = GithubOrgMembersResponse(
+            members=["AliceGH", "ghost"]
+        )
+        mock_ldap.return_value = LdapGithubUsernamesResponse(users=[])
+        result = await integration.compile_users_from_github_org(
+            github_org=_github_org(),
+            app_interface_users=users,
+            ldap_settings=_ldap_settings(),
+        )
+    assert result == ["alice"]
+    # The client-side warning (visible in MR checks) must name the member and
+    # point the reviewer to the Rover fix.
+    assert any(
+        "could not map GitHub member 'ghost'" in record.message
+        and "https://github.com/ghost" in record.message
+        and "Rover" in record.message
+        for record in caplog.records
+    )
+
+
+@pytest.mark.asyncio
+async def test_github_org_no_members_skips_ldap(
+    integration: SlackUsergroupsIntegration,
+) -> None:
+    with (
+        patch(f"{_MOD}.github_org_members", new_callable=AsyncMock) as mock_members,
+        patch(f"{_MOD}.ldap_github_usernames", new_callable=AsyncMock) as mock_ldap,
+    ):
+        mock_members.return_value = GithubOrgMembersResponse(members=[])
+        result = await integration.compile_users_from_github_org(
+            github_org=_github_org(),
+            app_interface_users=[_app_user("alice", "AliceGH")],
+            ldap_settings=_ldap_settings(),
+        )
+    assert result == []
+    mock_ldap.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_resolve_github_logins_via_ldap_empty_input(
+    integration: SlackUsergroupsIntegration,
+) -> None:
+    with patch(f"{_MOD}.ldap_github_usernames", new_callable=AsyncMock) as mock_ldap:
+        result = await integration._resolve_github_logins_via_ldap([], _ldap_settings())
+    assert result == {}
+    mock_ldap.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_resolve_github_logins_via_ldap_missing_credentials(
+    integration: SlackUsergroupsIntegration,
+) -> None:
+    with pytest.raises(RuntimeError, match="LDAP credentials not found"):
+        await integration._resolve_github_logins_via_ldap(
+            ["carol-gh"], _ldap_settings(with_credentials=False)
+        )
+
+
+# --- _process_permission ---
+
+
+@pytest.mark.asyncio
+async def test_process_permission_skip(
+    integration: SlackUsergroupsIntegration,
+) -> None:
+    result = await integration._process_permission(
+        _permission(skip=True), [], [], _ldap_settings(), None, None
+    )
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_process_permission_no_managed_usergroups(
+    integration: SlackUsergroupsIntegration,
+) -> None:
+    permission = _permission(workspace=_workspace(managed=[]))
+    result = await integration._process_permission(
+        permission, [], [], _ldap_settings(), None, None
+    )
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_process_permission_workspace_filter_mismatch(
+    integration: SlackUsergroupsIntegration,
+) -> None:
+    result = await integration._process_permission(
+        _permission(), [], [], _ldap_settings(), "other-workspace", None
+    )
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_process_permission_usergroup_filter_mismatch(
+    integration: SlackUsergroupsIntegration,
+) -> None:
+    result = await integration._process_permission(
+        _permission(), [], [], _ldap_settings(), None, "other-handle"
+    )
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_process_permission_handle_not_managed_raises(
+    integration: SlackUsergroupsIntegration,
+) -> None:
+    # handle differs from the workspace's managed_usergroups entry
+    permission = _permission(
+        handle="team-handle", workspace=_workspace(managed=["different-handle"])
+    )
+    with pytest.raises(KeyError, match="not in 'managedUsergroups'"):
+        await integration._process_permission(
+            permission, [], [], _ldap_settings(), None, None
+        )
+
+
+@pytest.mark.asyncio
+async def test_process_permission_builds_usergroup_with_notifications(
+    integration: SlackUsergroupsIntegration,
+) -> None:
+    permission = _permission(
+        roles=[RoleV1(users=[_frag_user("alice"), _frag_user("bob")])],
+        channels=["#b", "#a", "#a"],
+        notifications=[
+            SlackUsergroupNotificationV1(action="addUser", message="welcome"),
+            SlackUsergroupNotificationV1(action="removeUser", message="bye"),
+        ],
+    )
+    result = await integration._process_permission(
+        permission, [], [], _ldap_settings(), None, None
+    )
+    assert result is not None
+    workspace_name, usergroup = result
+    assert workspace_name == "coreos"
+    assert usergroup.handle == "team-handle"
+    assert usergroup.config.users == ["alice", "bob"]
+    assert usergroup.config.channels == ["#a", "#b"]
+    assert [n.action for n in usergroup.config.notifications] == [
+        "add-user",
+        "remove-user",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_process_permission_unknown_notification_raises(
+    integration: SlackUsergroupsIntegration,
+) -> None:
+    permission = _permission(
+        roles=[RoleV1(users=[_frag_user("alice")])],
+        notifications=[
+            SlackUsergroupNotificationV1(action="bogus", message="x"),
+        ],
+    )
+    with pytest.raises(ValueError, match="Unknown notification action"):
+        await integration._process_permission(
+            permission, [], [], _ldap_settings(), None, None
+        )
+
+
+# --- compile_desired_state_from_permissions ---
+
+
+@pytest.mark.asyncio
+async def test_compile_desired_state_from_permissions_builds_workspace(
+    integration: SlackUsergroupsIntegration,
+) -> None:
+    permission = _permission(roles=[RoleV1(users=[_frag_user("alice")])])
+    workspaces = await integration.compile_desired_state_from_permissions(
+        permissions=[permission],
+        app_interface_users=[],
+        vcs_instances=[],
+        ldap_settings=_ldap_settings(),
+    )
+    assert len(workspaces) == 1
+    ws = workspaces[0]
+    assert ws.name == "coreos"
+    assert ws.default_channel == "#general"
+    assert ws.token.path == "secret/slack/token"
+    assert [ug.handle for ug in ws.usergroups] == ["team-handle"]
+
+
+@pytest.mark.asyncio
+async def test_compile_desired_state_skips_workspace_without_integration(
+    integration: SlackUsergroupsIntegration,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    permission = _permission(
+        roles=[RoleV1(users=[_frag_user("alice")])],
+        workspace=_workspace(managed=["team-handle"], with_integration=False),
+    )
+    workspaces = await integration.compile_desired_state_from_permissions(
+        permissions=[permission],
+        app_interface_users=[],
+        vcs_instances=[],
+        ldap_settings=_ldap_settings(),
+    )
+    assert workspaces == []
+    assert any("no slack-usergroups integration" in r.message for r in caplog.records)
+
+
+# --- compile_desired_state_cluster_usergroups ---
+
+
+def _slack_workspace(name: str = "coreos") -> SlackWorkspace:
+    return SlackWorkspace(
+        name=name,
+        usergroups=[],
+        managed_usergroups=[],
+        default_channel="#general",
+        token=_vault_secret("secret/slack/token"),
+    )
+
+
+def test_cluster_usergroups_from_cluster_group_access(
+    integration: SlackUsergroupsIntegration,
+) -> None:
+    cluster = EnabledClusterV1(name="prod", auth=[], disable=None)
+    role = ClusterAccessRole(
+        name="r",
+        access=[
+            AccessV1(
+                cluster=AccessClusterV1(auth=[], name="prod"),
+                group="prod-admins",
+                namespace=None,
+            )
+        ],
+        expirationDate=None,
+        users=[_cluster_user("alice")],
+        tag_on_cluster_updates=None,
+    )
+    workspaces = integration.compile_desired_state_cluster_usergroups(
+        workspaces=[_slack_workspace()],
+        clusters=[cluster],
+        roles=[role],
+    )
+    ws = workspaces[0]
+    assert [ug.handle for ug in ws.usergroups] == ["prod-cluster"]
+    assert ws.usergroups[0].config.users == ["alice"]
+    # default channel is appended and usergroup registered as managed
+    assert ws.usergroups[0].config.channels == ["#general"]
+    assert "prod-cluster" in ws.managed_usergroups
+
+
+def test_cluster_usergroups_from_namespace_access(
+    integration: SlackUsergroupsIntegration,
+) -> None:
+    cluster = EnabledClusterV1(name="prod", auth=[], disable=None)
+    namespace = NamespaceV1(
+        cluster=NamespaceV1_ClusterV1(name="prod", auth=[]),
+        delete=None,
+        managedRoles=True,
+    )
+    role = ClusterAccessRole(
+        name="r",
+        access=[AccessV1(cluster=None, group=None, namespace=namespace)],
+        expirationDate=None,
+        users=[_cluster_user("alice")],
+        tag_on_cluster_updates=None,
+    )
+    workspaces = integration.compile_desired_state_cluster_usergroups(
+        workspaces=[_slack_workspace()],
+        clusters=[cluster],
+        roles=[role],
+    )
+    assert workspaces[0].usergroups[0].config.users == ["alice"]
+
+
+def test_cluster_usergroups_no_users_skipped(
+    integration: SlackUsergroupsIntegration,
+) -> None:
+    cluster = EnabledClusterV1(name="prod", auth=[], disable=None)
+    workspaces = integration.compile_desired_state_cluster_usergroups(
+        workspaces=[_slack_workspace()],
+        clusters=[cluster],
+        roles=[],
+    )
+    assert workspaces[0].usergroups == []
+
+
+def test_cluster_usergroups_respects_usergroup_filter(
+    integration: SlackUsergroupsIntegration,
+) -> None:
+    cluster = EnabledClusterV1(name="prod", auth=[], disable=None)
+    role = ClusterAccessRole(
+        name="r",
+        access=[
+            AccessV1(
+                cluster=AccessClusterV1(auth=[], name="prod"),
+                group="prod-admins",
+                namespace=None,
+            )
+        ],
+        expirationDate=None,
+        users=[_cluster_user("alice")],
+        tag_on_cluster_updates=None,
+    )
+    workspaces = integration.compile_desired_state_cluster_usergroups(
+        workspaces=[_slack_workspace()],
+        clusters=[cluster],
+        roles=[role],
+        desired_usergroup_name="other-cluster",
+    )
+    assert workspaces[0].usergroups == []
+
+
+# --- reconcile ---
+
+
+@pytest.mark.asyncio
+async def test_reconcile_builds_request_and_returns_response(
+    integration: SlackUsergroupsIntegration,
+) -> None:
+    usergroup = SlackUsergroup(
+        handle="team-handle",
+        config=SlackUsergroupConfig(users=["alice"], channels=["#general"]),
+    )
+    workspace = SlackWorkspace(
+        name="coreos",
+        usergroups=[usergroup],
+        managed_usergroups=["team-handle"],
+        default_channel="#general",
+        token=_vault_secret("secret/slack/token"),
+    )
+    with patch(f"{_MOD}.slack_usergroups", new_callable=AsyncMock) as mock_recon:
+        mock_recon.return_value = SlackUsergroupsTaskResponse(
+            id="req-1", status_url="http://api/status/req-1"
+        )
+        response = await integration.reconcile(workspaces=[workspace], dry_run=True)
+    assert response.id == "req-1"
+    request = mock_recon.call_args.args[0]
+    assert request.dry_run is True
+    assert request.workspaces[0].name == "coreos"
+    assert request.workspaces[0].token.path == "secret/slack/token"
+
+
+# --- async_run ---
+
+
+def _patch_async_run_deps(
+    integration: SlackUsergroupsIntegration,
+    *,
+    workspaces: list[SlackWorkspace],
+) -> tuple:
+    """Patch the gql-backed inputs and compilation steps of async_run."""
+    return (
+        patch(f"{_MOD}.gql"),
+        patch.object(type(integration), "get_permissions", return_value=[]),
+        patch.object(type(integration), "get_users", return_value=[]),
+        patch.object(type(integration), "get_clusters", return_value=[]),
+        patch.object(type(integration), "get_roles", return_value=[]),
+        patch(f"{_MOD}.get_vcs_instances", return_value=[]),
+        patch(f"{_MOD}.get_ldap_settings", return_value=_ldap_settings()),
+        patch.object(
+            integration,
+            "compile_desired_state_from_permissions",
+            new=AsyncMock(return_value=workspaces),
+        ),
+        patch.object(
+            integration,
+            "compile_desired_state_cluster_usergroups",
+            return_value=workspaces,
+        ),
+    )
+
+
+@pytest.mark.asyncio
+async def test_async_run_no_workspaces_returns_early(
+    integration: SlackUsergroupsIntegration,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    patches = _patch_async_run_deps(integration, workspaces=[])
+    with (
+        patches[0],
+        patches[1],
+        patches[2],
+        patches[3],
+        patches[4],
+        patches[5],
+        patches[6],
+        patches[7],
+        patches[8],
+        patch.object(integration, "reconcile", new=AsyncMock()) as mock_recon,
+    ):
+        await integration.async_run(dry_run=True)
+    mock_recon.assert_not_called()
+    assert any("No desired state found" in r.message for r in caplog.records)
+
+
+@pytest.mark.asyncio
+async def test_async_run_apply_does_not_poll(
+    integration: SlackUsergroupsIntegration,
+) -> None:
+    workspaces = [_slack_workspace()]
+    patches = _patch_async_run_deps(integration, workspaces=workspaces)
+    task_response = SlackUsergroupsTaskResponse(id="r", status_url="http://api/s")
+    with (
+        patches[0],
+        patches[1],
+        patches[2],
+        patches[3],
+        patches[4],
+        patches[5],
+        patches[6],
+        patches[7],
+        patches[8],
+        patch.object(
+            integration, "reconcile", new=AsyncMock(return_value=task_response)
+        ) as mock_recon,
+        patch.object(integration, "poll_task_status", new=AsyncMock()) as mock_poll,
+    ):
+        await integration.async_run(dry_run=False)
+    mock_recon.assert_awaited_once()
+    assert mock_recon.call_args.kwargs["dry_run"] is False
+    mock_poll.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_async_run_dry_run_polls_and_logs_actions(
+    integration: SlackUsergroupsIntegration,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    workspaces = [_slack_workspace()]
+    patches = _patch_async_run_deps(integration, workspaces=workspaces)
+    task_response = SlackUsergroupsTaskResponse(id="r", status_url="http://api/s")
+    task_result = SlackUsergroupsTaskResult(
+        status=TaskStatus.SUCCESS,
+        actions=[
+            SlackUsergroupActionCreate(
+                description="d", usergroup="ug", users=["alice"], workspace="coreos"
+            ),
+            SlackUsergroupActionUpdateUsers(
+                usergroup="ug",
+                users=["alice"],
+                users_to_add=["alice"],
+                users_to_remove=[],
+                workspace="coreos",
+            ),
+            SlackUsergroupActionUpdateMetadata(
+                channels=["#general"],
+                description="d",
+                usergroup="ug",
+                workspace="coreos",
+            ),
+        ],
+    )
+    with (
+        patches[0],
+        patches[1],
+        patches[2],
+        patches[3],
+        patches[4],
+        patches[5],
+        patches[6],
+        patches[7],
+        patches[8],
+        patch.object(
+            integration, "reconcile", new=AsyncMock(return_value=task_response)
+        ),
+        patch.object(
+            integration, "poll_task_status", new=AsyncMock(return_value=task_result)
+        ) as mock_poll,
+    ):
+        await integration.async_run(dry_run=True)
+    mock_poll.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_async_run_pending_task_exits(
+    integration: SlackUsergroupsIntegration,
+) -> None:
+    workspaces = [_slack_workspace()]
+    patches = _patch_async_run_deps(integration, workspaces=workspaces)
+    task_response = SlackUsergroupsTaskResponse(id="r", status_url="http://api/s")
+    task_result = SlackUsergroupsTaskResult(status=TaskStatus.PENDING, actions=[])
+    with (
+        patches[0],
+        patches[1],
+        patches[2],
+        patches[3],
+        patches[4],
+        patches[5],
+        patches[6],
+        patches[7],
+        patches[8],
+        patch.object(
+            integration, "reconcile", new=AsyncMock(return_value=task_response)
+        ),
+        patch.object(
+            integration, "poll_task_status", new=AsyncMock(return_value=task_result)
+        ),
+        pytest.raises(SystemExit),
+    ):
+        await integration.async_run(dry_run=True)
+
+
+@pytest.mark.asyncio
+async def test_async_run_errors_exit(
+    integration: SlackUsergroupsIntegration,
+) -> None:
+    workspaces = [_slack_workspace()]
+    patches = _patch_async_run_deps(integration, workspaces=workspaces)
+    task_response = SlackUsergroupsTaskResponse(id="r", status_url="http://api/s")
+    task_result = SlackUsergroupsTaskResult(
+        status=TaskStatus.SUCCESS, actions=[], errors=["boom"]
+    )
+    with (
+        patches[0],
+        patches[1],
+        patches[2],
+        patches[3],
+        patches[4],
+        patches[5],
+        patches[6],
+        patches[7],
+        patches[8],
+        patch.object(
+            integration, "reconcile", new=AsyncMock(return_value=task_response)
+        ),
+        patch.object(
+            integration, "poll_task_status", new=AsyncMock(return_value=task_result)
+        ),
+        pytest.raises(SystemExit),
+    ):
+        await integration.async_run(dry_run=True)

--- a/reconcile/test/test_slack_usergroups_api.py
+++ b/reconcile/test/test_slack_usergroups_api.py
@@ -8,6 +8,7 @@ orchestration (dry-run vs apply, polling, error handling).
 
 from __future__ import annotations
 
+import logging
 from typing import TYPE_CHECKING
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -750,23 +751,31 @@ async def test_github_org_logs_and_skips_unresolved(
         patch(f"{_MOD}.ldap_github_usernames", new_callable=AsyncMock) as mock_ldap,
     ):
         mock_members.return_value = GithubOrgMembersResponse(
-            members=["AliceGH", "ghost"]
+            members=["AliceGH", "ghost", "phantom"]
         )
         mock_ldap.return_value = LdapGithubUsernamesResponse(users=[])
-        result = await integration.compile_users_from_github_org(
-            github_org=_github_org(),
-            app_interface_users=users,
-            ldap_settings=_ldap_settings(),
-        )
+        with caplog.at_level(logging.WARNING):
+            result = await integration.compile_users_from_github_org(
+                github_org=_github_org(),
+                app_interface_users=users,
+                ldap_settings=_ldap_settings(),
+            )
     assert result == ["alice"]
-    # The client-side warning (visible in MR checks) must name the member and
-    # point the reviewer to the Rover fix.
-    assert any(
-        "could not map GitHub member 'ghost'" in record.message
-        and "https://github.com/ghost" in record.message
-        and "Rover" in record.message
-        for record in caplog.records
-    )
+    # Exactly ONE aggregated warning per org (keeps the #reconcile channel
+    # quiet), but every unmapped GitHub username stays visible so the MR author
+    # sees them in the app-interface MR check output, with the Rover fix hint.
+    warnings = [
+        r
+        for r in caplog.records
+        if r.levelno == logging.WARNING and "could not map" in r.message
+    ]
+    assert len(warnings) == 1
+    message = warnings[0].message
+    assert "ghost" in message
+    assert "phantom" in message
+    assert "https://github.com/ghost" in message
+    assert "https://github.com/phantom" in message
+    assert "Rover" in message
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Add **GitHub organization membership** as a source of truth for Slack usergroup members ([APPSRE-15221](https://redhat.atlassian.net/browse/APPSRE-15221)).

Use case: broadcasting to all members of a GitHub org (e.g. security announcements) without maintaining a parallel member list in app-interface.

GitHub org members are resolved to Red Hat `org_username`s in two stages:

1. **app-interface `github_username`** — the primary mapping.
2. **LDAP `rhatSocialURL` fallback** — for members not present in app-interface, the GitHub login is resolved to a Red Hat uid via the `rhatSocialURL` attribute (`Github->https://github.com/<login>`), scoped to `cn=users,cn=accounts`.

Members that cannot be resolved by either stage are **logged and skipped**. The client-side warning lists every unmapped member's GitHub profile URL and a hint to add it to their Rover page, so the message is actionable in app-interface MR check output (which only surfaces client integration logs).

### Change set (bottom-up across the three layers)

- **`reconcile/` GraphQL query** — new optional `github` field (org name + Vault token) on the slack-usergroups permission query.
- **`qontract_utils/` (Layer 1)** — stateless API clients: `github_org` (fetch org members) and `ldap_api` (resolve GitHub logins to uids via `rhatSocialURL`, accepting only bare `github.com/<login>` profile URLs and preserving original login casing; the lookup is paged via the RFC 2696 paged results control).
- **`qontract_api/` (Layer 2 + routers)** — workspace clients + external endpoints: `GET /api/v1/external/github-org/members` and `GET /api/v1/external/ldap/github-usernames` (cached with a dedicated TTL, guarded by the double-check locking pattern).
- **`qontract_api_client/`** — regenerated client for the new endpoints.
- **`reconcile/slack_usergroups_api.py`** — resolve org members client-side, honoring an app-interface user's Slack identity override (`gov_slack_email_local_part`) when present and otherwise using the LDAP-resolved `org_username` directly.
- **Fluentd config** — exclude the aggregated "could not map N GitHub member(s)" warning from the aggregated log stream (same treatment as the `request_id` exclusion), across `template.yaml`, the rendered `openshift/` manifests, and the golden helm fixtures.
- **Docs** — document the new source of truth and mapping behavior.

### Precise LDAP fallback

- **Bare-profile-only parsing + scoped ambiguity** (`ldap_api` + `qontract_api`, decbe09f) — associates link many kinds of `github.com` URLs in `rhatSocialURL`: their own profile, their own repos, organizations they belong to, and other people's repos. The parser previously took the first path segment of *any* github.com URL, which conflated all four — attributing org names (stackrox, openshift, …) or another user's repo owner to the linking associate, and logging an ambiguity warning for every ambiguous directory key at map-build time regardless of the org being reconciled. Now:
  - Layer 1 `_parse_github_login` accepts **only** a bare `github.com/<login>` URL (exactly one path segment). A repo owner also links their bare profile, so no genuine login is lost, but org / other-repo names are no longer misattributed.
  - Layer 1 `get_github_usernames` returns `dict[str, list[str]]`, grouping every uid that claims a (lowercased) login — pure data extraction, no dropping/logging.
  - Layer 2 `resolve_github_usernames` applies the ambiguity policy **scoped to the requested logins**: a requested login mapping to >1 uid is skipped and logged once; ambiguity on unrelated directory entries never reaches the logs.

### Review follow-ups (CodeRabbit)

- **Ambiguous GitHub logins** (`ldap_api`, 1c8044ab) — a GitHub login that maps case-insensitively to more than one distinct LDAP uid is now omitted from the mapping and logged, instead of letting arbitrary LDAP result order pick a winner. Added regression tests. (Superseded by the scoped-ambiguity handling in decbe09f above.)
- **Response contract** (`qontract_api`, ae4dc4e6) — `GithubOrgMembersResponse.members` and `LdapGithubUsernamesResponse.users` are now `Field(...)` (required) rather than `default_factory=list`, so the schema, `openapi.json`, and generated client all agree they are always present. Client regenerated (no diff).
- **Typed test fixtures** (`qontract_api`, 3c9f42d7) — the github-org and ldap github-usernames router tests build their request fixtures from `GithubOrgMembersParams` / `LdapGithubUsernamesRequest` / `LdapDirectSecret` and serialize via `model_dump`, so a schema change fails the fixture at construction instead of drifting silently.
- **Raw ldap3 entry contract** (`ldap_api`) — declined: `_paged_search` returns the generic ldap3 search-result entries consumed in-module (identical to the shape `get_users`/`get_group_members` already consume inline); the typed Pydantic contracts live at the boundary (`LdapUser`/`LdapGroup`/`LdapGithubUser`).

### Review follow-ups (hemslo)

- **Paginate LDAP lookup** (`ldap_api`, 6a4a0b01) — 389 Directory Server caps a single search response at ~2000 entries, so the unpaged `rhatSocialURL` lookup silently dropped associates past that limit. The lookup now uses the RFC 2696 paged results control (page size 1000), looping on the cookie until exhausted. Added a regression test asserting results merge across pages.
- **Invalidate both member caches** (`qontract_api`, d9097547) — `add_member_as_admin` cleared only the `:members` key; the `:all-members` key consumed by slack-usergroups was left stale until TTL. `_clear_cache` now invalidates both keys (each under a key-scoped lock).
- **Aggregate the unmapped-member warning** (`slack-usergroups`, 12bd1b17) — instead of one warning line per unmapped member, emit a single warning per org that still lists every unmapped login with its github.com profile URL, so MR-check output keeps full visibility for the MR author. The fluentd exclusion filter was updated to match the aggregated message (`could not map \d+ GitHub member`) and the openshift manifests regenerated.
- **Docs in sync with aggregated warning** (`docs`, 8fb87da0) — the GitHub-org-members doc section now describes the single aggregated per-org warning (listing every unresolved login) instead of one warning per login.
- **Cache partition by credential** — declined: in app-interface each GitHub org maps 1:1 to a credential, so the org-scoped cache key cannot collide across credentials.
- **Conditional LDAP settings load** — declined: the integration always needs LDAP settings to resolve org members, so an unconditional load is simplest.

## Test plan

- `make linter-test` — ruff check + format, clean.
- `make types-test` — mypy strict, clean.
- `make helm-test` — helm lint + `git diff --exit-code helm openshift`, clean (rendered manifests + fixtures regenerated).
- `make unittest` — reconcile + qontract_utils suites pass, including a comprehensive `reconcile/test/test_slack_usergroups_api.py` covering all user sources, permission processing, workspace assembly, and `async_run` orchestration (dry-run / apply / polling / errors), plus the github-org resolution paths.
- `qontract_api` and `qontract_utils` package `make test` pass (mypy + ruff + openapi-diff + pytest), including the new LDAP pagination, both-cache-invalidation, and scoped-ambiguity regression tests.

Verified against live LDAP that an org member present only in LDAP (valid `rhatSocialURL`, absent from app-interface) is now resolved rather than skipped.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added GitHub organization membership support for Slack user groups.
  * Added authenticated APIs for retrieving organization members and resolving GitHub usernames to LDAP users.
  * Added case-insensitive matching, caching, and LDAP fallback for membership resolution.
  * Added GitHub organization and token fields to Slack user group permissions.
* **Bug Fixes**
  * Unresolved or ambiguous members are skipped without interrupting processing, with consolidated warnings.
  * Reduced forwarding of expected member-mapping messages in integration logs.
* **Documentation**
  * Updated integration documentation with membership sources, workflows, validation, and API details.
* **Tests**
  * Added coverage for membership, LDAP resolution, caching, authentication, and fallback behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
