### PR TITLE
fix(ocm): decouple VaultSecret construction from generated GQL model

### DIFF
--- a/reconcile/test/utils/test_ocm.py
+++ b/reconcile/test/utils/test_ocm.py
@@ -4,8 +4,9 @@ from typing import TYPE_CHECKING, Any
 
 import pytest
 
-from reconcile.utils.ocm import OCM
+from reconcile.utils.ocm import OCM, OCMMap
 from reconcile.utils.ocm_base_client import OCMBaseClient
+from reconcile.utils.secret_reader import VaultSecretRef
 
 if TYPE_CHECKING:
     from pytest_mock import MockerFixture
@@ -101,3 +102,60 @@ def test__ready_for_app_interface(
 ) -> None:
     for cluster, readiness in clusters_by_readiness:
         assert ocm._ready_for_app_interface(cluster) == readiness
+
+
+@pytest.fixture
+def legacy_ocm_info() -> dict[str, Any]:
+    """Shape produced by the legacy dict-based CLUSTERS_QUERY, CLUSTER_PEERING_QUERY
+    and OCM_QUERY in reconcile/queries.py, which only select path/field/format/version
+    for accessTokenClientSecret (no `url`).
+    """
+    return {
+        "name": "ocm-instance",
+        "orgId": "org-id",
+        "accessTokenClientId": "client-id",
+        "accessTokenUrl": "https://sso.example.com/token",
+        "accessTokenClientSecret": {
+            "path": "some/vault/path",
+            "field": "client_secret",
+            "format": None,
+            "version": None,
+        },
+        "environment": {
+            "name": "prod",
+            "url": "https://api.openshift.com",
+            "accessTokenClientId": "env-client-id",
+            "accessTokenUrl": "https://sso.example.com/token",
+            "accessTokenClientSecret": {
+                "path": "env/vault/path",
+                "field": "client_secret",
+                "format": None,
+                "version": None,
+            },
+        },
+    }
+
+
+def test_ocmmap_init_ocm_client_with_legacy_dict_missing_url(
+    mocker: MockerFixture, legacy_ocm_info: dict[str, Any]
+) -> None:
+    """Regression test: reconcile/queries.py's legacy dict-based OCM queries never
+    select `url` for accessTokenClientSecret. OCMMap.init_ocm_client() must build
+    the OCM API client's secret reference without depending on the generated
+    (reconcile.gql_definitions) VaultSecret model, which now requires `url`.
+    """
+    init_ocm_base_client_mock = mocker.patch(
+        "reconcile.utils.ocm.ocm.init_ocm_base_client", autospec=True
+    )
+    mocker.patch("reconcile.utils.ocm.ocm.OCM", autospec=True)
+
+    OCMMap(ocms=[legacy_ocm_info])
+
+    init_ocm_base_client_mock.assert_called_once()
+    cfg = init_ocm_base_client_mock.call_args.kwargs["cfg"]
+    assert cfg.access_token_client_secret == VaultSecretRef(
+        path="some/vault/path",
+        field="client_secret",
+        version=None,
+        q_format=None,
+    )

--- a/reconcile/utils/ocm/ocm.py
+++ b/reconcile/utils/ocm/ocm.py
@@ -6,7 +6,6 @@ from typing import TYPE_CHECKING, Any
 from sretoolbox.utils import retry
 
 import reconcile.utils.aws_helper as awsh
-from reconcile.gql_definitions.fragments.vault_secret import VaultSecret
 from reconcile.utils.ocm.clusters import get_node_pools
 from reconcile.utils.ocm.products import (
     OCMProduct,
@@ -18,7 +17,7 @@ from reconcile.utils.ocm_base_client import (
     OCMBaseClient,
     init_ocm_base_client,
 )
-from reconcile.utils.secret_reader import SecretReader
+from reconcile.utils.secret_reader import SecretReader, VaultSecretRef
 
 if TYPE_CHECKING:
     from collections.abc import Iterable, Mapping, MutableMapping
@@ -873,7 +872,12 @@ class OCMMap:
                 url=url,
                 access_token_url=access_token_url,
                 access_token_client_id=access_token_client_id,
-                access_token_client_secret=VaultSecret(**access_token_client_secret),
+                access_token_client_secret=VaultSecretRef(
+                    path=access_token_client_secret["path"],
+                    field=access_token_client_secret["field"],
+                    version=access_token_client_secret.get("version"),
+                    q_format=access_token_client_secret.get("format"),
+                ),
             ),
             secret_reader=SecretReader(settings=self.settings),
         )

--- a/reconcile/utils/secret_reader.py
+++ b/reconcile/utils/secret_reader.py
@@ -4,6 +4,7 @@ from abc import (
     ABC,
     abstractmethod,
 )
