### PR TITLE
chore(acs): regenerate ACS GraphQL Models after Schema changes

### DIFF
--- a/reconcile/acs_policies.py
+++ b/reconcile/acs_policies.py
@@ -188,8 +188,7 @@ class AcsPoliciesIntegration(
             self._build_policy(gql_policy, notifier_name_to_id, cluster_name_to_id)
             for gql_policy in gql_acs_policies.query(query_func=query_func).acs_policies
             or []
-            if gql_policy.instance is not None
-            and gql_policy.instance.name == instance_name
+            if gql_policy.instance.name == instance_name
         ]
 
     def reconcile(

--- a/reconcile/acs_rbac.py
+++ b/reconcile/acs_rbac.py
@@ -166,10 +166,7 @@ class AcsRbacIntegration(QontractReconcileIntegration[AcsIntegrationParams]):
             for role in user.roles or []:
                 for permission in role.oidc_permissions or []:
                     if isinstance(permission, OidcPermissionAcsV1):
-                        if (
-                            permission.instance is None
-                            or permission.instance.name != instance_name
-                        ):
+                        if permission.instance.name != instance_name:
                             continue
                         permission_usernames[
                             Permission(**permission.model_dump(by_alias=True))

--- a/reconcile/gql_definitions/acs/acs_policies.py
+++ b/reconcile/gql_definitions/acs/acs_policies.py
@@ -134,7 +134,7 @@ class AcsPolicyConditionsImageAgeV1(AcsPolicyConditionsV1):
 
 class AcsPolicyV1(ConfiguredBaseModel):
     name: str = Field(..., alias="name")
-    instance: Optional[AcsInstanceV1] = Field(..., alias="instance")
+    instance: AcsInstanceV1 = Field(..., alias="instance")
     description: Optional[str] = Field(..., alias="description")
     severity: str = Field(..., alias="severity")
     categories: list[str] = Field(..., alias="categories")

--- a/reconcile/gql_definitions/acs/acs_rbac.py
+++ b/reconcile/gql_definitions/acs/acs_rbac.py
@@ -80,7 +80,7 @@ class NamespaceV1(ConfiguredBaseModel):
 
 
 class OidcPermissionAcsV1(OidcPermissionV1):
-    instance: Optional[AcsInstanceV1] = Field(..., alias="instance")
+    instance: AcsInstanceV1 = Field(..., alias="instance")
     permission_set: str = Field(..., alias="permission_set")
     clusters: Optional[list[ClusterV1]] = Field(..., alias="clusters")
     namespaces: Optional[list[NamespaceV1]] = Field(..., alias="namespaces")

--- a/reconcile/gql_definitions/introspection.json
+++ b/reconcile/gql_definitions/introspection.json
@@ -8833,9 +8833,13 @@
                             "description": null,
                             "args": [],
                             "type": {
-                                "kind": "OBJECT",
-                                "name": "AcsInstance_v1",
-                                "ofType": null
+                                "kind": "NON_NULL",
+                                "name": null,
+                                "ofType": {
+                                    "name": "AcsInstance_v1",
+                                    "kind": "OBJECT",
+                                    "ofType": null
+                                }
                             },
                             "isDeprecated": false,
                             "deprecationReason": null
@@ -34632,9 +34636,13 @@
                             "description": null,
                             "args": [],
                             "type": {
-                                "kind": "OBJECT",
-                                "name": "AcsInstance_v1",
-                                "ofType": null
+                                "kind": "NON_NULL",
+                                "name": null,
+                                "ofType": {
+                                    "name": "AcsInstance_v1",
+                                    "kind": "OBJECT",
+                                    "ofType": null
+                                }
                             },
                             "isDeprecated": false,
                             "deprecationReason": null

--- a/reconcile/test/test_acs_policies.py
+++ b/reconcile/test/test_acs_policies.py
@@ -484,28 +484,3 @@ def test_get_desired_state_filters_by_instance(
         clusters=api_response_list_clusters,
     )
     assert result == []
-
-
-def test_get_desired_state_excludes_policies_without_instance(
-    mocker: MockerFixture,
-    query_data_desired_state: AcsPolicyQueryData,
-    api_response_list_notifiers: list[AcsPolicyApi.NotifierIdentifiers],
-    api_response_list_clusters: list[AcsPolicyApi.ClusterIdentifiers],
-) -> None:
-    # Strict filter: policies with instance=None are excluded
-    for policy in query_data_desired_state.acs_policies or []:
-        policy.instance = None
-
-    query_func = mocker.patch(
-        "reconcile.gql_definitions.acs.acs_policies.query", autospec=True
-    )
-    query_func.return_value = query_data_desired_state
-
-    integration = AcsPoliciesIntegration()
-    result = integration.get_desired_state(
-        query_func=query_func,
-        instance_name="app-sre-acs",
-        notifiers=api_response_list_notifiers,
-        clusters=api_response_list_clusters,
-    )
-    assert result == []

--- a/reconcile/test/test_acs_rbac.py
+++ b/reconcile/test/test_acs_rbac.py
@@ -919,23 +919,3 @@ def test_get_desired_state_filters_by_instance(
     result = integration.get_desired_state(query_func, "other-instance")
 
     assert result == []
-
-
-def test_get_desired_state_excludes_permissions_without_instance(
-    mocker: MockerFixture,
-    query_data_desired_state: AcsRbacQueryData,
-) -> None:
-    # Strict filter: permissions with instance=None are excluded
-    for user in query_data_desired_state.acs_rbacs or []:
-        for role in user.roles or []:
-            for perm in role.oidc_permissions or []:
-                if isinstance(perm, OidcPermissionAcsV1):
-                    perm.instance = None
-
-    query_func = mocker.patch("reconcile.acs_rbac.acs_rbac_query", autospec=True)
-    query_func.return_value = query_data_desired_state
-
-    integration = AcsRbacIntegration()
-    result = integration.get_desired_state(query_func, "app-sre-acs")
-
-    assert result == []


### PR DESCRIPTION
## Summary

This PR regenerates the GraphQL Python models for ACS (Advanced Cluster Security). The qontract-schemas repo made the `instance` field required on `AcsPolicy_v1` and `OidcPermissionAcs_v1`.

REF: https://redhat.atlassian.net/browse/APPSRE-14643

---

## Context

The qontract-schemas repository merged commit `9fd9c78` on August 18, 2026:
> "chore(acs): make instance Required for ACS Policies and Permissions (#1054)"

This schema change set `isRequired: true` on the `instance` field for both ACS GraphQL types. The generated Python models in qontract-reconcile did not match the updated schema. This PR regenerates them.

---

## Changes

### Generated Files (via `make gql-query-classes`)

**`reconcile/gql_definitions/acs/acs_policies.py`**
- Changed `instance: Optional[AcsInstanceV1]` → `instance: AcsInstanceV1` on `AcsPolicyV1`

**`reconcile/gql_definitions/acs/acs_rbac.py`**
- Changed `instance: Optional[AcsInstanceV1]` → `instance: AcsInstanceV1` on `OidcPermissionAcsV1`

**`reconcile/gql_definitions/introspection.json`**
- Updated to reflect the schema change (large JSON diff, reflects the full GraphQL introspection result)

**Type Error Fixes**
- `reconcile/acs_policies.py` - Removed redundant `is not None` check (line 191)
- `reconcile/acs_rbac.py` - Removed redundant `is None or` check (line 169-171)
- `reconcile/test/test_acs_policies.py` 
   - Deleted `test_get_desired_state_excludes_policies_without_instance` (tests impossible scenario)
- `reconcile/test/test_acs_rbac.py`
   - Deleted `test_get_desired_state_excludes_permissions_without_instance` (tests impossible scenario)

---

## Dependencies

- https://gitlab.cee.redhat.com/service/app-interface/-/merge_requests/202408

---

## Testing

- [x] Generated files pass `make format`
- [x] Generated files pass `make linter-test`
- [x] Generated files pass `make types-test`
- [x] Generated files pass `make unittest`
- [x] Verify app-interface data has been migrated (Phase 3 complete)
- [x] Run `qontract-reconcile acs-rbac --dry-run` to verify RBAC query succeeds
- [x] Run `qontract-reconcile acs-policies --dry-run` to verify policies query succeeds


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Schema Updates**
  - ACS policy and OIDC permission records now require an associated ACS instance.
  - GraphQL introspection now identifies the relevant ACS instance fields as non-nullable.

- **Compatibility**
  - Requests or responses that omit the ACS instance, or provide a null value, may no longer conform to the schema.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->