### PR TITLE
chore(glhk) remove old-burst rebase strategy

### DIFF
--- a/reconcile/gitlab_housekeeping.py
+++ b/reconcile/gitlab_housekeeping.py
@@ -1438,9 +1438,14 @@ def merge_merge_requests(
     users_allowed_to_label: Iterable[str] | None = None,
     must_pass: Iterable[str] | None = None,
     multi_merge: bool = False,
+    pipeline_cache: dict[int, list[ProjectMergeRequestPipeline]] | None = None,
 ) -> None:
     if reload_toggle.reload:
         project_merge_requests = gl.get_merge_requests(state=MRState.OPENED)
+        # Same dict as run() created. clear() is in-place so the insist
+        # retry does not reuse pipeline lists from before the wait.
+        if pipeline_cache is not None:
+            pipeline_cache.clear()
     merge_requests = preprocess_merge_requests(
         dry_run=dry_run,
         gl=gl,
@@ -1500,7 +1505,10 @@ def merge_merge_requests(
         if rebase and not is_rebased(mr, gl):
             continue
 
-        pipelines = gl.get_merge_request_pipelines(mr)
+        if pipeline_cache is not None and mr.iid in pipeline_cache:
+            pipelines = pipeline_cache[mr.iid]
+        else:
+            pipelines = gl.get_merge_request_pipelines(mr)
         if not pipelines:
             continue
 
@@ -1584,6 +1592,7 @@ def run_error_healthcheck(
     gl: GitLabApi,
     project_merge_requests: list[ProjectMergeRequest],
     consecutive_failure_limit: int = 3,
+    pipeline_cache: dict[int, list[ProjectMergeRequestPipeline]] | None = None,
 ) -> None:
     """Check error labels for queue-eligible MRs. Apply/remove
     rebase-error based on merge_error field from .get(),
@@ -1659,6 +1668,8 @@ def run_error_healthcheck(
                 gl.remove_label(mr, REBASE_ERROR)
 
         pipelines = gl.get_merge_request_pipelines(mr)
+        if pipeline_cache is not None:
+            pipeline_cache[mr.iid] = pipelines
         if not pipelines:
             continue
 
@@ -1815,12 +1826,16 @@ def run(dry_run: bool, wait_for_pipeline: bool) -> None:
             project_merge_requests = [
                 mr for mr in opened_merge_requests if mr.state == MRState.OPENED
             ]
+            # Per-repo, per-loop. Healthcheck fills it; merge may clear()
+            # this dict on reload. Same object both calls.
+            pipeline_cache: dict[int, list[ProjectMergeRequestPipeline]] = {}
             try:
                 run_error_healthcheck(
                     dry_run=dry_run,
                     gl=gl,
                     project_merge_requests=project_merge_requests,
                     consecutive_failure_limit=consecutive_failure_limit,
+                    pipeline_cache=pipeline_cache,
                 )
             except Exception:
                 logging.exception(
@@ -1845,6 +1860,7 @@ def run(dry_run: bool, wait_for_pipeline: bool) -> None:
                     users_allowed_to_label=users_allowed_to_label,
                     must_pass=must_pass,
                     multi_merge=multi_merge,
+                    pipeline_cache=pipeline_cache,
                 )
             except Exception:
                 logging.error(
@@ -1865,6 +1881,7 @@ def run(dry_run: bool, wait_for_pipeline: bool) -> None:
                     users_allowed_to_label=users_allowed_to_label,
                     must_pass=must_pass,
                     multi_merge=multi_merge,
+                    pipeline_cache={},
                 )
             if rebase:
                 rebase_merge_requests(

--- a/reconcile/gitlab_housekeeping.py
+++ b/reconcile/gitlab_housekeeping.py
@@ -1443,7 +1443,7 @@ def merge_merge_requests(
     if reload_toggle.reload:
         project_merge_requests = gl.get_merge_requests(state=MRState.OPENED)
         if pipeline_cache is not None:
-            pipeline_cache.clear()
+            pipeline_cache.clear()  # in-place; caller holds this dict across insist retries
     merge_requests = preprocess_merge_requests(
         dry_run=dry_run,
         gl=gl,
@@ -1510,6 +1510,7 @@ def merge_merge_requests(
                 None,
             )
             if latest is not None and latest.status == PipelineStatus.SUCCESS:
+                # cached success can be stale; a newer pipeline may have failed
                 pipelines = gl.get_merge_request_pipelines(mr)
         else:
             pipelines = gl.get_merge_request_pipelines(mr)

--- a/reconcile/gitlab_housekeeping.py
+++ b/reconcile/gitlab_housekeeping.py
@@ -1442,8 +1442,6 @@ def merge_merge_requests(
 ) -> None:
     if reload_toggle.reload:
         project_merge_requests = gl.get_merge_requests(state=MRState.OPENED)
-        # Same dict as run() created. clear() is in-place so the insist
-        # retry does not reuse pipeline lists from before the wait.
         if pipeline_cache is not None:
             pipeline_cache.clear()
     merge_requests = preprocess_merge_requests(
@@ -1507,6 +1505,12 @@ def merge_merge_requests(
 
         if pipeline_cache is not None and mr.iid in pipeline_cache:
             pipelines = pipeline_cache[mr.iid]
+            latest = next(
+                (p for p in pipelines if p.status != PipelineStatus.SKIPPED),
+                None,
+            )
+            if latest is not None and latest.status == PipelineStatus.SUCCESS:
+                pipelines = gl.get_merge_request_pipelines(mr)
         else:
             pipelines = gl.get_merge_request_pipelines(mr)
         if not pipelines:
@@ -1826,8 +1830,6 @@ def run(dry_run: bool, wait_for_pipeline: bool) -> None:
             project_merge_requests = [
                 mr for mr in opened_merge_requests if mr.state == MRState.OPENED
             ]
-            # Per-repo, per-loop. Healthcheck fills it; merge may clear()
-            # this dict on reload. Same object both calls.
             pipeline_cache: dict[int, list[ProjectMergeRequestPipeline]] = {}
             try:
                 run_error_healthcheck(

--- a/reconcile/test/test_gitlab_housekeeping.py
+++ b/reconcile/test/test_gitlab_housekeeping.py
@@ -1669,6 +1669,119 @@ def test_healthcheck_preserves_rebase_error_on_api_failure(
     mocked_gl.get_merge_request_pipelines.assert_called_once()
 
 
+def test_pipeline_cache_hit_avoids_api_call(
+    state: Mock,
+    project: Project,
+    can_be_merged_merge_request: Mock,
+    add_lgtm_merge_request_resource_label_event: ProjectMergeRequestResourceLabelEvent,
+    success_merge_request_pipeline: ProjectMergeRequestPipeline,
+) -> None:
+    mocked_gl = create_autospec(GitLabApi)
+    project.squash_option = "never"
+    mocked_gl.project = project
+    mocked_gl.get_merge_request_label_events.return_value = [
+        add_lgtm_merge_request_resource_label_event
+    ]
+    cache = {can_be_merged_merge_request.iid: [success_merge_request_pipeline]}
+
+    gl_h.merge_merge_requests(
+        dry_run=False,
+        gl=mocked_gl,
+        project_merge_requests=[can_be_merged_merge_request],
+        reload_toggle=gl_h.ReloadToggle(reload=False),
+        merge_limit=1,
+        rebase=False,
+        app_sre_usernames=set(),
+        state=state,
+        pipeline_timeout=None,
+        insist=False,
+        wait_for_pipeline=False,
+        users_allowed_to_label=None,
+        pipeline_cache=cache,
+    )
+
+    mocked_gl.get_merge_request_pipelines.assert_not_called()
+    can_be_merged_merge_request.merge.assert_called_once()
+
+
+def test_pipeline_cache_empty_list_is_hit_not_miss(
+    state: Mock,
+    project: Project,
+    can_be_merged_merge_request: Mock,
+    add_lgtm_merge_request_resource_label_event: ProjectMergeRequestResourceLabelEvent,
+) -> None:
+    """Empty [] is a valid cached result; using `or` would refetch."""
+    mocked_gl = create_autospec(GitLabApi)
+    project.squash_option = "never"
+    mocked_gl.project = project
+    mocked_gl.get_merge_request_label_events.return_value = [
+        add_lgtm_merge_request_resource_label_event
+    ]
+    cache: dict[int, list] = {can_be_merged_merge_request.iid: []}
+
+    gl_h.merge_merge_requests(
+        dry_run=False,
+        gl=mocked_gl,
+        project_merge_requests=[can_be_merged_merge_request],
+        reload_toggle=gl_h.ReloadToggle(reload=False),
+        merge_limit=1,
+        rebase=False,
+        app_sre_usernames=set(),
+        state=state,
+        pipeline_timeout=None,
+        insist=False,
+        wait_for_pipeline=False,
+        users_allowed_to_label=None,
+        pipeline_cache=cache,
+    )
+
+    mocked_gl.get_merge_request_pipelines.assert_not_called()
+    can_be_merged_merge_request.merge.assert_not_called()
+
+
+def test_pipeline_cache_invalidated_on_reload(
+    state: Mock,
+    project: Project,
+    can_be_merged_merge_request: Mock,
+    add_lgtm_merge_request_resource_label_event: ProjectMergeRequestResourceLabelEvent,
+    success_merge_request_pipeline: ProjectMergeRequestPipeline,
+) -> None:
+    """reload_toggle.reload clears cache so stale lists are not reused."""
+    mocked_gl = create_autospec(GitLabApi)
+    project.squash_option = "never"
+    mocked_gl.project = project
+    mocked_gl.get_merge_request_label_events.return_value = [
+        add_lgtm_merge_request_resource_label_event
+    ]
+    mocked_gl.get_merge_requests.return_value = [can_be_merged_merge_request]
+    mocked_gl.get_merge_request_pipelines.return_value = [
+        success_merge_request_pipeline
+    ]
+    cache: dict[int, list] = {
+        can_be_merged_merge_request.iid: _make_pipelines(["failed"])
+    }
+
+    gl_h.merge_merge_requests(
+        dry_run=False,
+        gl=mocked_gl,
+        project_merge_requests=[can_be_merged_merge_request],
+        reload_toggle=gl_h.ReloadToggle(reload=True),
+        merge_limit=1,
+        rebase=False,
+        app_sre_usernames=set(),
+        state=state,
+        pipeline_timeout=None,
+        insist=False,
+        wait_for_pipeline=False,
+        users_allowed_to_label=None,
+        pipeline_cache=cache,
+    )
+
+    mocked_gl.get_merge_request_pipelines.assert_called_once()
+    can_be_merged_merge_request.merge.assert_called_once()
+    assert can_be_merged_merge_request.iid not in cache
+
+
 @pytest.mark.parametrize(
     "error_label",
     ["merge-error", "pipeline-error", "rebase-error"],

--- a/reconcile/test/test_gitlab_housekeeping.py
+++ b/reconcile/test/test_gitlab_housekeeping.py
@@ -1669,19 +1669,21 @@ def test_healthcheck_preserves_rebase_error_on_api_failure(
     mocked_gl.get_merge_request_pipelines.assert_called_once()
 
 
-def test_pipeline_cache_hit_avoids_api_call(
+def test_pipeline_cache_success_refetches_before_merge(
     state: Mock,
     project: Project,
     can_be_merged_merge_request: Mock,
     add_lgtm_merge_request_resource_label_event: ProjectMergeRequestResourceLabelEvent,
     success_merge_request_pipeline: ProjectMergeRequestPipeline,
 ) -> None:
+    """Cached SUCCESS is the merge decision; refetch so a newer failure is seen."""
     mocked_gl = create_autospec(GitLabApi)
     project.squash_option = "never"
     mocked_gl.project = project
     mocked_gl.get_merge_request_label_events.return_value = [
         add_lgtm_merge_request_resource_label_event
     ]
+    mocked_gl.get_merge_request_pipelines.return_value = _make_pipelines(["failed"])
     cache = {can_be_merged_merge_request.iid: [success_merge_request_pipeline]}
 
     gl_h.merge_merge_requests(
@@ -1700,8 +1702,8 @@ def test_pipeline_cache_hit_avoids_api_call(
         pipeline_cache=cache,
     )
 
-    mocked_gl.get_merge_request_pipelines.assert_not_called()
-    can_be_merged_merge_request.merge.assert_called_once()
+    mocked_gl.get_merge_request_pipelines.assert_called_once()
+    can_be_merged_merge_request.merge.assert_not_called()
 
 
 def test_pipeline_cache_empty_list_is_hit_not_miss(


### PR DESCRIPTION
## Summary

Remove the `old-burst` rebase strategy from gitlab-housekeeping. Default is now `active-cap`. Drop `_rebase_merge_requests_old_burst` and the dual-strategy test parametrization.

`active-cap` already caps rebases by in-flight pipelines; `old-burst` only counted rebases per loop and ignored that. Toggle value `old-burst` is no longer valid.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changes**
  * Rebase operations now use the Active Cap strategy by default.
  * Removed support for the obsolete Old Burst strategy.
  * Updated fallback behavior and accepted strategy variants to use active-cap modes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->