+from dataclasses import dataclass
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -42,6 +43,19 @@ class HasSecret(Protocol):
     field: str
     version: int | None
     q_format: str | None
+
+
+@dataclass
+class VaultSecretRef:
+    """Concrete HasSecret implementation for call sites that build a secret
+    reference from raw data (dicts, env vars, ...) rather than a generated
+    GraphQL model. reconcile/utils must not depend on reconcile.gql_definitions.
+    """
+
+    path: str
+    field: str
+    version: int | None = None
+    q_format: str | None = None
 
 
 class SecretReaderBase(ABC):

--- a/reconcile/utils/state.py
+++ b/reconcile/utils/state.py
@@ -19,7 +19,6 @@ from pydantic import BaseModel
 from reconcile.gql_definitions.common.app_interface_state_settings import (
     AppInterfaceStateConfigurationS3V1,
 )
-from reconcile.gql_definitions.fragments.vault_secret import VaultSecret
 from reconcile.typed_queries.app_interface_state_settings import (
     get_app_interface_state_settings,
 )
@@ -31,6 +30,7 @@ from reconcile.utils.aws_api import aws_config_file_path
 from reconcile.utils.json import json_dumps
 from reconcile.utils.secret_reader import (
     SecretReaderBase,
+    VaultSecretRef,
     create_secret_reader,
 )
 
@@ -141,11 +141,9 @@ def acquire_state_settings(
             f"access state via access credentials from vault secret {state_bucket_vault_secret} version {state_bucket_vault_secret_version or 'latest'})"
         )
         secret = secret_reader.read_all_secret(
-            VaultSecret(
+            VaultSecretRef(
                 path=state_bucket_vault_secret,
                 field="all",
-                format=None,
-                url=None,
                 version=int(state_bucket_vault_secret_version)
                 if state_bucket_vault_secret_version
                 else None,


### PR DESCRIPTION
## Summary

Follow-up to #5816. [@hemslo's review comment](https://github.com/app-sre/qontract-reconcile/pull/5816#discussion_r3977520548) (posted after the PR merged) is correct:

- The generated `VaultSecret` model's new `url` field is nullable in type syntax but required at construction time (`Field(...)`).
- The legacy dict-based `CLUSTERS_QUERY`, `CLUSTER_PEERING_QUERY` and `OCM_QUERY` in `reconcile/queries.py` only ever select `path`/`field`/`format`/`version` for `accessTokenClientSecret` — never `url`.
- Those raw dicts flow into `OCMMap.init_ocm_client()`, which builds `VaultSecret(**access_token_client_secret)` directly — this now raises a `pydantic.ValidationError` for every legacy OCM integration path (e.g. `terraform_vpc_peerings.py` via `queries.get_clusters_with_peering_settings()`, or any `OCMMap(clusters=...)`/`OCMMap(ocms=...)` caller).
- This wasn't caught by existing tests because they all patch out `init_ocm_client_from_cluster`/`init_ocm_client` entirely (see `test_ocm_clusters.py`, `test_ocm_additional_routers.py`), so the `VaultSecret(...)` construction never actually ran in CI.

## Fix

Rather than adding `url` to the legacy query selections (it isn't consumed anywhere yet per #5816) or relaxing the generated model, this removes the `reconcile.gql_definitions` dependency from `reconcile/utils` entirely for this construction:

- Add a plain `VaultSecretRef` dataclass implementing the existing `HasSecret` protocol in `reconcile/utils/secret_reader.py`.
- Use it in `reconcile/utils/ocm/ocm.py` (legacy dict path) and `reconcile/utils/state.py` (env-var path) instead of the generated `VaultSecret` model — `reconcile/utils` should not depend on generated GraphQL query types.

## Test plan

- [x] Added `test_ocmmap_init_ocm_client_with_legacy_dict_missing_url` in `reconcile/test/utils/test_ocm.py`, exercising `OCMMap.init_ocm_client()` end-to-end (not mocked away) with a legacy-shaped dict lacking `url`.
- [x] Verified the test fails with `pydantic.ValidationError: url Field required` against the pre-fix code, and passes after the fix (TDD).
- [x] `uv run mypy` clean on all changed files.
- [x] `uv run ruff check` / `ruff format --check` clean.
- [x] Existing `reconcile/test/utils/test_state.py`, `reconcile/test/test_secret_reader.py`, `reconcile/test/test_ocm_clusters.py`, `reconcile/test/test_ocm_additional_routers.py`, `reconcile/test/ocm/` all still pass (466 tests).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility with legacy Vault secret configurations.
  * Preserved optional secret version and format settings when connecting to OCM.
  * Maintained existing Vault state credential version handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->