### PR TITLE
fix: point stale dev-guidelines links at app-interface directly

### DIFF
--- a/reconcile/aus/advanced_upgrade_service.py
+++ b/reconcile/aus/advanced_upgrade_service.py
@@ -282,7 +282,7 @@ def _build_org_upgrade_specs_for_ocm_env(
 def aus_label_key(config_atom: str | None = None) -> str:
     """
     Generates label keys for aus, compliant with the naming schema defined in
-    https://service.pages.redhat.com/dev-guidelines/docs/sre-capabilities/framework/ocm-labels/
+    https://gitlab.cee.redhat.com/service/app-interface/-/blob/master/docs/platform-users/platform-services/sre-capabilities/ocm-labels.md
     """
     return sre_capability_label_key("aus", config_atom)
 

--- a/reconcile/oum/standalone.py
+++ b/reconcile/oum/standalone.py
@@ -136,7 +136,7 @@ class OCMStandaloneUserManagementIntegration(OCMUserManagementIntegration):
 def user_mgmt_label_key(config_atom: str) -> str:
     """
     Generates label keys for the user management authz capability, compliant with the naming
-    scheme defined in https://service.pages.redhat.com/dev-guidelines/docs/sre-capabilities/framework/ocm-labels/
+    scheme defined in https://gitlab.cee.redhat.com/service/app-interface/-/blob/master/docs/platform-users/platform-services/sre-capabilities/ocm-labels.md
     """
     return sre_capability_label_key("user-mgmt", config_atom)
 

--- a/reconcile/rhidp_api/common.py
+++ b/reconcile/rhidp_api/common.py
@@ -26,7 +26,7 @@ if TYPE_CHECKING:
     from reconcile.gql_definitions.fragments.ocm_environment import OCMEnvironment
 
 # Generates label keys for rhidp, compliant with the naming schema defined in
-# https://service.pages.redhat.com/dev-guidelines/docs/sre-capabilities/framework/ocm-labels/
+# https://gitlab.cee.redhat.com/service/app-interface/-/blob/master/docs/platform-users/platform-services/sre-capabilities/ocm-labels.md
 RHIDP_NAMESPACE_LABEL_KEY = sre_capability_label_key("rhidp")
 STATUS_LABEL_KEY = sre_capability_label_key("rhidp", "status")
 ISSUER_LABEL_KEY = sre_capability_label_key("rhidp", "issuer")

--- a/reconcile/utils/ocm/sre_capability_labels.py
+++ b/reconcile/utils/ocm/sre_capability_labels.py
@@ -20,7 +20,7 @@ def sre_capability_label_key(
 ) -> str:
     """
     Generates label keys compliant with the naming schema defined in
-    https://service.pages.redhat.com/dev-guidelines/docs/sre-capabilities/framework/ocm-labels/
+    https://gitlab.cee.redhat.com/service/app-interface/-/blob/master/docs/platform-users/platform-services/sre-capabilities/ocm-labels.md
     """
     if config_atom is None:
         return f"sre-capabilities.{sre_capability}"


### PR DESCRIPTION
## Summary
- `service/dev-guidelines` has been archived and its Pages site no longer serves content (404s)
- Its docs were migrated into `app-interface` back in January
- Point the 4 remaining naming-schema doc references at the doc's new home instead of the dead site

## Ticket
APPSRE-15229

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated references to the OCM labels naming schema documentation across reconciliation components.
  * Replaced outdated documentation links with the current app-interface documentation URL.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->