### PR TITLE
fix(openshift): defer validation for missing namespaces

### DIFF
--- a/reconcile/openshift_base.py
+++ b/reconcile/openshift_base.py
@@ -1179,11 +1179,13 @@ def _validate_resources_used_exist(
     kind: str,
     name: str,
     used_kind: str,
+    namespace_exists_cache: dict[tuple[str, str], bool],
 ) -> None:
     used_resources = oc.get_resources_used_in_pod_spec(
         spec, used_kind, include_optional=False
     )
     for used_name, used_keys in used_resources.items():
+        err_base = f"[{cluster}/{namespace}] [{kind}/{name}] {used_kind} {used_name}"
         # perhaps used resource is deployed together with the using resource?
         desired_resource = ri.get_desired(cluster, namespace, used_kind, used_name)
         # if not, perhaps it's a secret that will be created from a Service's
@@ -1221,10 +1223,22 @@ def _validate_resources_used_exist(
             resource = desired_resource.body
         else:
             # no. perhaps used resource exists in the namespace?
+            if namespace != "cluster":
+                namespace_key = (cluster, namespace)
+                if (
+                    namespace_exists := namespace_exists_cache.get(namespace_key)
+                ) is None:
+                    namespace_exists = oc.project_exists(namespace)
+                    namespace_exists_cache[namespace_key] = namespace_exists
+                if not namespace_exists:
+                    logging.warning(
+                        f"{err_base} namespace does not exist; "
+                        "skipping planned resource validation"
+                    )
+                    continue
             resource = oc.get(
                 namespace, used_kind, name=used_name, allow_not_found=True
             )
-        err_base = f"[{cluster}/{namespace}] [{kind}/{name}] {used_kind} {used_name}"
         if not resource:
             # no. where is used resource hiding? we can't find it anywhere
             logging.error(f"{err_base} does not exist")
@@ -1243,6 +1257,7 @@ def _validate_resources_used_exist(
 
 
 def validate_planned_data(ri: ResourceInventory, oc_map: ClusterMap) -> None:
+    namespace_exists_cache: dict[tuple[str, str], bool] = {}
     for cluster, namespace, kind, data in ri:
         oc = oc_map.get_cluster(cluster)
 
@@ -1250,10 +1265,26 @@ def validate_planned_data(ri: ResourceInventory, oc_map: ClusterMap) -> None:
             if kind in {"Deployment", "DeploymentConfig"}:
                 spec = d_item.body["spec"]["template"]["spec"]
                 _validate_resources_used_exist(
-                    ri, oc, spec, cluster, namespace, kind, name, "Secret"
+                    ri,
+                    oc,
+                    spec,
+                    cluster,
+                    namespace,
+                    kind,
+                    name,
+                    "Secret",
+                    namespace_exists_cache,
                 )
                 _validate_resources_used_exist(
-                    ri, oc, spec, cluster, namespace, kind, name, "ConfigMap"
+                    ri,
+                    oc,
+                    spec,
+                    cluster,
+                    namespace,
+                    kind,
+                    name,
+                    "ConfigMap",
+                    namespace_exists_cache,
                 )
 
 

--- a/reconcile/test/test_openshift_base.py
+++ b/reconcile/test/test_openshift_base.py
@@ -952,6 +952,228 @@ def build_openshift_resource_2() -> resource.OpenshiftResource:
     )
 
 
+def test_validate_resources_used_exist_skips_missing_namespace(
+    resource_inventory: resource.ResourceInventory,
+    oc_cs1: MagicMock,
+) -> None:
+    oc_cs1.get_resources_used_in_pod_spec.return_value = {
+        "missing-secret": {"required-key"}
+    }
+    oc_cs1.project_exists.return_value = False
+
+    sut._validate_resources_used_exist(
+        resource_inventory,
+        oc_cs1,
+        {"containers": []},
+        "cs1",
+        "ns1",
+        "Deployment",
+        "deployment",
+        "Secret",
+        {},
+    )
+
+    assert not resource_inventory.has_error_registered()
+    oc_cs1.project_exists.assert_called_once_with("ns1")
+    oc_cs1.get.assert_not_called()
+
+
+@pytest.mark.parametrize("used_kind", ["Secret", "ConfigMap"])
+def test_validate_resources_used_exist_reports_missing_resource(
+    resource_inventory: resource.ResourceInventory,
+    oc_cs1: MagicMock,
+    used_kind: str,
+) -> None:
+    oc_cs1.get_resources_used_in_pod_spec.return_value = {
+        f"missing-{used_kind.lower()}": set()
+    }
+    oc_cs1.project_exists.return_value = True
+    oc_cs1.get.return_value = {}
+
+    sut._validate_resources_used_exist(
+        resource_inventory,
+        oc_cs1,
+        {"containers": []},
+        "cs1",
+        "ns1",
+        "Deployment",
+        "deployment",
+        used_kind,
+        {},
+    )
+
+    assert resource_inventory.has_error_registered()
+    oc_cs1.project_exists.assert_called_once_with("ns1")
+    oc_cs1.get.assert_called_once_with(
+        "ns1",
+        used_kind,
+        name=f"missing-{used_kind.lower()}",
+        allow_not_found=True,
+    )
+
+
+def test_validate_resources_used_exist_preserves_resource_errors(
+    resource_inventory: resource.ResourceInventory,
+    oc_cs1: MagicMock,
+) -> None:
+    oc_cs1.get_resources_used_in_pod_spec.return_value = {"secret": set()}
+    oc_cs1.project_exists.return_value = True
+    oc_cs1.get.side_effect = oc.StatusCodeError("Forbidden")
+
+    with pytest.raises(oc.StatusCodeError, match="Forbidden"):
+        sut._validate_resources_used_exist(
+            resource_inventory,
+            oc_cs1,
+            {"containers": []},
+            "cs1",
+            "ns1",
+            "Deployment",
+            "deployment",
+            "Secret",
+            {},
+        )
+
+
+def test_validate_resources_used_exist_preserves_namespace_errors(
+    resource_inventory: resource.ResourceInventory,
+    oc_cs1: MagicMock,
+) -> None:
+    oc_cs1.get_resources_used_in_pod_spec.return_value = {"secret": set()}
+    oc_cs1.project_exists.side_effect = oc.StatusCodeError("Forbidden")
+
+    with pytest.raises(oc.StatusCodeError, match="Forbidden"):
+        sut._validate_resources_used_exist(
+            resource_inventory,
+            oc_cs1,
+            {"containers": []},
+            "cs1",
+            "ns1",
+            "Deployment",
+            "deployment",
+            "Secret",
+            {},
+        )
+
+    oc_cs1.get.assert_not_called()
+
+
+def test_validate_resources_used_exist_validates_desired_resource_keys(
+    resource_inventory: resource.ResourceInventory,
+    oc_cs1: MagicMock,
+) -> None:
+    resource_inventory.initialize_resource_type("cs1", "ns1", "Secret")
+    resource_inventory.add_desired(
+        "cs1",
+        "ns1",
+        "Secret",
+        "secret",
+        build_openshift_resource(
+            kind="Secret", api_version="v1", name="secret", extra_body={"data": {}}
+        ),
+    )
+    oc_cs1.get_resources_used_in_pod_spec.return_value = {"secret": {"required-key"}}
+
+    sut._validate_resources_used_exist(
+        resource_inventory,
+        oc_cs1,
+        {"containers": []},
+        "cs1",
+        "ns1",
+        "Deployment",
+        "deployment",
+        "Secret",
+        {},
+    )
+
+    assert resource_inventory.has_error_registered()
+    oc_cs1.project_exists.assert_not_called()
+    oc_cs1.get.assert_not_called()
+
+
+def test_validate_resources_used_exist_validates_serving_cert_keys(
+    resource_inventory: resource.ResourceInventory,
+    oc_cs1: MagicMock,
+) -> None:
+    resource_inventory.initialize_resource_type("cs1", "ns1", "Service")
+    resource_inventory.add_desired(
+        "cs1",
+        "ns1",
+        "Service",
+        "service",
+        build_openshift_resource(
+            kind="Service",
+            api_version="v1",
+            name="service",
+            extra_body={
+                "metadata": {
+                    "annotations": {
+                        "service.beta.openshift.io/serving-cert-secret-name": "secret"
+                    }
+                }
+            },
+        ),
+    )
+    oc_cs1.get_resources_used_in_pod_spec.return_value = {"secret": {"required-key"}}
+
+    sut._validate_resources_used_exist(
+        resource_inventory,
+        oc_cs1,
+        {"containers": []},
+        "cs1",
+        "ns1",
+        "Deployment",
+        "deployment",
+        "Secret",
+        {},
+    )
+
+    assert resource_inventory.has_error_registered()
+    oc_cs1.project_exists.assert_not_called()
+    oc_cs1.get.assert_not_called()
+
+
+def test_validate_planned_data_caches_namespace_checks(
+    resource_inventory: resource.ResourceInventory,
+    oc_map: oc.OC_Map,
+    oc_cs1: MagicMock,
+) -> None:
+    resource_inventory.initialize_resource_type("cs1", "ns1", "Deployment")
+    resource_inventory.add_desired(
+        "cs1",
+        "ns1",
+        "Deployment",
+        "deployment",
+        build_openshift_resource(
+            kind="Deployment",
+            api_version="apps/v1",
+            name="deployment",
+            extra_body={
+                "spec": {
+                    "template": {
+                        "spec": {"containers": [{"name": "app", "image": "image"}]}
+                    }
+                }
+            },
+        ),
+    )
+
+    def get_used_resources(
+        _spec: Mapping[str, Any], used_kind: str, include_optional: bool
+    ) -> dict[str, set[str]]:
+        assert not include_optional
+        return {f"missing-{used_kind.lower()}": set()}
+
+    oc_cs1.get_resources_used_in_pod_spec.side_effect = get_used_resources
+    oc_cs1.project_exists.return_value = True
+    oc_cs1.get.return_value = {}
+
+    sut.validate_planned_data(resource_inventory, oc_map)
+
+    assert resource_inventory.has_error_registered()
+    oc_cs1.project_exists.assert_called_once_with("ns1")
+    assert oc_cs1.get.call_count == 2
+
+
 @pytest.fixture
 def diff_result() -> DiffResult:
     r1 = build_openshift_resource_1()


### PR DESCRIPTION
## Summary

- Defer planned Secret and ConfigMap existence validation when the target namespace is confirmed absent.
- Cache namespace checks per cluster and namespace for the validation run.
- Preserve desired-resource key validation and existing namespace, Forbidden, and discovery errors.

## Context

openshift-saas-deploy waits for target namespaces to be created, but planned dependency validation can query unresolved resources before that happens. This change avoids treating a missing namespace as a missing dependency while retaining failures for existing namespaces and access errors.

## Verification

- Focused validator tests: 8 passed
- reconcile/test/test_openshift_base.py: 67 passed
- mypy: clean across 1,197 source files
- Full ruff lint and formatting checks: passed
- Repository suite: 4,109 passed; 9 unrelated Prometheus rule tester failures because promtool-3.9.1 is unavailable in the environment
- Pre-commit hook: passed

Related: https://gitlab.cee.redhat.com/service/app-interface/-/merge_requests/205785


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved validation of referenced resources when their namespace does not exist.
  - Skips unavailable resource checks in missing namespaces and records a warning instead of querying the cluster.
  - Reports missing Secret and ConfigMap resources more accurately.
  - Reuses namespace checks during validation to avoid redundant lookups.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->